### PR TITLE
Use an absolute path for GIT_MEDIA_PROGRESS rather than a file:/// URI

### DIFF
--- a/commands/smudge_test.go
+++ b/commands/smudge_test.go
@@ -20,7 +20,7 @@ func TestSmudge(t *testing.T) {
 	cmd := repo.Command("smudge", "somefile")
 	cmd.Input = bytes.NewBufferString("version http://git-media.io/v/2\noid sha256:SOMEOID\nsize 9\n")
 	cmd.Output = "whatever"
-	cmd.Env = append(cmd.Env, "GIT_MEDIA_PROGRESS=file://"+progressFile)
+	cmd.Env = append(cmd.Env, "GIT_MEDIA_PROGRESS="+progressFile)
 
 	cmd.Before(func() {
 		path := filepath.Join(repo.Path, ".git", "media", "SO", "ME")


### PR DESCRIPTION
On Windows, the parsing of `file://` URIs doesn't seem to handle drive letters very well. This change lets GIT_MEDIA_PROGRESS just be an absolute path. See also #133 

/cc @github/windows @github/mac for desktop client updates
