### PR TITLE
Update download link to point to releases page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,8 @@ file from a Git Media server.
 
 The client lives in [github/git-media](https://github.com/github/git-media).
 
-Download the [latest release](https://github.com/github/git-media/releases).
+Download the [latest release](https://github.com/github/git-media/releases) and run the
+included `install.sh` script.
 
 ### Configure Git
 


### PR DESCRIPTION
This way we don't have to update the README every time there's a new release. :sparkles: Also added a note about `install.sh` but wasn't sure about that one, since the script is more of a convenience than a requirement.

/cc @technoweenie @github/git-media 
