### PR TITLE
Send real stats in the progress callback instead of %

### DIFF
--- a/commands/smudge_test.go
+++ b/commands/smudge_test.go
@@ -39,10 +39,9 @@ func TestSmudge(t *testing.T) {
 		progress, err := ioutil.ReadFile(progressFile)
 		assert.Equal(t, nil, err)
 		progLines := bytes.Split(progress, []byte("\n"))
-		assert.Equal(t, 3, len(progLines))
-		assert.Equal(t, "smudge 1/1 0/0 somefile", string(progLines[0]))
-		assert.Equal(t, "smudge 1/1 9/9 somefile", string(progLines[1]))
-		assert.Equal(t, "", string(progLines[2]))
+		assert.Equal(t, 2, len(progLines))
+		assert.Equal(t, "smudge 1/1 9/9 somefile", string(progLines[0]))
+		assert.Equal(t, "", string(progLines[1]))
 	})
 
 	// smudge with custom hook

--- a/gitmedia/util.go
+++ b/gitmedia/util.go
@@ -86,7 +86,6 @@ func CopyCallbackFile(event, filename string, index, totalFiles int) (CopyCallba
 
 		return nil
 	})
-	file.Write([]byte(fmt.Sprintf("%s %d/%d 0/0 %s\n", event, index, totalFiles, filename)))
 
 	return cb, file, nil
 }


### PR DESCRIPTION
The format is now:

```
{event} {index}/{totalFiles} {sentBytes}/{totalBytes} {filename}
```

One caveat: The initial entry will have 0/0 sent/total bytes.  This is because we don't always know the size ahead of time.  Should we leave that first message out then?

/cc @joshaber 
