### PR TITLE
filter-process: less flushing

### DIFF
--- a/git/pkt_line.go
+++ b/git/pkt_line.go
@@ -104,10 +104,6 @@ func (p *pktline) writePacket(data []byte) error {
 		return err
 	}
 
-	if err := p.w.Flush(); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/git/pkt_line_test.go
+++ b/git/pkt_line_test.go
@@ -169,14 +169,15 @@ func TestPktLineWritesPackets(t *testing.T) {
 	var buf bytes.Buffer
 
 	rw := newPktline(nil, &buf)
-	err := rw.writePacket([]byte{
+	require.Nil(t, rw.writePacket([]byte{
 		0x1, 0x2, 0x3, 0x4,
-	})
+	}))
+	require.Nil(t, rw.writeFlush())
 
-	assert.Nil(t, err)
 	assert.Equal(t, []byte{
 		0x30, 0x30, 0x30, 0x38, // 0008 (hex. length)
 		0x1, 0x2, 0x3, 0x4, // payload
+		0x30, 0x30, 0x30, 0x30, // 0000 (flush packet)
 	}, buf.Bytes())
 }
 
@@ -205,12 +206,14 @@ func TestPktLineWritesPacketText(t *testing.T) {
 	var buf bytes.Buffer
 
 	rw := newPktline(nil, &buf)
-	err := rw.writePacketText("abcd")
 
-	assert.Nil(t, err)
+	require.Nil(t, rw.writePacketText("abcd"))
+	require.Nil(t, rw.writeFlush())
+
 	assert.Equal(t, []byte{
 		0x30, 0x30, 0x30, 0x39, // 0009 (hex. length)
 		0x61, 0x62, 0x63, 0x64, 0xa, // "abcd\n" (payload)
+		0x30, 0x30, 0x30, 0x30, // 0000 (flush packet)
 	}, buf.Bytes())
 }
 


### PR DESCRIPTION
Previously, we flushed intermediate data out of the underlying *bufio.Writer
used by the implementation of `pkt-line` in `*git.pktline` after _every_ write.
This means that we would flush after partial packets, whole packets, and after
pkt-line flush sequences. This is unnecessary.

Let us instead flush only after an entire packet has been written, after
writing the `0000` flush sequence.

/ref git-lfs/git-lfs#1640

---

/cc @technoweenie @larsxschneider 