### PR TITLE
add ts package, needed for windows

### DIFF
--- a/.vendor/src/github.com/olekukonko/ts/.travis.yml
+++ b/.vendor/src/github.com/olekukonko/ts/.travis.yml
@@ -1,0 +1,6 @@
+language: go
+
+go:
+  - 1.1
+  - 1.2
+  - tip

--- a/.vendor/src/github.com/olekukonko/ts/LICENCE
+++ b/.vendor/src/github.com/olekukonko/ts/LICENCE
@@ -1,0 +1,19 @@
+Copyright (C) 2014 by Oleku Konko
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/.vendor/src/github.com/olekukonko/ts/README.md
+++ b/.vendor/src/github.com/olekukonko/ts/README.md
@@ -1,0 +1,28 @@
+ts (Terminal Size)
+==
+
+[![Build Status](https://travis-ci.org/olekukonko/ts.png?branch=master)](https://travis-ci.org/olekukonko/ts) [![Total views](https://sourcegraph.com/api/repos/github.com/olekukonko/ts/counters/views.png)](https://sourcegraph.com/github.com/olekukonko/ts)
+
+Simple go Application to get Terminal Size. So Many Implementations do not support windows but `ts` has full windows support.
+Run `go get github.com/olekukonko/ts` to download and install
+
+#### Example
+
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/olekukonko/ts"
+)
+
+func main() {
+	size, _ := ts.GetSize()
+	fmt.Println(size.Col())  // Get Width
+	fmt.Println(size.Row())  // Get Height
+	fmt.Println(size.PosX()) // Get X position
+	fmt.Println(size.PosY()) // Get Y position
+}
+```
+
+[See Documentation](http://godoc.org/github.com/olekukonko/ts)

--- a/.vendor/src/github.com/olekukonko/ts/doc.go
+++ b/.vendor/src/github.com/olekukonko/ts/doc.go
@@ -1,0 +1,36 @@
+// Copyright 2014 Oleku Konko All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+// This module is a Terminal  API for the Go Programming Language.
+// The protocols were written in pure Go and works on windows and unix systems
+
+/**
+
+Simple go Application to get Terminal Size. So Many Implementations do not support windows but `ts` has full windows support.
+Run `go get github.com/olekukonko/ts` to download and install
+
+Installation
+
+Minimum requirements are Go 1.1+ with fill Windows support
+
+Example
+
+	package main
+
+	import (
+		"fmt"
+		"github.com/olekukonko/ts"
+	)
+
+	func main() {
+		size, _ := ts.GetSize()
+		fmt.Println(size.Col())  // Get Width
+		fmt.Println(size.Row())  // Get Height
+		fmt.Println(size.PosX()) // Get X position
+		fmt.Println(size.PosY()) // Get Y position
+	}
+
+**/
+
+package ts

--- a/.vendor/src/github.com/olekukonko/ts/ts.go
+++ b/.vendor/src/github.com/olekukonko/ts/ts.go
@@ -1,0 +1,36 @@
+// Copyright 2014 Oleku Konko All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+// This module is a Terminal  API for the Go Programming Language.
+// The protocols were written in pure Go and works on windows and unix systems
+
+package ts
+
+// Return System Size
+type Size struct {
+	row  uint16
+	col  uint16
+	posX uint16
+	posY uint16
+}
+
+// Get Terminal Width
+func (w Size) Col() int {
+	return int(w.col)
+}
+
+// Get Terminal Height
+func (w Size) Row() int {
+	return int(w.row)
+}
+
+// Get Position X
+func (w Size) PosX() int {
+	return int(w.posX)
+}
+
+// Get Position Y
+func (w Size) PosY() int {
+	return int(w.posY)
+}

--- a/.vendor/src/github.com/olekukonko/ts/ts_darwin.go
+++ b/.vendor/src/github.com/olekukonko/ts/ts_darwin.go
@@ -1,0 +1,14 @@
+// +build darwin
+
+// Copyright 2014 Oleku Konko All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+// This module is a Terminal  API for the Go Programming Language.
+// The protocols were written in pure Go and works on windows and unix systems
+
+package ts
+
+const (
+	TIOCGWINSZ = 0x40087468
+)

--- a/.vendor/src/github.com/olekukonko/ts/ts_linux.go
+++ b/.vendor/src/github.com/olekukonko/ts/ts_linux.go
@@ -1,0 +1,13 @@
+// +build linux
+
+// Copyright 2014 Oleku Konko All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+// This module is a Terminal  API for the Go Programming Language.
+// The protocols were written in pure Go and works on windows and unix systems
+package ts
+
+const (
+	TIOCGWINSZ = 0x5413
+)

--- a/.vendor/src/github.com/olekukonko/ts/ts_other.go
+++ b/.vendor/src/github.com/olekukonko/ts/ts_other.go
@@ -1,0 +1,14 @@
+// +build !windows,!darwin,!freebsd,!netbsd,!openbsd,!linux
+
+// Copyright 2014 Oleku Konko All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+// This module is a Terminal  API for the Go Programming Language.
+// The protocols were written in pure Go and works on windows and unix systems
+
+package ts
+
+const (
+	TIOCGWINSZ = 0
+)

--- a/.vendor/src/github.com/olekukonko/ts/ts_test.go
+++ b/.vendor/src/github.com/olekukonko/ts/ts_test.go
@@ -1,0 +1,32 @@
+// Copyright 2014 Oleku Konko All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+// This module is a Terminal  API for the Go Programming Language.
+// The protocols were written in pure Go and works on windows and unix systems
+
+package ts
+
+import (
+	"fmt"
+	"testing"
+)
+
+func ExampleGetSize() {
+	size, _ := GetSize()
+	fmt.Println(size.Col())  // Get Width
+	fmt.Println(size.Row())  // Get Height
+	fmt.Println(size.PosX()) // Get X position
+	fmt.Println(size.PosY()) // Get Y position
+}
+
+func TestSize(t *testing.T) {
+	size, err := GetSize()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if size.Col() == 0 || size.Row() == 0 {
+		t.Fatalf("Screen Size Failed")
+	}
+}

--- a/.vendor/src/github.com/olekukonko/ts/ts_unix.go
+++ b/.vendor/src/github.com/olekukonko/ts/ts_unix.go
@@ -1,0 +1,14 @@
+// +build  freebsd netbsd openbsd
+
+// Copyright 2014 Oleku Konko All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+// This module is a Terminal  API for the Go Programming Language.
+// The protocols were written in pure Go and works on windows and unix systems
+
+package ts
+
+const (
+	TIOCGWINSZ = 0x40087468
+)

--- a/.vendor/src/github.com/olekukonko/ts/ts_windows.go
+++ b/.vendor/src/github.com/olekukonko/ts/ts_windows.go
@@ -1,0 +1,64 @@
+// +build windows
+
+// Copyright 2014 Oleku Konko All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+// This module is a Terminal  API for the Go Programming Language.
+// The protocols were written in pure Go and works on windows and unix systems
+
+package ts
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+var (
+	kernel32 = syscall.NewLazyDLL("kernel32.dll")
+
+	// Retrieves information about the specified console screen buffer.
+	// See http://msdn.microsoft.com/en-us/library/windows/desktop/ms683171(v=vs.85).aspx
+	screenBufferInfo = kernel32.NewProc("GetConsoleScreenBufferInfo")
+)
+
+//   Contains information about a console screen buffer.
+// http://msdn.microsoft.com/en-us/library/windows/desktop/ms682093(v=vs.85).aspx
+type CONSOLE_SCREEN_BUFFER_INFO struct {
+	DwSize              COORD
+	DwCursorPosition    COORD
+	WAttributes         uint16
+	SrWindow            SMALL_RECT
+	DwMaximumWindowSize COORD
+}
+
+// Defines the coordinates of a character cell in a console screen buffer.
+// The origin of the coordinate system (0,0) is at the top, left cell of the buffer.
+// See http://msdn.microsoft.com/en-us/library/windows/desktop/ms682119(v=vs.85).aspx
+type COORD struct {
+	X, Y uint16
+}
+
+// Defines the coordinates of the upper left and lower right corners of a rectangle.
+// See http://msdn.microsoft.com/en-us/library/windows/desktop/ms686311(v=vs.85).aspx
+type SMALL_RECT struct {
+	Left, Top, Right, Bottom uint16
+}
+
+func GetSize() (ws Size, err error) {
+	var info CONSOLE_SCREEN_BUFFER_INFO
+	rc, _, err := screenBufferInfo.Call(
+		uintptr(syscall.Stdout),
+		uintptr(unsafe.Pointer(&info)))
+
+	if rc == 0 {
+		return ws, err
+	}
+
+	ws = Size{info.SrWindow.Bottom,
+		info.SrWindow.Right,
+		info.DwCursorPosition.X,
+		info.DwCursorPosition.Y}
+
+	return ws, nil
+}

--- a/.vendor/src/github.com/olekukonko/ts/ts_x.go
+++ b/.vendor/src/github.com/olekukonko/ts/ts_x.go
@@ -1,0 +1,46 @@
+// +build !windows
+
+// Copyright 2014 Oleku Konko All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+// This module is a Terminal API for the Go Programming Language.
+// The protocols were written in pure Go and works on windows and unix systems
+
+package ts
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// Get Windows Size
+func GetSize() (ws Size, err error) {
+	_, _, ec := syscall.Syscall(syscall.SYS_IOCTL,
+		uintptr(syscall.Stdout),
+		uintptr(TIOCGWINSZ),
+		uintptr(unsafe.Pointer(&ws)))
+
+	err = getError(ec)
+
+	if TIOCGWINSZ == 0 && err != nil {
+		ws = Size{80, 25, 0, 0}
+	}
+	return ws, err
+}
+
+func getError(ec interface{}) (err error) {
+	switch v := ec.(type) {
+
+	case syscall.Errno: // Some implementation return syscall.Errno number
+		if v != 0 {
+			err = syscall.Errno(v)
+		}
+
+	case error: // Some implementation return error
+		err = ec.(error)
+	default:
+		err = nil
+	}
+	return
+}

--- a/Godeps
+++ b/Godeps
@@ -2,4 +2,5 @@ github.com/bmizerany/assert     e17e99893cb6509f428e1728281c2ad60a6b31e3
 github.com/cheggaaa/pb          e31a080772d3b0a093038a1d8cb7741c2f4c7ed3
 github.com/kr/pretty            bc9499caa0f45ee5edb2f0209fbd61fbf3d9018f
 github.com/kr/text              6807e777504f54ad073ecef66747de158294b639
+github.com/olekukonko/ts        ecf753e7c962639ab5a1fb46f7da627d4c0a04b8
 github.com/streadway/simpleuuid 6617b501e485b77e61b98cd533aefff9e258b5a7


### PR DESCRIPTION
Saw this while running `script/bootstrap -all`:

```
Building for windows/amd64
.vendor/src/github.com/cheggaaa/pb/pb_win.go:6:2: cannot find package "github.com/olekukonko/ts" in any of:
    /opt/boxen/goenv/versions/1.2.1/src/pkg/github.com/olekukonko/ts (from $GOROOT)
    /Users/rick/github/git-media/.vendor/src/github.com/olekukonko/ts (from $GOPATH)

 - cp script/install.bat.example bin/releases/windows-amd64/git-media-v0.0.1/install.bat

 - zip -j bin/releases/git-media-windows-amd64-v0.0.1.zip bin/releases/windows-amd64/git-media-v0.0.1/install.bat
  adding: install.bat (deflated 43%)
```
