### PR TITLE
start reading off the Watch() channel before sending any input

### DIFF
--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -52,6 +52,7 @@ func prePushCommand(cmd *cobra.Command, args []string) {
 
 	cfg.CurrentRemote = args[0]
 	ctx := newUploadContext(prePushDryRun)
+	ctx.DryRun = prePushDryRun
 
 	scanOpt := lfs.NewScanRefsOptions()
 	scanOpt.ScanMode = lfs.ScanLeftToRemoteMode

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -122,6 +122,7 @@ func pushCommand(cmd *cobra.Command, args []string) {
 
 	cfg.CurrentRemote = args[0]
 	ctx := newUploadContext(pushDryRun)
+	ctx.DryRun = pushDryRun
 
 	if useStdin {
 		requireStdin("Run this command from the Git pre-push hook, or leave the --stdin flag off.")


### PR DESCRIPTION
Backport #1671 for v1.4.4.

Note: The CircleCI build is fine, since this release branch doesn't have a `circle.yml` file.