### PR TITLE
1.5/fedora 24

### DIFF
--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -35,6 +35,7 @@ $distro_name_map = {
     el/7
     fedora/22
     fedora/23
+    fedora/24
   ),
   "debian/7" => %w(
     debian/wheezy


### PR DESCRIPTION
After shipped v1.5.1, I looked into why Fedora 24 isn't working. Turns out I just needed to add it to the list.

@JonasT: Does this work for you?