### PR TITLE
Ship 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Git LFS Changelog
 
+## 1.5.1 (18 November, 2016)
+
+### Bugs
+
+* cat-file --batch parser errors on non-lfs git blobs #1680 (@technoweenie)
+
 ## 1.5.0 (17 November, 2016)
 
 ### Features

--- a/config/version.go
+++ b/config/version.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	GitCommit   string
-	Version     = "1.5.0"
+	Version     = "1.5.1"
 	VersionDesc string
 )
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+git-lfs (1.5.1) stable; urgency=low
+
+  * New upstream version
+
+ -- Stephen Gelman <gelman@getbraintree.com>  Fri, 18 Nov 2016 14:29:00 +0000
+
 git-lfs (1.5.0) stable; urgency=low
 
   * New upstream version

--- a/lfs/lfs.go
+++ b/lfs/lfs.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	Version = "1.5.0"
+	Version = "1.5.1"
 )
 
 var (

--- a/rpm/SPECS/git-lfs.spec
+++ b/rpm/SPECS/git-lfs.spec
@@ -1,5 +1,5 @@
 Name:           git-lfs
-Version:        1.5.0
+Version:        1.5.1
 Release:        1%{?dist}
 Summary:        Git extension for versioning large files
 

--- a/script/build.go
+++ b/script/build.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"os"
@@ -202,12 +205,14 @@ func unixInstaller(textfiles []string, buildos, buildarch, dir string, buildMatr
 	}
 
 	name := zipName(buildos, buildarch) + ".tar.gz"
-
-	addToMatrix(buildMatrix, buildos, buildarch, name)
-
 	cmd = exec.Command("tar", "czf", "../"+name, filepath.Base(dir))
 	cmd.Dir = filepath.Dir(dir)
-	return logAndRun(cmd)
+	if err := logAndRun(cmd); err != nil {
+		return nil
+	}
+
+	addToMatrix(buildMatrix, buildos, buildarch, name)
+	return nil
 }
 
 func winInstaller(textfiles []string, buildos, buildarch, dir string, buildMatrix map[string]Release) error {
@@ -232,22 +237,45 @@ func winInstaller(textfiles []string, buildos, buildarch, dir string, buildMatri
 		return err
 	}
 
-	addToMatrix(buildMatrix, buildos, buildarch, name)
-
 	args := make([]string, len(matches)+2)
 	args[0] = "-j" // junk the zip paths
 	args[1] = full
 	copy(args[2:], matches)
 
 	cmd := exec.Command("zip", args...)
-	return logAndRun(cmd)
+	if err := logAndRun(cmd); err != nil {
+		return err
+	}
+
+	addToMatrix(buildMatrix, buildos, buildarch, name)
+	return nil
 }
 
 func addToMatrix(buildMatrix map[string]Release, buildos, buildarch, name string) {
 	buildMatrix[fmt.Sprintf("%s-%s", buildos, buildarch)] = Release{
 		Label:    releaseLabel(buildos, buildarch),
 		Filename: name,
+		SHA256:   hashRelease(name),
 	}
+}
+
+func hashRelease(name string) string {
+	full := filepath.Join("bin/releases", name)
+	file, err := os.Open(full)
+	if err != nil {
+		fmt.Printf("unable to open release %q: %+v\n", full, err)
+		os.Exit(1)
+	}
+
+	defer file.Close()
+
+	h := sha256.New()
+	if _, err = io.Copy(h, file); err != nil {
+		fmt.Printf("error reading release %q: %+v\n", full, err)
+		os.Exit(1)
+	}
+
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 func logAndRun(cmd *exec.Cmd) error {

--- a/script/release.go
+++ b/script/release.go
@@ -39,6 +39,12 @@ func mainRelease() {
 		release(rel)
 		fmt.Println()
 	}
+
+	fmt.Println("SHA-256 hashes:")
+	for _, rel := range buildMatrix {
+		fmt.Println(rel.SHA256, rel.Filename)
+	}
+
 }
 
 func release(rel Release) {

--- a/script/script.go
+++ b/script/script.go
@@ -8,6 +8,7 @@ import (
 type Release struct {
 	Label    string
 	Filename string
+	SHA256   string
 }
 
 var SubCommand = flag.String("cmd", "", "Command: build or release")

--- a/script/windows-installer/inno-setup-git-lfs-installer.iss
+++ b/script/windows-installer/inno-setup-git-lfs-installer.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Git LFS"
-#define MyAppVersion "1.5.0"
+#define MyAppVersion "1.5.1"
 #define MyAppPublisher "GitHub, Inc"
 #define MyAppURL "https://git-lfs.github.com/"
 #define MyAppFilePrefix "git-lfs-windows"


### PR DESCRIPTION
This bumps the version number, and adds some code to track the sha-256 hashes of the built binaries.