### PR TITLE
Adding copy for the early access program

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ requests in parallel for faster transfers.
 
 ## Known Implementations
 
-- [GitHub.com](github.com/early_access/large_file_storage) (support coming soon!)
+- [GitHub.com](https://github.com/early_access/large_file_storage) (support coming soon!)
 - [github/lfs-test-server](https://github.com/github/lfs-test-server) (reference server implementation)
 
 ## Getting Started


### PR DESCRIPTION
Based on the pre-release findings, there's a likelihood that people will download the client and try to use it with GitHub immediately and fail. Let's reduce potential support load by being explicit. :sparkles: 

/cc @tclem @bkeepers @technoweenie 
