### PR TITLE
Remove the license description from the license itself

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-This project is licensed under the [MIT license](https://en.wikipedia.org/wiki/MIT_License). 
+MIT License
 
 Copyright (c) GitHub, Inc. and Git LFS contributors
 


### PR DESCRIPTION
This PR removes the "This project is licensed under the MIT license" line from the license, and replaces it with just the license title (which itself, is optional).

This will allow GitHub to properly detect the license, because right now it doesn't know what that extra line of custom text means, or if it has any legal implications (and thus doesn't call the license MIT).

/cc @technoweenie 