### PR TITLE
Fast walk no channels

### DIFF
--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/rubyist/tracerx"
@@ -184,24 +183,17 @@ func findAttributeFiles() []string {
 		paths = append(paths, repoAttributes)
 	}
 
-	fchan, errchan := tools.FastWalkGitRepo(config.LocalWorkingDir)
-	var waitg sync.WaitGroup
-	waitg.Add(2)
-	go func() {
-		for o := range fchan {
-			if !o.Info.IsDir() && (o.Info.Name() == ".gitattributes") {
-				paths = append(paths, filepath.Join(o.ParentDir, o.Info.Name()))
-			}
-		}
-		waitg.Done()
-	}()
-	go func() {
-		for err := range errchan {
+	tools.FastWalkGitRepo(config.LocalWorkingDir, func(parentDir string, info os.FileInfo, err error) {
+		if err != nil {
 			tracerx.Printf("Error finding .gitattributes: %v", err)
+			return
 		}
-		waitg.Done()
-	}()
-	waitg.Wait()
+
+		if info.IsDir() || info.Name() != ".gitattributes" {
+			return
+		}
+		paths = append(paths, filepath.Join(parentDir, info.Name()))
+	})
 
 	return paths
 }

--- a/filepathfilter/filepathfilterbench/bench_test.go
+++ b/filepathfilter/filepathfilterbench/bench_test.go
@@ -48,7 +48,7 @@ func benchmarkTree(b *testing.B) []string {
 		b.Fatal(err)
 	}
 
