### PR TITLE
Add copyright date to license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) GitHub, Inc. and Git LFS contributors
+Copyright (c) 2014-2016 GitHub, Inc. and Git LFS contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This is a quick fix to get license detection working while it's fixed upstream.

The underlying copyright regex [assumes there's a copyright date](https://github.com/benbalter/licensee/blob/master/lib/licensee/matchers/copyright_matcher.rb#L8), the year field being present in the original license template.

This PR simply adds the year, so that the license matches the regex. See http://ben.balter.com/2015/06/03/copyright-notices-for-websites-and-open-source-projects/ for background on why that is the "proper" copyright notice (although this change should have no legal significance). 