### PR TITLE
put git-media's tmp in the media dir

### DIFF
--- a/commands/env_test.go
+++ b/commands/env_test.go
@@ -20,7 +20,7 @@ func TestEnv(t *testing.T) {
 		"LocalWorkingDir": repo.Path,
 		"LocalGitDir":     filepath.Join(repo.Path, ".git"),
 		"LocalMediaDir":   filepath.Join(repo.Path, ".git", "media"),
-		"TempDir":         filepath.Join(os.TempDir(), "git-media"),
+		"TempDir":         filepath.Join(repo.Path, ".git", "media", "tmp"),
 	})
 }
 
@@ -34,7 +34,7 @@ func TestEnvWithMediaUrl(t *testing.T) {
 		"LocalWorkingDir": repo.Path,
 		"LocalGitDir":     filepath.Join(repo.Path, ".git"),
 		"LocalMediaDir":   filepath.Join(repo.Path, ".git", "media"),
-		"TempDir":         filepath.Join(os.TempDir(), "git-media"),
+		"TempDir":         filepath.Join(repo.Path, ".git", "media", "tmp"),
 	})
 }
 
@@ -48,7 +48,7 @@ func TestEnvWithSubmoduleFromRepository(t *testing.T) {
 		"LocalWorkingDir": repo.Path,
 		"LocalGitDir":     filepath.Join(repo.Path, ".git"),
 		"LocalMediaDir":   filepath.Join(repo.Path, ".git", "media"),
-		"TempDir":         filepath.Join(os.TempDir(), "git-media"),
+		"TempDir":         filepath.Join(repo.Path, ".git", "media", "tmp"),
 	})
 
 	cmd.Before(func() {
@@ -73,7 +73,7 @@ func TestEnvWithSubmoduleFromSubmodule(t *testing.T) {
 		"LocalWorkingDir": repo.Path,
 		"LocalGitDir":     filepath.Join(repo.Path, ".git"),
 		"LocalMediaDir":   filepath.Join(repo.Path, ".git", "media"),
-		"TempDir":         filepath.Join(os.TempDir(), "git-media"),
+		"TempDir":         filepath.Join(repo.Path, ".git", "media", "tmp"),
 	})
 
 	cmd.Before(func() {

--- a/gitmedia/gitmedia.go
+++ b/gitmedia/gitmedia.go
@@ -60,6 +60,7 @@ func init() {
 	if err == nil {
 		LocalMediaDir = filepath.Join(LocalGitDir, "media")
 		LocalLogDir = filepath.Join(LocalMediaDir, "logs")
+		TempDir = filepath.Join(LocalMediaDir, "tmp")
 		queueDir = setupQueueDir()
 
 		if err := os.MkdirAll(TempDir, 0744); err != nil {


### PR DESCRIPTION
Seems weird having a global temp dir.  This puts it in the repository's .git directory.