-	infoCh, errCh := tools.FastWalkGitRepo(filepath.Dir(wd))
+	infoCh, errCh := tools.FastWalkGitRepoChannels(filepath.Dir(wd))
 
 	go func() {
 		for i := range infoCh {

--- a/filepathfilter/filepathfilterbench/bench_test.go
+++ b/filepathfilter/filepathfilterbench/bench_test.go
@@ -48,19 +48,15 @@ func benchmarkTree(b *testing.B) []string {
 		b.Fatal(err)
 	}
 
-	infoCh, errCh := tools.FastWalkGitRepoChannels(filepath.Dir(wd))
-
-	go func() {
-		for i := range infoCh {
-			benchmarkFiles = append(benchmarkFiles, filepath.Join(i.ParentDir, i.Info.Name()))
-		}
-	}()
-
 	hasErrors := false
-	for err := range errCh {
-		hasErrors = true
-		b.Error(err)
-	}
+	tools.FastWalkGitRepo(filepath.Dir(wd), func(parent string, info os.FileInfo, err error) {
+		if err != nil {
+			hasErrors = true
+			b.Error(err)
+			return
+		}
+		benchmarkFiles = append(benchmarkFiles, filepath.Join(parent, info.Name()))
+	})
 
 	if hasErrors {
 		b.Fatal("has errors :(")

--- a/tools/filetools.go
+++ b/tools/filetools.go
@@ -211,12 +211,10 @@ func fastWalkFileOrDir(parentDir string, itemFi os.FileInfo, excludeFilename str
 
 	if len(excludeFilename) > 0 {
 		possibleExcludeFile := filepath.Join(fullPath, excludeFilename)
-		if FileExists(possibleExcludeFile) {
-			var err error
-			excludePaths, err = loadExcludeFilename(possibleExcludeFile, fullPath, excludePaths)
-			if err != nil {
-				fiChan <- fastWalkInfo{Err: err}
-			}
+		var err error
+		excludePaths, err = loadExcludeFilename(possibleExcludeFile, fullPath, excludePaths)
+		if err != nil {
+			fiChan <- fastWalkInfo{Err: err}
 		}
 	}
 
@@ -256,6 +254,9 @@ func fastWalkFileOrDir(parentDir string, itemFi os.FileInfo, excludeFilename str
 func loadExcludeFilename(filename, parentDir string, excludePaths []filepathfilter.Pattern) ([]filepathfilter.Pattern, error) {
 	f, err := os.OpenFile(filename, os.O_RDONLY, 0644)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return excludePaths, nil
+		}
 		return excludePaths, err
 	}
 	defer f.Close()


### PR DESCRIPTION
This is an exploration of a new `FastWalkGitRepo` api that accepts a function callback, instead of returning channels. I've been thinking about the `gitscanner` public interface for a few weeks, and I keep coming back to the fact that we should not be exposing channels to end users (even if _we_ are the end users too). I picked `FastWalkGitRepo()` as a guinea pig, since it's much simpler. 

The `commands/command_track.go` changes look much better to me. The new version is focused on what the command needs, and not reading channels concurrently.

I wrote this as a parallel implementation so I could compare the benchmark side by side, and don't see a big difference:

```
$ script/test tools -v -run Bench -bench . -count 5
BenchmarkFastWalkGitRepoChannels-8   	       1	3059166517 ns/op
--- BENCH: BenchmarkFastWalkGitRepoChannels-8
	filetools_test.go:79: files: 20008, errors: 0
BenchmarkFastWalkGitRepoChannels-8   	       1	3052510253 ns/op
--- BENCH: BenchmarkFastWalkGitRepoChannels-8
	filetools_test.go:79: files: 20008, errors: 0
BenchmarkFastWalkGitRepoChannels-8   	       1	2763236760 ns/op
--- BENCH: BenchmarkFastWalkGitRepoChannels-8
	filetools_test.go:79: files: 20008, errors: 0
BenchmarkFastWalkGitRepoChannels-8   	       1	2656352784 ns/op
--- BENCH: BenchmarkFastWalkGitRepoChannels-8
	filetools_test.go:79: files: 20008, errors: 0
BenchmarkFastWalkGitRepoChannels-8   	       1	2676479922 ns/op
--- BENCH: BenchmarkFastWalkGitRepoChannels-8
	filetools_test.go:79: files: 20008, errors: 0
BenchmarkFastWalkGitRepoCallback-8   	       1	2679861166 ns/op
--- BENCH: BenchmarkFastWalkGitRepoCallback-8
	filetools_test.go:102: files: 20007, errors: 0
BenchmarkFastWalkGitRepoCallback-8   	       1	2744682179 ns/op
--- BENCH: BenchmarkFastWalkGitRepoCallback-8
	filetools_test.go:102: files: 20008, errors: 0
BenchmarkFastWalkGitRepoCallback-8   	       1	2691585917 ns/op
--- BENCH: BenchmarkFastWalkGitRepoCallback-8
	filetools_test.go:102: files: 20008, errors: 0
BenchmarkFastWalkGitRepoCallback-8   	       1	2903895731 ns/op
--- BENCH: BenchmarkFastWalkGitRepoCallback-8
	filetools_test.go:102: files: 20007, errors: 0
BenchmarkFastWalkGitRepoCallback-8   	       1	2701274878 ns/op
--- BENCH: BenchmarkFastWalkGitRepoCallback-8
	filetools_test.go:102: files: 20008, errors: 0
PASS
ok  	github.com/git-lfs/git-lfs/tools	27.942s
```

If you all agree this is a favorable change, I'll remove all the old code, and start on a change to the `gitscanner` like this:

```go
// pseudo code, I haven't exactly looked all these funcs up
tq := newBatchTransferQueue()

// non blocking!
scanner := gitscanner.New(func(p *lfs.WrappedPointer, err error) {
  // queue up to download this object
  tq.Add(p)
})
scanner.RemoteForPush("origin")

// not implemented yet, but would add file path inc/exc filtering to all applicable scans
scanner.Filter = filepathfilter.New(inc, exc)

for _, ref := range pushRefs {
    // blocking call until `rev-list` is done
    // then calls callback given to New()
    scanner.ScanLeftToRemote(ref)
}

// any internal channel clean up, make sure all callbacks have been called
scanner.Close()
```