### PR TITLE
start reading off the Watch() channel before sending any input

### DIFF
--- a/commands/command_prune.go
+++ b/commands/command_prune.go
@@ -114,6 +114,7 @@ func prune(fetchPruneConfig config.FetchPruneConfig, verifyRemote, dryRun, verbo
 	var totalSize int64
 	var verboseOutput bytes.Buffer
 	var verifyc chan string
+	var verifywait sync.WaitGroup
 
 	if verifyRemote {
 		cfg.CurrentRemote = fetchPruneConfig.PruneRemoteName
@@ -123,6 +124,15 @@ func prune(fetchPruneConfig config.FetchPruneConfig, verifyRemote, dryRun, verbo
 
 		// this channel is filled with oids for which Check() succeeded & Transfer() was called
 		verifyc = verifyQueue.Watch()
+		verifywait.Add(1)
+		go func() {
+			for oid := range verifyc {
+				verifiedObjects.Add(oid)
+				tracerx.Printf("VERIFIED: %v", oid)
+				progressChan <- PruneProgress{PruneProgressTypeVerify, 1}
+			}
+			verifywait.Done()
+		}()
 	}
 
 	for _, file := range localObjects {
@@ -143,16 +153,6 @@ func prune(fetchPruneConfig config.FetchPruneConfig, verifyRemote, dryRun, verbo
 	}
 
 	if verifyRemote {
-		var verifywait sync.WaitGroup
-		verifywait.Add(1)
-		go func() {
-			for oid := range verifyc {
-				verifiedObjects.Add(oid)
-				tracerx.Printf("VERIFIED: %v", oid)
-				progressChan <- PruneProgress{PruneProgressTypeVerify, 1}
-			}
-			verifywait.Done()
-		}()
 		verifyQueue.Wait()
 		verifywait.Wait()
 		close(progressChan) // after verify (uses spinner) but before check


### PR DESCRIPTION
This ensures that all transfers by the `checkQueue` are set as uploaded. I thought this might also be the cause of a deadlock, but now I don't think so. Nothing is waiting for `len(missing)` items to flow through `transferc`.