### PR TITLE
install hooks with `git media path`

### DIFF
--- a/commands/command_path.go
+++ b/commands/command_path.go
@@ -15,6 +15,8 @@ type PathCommand struct {
 }
 
 func (c *PathCommand) Run() {
+	gitmedia.InstallHooks(false)
+
 	var sub string
 	if len(c.SubCommands) > 0 {
 		sub = c.SubCommands[0]

--- a/commands/path_test.go
+++ b/commands/path_test.go
@@ -2,6 +2,8 @@ package commands
 
 import (
 	"github.com/bmizerany/assert"
+	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -9,6 +11,9 @@ import (
 func TestPath(t *testing.T) {
 	repo := NewRepository(t, "attributes")
 	defer repo.Test()
+
+	prePushHookFile := filepath.Join(repo.Path, ".git", "hooks", "pre-push")
+	customHook := []byte("echo 'yo'")
 
 	cmd := repo.Command("path")
 	cmd.Output = "Listing paths\n" +
@@ -18,8 +23,19 @@ func TestPath(t *testing.T) {
 		"    *.png (a/b/.gitattributes)"
 
 	cmd.Before(func() {
+		// write attributes file in .git
 		path := filepath.Join(".git", "info", "attributes")
 		repo.WriteFile(path, "*.mov filter=media -crlf\n")
+
+		// add hook
+		err := ioutil.WriteFile(prePushHookFile, customHook, 0755)
+		assert.Equal(t, nil, err)
+	})
+
+	cmd.After(func() {
+		by, err := ioutil.ReadFile(prePushHookFile)
+		assert.Equal(t, nil, err)
+		assert.Equal(t, string(customHook), string(by))
 	})
 }
 
@@ -27,14 +43,22 @@ func TestPathOnEmptyRepository(t *testing.T) {
 	repo := NewRepository(t, "empty")
 	defer repo.Test()
 
+	prePushHookFile := filepath.Join(repo.Path, ".git", "hooks", "pre-push")
+
 	cmd := repo.Command("path", "add", "*.gif")
 	cmd.Output = "Adding path *.gif"
 	cmd.After(func() {
+		// assert path was added
 		assert.Equal(t, "*.gif filter=media -crlf\n", repo.ReadFile(".gitattributes"))
 
 		expected := "Listing paths\n    *.gif (.gitattributes)\n"
 
 		assert.Equal(t, expected, repo.MediaCmd("path"))
+
+		// assert hook was created
+		stat, err := os.Stat(prePushHookFile)
+		assert.Equal(t, nil, err)
+		assert.Equal(t, false, stat.IsDir())
 	})
 
 	cmd = repo.Command("path")


### PR DESCRIPTION
I'm trying to reduce how often specific git-media commands are run explicitly by users.  
