### PR TITLE
disable redirects for enterprise support during pre-release

### DIFF
--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -134,8 +134,12 @@ func pushAsset(oid, filename string, index, totalFiles int) *hawser.WrappedError
 	}
 
 	linkMeta, status, err := hawserclient.Post(path, filename)
-	if err != nil {
+	if err != nil && status != 302 {
 		return hawser.Errorf(err, "Error starting file upload %s (%s)", filename, oid)
+	}
+
+	if status == 200 {
+		return nil
 	}
 
 	cb, file, cbErr := hawser.CopyCallbackFile("push", filename, index, totalFiles)
@@ -146,7 +150,7 @@ func pushAsset(oid, filename string, index, totalFiles int) *hawser.WrappedError
 		defer file.Close()
 	}
 
-	if status == 405 {
+	if status == 405 || status == 302 {
 		// Do the old style OPTIONS + PUT
 		status, err := hawserclient.Options(path)
 		if err != nil {
@@ -166,7 +170,7 @@ func pushAsset(oid, filename string, index, totalFiles int) *hawser.WrappedError
 	} // End old style
 
 	if status != 201 {
-		return nil
+		return hawser.Errorf(err, "Unexpected HTTP response: %d for %s (%s)", status, filename, oid)
 	}
 
 	err = hawserclient.ExternalPut(path, filename, linkMeta, cb)

--- a/hawser/config.go
+++ b/hawser/config.go
@@ -18,8 +18,9 @@ type Configuration struct {
 }
 
 var (
-	Config       = &Configuration{}
-	httpPrefixRe = regexp.MustCompile("\\Ahttps?://")
+	Config        = &Configuration{}
+	httpPrefixRe  = regexp.MustCompile("\\Ahttps?://")
+	RedirectError = fmt.Errorf("Unexpected redirection")
 )
 
 func HttpClient() *http.Client {
@@ -34,6 +35,9 @@ func (c *Configuration) HttpClient() *http.Client {
 			tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 		}
 		c.httpClient = &http.Client{Transport: tr}
+		c.httpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+			return RedirectError
+		}
 	}
 	return c.httpClient
 }

--- a/hawserclient/client.go
+++ b/hawserclient/client.go
@@ -287,6 +287,10 @@ func doRequest(req *http.Request, creds Creds) (*http.Response, *hawser.WrappedE
 
 	var wErr *hawser.WrappedError
 
+	if err == hawser.RedirectError {
+		err = nil
+	}
+
 	if err == nil {
 		if res.StatusCode > 299 {
 			// An auth error should be 403.  Could be 404 also.
@@ -304,7 +308,7 @@ func doRequest(req *http.Request, creds Creds) (*http.Response, *hawser.WrappedE
 		} else {
 			execCreds(creds, "approve")
 		}
-	} else {
+	} else if res.StatusCode != 302 { // hack for pre-release
 		wErr = hawser.Errorf(err, "Error sending HTTP request to %s", req.URL.String())
 	}
 


### PR DESCRIPTION
This fixes an issue with the latest `git-hawser` client communicating with the old GitHub Enterprise 2.1 server.  Basically, the `POST /objects` request in the latest API spec hits the default route of the media app, which simply redirects to the GHE homepage.  This is a quick hack to treat this 302 like a 405 response.  
