### PR TITLE
GitLFS requires Go 1.7+

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ them as separate pull requests.
 
 ### Prerequisites
 
-Git LFS depends on having a working Go 1.7+ environment, with your standard
+Git LFS depends on having a working Go 1.7.3+ environment, with your standard
 `$GOROOT` and `$GOPATH` environment variables set.
 
 On RHEL etc. e.g. Red Hat Enterprise Linux Server release 7.2 (Maipo), you will neet the minimum packages installed to build Git LFS:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ them as separate pull requests.
 
 ### Prerequisites
 
-Git LFS depends on having a working Go 1.5+ environment, with your standard
+Git LFS depends on having a working Go 1.7+ environment, with your standard
 `$GOROOT` and `$GOPATH` environment variables set.
 
 On RHEL etc. e.g. Red Hat Enterprise Linux Server release 7.2 (Maipo), you will neet the minimum packages installed to build Git LFS:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ preferences.
 * Mac users can install from [Homebrew](https://github.com/Homebrew/homebrew) with `brew install git-lfs`, or from [MacPorts](https://www.macports.org) with `port install git-lfs`.
 * Windows users can install from [Chocolatey](https://chocolatey.org/) with `choco install git-lfs`.
 * [Binary packages are available][rel] for Windows, Mac, Linux, and FreeBSD.
-* You can build it with Go 1.5+. See the [Contributing Guide](./CONTRIBUTING.md) for instructions.
+* You can build it with Go 1.7.3+. See the [Contributing Guide](./CONTRIBUTING.md) for instructions.
 
 [rel]: https://github.com/git-lfs/git-lfs/releases
 


### PR DESCRIPTION
Apparently the process-filter does not work with Go below version 1.7
cf. https://github.com/git-lfs/git-lfs/pull/1699#issuecomment-262303880