### PR TITLE
Pre push tracing

### DIFF
--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/github/git-lfs/git"
 	"github.com/github/git-lfs/lfs"
+	"github.com/rubyist/tracerx"
 	"github.com/spf13/cobra"
 )
 
@@ -65,6 +66,8 @@ func prePushCommand(cmd *cobra.Command, args []string) {
 		if len(line) == 0 {
 			continue
 		}
+
+		tracerx.Printf("pre-push: %s", line)
 
 		left, right := decodeRefs(line)
 		if left == prePushDeleteBranch {

--- a/httputil/http.go
+++ b/httputil/http.go
@@ -272,7 +272,7 @@ func (c *CountingReadCloser) Read(b []byte) (int, error) {
 
 	c.Count += n
 
-	if c.isTraceableType {
+	if n > 0 && c.isTraceableType {
 		chunk := string(b[0:n])
 		if c.useGitTrace {
 			tracerx.Printf("HTTP: %s", chunk)


### PR DESCRIPTION
I've wanted this pre-push tracing for awhile. Makes it easier to see why pushes aren't uploading the objects you think they should.

Also, this gets rid of an extra `trace git-lfs: HTTP:` when you add `GIT_TRACE=` to any Git LFS commands that make HTTP requests.