### PR TITLE
fix for naughty naughty directory recursion in Windows

### DIFF
--- a/gitmedia/gitmedia.go
+++ b/gitmedia/gitmedia.go
@@ -92,7 +92,8 @@ func resolveGitDir() (string, string, error) {
 }
 
 func recursiveResolveGitDir(dir string) (string, string, error) {
-	if len(dir) == 1 && dir[0] == os.PathSeparator {
+	var cleanDir = filepath.Clean(dir)
+	if cleanDir[len(cleanDir)-1] == os.PathSeparator {
 		return "", "", fmt.Errorf("Git repository not found")
 	}
 


### PR DESCRIPTION
Fixes #108 

Obligatory warning:

![](http://all-images.org/wp-content/uploads/2013/12/643917_555674231115834_703158588_n.png)

After being shouted at by the go compiler a bunch, I think I've found a better way to check for the filesystem root using a gem in the `filepath` docs:

http://golang.org/pkg/path/filepath/#Clean

> The returned path ends in a slash only if it represents a root directory, such as "/" on Unix or `C:\` on Windows.

Combining that with checking the last character on the file path (not the only character) _should_ catch this issue we're facing with finding the root of a Windows drive.

Thoughts?
