### PR TITLE
re-enable push and pre-push dry-run flags

### DIFF
--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -53,6 +53,7 @@ func prePushCommand(cmd *cobra.Command, args []string) {
 
 	cfg.CurrentRemote = args[0]
 	ctx := newUploadContext(prePushDryRun)
+	ctx.DryRun = prePushDryRun
 
 	scanOpt := lfs.NewScanRefsOptions()
 	scanOpt.ScanMode = lfs.ScanLeftToRemoteMode

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -123,6 +123,7 @@ func pushCommand(cmd *cobra.Command, args []string) {
 
 	cfg.CurrentRemote = args[0]
 	ctx := newUploadContext(pushDryRun)
+	ctx.DryRun = pushDryRun
 
 	if useStdin {
 		requireStdin("Run this command from the Git pre-push hook, or leave the --stdin flag off.")


### PR DESCRIPTION
My push/pre-push refactoring (https://github.com/git-lfs/git-lfs/pull/1128) inadvertently broke dry runs of these commands.