### PR TITLE
cat file --batch: read all of the bytes

### DIFF
--- a/lfs/gitscanner_catfilebatch.go
+++ b/lfs/gitscanner_catfilebatch.go
@@ -107,7 +107,17 @@ func scanPointer(r *bufio.Reader) (*WrappedPointer, error) {
 		}
 
 		size, _ := strconv.Atoi(string(fields[2]))
-		p, err := DecodePointer(io.LimitReader(r, int64(size)))
+		buf := make([]byte, size)
+		read, err := io.ReadFull(r, buf)
+		if err != nil {
+			return nil, err
+		}
+
+		if size != read {
+			return nil, fmt.Errorf("expected %d bytes, read %d bytes", size, read)
+		}
+
+		p, err := DecodePointer(bytes.NewBuffer(buf[0:read]))
 		if err == nil {
 			pointer = &WrappedPointer{
 				Sha1:    string(fields[0]),


### PR DESCRIPTION
Applies #1680 for v1.5.1.