### PR TITLE
Allow non lfs test files

### DIFF
--- a/git/git_test.go
+++ b/git/git_test.go
@@ -25,26 +25,26 @@ func TestCurrentRefAndCurrentRemoteRef(t *testing.T) {
 	// only interested in branches
 	inputs := []*test.CommitInput{
 		{ // 0
-			Files: []*test.LFSInput{
-				{Filename: "file1.txt", Size: 20},
+			Files: []test.BlobInput{
+				test.NewLFSInput("file1.txt", test.RandInput(t, 20)),
 			},
 		},
 		{ // 1
 			NewBranch: "branch2",
-			Files: []*test.LFSInput{
-				{Filename: "file1.txt", Size: 25},
+			Files: []test.BlobInput{
+				test.NewLFSInput("file1.txt", test.RandInput(t, 25)),
 			},
 		},
 		{ // 2
 			ParentBranches: []string{"master"}, // back on master
-			Files: []*test.LFSInput{
-				{Filename: "file1.txt", Size: 30},
+			Files: []test.BlobInput{
+				test.NewLFSInput("file1.txt", test.RandInput(t, 30)),
 			},
 		},
 		{ // 3
 			NewBranch: "branch3",
-			Files: []*test.LFSInput{
-				{Filename: "file1.txt", Size: 32},
+			Files: []test.BlobInput{
+				test.NewLFSInput("file1.txt", test.RandInput(t, 32)),
 			},
 		},
 	}
@@ -91,44 +91,44 @@ func TestRecentBranches(t *testing.T) {
 	inputs := []*test.CommitInput{
 		{ // 0
 			CommitDate: now.AddDate(0, 0, -20),
-			Files: []*test.LFSInput{
-				{Filename: "file1.txt", Size: 20},
+			Files: []test.BlobInput{
+				test.NewLFSInput("file1.txt", test.RandInput(t, 20)),
 			},
 		},
 		{ // 1
 			CommitDate: now.AddDate(0, 0, -15),
 			NewBranch:  "excluded_branch", // new branch & tag but too old
 			Tags:       []string{"excluded_tag"},
-			Files: []*test.LFSInput{
-				{Filename: "file1.txt", Size: 25},
+			Files: []test.BlobInput{
+				test.NewLFSInput("file1.txt", test.RandInput(t, 25)),
 			},
 		},
 		{ // 2
 			CommitDate:     now.AddDate(0, 0, -12),
 			ParentBranches: []string{"master"}, // back on master
-			Files: []*test.LFSInput{
-				{Filename: "file1.txt", Size: 30},
+			Files: []test.BlobInput{
+				test.NewLFSInput("file1.txt", test.RandInput(t, 30)),
 			},
 		},
 		{ // 3
 			CommitDate: now.AddDate(0, 0, -6),
 			NewBranch:  "included_branch", // new branch within 7 day limit
-			Files: []*test.LFSInput{
-				{Filename: "file1.txt", Size: 32},
+			Files: []test.BlobInput{
+				test.NewLFSInput("file1.txt", test.RandInput(t, 32)),
 			},
 		},
 		{ // 4
 			CommitDate: now.AddDate(0, 0, -3),
 			NewBranch:  "included_branch_2", // new branch within 7 day limit
-			Files: []*test.LFSInput{
-				{Filename: "file1.txt", Size: 36},
+			Files: []test.BlobInput{
+				test.NewLFSInput("file1.txt", test.RandInput(t, 36)),
 			},
 		},
 		{ // 5
 			// Final commit, current date/time
 			ParentBranches: []string{"master"}, // back on master
-			Files: []*test.LFSInput{
-				{Filename: "file1.txt", Size: 21},
+			Files: []test.BlobInput{
+				test.NewLFSInput("file1.txt", test.RandInput(t, 21)),
 			},
 		},
 	}
@@ -217,28 +217,28 @@ func TestWorkTrees(t *testing.T) {
 	// only interested in branches & dates
 	inputs := []*test.CommitInput{
 		{ // 0
-			Files: []*test.LFSInput{
-				{Filename: "file1.txt", Size: 20},
+			Files: []test.BlobInput{
+				test.NewLFSInput("file1.txt", test.RandInput(t, 20)),
 			},
 		},
 		{ // 1
 			NewBranch: "branch2",
-			Files: []*test.LFSInput{
-				{Filename: "file1.txt", Size: 25},
+			Files: []test.BlobInput{
+				test.NewLFSInput("file1.txt", test.RandInput(t, 25)),
 			},
 		},
 		{ // 2
 			NewBranch:      "branch3",
 			ParentBranches: []string{"master"}, // back on master
-			Files: []*test.LFSInput{
-				{Filename: "file1.txt", Size: 30},
+			Files: []test.BlobInput{
+				test.NewLFSInput("file1.txt", test.RandInput(t, 30)),
 			},
 		},
 		{ // 3
 			NewBranch:      "branch4",
 			ParentBranches: []string{"master"}, // back on master
-			Files: []*test.LFSInput{
-				{Filename: "file1.txt", Size: 40},
+			Files: []test.BlobInput{
+				test.NewLFSInput("file1.txt", test.RandInput(t, 40)),
 			},
 		},
 	}
@@ -316,19 +316,19 @@ func TestGetTrackedFiles(t *testing.T) {
 	// only interested in branches
 	inputs := []*test.CommitInput{
 		{ // 0
-			Files: []*test.LFSInput{
-				{Filename: "file1.txt", Size: 20},
-				{Filename: "file2.txt", Size: 20},
-				{Filename: "folder1/file10.txt", Size: 20},
-				{Filename: "folder1/anotherfile.txt", Size: 20},
+			Files: []test.BlobInput{
+				test.NewLFSInput("file1.txt", test.RandInput(t, 20)),
+				test.NewLFSInput("file2.txt", test.RandInput(t, 20)),
+				test.NewLFSInput("folder1/file10.txt", test.RandInput(t, 20)),
+				test.NewLFSInput("folder1/anotherfile.txt", test.RandInput(t, 20)),
 			},
 		},
 		{ // 1
-			Files: []*test.LFSInput{
-				{Filename: "file3.txt", Size: 20},
-				{Filename: "file4.txt", Size: 20},
-				{Filename: "folder2/something.txt", Size: 20},
-				{Filename: "folder2/folder3/deep.txt", Size: 20},
+			Files: []test.BlobInput{
+				test.NewLFSInput("file3.txt", test.RandInput(t, 20)),
+				test.NewLFSInput("file4.txt", test.RandInput(t, 20)),
+				test.NewLFSInput("folder2/something.txt", test.RandInput(t, 20)),
+				test.NewLFSInput("folder2/folder3/deep.txt", test.RandInput(t, 20)),
 			},
 		},
 	}
@@ -416,15 +416,15 @@ func TestLocalRefs(t *testing.T) {
 
 	repo.AddCommits([]*test.CommitInput{
 		{
-			Files: []*test.LFSInput{
-				{Filename: "file1.txt", Size: 20},
+			Files: []test.BlobInput{
+				test.NewLFSInput("file1.txt", test.RandInput(t, 20)),
 			},
 		},
 		{
 			NewBranch:      "branch",
 			ParentBranches: []string{"master"},
-			Files: []*test.LFSInput{
-				{Filename: "file1.txt", Size: 20},
+			Files: []test.BlobInput{
+				test.NewLFSInput("file1.txt", test.RandInput(t, 20)),
 			},
 		},
 	})

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -25,25 +25,25 @@ func TestCurrentRefAndCurrentRemoteRef(t *testing.T) {
 	// only interested in branches
 	inputs := []*test.CommitInput{
 		{ // 0
-			Files: []*test.FileInput{
+			Files: []*test.LFSInput{
 				{Filename: "file1.txt", Size: 20},
 			},
 		},
 		{ // 1
 			NewBranch: "branch2",
-			Files: []*test.FileInput{
+			Files: []*test.LFSInput{
 				{Filename: "file1.txt", Size: 25},
 			},
 		},
 		{ // 2
 			ParentBranches: []string{"master"}, // back on master
-			Files: []*test.FileInput{
+			Files: []*test.LFSInput{
 				{Filename: "file1.txt", Size: 30},
 			},
 		},
 		{ // 3
 			NewBranch: "branch3",
-			Files: []*test.FileInput{
+			Files: []*test.LFSInput{
 				{Filename: "file1.txt", Size: 32},
 			},
 		},
@@ -91,7 +91,7 @@ func TestRecentBranches(t *testing.T) {
 	inputs := []*test.CommitInput{
 		{ // 0
 			CommitDate: now.AddDate(0, 0, -20),
-			Files: []*test.FileInput{
+			Files: []*test.LFSInput{
 				{Filename: "file1.txt", Size: 20},
 			},
 		},
@@ -99,35 +99,35 @@ func TestRecentBranches(t *testing.T) {
 			CommitDate: now.AddDate(0, 0, -15),
 			NewBranch:  "excluded_branch", // new branch & tag but too old
 			Tags:       []string{"excluded_tag"},
-			Files: []*test.FileInput{
+			Files: []*test.LFSInput{
 				{Filename: "file1.txt", Size: 25},
 			},
 		},
 		{ // 2
 			CommitDate:     now.AddDate(0, 0, -12),
 			ParentBranches: []string{"master"}, // back on master
-			Files: []*test.FileInput{
+			Files: []*test.LFSInput{
 				{Filename: "file1.txt", Size: 30},
 			},
 		},
 		{ // 3
 			CommitDate: now.AddDate(0, 0, -6),
 			NewBranch:  "included_branch", // new branch within 7 day limit
-			Files: []*test.FileInput{
+			Files: []*test.LFSInput{
 				{Filename: "file1.txt", Size: 32},
 			},
 		},
 		{ // 4
 			CommitDate: now.AddDate(0, 0, -3),
 			NewBranch:  "included_branch_2", // new branch within 7 day limit
-			Files: []*test.FileInput{
+			Files: []*test.LFSInput{
 				{Filename: "file1.txt", Size: 36},
 			},
 		},
 		{ // 5
 			// Final commit, current date/time
 			ParentBranches: []string{"master"}, // back on master
-			Files: []*test.FileInput{
+			Files: []*test.LFSInput{
 				{Filename: "file1.txt", Size: 21},
 			},
 		},
@@ -217,27 +217,27 @@ func TestWorkTrees(t *testing.T) {
 	// only interested in branches & dates
 	inputs := []*test.CommitInput{
 		{ // 0
-			Files: []*test.FileInput{
+			Files: []*test.LFSInput{
 				{Filename: "file1.txt", Size: 20},
 			},
 		},
 		{ // 1
 			NewBranch: "branch2",
-			Files: []*test.FileInput{
+			Files: []*test.LFSInput{
 				{Filename: "file1.txt", Size: 25},
 			},
 		},
 		{ // 2
 			NewBranch:      "branch3",
 			ParentBranches: []string{"master"}, // back on master
-			Files: []*test.FileInput{
+			Files: []*test.LFSInput{
 				{Filename: "file1.txt", Size: 30},
 			},
 		},
 		{ // 3
 			NewBranch:      "branch4",
 			ParentBranches: []string{"master"}, // back on master
-			Files: []*test.FileInput{
+			Files: []*test.LFSInput{
 				{Filename: "file1.txt", Size: 40},
 			},
 		},
@@ -316,7 +316,7 @@ func TestGetTrackedFiles(t *testing.T) {
 	// only interested in branches
 	inputs := []*test.CommitInput{
 		{ // 0
-			Files: []*test.FileInput{
+			Files: []*test.LFSInput{
 				{Filename: "file1.txt", Size: 20},
 				{Filename: "file2.txt", Size: 20},
 				{Filename: "folder1/file10.txt", Size: 20},
@@ -324,7 +324,7 @@ func TestGetTrackedFiles(t *testing.T) {
 			},
 		},
 		{ // 1
-			Files: []*test.FileInput{
+			Files: []*test.LFSInput{
 				{Filename: "file3.txt", Size: 20},
 				{Filename: "file4.txt", Size: 20},
 				{Filename: "folder2/something.txt", Size: 20},
@@ -416,14 +416,14 @@ func TestLocalRefs(t *testing.T) {
 
 	repo.AddCommits([]*test.CommitInput{
 		{
-			Files: []*test.FileInput{
+			Files: []*test.LFSInput{
 				{Filename: "file1.txt", Size: 20},
 			},
 		},
 		{
 			NewBranch:      "branch",
 			ParentBranches: []string{"master"},
-			Files: []*test.FileInput{
+			Files: []*test.LFSInput{
 				{Filename: "file1.txt", Size: 20},
 			},
 		},

--- a/lfs/lfs_test.go
+++ b/lfs/lfs_test.go
@@ -38,10 +38,10 @@ func TestAllCurrentObjectsSome(t *testing.T) {
 	// We're not testing commits here, just storage, so just create a single
 	// commit input with lots of files to generate many oids
 	numFiles := 20
-	files := make([]*test.FileInput, 0, numFiles)
+	files := make([]*test.LFSInput, 0, numFiles)
 	for i := 0; i < numFiles; i++ {
 		// Must be >=16 bytes for each file to be unique
-		files = append(files, &test.FileInput{Filename: fmt.Sprintf("file%d.txt", i), Size: 30})
+		files = append(files, &test.LFSInput{Filename: fmt.Sprintf("file%d.txt", i), Size: 30})
 	}
 
 	inputs := []*test.CommitInput{

--- a/lfs/lfs_test.go
+++ b/lfs/lfs_test.go
@@ -38,10 +38,11 @@ func TestAllCurrentObjectsSome(t *testing.T) {
 	// We're not testing commits here, just storage, so just create a single
 	// commit input with lots of files to generate many oids
 	numFiles := 20
-	files := make([]*test.LFSInput, 0, numFiles)
+	files := make([]test.BlobInput, 0, numFiles)
 	for i := 0; i < numFiles; i++ {
 		// Must be >=16 bytes for each file to be unique
-		files = append(files, &test.LFSInput{Filename: fmt.Sprintf("file%d.txt", i), Size: 30})
+		filename := fmt.Sprintf("file%d.txt", i)
+		files = append(files, test.NewLFSInput(filename, test.RandInput(t, 30)))
 	}
 
 	inputs := []*test.CommitInput{

--- a/lfs/scanner_git_test.go
+++ b/lfs/scanner_git_test.go
@@ -24,25 +24,25 @@ func TestScanUnpushed(t *testing.T) {
 
 	inputs := []*test.CommitInput{
 		{ // 0
-			Files: []*test.FileInput{
+			Files: []*test.LFSInput{
 				{Filename: "file1.txt", Size: 20},
 			},
 		},
 		{ // 1
 			NewBranch: "branch2",
-			Files: []*test.FileInput{
+			Files: []*test.LFSInput{
 				{Filename: "file1.txt", Size: 25},
 			},
 		},
 		{ // 2
 			ParentBranches: []string{"master"}, // back on master
-			Files: []*test.FileInput{
+			Files: []*test.LFSInput{
 				{Filename: "file1.txt", Size: 30},
 			},
 		},
 		{ // 3
 			NewBranch: "branch3",
-			Files: []*test.FileInput{
+			Files: []*test.LFSInput{
 				{Filename: "file1.txt", Size: 32},
 			},
 		},
@@ -99,7 +99,7 @@ func TestScanPreviousVersions(t *testing.T) {
 	inputs := []*test.CommitInput{
 		{ // 0
 			CommitDate: now.AddDate(0, 0, -20),
-			Files: []*test.FileInput{
+			Files: []*test.LFSInput{
 				{Filename: "file1.txt", Size: 20},
 				{Filename: "file2.txt", Size: 30},
 				{Filename: "folder/nested.txt", Size: 40},
@@ -108,14 +108,14 @@ func TestScanPreviousVersions(t *testing.T) {
 		},
 		{ // 1
 			CommitDate: now.AddDate(0, 0, -10),
-			Files: []*test.FileInput{
+			Files: []*test.LFSInput{
 				{Filename: "file2.txt", Size: 22},
 			},
 		},
 		{ // 2
 			NewBranch:  "excluded",
 			CommitDate: now.AddDate(0, 0, -6),
-			Files: []*test.FileInput{
+			Files: []*test.LFSInput{
 				{Filename: "file2.txt", Size: 12},
 				{Filename: "folder/nested2.txt", Size: 16},
 			},
@@ -123,13 +123,13 @@ func TestScanPreviousVersions(t *testing.T) {
 		{ // 3
 			ParentBranches: []string{"master"},
 			CommitDate:     now.AddDate(0, 0, -4),
-			Files: []*test.FileInput{
+			Files: []*test.LFSInput{
 				{Filename: "folder/nested.txt", Size: 42},
 				{Filename: "folder/nested2.txt", Size: 6},
 			},
 		},
 		{ // 4
-			Files: []*test.FileInput{
+			Files: []*test.LFSInput{
 				{Filename: "folder/nested.txt", Size: 22},
 			},
 		},

--- a/lfs/scanner_git_test.go
+++ b/lfs/scanner_git_test.go
@@ -24,26 +24,26 @@ func TestScanUnpushed(t *testing.T) {
 
 	inputs := []*test.CommitInput{
 		{ // 0
-			Files: []*test.LFSInput{
-				{Filename: "file1.txt", Size: 20},
+			Files: []test.BlobInput{
+				test.NewLFSInput("file1.txt", test.RandInput(t, 20)),
 			},
 		},
 		{ // 1
 			NewBranch: "branch2",
-			Files: []*test.LFSInput{
-				{Filename: "file1.txt", Size: 25},
+			Files: []test.BlobInput{
+				test.NewLFSInput("file1.txt", test.RandInput(t, 25)),
 			},
 		},
 		{ // 2
 			ParentBranches: []string{"master"}, // back on master
-			Files: []*test.LFSInput{
-				{Filename: "file1.txt", Size: 30},
+			Files: []test.BlobInput{
+				test.NewLFSInput("file1.txt", test.RandInput(t, 30)),
 			},
 		},
 		{ // 3
 			NewBranch: "branch3",
-			Files: []*test.LFSInput{
-				{Filename: "file1.txt", Size: 32},
+			Files: []test.BlobInput{
+				test.NewLFSInput("file1.txt", test.RandInput(t, 32)),
 			},
 		},
 	}
@@ -99,38 +99,38 @@ func TestScanPreviousVersions(t *testing.T) {
 	inputs := []*test.CommitInput{
 		{ // 0
 			CommitDate: now.AddDate(0, 0, -20),
-			Files: []*test.LFSInput{
-				{Filename: "file1.txt", Size: 20},
-				{Filename: "file2.txt", Size: 30},
-				{Filename: "folder/nested.txt", Size: 40},
-				{Filename: "folder/nested2.txt", Size: 31},
+			Files: []test.BlobInput{
+				test.NewLFSInput("file1.txt", test.RandInput(t, 20)),
+				test.NewLFSInput("file2.txt", test.RandInput(t, 30)),
+				test.NewLFSInput("folder/nested.txt", test.RandInput(t, 40)),
+				test.NewLFSInput("folder/nested2.txt", test.RandInput(t, 31)),
 			},
 		},
 		{ // 1
 			CommitDate: now.AddDate(0, 0, -10),
-			Files: []*test.LFSInput{
-				{Filename: "file2.txt", Size: 22},
+			Files: []test.BlobInput{
+				test.NewLFSInput("file2.txt", test.RandInput(t, 22)),
 			},
 		},
 		{ // 2
 			NewBranch:  "excluded",
 			CommitDate: now.AddDate(0, 0, -6),
-			Files: []*test.LFSInput{
-				{Filename: "file2.txt", Size: 12},
-				{Filename: "folder/nested2.txt", Size: 16},
+			Files: []test.BlobInput{
+				test.NewLFSInput("file2.txt", test.RandInput(t, 12)),
+				test.NewLFSInput("folder/nested2.txt", test.RandInput(t, 16)),
 			},
 		},
 		{ // 3
 			ParentBranches: []string{"master"},
 			CommitDate:     now.AddDate(0, 0, -4),
-			Files: []*test.LFSInput{
-				{Filename: "folder/nested.txt", Size: 42},
-				{Filename: "folder/nested2.txt", Size: 6},
+			Files: []test.BlobInput{
+				test.NewLFSInput("folder/nested.txt", test.RandInput(t, 42)),
+				test.NewLFSInput("folder/nested2.txt", test.RandInput(t, 6)),
 			},
 		},
 		{ // 4
-			Files: []*test.LFSInput{
-				{Filename: "folder/nested.txt", Size: 22},
+			Files: []test.BlobInput{
+				test.NewLFSInput("folder/nested.txt", test.RandInput(t, 22)),
 			},
 		},
 	}

--- a/test/git-lfs-test-server-api/main.go
+++ b/test/git-lfs-test-server-api/main.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"log"
 	"math/rand"
 	"os"
 	"strconv"
@@ -148,10 +149,12 @@ func buildTestData() (oidsExist, oidsMissing []TestObject, err error) {
 	// just one commit
 	commit := test.CommitInput{CommitterName: "A N Other", CommitterEmail: "noone@somewhere.com"}
 	var totalSize int64
+
+	logger := log.New(os.Stderr, "", log.LstdFlags)
 	for i := 0; i < oidCount; i++ {
 		filename := fmt.Sprintf("file%d.dat", i)
 		sz := int64(rand.Intn(200)) + 50
-		commit.Files = append(commit.Files, &test.LFSInput{Filename: filename, Size: sz})
+		commit.Files = append(commit.Files, test.NewLFSInput(filename, test.RandInput(logger, sz)))
 		totalSize += sz
 	}
 	outputs := repo.AddCommits([]*test.CommitInput{&commit})

--- a/test/git-lfs-test-server-api/main.go
+++ b/test/git-lfs-test-server-api/main.go
@@ -151,7 +151,7 @@ func buildTestData() (oidsExist, oidsMissing []TestObject, err error) {
 	for i := 0; i < oidCount; i++ {
 		filename := fmt.Sprintf("file%d.dat", i)
 		sz := int64(rand.Intn(200)) + 50
-		commit.Files = append(commit.Files, &test.FileInput{Filename: filename, Size: sz})
+		commit.Files = append(commit.Files, &test.LFSInput{Filename: filename, Size: sz})
 		totalSize += sz
 	}
 	outputs := repo.AddCommits([]*test.CommitInput{&commit})


### PR DESCRIPTION
#1650 needs a way to test against generated git repos. I wanted to use `*test.Repo` for this, but it only ever writes LFS objects. So, this PR refactors that code so that it uses a `test.BlobInput` interface, giving me an opportunity to write a `test.FileInput` implementation.

This changes the interface to construct the `test.LFSInput` objects:

```diff
-{Filename: "file1.txt", Size: 25},
+test.NewLFSInput("file1.txt", test.RandInput(t, 25)),
```

It's longer, but explicit. Also, it's easy to add a static string:

```diff
+test.NewLFSInput("file1.txt", "booya"),
```

This also removes the custom random content generator. I'm not sure we need anything fancy, when tests only generate up to 42 bytes, and the api command only generates up to 250.

/cc @sinbad