### PR TITLE
script/release

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -11,4 +11,4 @@ rm -f $LOCALSRCDIR
 ln -s `pwd` $LOCALSRCDIR
 
 GOPATH="`pwd`/.vendor" \
-  go run script/build.go "$@"
+  go run script/*.go -cmd build "$@"

--- a/script/build.go
+++ b/script/build.go
@@ -25,12 +25,7 @@ var (
 	}
 )
 
-type Release struct {
-	Label    string
-	Filename string
-}
-
-func main() {
+func mainBuild() {
 	cmd, err := exec.Command("script/fmt").Output()
 	if err != nil {
 		panic(err)
@@ -40,7 +35,6 @@ func main() {
 		fmt.Println(string(cmd))
 	}
 
-	flag.Parse()
 	if *ShowHelp {
 		fmt.Println("usage: script/bootstrap [-os] [-arch] [-all]")
 		flag.PrintDefaults()

--- a/script/release
+++ b/script/release
@@ -1,4 +1,4 @@
 #!/bin/sh
 script/fmt
 GOPATH="`pwd`/.vendor" \
-  go run script/release.go "$@"
+  go run script/*.go -cmd release "$@"

--- a/script/release.go
+++ b/script/release.go
@@ -9,19 +9,12 @@ import (
 	"os/exec"
 )
 
-type Release struct {
-	Label    string
-	Filename string
-}
-
 var (
 	ReleaseId    = flag.Int("id", 0, "github/git-media Release ID")
 	uploadUrlFmt = "https://uploads.github.com/repos/github/git-media/releases/%d/assets?%s"
 )
 
-func main() {
-	flag.Parse()
-
+func mainRelease() {
 	if *ReleaseId < 1 {
 		fmt.Println("Need a valid github/git-media release id.")
 		fmt.Println("usage: script/release -id")

--- a/script/script.go
+++ b/script/script.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+type Release struct {
+	Label    string
+	Filename string
+}
+
+var SubCommand = flag.String("cmd", "", "Command: build or release")
+
+func main() {
+	flag.Parse()
+	switch *SubCommand {
+	case "build":
+		mainBuild()
+	case "release":
+		mainRelease()
+	default:
+		fmt.Println("Unknown command:", *SubCommand)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
Add's a release script that uploads the compiled binaries to the Releases API with the proper labels and everything.

![release_v0_2_1_ _github_git-media](https://cloud.githubusercontent.com/assets/21/4172990/2b738b36-3552-11e4-8764-1ac0c6f7b579.png)
