### PR TITLE
Update tracerx

### DIFF
--- a/.vendor/src/github.com/rubyist/tracerx/tracerx.go
+++ b/.vendor/src/github.com/rubyist/tracerx/tracerx.go
@@ -94,17 +94,17 @@ func Enable(key string) {
 
 func getTracer(key string) *tracer {
 	uppedKey := strings.ToUpper(key)
+
+	tracerLock.Lock()
 	tracer, ok := tracers[uppedKey]
 	if !ok {
 		tracer = initializeTracer(uppedKey)
 	}
+	tracerLock.Unlock()
 	return tracer
 }
 
 func initializeTracer(key string) *tracer {
-	tracerLock.Lock()
-	defer tracerLock.Unlock()
-
 	if tracer, ok := tracers[key]; ok {
 		return tracer // Someone else initialized while we were blocked
 	}

--- a/Godeps
+++ b/Godeps
@@ -6,4 +6,4 @@ github.com/olekukonko/ts                      ecf753e7c962639ab5a1fb46f7da627d4c
 github.com/spf13/cobra                        864687ae689edc28688c67edef47e3d2ad651a1b
 github.com/spf13/pflag                        463bdc838f2b35e9307e91d480878bda5fff7232
 github.com/technoweenie/go-contentaddressable 38171def3cd15e3b76eb156219b3d48704643899
-github.com/rubyist/tracerx                    b869498bff1ad54bb2df3b98d11f3b6dcefbddc6
+github.com/rubyist/tracerx                    f6aa9369b3277bc21384878e8279642da722f407


### PR DESCRIPTION
More correct concurrent access for tracers, reported in https://github.com/rubyist/tracerx/issues/1
