### PR TITLE
upload debian 9 builds

### DIFF
--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -51,6 +51,9 @@ $distro_name_map = {
     ubuntu/wily
     ubuntu/xenial
   ),
+  "debian/9" => %w(
+    debian/stretch
+  )
 }
 
 # caches distro id lookups
@@ -89,6 +92,7 @@ package_files.each do |full_path|
   os, distro = case full_path
   when /debian\/7/ then ["Debian 7", "debian/wheezy"]
   when /debian\/8/ then ["Debian 8", "debian/jessie"]
+  when /debian\/9/ then ["Debian 9", "debian/stretch"]
   when /centos\/5/ then ["RPM RHEL 5/CentOS 5", "el/5"]
   when /centos\/6/ then ["RPM RHEL 6/CentOS 6", "el/6"]
   when /centos\/7/ then ["RPM RHEL 7/CentOS 7", "el/7"]


### PR DESCRIPTION
Building in the [debian 9 docker image](https://github.com/git-lfs/build-dockers/blob/0b0b98d4214df67e5d123cb3236dc680e29e07f5/debian/9/Dockerfile) fails with this:

```
dh binary --buildsystem=golang --with=golang
   dh_testroot -O--buildsystem=golang
   dh_prep -O--buildsystem=golang
   debian/rules override_dh_auto_install
make[1]: Entering directory '/tmp/docker_run/src/github.com/github/git-lfs/i386'
mkdir -p debian/git-lfs/usr/bin
cp obj-i686-linux-gnu/bin/git-lfs debian/git-lfs/usr/bin/
make[1]: Leaving directory '/tmp/docker_run/src/github.com/github/git-lfs/i386'
   dh_installdocs -O--buildsystem=golang
   dh_installchangelogs -O--buildsystem=golang
   dh_installman -O--buildsystem=golang
   dh_lintian -O--buildsystem=golang
   dh_perl -O--buildsystem=golang
   dh_link -O--buildsystem=golang
   dh_strip_nondeterminism -O--buildsystem=golang
   dh_compress -O--buildsystem=golang
   dh_fixperms -O--buildsystem=golang
   debian/rules override_dh_strip
make[1]: Entering directory '/tmp/docker_run/src/github.com/github/git-lfs/i386'
# strip disabled as golang upstream doesn't support it and it makes go
# crash. See https://launchpad.net/bugs/1200255.
make[1]: Leaving directory '/tmp/docker_run/src/github.com/github/git-lfs/i386'
   dh_makeshlibs -O--buildsystem=golang
   dh_shlibdeps -O--buildsystem=golang
   dh_installdeb -O--buildsystem=golang
   dh_golang -O--buildsystem=golang
dpkg-query: no path found matching pattern /usr/local/go/src/bufio/bufio.go
dpkg-query: no path found matching pattern /usr/local/go/src/bytes/buffer.go
dpkg-query: no path found matching pattern /usr/local/go/src/compress/flate/deflate.go
dpkg-query: no path found matching pattern /usr/local/go/src/compress/gzip/gunzip.go
dpkg-query: no path found matching pattern /usr/local/go/src/container/list/list.go
dpkg-query: no path found matching pattern /usr/local/go/src/context/context.go
dpkg-query: no path found matching pattern /usr/local/go/src/crypto/crypto.go
dpkg-query: no path found matching pattern /usr/local/go/src/crypto/aes/block.go
dpkg-query: no path found matching pattern /usr/local/go/src/crypto/cipher/cbc.go
dpkg-query: no path found matching pattern /usr/local/go/src/crypto/des/block.go
dpkg-query: no path found matching pattern /usr/local/go/src/crypto/dsa/dsa.go
dpkg-query: no path found matching pattern /usr/local/go/src/crypto/ecdsa/ecdsa.go
dpkg-query: no path found matching pattern /usr/local/go/src/crypto/elliptic/elliptic.go
dpkg-query: no path found matching pattern /usr/local/go/src/crypto/hmac/hmac.go
dpkg-query: no path found matching pattern /usr/local/go/src/crypto/md5/md5.go
dpkg-query: no path found matching pattern /usr/local/go/src/crypto/rand/eagain.go
dpkg-query: no path found matching pattern /usr/local/go/src/crypto/rc4/rc4.go
dpkg-query: no path found matching pattern /usr/local/go/src/crypto/rsa/pkcs1v15.go
dpkg-query: no path found matching pattern /usr/local/go/src/crypto/sha1/sha1.go
dpkg-query: no path found matching pattern /usr/local/go/src/crypto/sha256/sha256.go
dpkg-query: no path found matching pattern /usr/local/go/src/crypto/sha512/sha512.go
dpkg-query: no path found matching pattern /usr/local/go/src/crypto/subtle/constant_time.go
dpkg-query: no path found matching pattern /usr/local/go/src/crypto/tls/alert.go
dpkg-query: no path found matching pattern /usr/local/go/src/crypto/x509/cert_pool.go
dpkg-query: no path found matching pattern /usr/local/go/src/crypto/x509/pkix/pkix.go
dpkg-query: no path found matching pattern /usr/local/go/src/encoding/encoding.go
dpkg-query: no path found matching pattern /usr/local/go/src/encoding/asn1/asn1.go
dpkg-query: no path found matching pattern /usr/local/go/src/encoding/base64/base64.go
dpkg-query: no path found matching pattern /usr/local/go/src/encoding/binary/binary.go
dpkg-query: no path found matching pattern /usr/local/go/src/encoding/hex/hex.go
dpkg-query: no path found matching pattern /usr/local/go/src/encoding/json/decode.go
dpkg-query: no path found matching pattern /usr/local/go/src/encoding/pem/pem.go
dpkg-query: no path found matching pattern /usr/local/go/src/errors/errors.go
dpkg-query: no path found matching pattern /usr/local/go/src/flag/flag.go
dpkg-query: no path found matching pattern /usr/local/go/src/fmt/doc.go
dpkg-query: no path found matching pattern /usr/local/go/src/go/ast/ast.go
dpkg-query: no path found matching pattern /usr/local/go/src/go/build/build.go
dpkg-query: no path found matching pattern /usr/local/go/src/go/doc/comment.go
dpkg-query: no path found matching pattern /usr/local/go/src/go/parser/interface.go
dpkg-query: no path found matching pattern /usr/local/go/src/go/scanner/errors.go
dpkg-query: no path found matching pattern /usr/local/go/src/go/token/position.go
dpkg-query: no path found matching pattern /usr/local/go/src/hash/hash.go
dpkg-query: no path found matching pattern /usr/local/go/src/hash/crc32/crc32.go
dpkg-query: no path found matching pattern /usr/local/go/src/internal/nettrace/nettrace.go
dpkg-query: no path found matching pattern /usr/local/go/src/internal/race/doc.go
dpkg-query: no path found matching pattern /usr/local/go/src/internal/singleflight/singleflight.go
dpkg-query: no path found matching pattern /usr/local/go/src/internal/syscall/unix/getrandom_linux.go
dpkg-query: no path found matching pattern /usr/local/go/src/io/io.go
dpkg-query: no path found matching pattern /usr/local/go/src/io/ioutil/ioutil.go
dpkg-query: no path found matching pattern /usr/local/go/src/log/log.go
dpkg-query: no path found matching pattern /usr/local/go/src/math/abs.go
dpkg-query: no path found matching pattern /usr/local/go/src/math/big/accuracy_string.go
dpkg-query: no path found matching pattern /usr/local/go/src/math/rand/exp.go
dpkg-query: no path found matching pattern /usr/local/go/src/mime/encodedword.go
dpkg-query: no path found matching pattern /usr/local/go/src/mime/multipart/formdata.go
dpkg-query: no path found matching pattern /usr/local/go/src/mime/quotedprintable/reader.go
dpkg-query: no path found matching pattern /usr/local/go/src/net/addrselect.go
dpkg-query: no path found matching pattern /usr/local/go/src/net/http/client.go
dpkg-query: no path found matching pattern /usr/local/go/src/net/http/httptrace/trace.go
dpkg-query: no path found matching pattern /usr/local/go/src/net/http/httputil/dump.go
dpkg-query: no path found matching pattern /usr/local/go/src/net/http/internal/chunked.go
dpkg-query: no path found matching pattern /usr/local/go/src/net/textproto/header.go
dpkg-query: no path found matching pattern /usr/local/go/src/net/url/url.go
dpkg-query: no path found matching pattern /usr/local/go/src/os/dir_unix.go
dpkg-query: no path found matching pattern /usr/local/go/src/os/exec/exec.go
dpkg-query: no path found matching pattern /usr/local/go/src/os/signal/doc.go
dpkg-query: no path found matching pattern /usr/local/go/src/path/match.go
dpkg-query: no path found matching pattern /usr/local/go/src/path/filepath/match.go
dpkg-query: no path found matching pattern /usr/local/go/src/reflect/deepequal.go
dpkg-query: no path found matching pattern /usr/local/go/src/regexp/backtrack.go
dpkg-query: no path found matching pattern /usr/local/go/src/regexp/syntax/compile.go
dpkg-query: no path found matching pattern /usr/local/go/src/runtime/alg.go
dpkg-query: no path found matching pattern /usr/local/go/src/runtime/debug/garbage.go
dpkg-query: no path found matching pattern /usr/local/go/src/runtime/internal/atomic/atomic_386.go
dpkg-query: no path found matching pattern /usr/local/go/src/runtime/internal/sys/arch.go
dpkg-query: no path found matching pattern /usr/local/go/src/runtime/pprof/pprof.go
dpkg-query: no path found matching pattern /usr/local/go/src/runtime/trace/trace.go
dpkg-query: no path found matching pattern /usr/local/go/src/sort/search.go
dpkg-query: no path found matching pattern /usr/local/go/src/strconv/atob.go
dpkg-query: no path found matching pattern /usr/local/go/src/strings/compare.go
dpkg-query: no path found matching pattern /usr/local/go/src/sync/cond.go
dpkg-query: no path found matching pattern /usr/local/go/src/sync/atomic/doc.go
dpkg-query: no path found matching pattern /usr/local/go/src/syscall/env_unix.go
dpkg-query: no path found matching pattern /usr/local/go/src/testing/allocs.go
dpkg-query: no path found matching pattern /usr/local/go/src/text/tabwriter/tabwriter.go
dpkg-query: no path found matching pattern /usr/local/go/src/text/template/doc.go
dpkg-query: no path found matching pattern /usr/local/go/src/text/template/parse/lex.go
dpkg-query: no path found matching pattern /usr/local/go/src/time/format.go
dpkg-query: no path found matching pattern /usr/local/go/src/unicode/casetables.go
dpkg-query: no path found matching pattern /usr/local/go/src/unicode/utf16/utf16.go
dpkg-query: no path found matching pattern /usr/local/go/src/unicode/utf8/utf8.go
dpkg-query: no path found matching pattern /usr/local/go/src/unsafe/unsafe.go
dpkg-query: no path found matching pattern /usr/local/go/src/vendor/golang_org/x/net/http2/hpack/encode.go
dpkg-query: no path found matching pattern /usr/local/go/src/vendor/golang_org/x/net/lex/httplex/httplex.go
dpkg-query --search failed with code 31488,  at /usr/bin/dh_golang line 71.
debian/rules:23: recipe for target 'binary' failed
make: *** [binary] Error 123
dpkg-buildpackage: error: debian/rules binary gave error exit status 2
```
