### PR TITLE
Fix broken links to the man pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ Git Media
 
 Command line tool for managing large files on GitHub.
 
-See the [Git Media overview](https://github.com/github/git-media/tree/master/docs) and [man pages](https://github.com/github/git-media/tree/master/man).
+See the [Git Media overview](https://github.com/github/git-media/tree/master/docs) and [man pages](https://github.com/github/git-media/tree/master/docs/man).

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ file from a Git Media server.
 
 * The Client
   * [Specification](spec.md)
-  * [Commands](../man)
+  * [Commands](man)
 * The Server
   * [API](api.md)
 


### PR DESCRIPTION
The links from `README.md` and from `docs/README.md` to the man pages are currently broken. They point to `man`, which is a build product that doesn't exist in the source code.

Instead, point at `docs/man`, where the source code for the man pages is located. The man pages here are not formatted beautifully, but are quite readable.

If you had more elaborate plans, for example somehow causing the man pages to be built on the server, then this PR might be inappropriate. But right now the links are broken, so _something_ should be done.
