### PR TITLE
Updates the spec to support redirects for GET and PUT

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -214,9 +214,10 @@ get the current URL to send a file.
 
 ## Callbacks
 
-Git Media clients issue a GET or OPTIONS preflight request, which can potentially
-return a "callback" link relation.  If given, The Git Media server expects a
-POST to the callback href after a successful upload.  Git Media clients send:
+When Git Media clients issue a POST request to initiate an object upload, the
+response can potentially return a "callback" link relation.  If given, The Git
+Media server expects a POST to the callback href after a successful upload.  Git
+Media clients send:
 
 * `oid` - The String OID of the Git Media object.
 * `status` - The HTTP status of the redirected PUT request.
@@ -229,4 +230,6 @@ POST to the callback href after a successful upload.  Git Media clients send:
 > Content-Length: 123
 >
 > {"oid": "{oid}", "status": 200, "body": "ok"}
+>
+< HTTP/1.1 200 OK
 ```


### PR DESCRIPTION
This adds redirections to the Git Media API.  GET requests can return the raw data, or redirect to a new location.

[rendered](https://github.com/github/git-media/blob/redirection-proposal/docs/api.md)
1. Return the raw content.
   
   ```
   curl https://my-media.com/objects/{oid} -H "Accept: application/vnd.git-media" -u user:pass
   HTTP/1.1 200 OK
   Content-Type: application/octet-stream
   Content-Size: 123
   
   {object contents}
   ```
2. Redirect to a different host.  This is how GitHub's server will work.
   
   ```
   curl -L https://github.com/user/repo/objects/{oid} -H "Accept: application/vnd.git-media" -u user:pass
   HTTP/1.1 302 Found
   Location: https://my-media.com/objects/{oid}?token=whatever
   
   HTTP/1.1 200 OK
   Content-Type: application/octet-stream
   Content-Size: 123
   
   {object contents}
   ```

Uploads are preceded with a pre-flight request.  This request determines if the media server already has the object.

```
$ curl https://my-media.com/objects/{oid} -u user:pass \
  -H "Accept: application/vnd.git-media"

HTTP/1.1 200 Ok
{
  "oid": "abcdef",
  "_links": {
    "upload": { "href": "https://my-media.com/objects/{oid}" }
  }
}
```

Depending on the output, the client can see (assuming authorization is valid):
- If the `oid` and `size` properties exist, without an "upload" link relation, the object exists on the server.
- If there is an "upload" link relation, the file needs to be uploaded.
- If there is a "callback" link relation, the client needs to POST to it after the file has been uploaded.
- [ ] Approve the spec
- [ ] Write integration tests
- [ ] Implement client code
