### PR TITLE
filter-process: exit with error if we detect an unknown command from Git

### DIFF
--- a/commands/command_filter_process.go
+++ b/commands/command_filter_process.go
@@ -89,7 +89,7 @@ func filterCommand(cmd *cobra.Command, args []string) {
 			w = git.NewPktlineWriter(os.Stdout, smudgeFilterBufferCapacity)
 			err = filterSmudge(w, req.Payload, req.Header["pathname"])
 		default:
-			ExitWithError(fmt.Errorf("Unknown command '%s'", req.Header["command"]))
+			ExitWithError(fmt.Errorf("Unknown command %q", req.Header["command"]))
 		}
 
 		var status string

--- a/commands/command_filter_process.go
+++ b/commands/command_filter_process.go
@@ -73,7 +73,6 @@ func filterCommand(cmd *cobra.Command, args []string) {
 		ExitWithError(err)
 	}
 
-Scan:
 	for s.Scan() {
 		var err error
 		var w *git.PktlineWriter
@@ -90,8 +89,7 @@ Scan:
 			w = git.NewPktlineWriter(os.Stdout, smudgeFilterBufferCapacity)
 			err = filterSmudge(w, req.Payload, req.Header["pathname"])
 		default:
-			fmt.Errorf("Unknown command %s", cmd)
-			break Scan
+			ExitWithError(fmt.Errorf("Unknown command '%s'", req.Header["command"]))
 		}
 
 		var status string


### PR DESCRIPTION
This fixes the error reporting for https://github.com/git-lfs/git-lfs/issues/1697