### PR TITLE
encryption proposal

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -23,18 +23,19 @@ a sample pointer file:
 version http://git-media.io/v/2
 oid sha256:1d7a214614ab2935c943f9e0ff69d22eadbb8f32b1258daaa5e2ca24d17e2393
 size 12345
-compression type=gzip oid=sha256:2d7a214614ab2935c943f9e0ff69d22eadbb8f32b1258daaa5e2ca24d17e2393
-encryption type=aes256 oid=sha256:3d7a214614ab2935c943f9e0ff69d22eadbb8f32b1258daaa5e2ca24d17e2393
+compression type=gzip oid=sha256:2d7a214614ab2935c943f9e0ff69d22eadbb8f32b1258daaa5e2ca24d17e2393 size=1234
+encryption type=aes256 oid=sha256:3d7a214614ab2935c943f9e0ff69d22eadbb8f32b1258daaa5e2ca24d17e2393 size=123
 (ending \n)
 ```
 
 In this example, `1d7a214` is the OID of the file before compression and 
 encryption.  The object is then compressed with gzip, resulting in an OID
-of `2d7a214`.  Then, it is encrypted with the aes256 algorithm using the
-full `1d7a214` OID as the key, resulting in an OID of `3d7a214`.  This 
-final OID is used for the Git Media API requests.  Git Media will then run 
-these steps in reverse after downloading the object from the Git Media API.  
-Files can be compressed, encrypted, or both (but always in that order).
+of `2d7a214`, and a size of 1234.  Then, it is encrypted with the aes256 
+algorithm using the full `1d7a214` OID as the key, resulting in an OID of 
+`3d7a214`, and a size of 123.  This final OID is used for the Git Media API 
+requests.  Git Media will then runthese steps in reverse after downloading 
+the object from the Git Media API.   Files can be compressed, encrypted, or
+both (but always in that order).
 
 The pointer file should be small (less than 400 bytes), and consist of only
 ASCII characters.  Libraries that generate this should write the file


### PR DESCRIPTION
This is an updated proposal for supporting encryption and compression in the Git Media client.  This is to support the use case of keeping object privacy from external object stores that aren't completely trusted.

It is not meant to be some kind of access control inside the Git repository.  If a user can clone a repository, it should also be able to download and decrypt files.  The key (the file's original OID) is only tracked in the pointer file.

There is the big caveat that recovering from key or algorithm compromises will require an entire Git history rewrite.  But this system is much simpler than building key management into the Git Media API.

/cc @github/git-media 
