### PR TITLE
add support for alternate remotes

### DIFF
--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -62,6 +62,8 @@ func pushCommand(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
+	hawser.Config.CurrentRemote = args[0]
+
 	if useStdin {
 		refsData, err := ioutil.ReadAll(os.Stdin)
 		if err != nil {

--- a/hawser/config.go
+++ b/hawser/config.go
@@ -12,15 +12,17 @@ import (
 )
 
 type Configuration struct {
-	gitConfig  map[string]string
-	remotes    []string
-	httpClient *http.Client
+	CurrentRemote string
+	gitConfig     map[string]string
+	remotes       []string
+	httpClient    *http.Client
 }
 
 var (
-	Config        = &Configuration{}
-	httpPrefixRe  = regexp.MustCompile("\\Ahttps?://")
+	Config        = &Configuration{CurrentRemote: defaultRemote}
 	RedirectError = fmt.Errorf("Unexpected redirection")
+	httpPrefixRe  = regexp.MustCompile("\\Ahttps?://")
+	defaultRemote = "origin"
 )
 
 func HttpClient() *http.Client {
@@ -47,10 +49,20 @@ func (c *Configuration) Endpoint() string {
 		return url
 	}
 
-	return c.RemoteEndpoint("origin")
+	if len(c.CurrentRemote) > 0 && c.CurrentRemote != defaultRemote {
+		if endpoint := c.RemoteEndpoint(c.CurrentRemote); len(endpoint) > 0 {
+			return endpoint
+		}
+	}
+
+	return c.RemoteEndpoint(defaultRemote)
 }
 
 func (c *Configuration) RemoteEndpoint(remote string) string {
+	if len(remote) == 0 {
+		remote = defaultRemote
+	}
+
 	if url, ok := c.GitConfig("remote." + remote + ".hawser"); ok {
 		return url
 	}

--- a/hawser/config_test.go
+++ b/hawser/config_test.go
@@ -26,6 +26,32 @@ func TestEndpointOverridesOrigin(t *testing.T) {
 	assert.Equal(t, "abc", config.Endpoint())
 }
 
+func TestEndpointNoOverrideDefaultRemote(t *testing.T) {
+	config := &Configuration{
+		gitConfig: map[string]string{
+			"remote.origin.hawser": "abc",
+			"remote.other.hawser":  "def",
+		},
+		remotes: []string{},
+	}
+
+	assert.Equal(t, "abc", config.Endpoint())
+}
+
+func TestEndpointUseAlternateRemote(t *testing.T) {
+	config := &Configuration{
+		gitConfig: map[string]string{
+			"remote.origin.hawser": "abc",
+			"remote.other.hawser":  "def",
+		},
+		remotes: []string{},
+	}
+
+	config.CurrentRemote = "other"
+
+	assert.Equal(t, "def", config.Endpoint())
+}
+
 func TestEndpointAddsMediaSuffix(t *testing.T) {
 	config := &Configuration{
 		gitConfig: map[string]string{"remote.origin.url": "https://example.com/foo/bar"},


### PR DESCRIPTION
I ran into this in QA again.  Right now `git hawser push` always defaults to the origin branch.  So it's difficult to test a single hawser-test repository against github.com and enterprise.  This patch gets the current remote from the first arg in `git hawser push`.  This is basically what Git is doing:

```
echo "refs/heads/master OLDSHA refs/heads/master NEWSHA" | ./git/hooks/pre-push origin https://github.com/hawser/git-hawser
```

This patch sets the `CurrentRemote` property to the first command line arg, which is `origin` in my example above.

There are cases where no remote name will be given, so it's just a URL.  Since that git config won't exist, it will fall back to `origin`.  Though I almost want to have it bail early in that case, so you're not pushing some files to an unexpected URL.
