### PR TITLE
Locking: move lock funcs to own package

### DIFF
--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -28,7 +28,7 @@ func lockCommand(cmd *cobra.Command, args []string) {
 		Exit(err.Error())
 	}
 
-	id, err := locking.Lock(path, lockRemote)
+	id, err := locking.LockFile(path, lockRemote)
 	if err != nil {
 		Exit("Lock failed: %v", err)
 	}

--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -6,36 +6,21 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/git-lfs/git-lfs/api"
-	"github.com/git-lfs/git-lfs/config"
 	"github.com/git-lfs/git-lfs/git"
+	"github.com/git-lfs/git-lfs/locking"
 	"github.com/spf13/cobra"
 )
 
 var (
 	lockRemote     string
 	lockRemoteHelp = "specify which remote to use when interacting with locks"
-
-	// TODO(taylor): consider making this (and the above flag) a property of
-	// some parent-command, or another similarly less ugly way of handling
-	// this
-	setLockRemoteFor = func(c *config.Configuration) {
-		c.CurrentRemote = lockRemote
-	}
 )
 
 func lockCommand(cmd *cobra.Command, args []string) {
-	setLockRemoteFor(cfg)
 
 	if len(args) == 0 {
 		Print("Usage: git lfs lock <path>")
 		return
-	}
-
-	latest, err := git.CurrentRemoteRef()
-	if err != nil {
-		Error(err.Error())
-		Exit("Unable to determine lastest remote ref for branch.")
 	}
 
 	path, err := lockPath(args[0])
@@ -43,23 +28,12 @@ func lockCommand(cmd *cobra.Command, args []string) {
 		Exit(err.Error())
 	}
 
-	s, resp := API.Locks.Lock(&api.LockRequest{
-		Path:               path,
-		Committer:          api.CurrentCommitter(),
-		LatestRemoteCommit: latest.Sha,
-	})
-
-	if _, err := API.Do(s); err != nil {
-		Error(err.Error())
-		Exit("Error communicating with LFS API.")
+	id, err := locking.Lock(path, lockRemote)
+	if err != nil {
+		Exit("Lock failed: %v", err)
 	}
 
-	if len(resp.Err) > 0 {
-		Error(resp.Err)
-		Exit("Server unable to create lock.")
-	}
-
-	Print("\n'%s' was locked (%s)", args[0], resp.Lock.Id)
+	Print("\n'%s' was locked (%s)", args[0], id)
 }
 
 // lockPaths relativizes the given filepath such that it is relative to the root

--- a/commands/command_locks.go
+++ b/commands/command_locks.go
@@ -17,13 +17,12 @@ func locksCommand(cmd *cobra.Command, args []string) {
 	}
 
 	var lockCount int
-	locks := locking.SearchLocks(lockRemote, filters, locksCmdFlags.Limit)
-
-	for lock := range locks.Results {
-		Print("%s\t%s <%s>", lock.Path, lock.Committer.Name, lock.Committer.Email)
+	locks, err := locking.SearchLocks(lockRemote, filters, locksCmdFlags.Limit)
+	// Print any we got before exiting
+	for _, lock := range locks {
+		Print("%s\t%s <%s>", lock.Path, lock.Name, lock.Email)
 		lockCount++
 	}
-	err = locks.Wait()
 
 	if err != nil {
 		Exit("Error while retrieving locks: %v", err)

--- a/commands/command_unlock.go
+++ b/commands/command_unlock.go
@@ -1,20 +1,12 @@
 package commands
 
 import (
-	"errors"
+	"github.com/git-lfs/git-lfs/locking"
 
-	"github.com/git-lfs/git-lfs/api"
 	"github.com/spf13/cobra"
 )
 
 var (
-	// errNoMatchingLocks is an error returned when no matching locks were
-	// able to be resolved
-	errNoMatchingLocks = errors.New("lfs: no matching locks found")
-	// errLockAmbiguous is an error returned when multiple matching locks
-	// were found
-	errLockAmbiguous = errors.New("lfs: multiple locks found; ambiguous")
-
 	unlockCmdFlags unlockFlags
 )
 
@@ -29,67 +21,26 @@ type unlockFlags struct {
 }
 
 func unlockCommand(cmd *cobra.Command, args []string) {
-	setLockRemoteFor(cfg)
-
-	var id string
 	if len(args) != 0 {
 		path, err := lockPath(args[0])
 		if err != nil {
-			Error(err.Error())
+			Exit("Unable to determine path: %v", err.Error())
 		}
 
-		if id, err = lockIdFromPath(path); err != nil {
-			Error(err.Error())
+		err = locking.Unlock(path, lockRemote, unlockCmdFlags.Force)
+		if err != nil {
+			Exit("Unable to unlock: %v", err.Error())
 		}
 	} else if unlockCmdFlags.Id != "" {
-		id = unlockCmdFlags.Id
+		err := locking.UnlockById(unlockCmdFlags.Id, lockRemote, unlockCmdFlags.Force)
+		if err != nil {
+			Exit("Unable to unlock %v: %v", unlockCmdFlags.Id, err.Error())
+		}
 	} else {
 		Error("Usage: git lfs unlock (--id my-lock-id | <path>)")
 	}
 
-	s, resp := API.Locks.Unlock(id, unlockCmdFlags.Force)
-
-	if _, err := API.Do(s); err != nil {
-		Error(err.Error())
-		Exit("Error communicating with LFS API.")
-	}
-
-	if len(resp.Err) > 0 {
-		Error(resp.Err)
-		Exit("Server unable to unlock lock.")
-	}
-
-	Print("'%s' was unlocked (%s)", args[0], resp.Lock.Id)
-}
-
-// lockIdFromPath makes a call to the LFS API and resolves the ID for the locked
-// locked at the given path.
-//
-// If the API call failed, an error will be returned. If multiple locks matched
-// the given path (should not happen during real-world usage), an error will be
-// returnd. If no locks matched the given path, an error will be returned.
-//
-// If the API call is successful, and only one lock matches the given filepath,
-// then its ID will be returned, along with a value of "nil" for the error.
-func lockIdFromPath(path string) (string, error) {
-	s, resp := API.Locks.Search(&api.LockSearchRequest{
-		Filters: []api.Filter{
-			{"path", path},
-		},
-	})
-
-	if _, err := API.Do(s); err != nil {
-		return "", err
-	}
-
-	switch len(resp.Locks) {
-	case 0:
-		return "", errNoMatchingLocks
-	case 1:
-		return resp.Locks[0].Id, nil
-	default:
-		return "", errLockAmbiguous
-	}
+	Print("'%s' was unlocked", args[0])
 }
 
 func init() {

--- a/commands/command_unlock.go
+++ b/commands/command_unlock.go
@@ -27,12 +27,12 @@ func unlockCommand(cmd *cobra.Command, args []string) {
 			Exit("Unable to determine path: %v", err.Error())
 		}
 
-		err = locking.Unlock(path, lockRemote, unlockCmdFlags.Force)
+		err = locking.UnlockFile(path, lockRemote, unlockCmdFlags.Force)
 		if err != nil {
 			Exit("Unable to unlock: %v", err.Error())
 		}
 	} else if unlockCmdFlags.Id != "" {
-		err := locking.UnlockById(unlockCmdFlags.Id, lockRemote, unlockCmdFlags.Force)
+		err := locking.UnlockFileById(unlockCmdFlags.Id, lockRemote, unlockCmdFlags.Force)
 		if err != nil {
 			Exit("Unable to unlock %v: %v", unlockCmdFlags.Id, err.Error())
 		}

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/git-lfs/git-lfs/api"
 	"github.com/git-lfs/git-lfs/config"
 	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/filepathfilter"
@@ -25,10 +24,6 @@ import (
 //go:generate go run ../docs/man/mangen.go
 
 var (
-	// API is a package-local instance of the API client for use within
-	// various command implementations.
-	API = api.NewClient(nil)
-
 	Debugging    = false
 	ErrorBuffer  = &bytes.Buffer{}
 	ErrorWriter  = io.MultiWriter(os.Stderr, ErrorBuffer)

--- a/locking/cache.go
+++ b/locking/cache.go
@@ -1,0 +1,36 @@
+package locking
+
+// This file caches active locks locally so that we can more easily retrieve
+// a list of locally locked files without consulting the server
+// This only includes locks which the local committer has taken, not all locks
+
+// Cache a successful lock for faster local lookup later
+func cacheLock(filePath, id string) error {
+	// TODO
+	return nil
+}
+
+// Remove a cached lock by path becuase it's been relinquished
+func cacheUnlock(filePath string) error {
+	// TODO
+	return nil
+}
+
+// Remove a cached lock by id becuase it's been relinquished
+func cacheUnlockById(id string) error {
+	// TODO
+	return nil
+}
+
+// Get the list of cached locked files
+func cachedLocks() []string {
+	// TODO
+	return nil
+}
+
+// Fetch locked files for the current committer and cache them locally
+// This can be used to sync up locked files when moving machines
+func fetchLocksToCache(remoteName string) error {
+	// TODO
+	return nil
+}

--- a/locking/locks.go
+++ b/locking/locks.go
@@ -13,7 +13,7 @@ import (
 var (
 	// API is a package-local instance of the API client for use within
 	// various command implementations.
-	API = api.NewClient(nil)
+	apiClient = api.NewClient(nil)
 	// errNoMatchingLocks is an error returned when no matching locks were
 	// able to be resolved
 	errNoMatchingLocks = errors.New("lfs: no matching locks found")
@@ -37,13 +37,13 @@ func Lock(path, remote string) (id string, e error) {
 		return "", err
 	}
 
-	s, resp := API.Locks.Lock(&api.LockRequest{
+	s, resp := apiClient.Locks.Lock(&api.LockRequest{
 		Path:               path,
 		Committer:          api.CurrentCommitter(),
 		LatestRemoteCommit: latest.Sha,
 	})
 
-	if _, err := API.Do(s); err != nil {
+	if _, err := apiClient.Do(s); err != nil {
 		return "", fmt.Errorf("Error communicating with LFS API: %v", err)
 	}
 
@@ -79,9 +79,9 @@ func Unlock(path, remote string, force bool) error {
 // Unlock attempts to unlock a lock with a given id on the remote
 // Force causes the file to be unlocked from other users as well
 func UnlockById(id, remote string, force bool) error {
-	s, resp := API.Locks.Unlock(id, force)
+	s, resp := apiClient.Locks.Unlock(id, force)
 
-	if _, err := API.Do(s); err != nil {
+	if _, err := apiClient.Do(s); err != nil {
 		return fmt.Errorf("Error communicating with LFS API: %v", err)
 	}
 
@@ -134,8 +134,8 @@ func SearchLocks(remote string, filter map[string]string, limit int) *LockChanne
 		query := &api.LockSearchRequest{Filters: apifilters}
 	QueryLoop:
 		for {
-			s, resp := API.Locks.Search(query)
-			if _, err := API.Do(s); err != nil {
+			s, resp := apiClient.Locks.Search(query)
+			if _, err := apiClient.Do(s); err != nil {
 				errChan <- fmt.Errorf("Error communicating with LFS API: %v", err)
 				break
 			}
@@ -177,13 +177,13 @@ func SearchLocks(remote string, filter map[string]string, limit int) *LockChanne
 // If the API call is successful, and only one lock matches the given filepath,
 // then its ID will be returned, along with a value of "nil" for the error.
 func lockIdFromPath(path string) (string, error) {
-	s, resp := API.Locks.Search(&api.LockSearchRequest{
+	s, resp := apiClient.Locks.Search(&api.LockSearchRequest{
 		Filters: []api.Filter{
 			{"path", path},
 		},
 	})
 
-	if _, err := API.Do(s); err != nil {
+	if _, err := apiClient.Do(s); err != nil {
 		return "", err
 	}
 

--- a/locking/locks.go
+++ b/locking/locks.go
@@ -14,12 +14,12 @@ var (
 	// API is a package-local instance of the API client for use within
 	// various command implementations.
 	apiClient = api.NewClient(nil)
-	// errNoMatchingLocks is an error returned when no matching locks were
+	// ErrNoMatchingLocks is an error returned when no matching locks were
 	// able to be resolved
-	errNoMatchingLocks = errors.New("lfs: no matching locks found")
-	// errLockAmbiguous is an error returned when multiple matching locks
+	ErrNoMatchingLocks = errors.New("lfs: no matching locks found")
+	// ErrLockAmbiguous is an error returned when multiple matching locks
 	// were found
-	errLockAmbiguous = errors.New("lfs: multiple locks found; ambiguous")
+	ErrLockAmbiguous = errors.New("lfs: multiple locks found; ambiguous")
 )
 
 // LockFile attempts to lock a file on the given remote name
@@ -207,10 +207,10 @@ func lockIdFromPath(path string) (string, error) {
 
 	switch len(resp.Locks) {
 	case 0:
-		return "", errNoMatchingLocks
+		return "", ErrNoMatchingLocks
 	case 1:
 		return resp.Locks[0].Id, nil
 	default:
-		return "", errLockAmbiguous
+		return "", ErrLockAmbiguous
 	}
 }

--- a/locking/locks.go
+++ b/locking/locks.go
@@ -1,0 +1,198 @@
+package locking
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/git-lfs/git-lfs/api"
+	"github.com/git-lfs/git-lfs/config"
+	"github.com/git-lfs/git-lfs/git"
+	"github.com/git-lfs/git-lfs/tools"
+)
+
+var (
+	// API is a package-local instance of the API client for use within
+	// various command implementations.
+	API = api.NewClient(nil)
+	// errNoMatchingLocks is an error returned when no matching locks were
+	// able to be resolved
+	errNoMatchingLocks = errors.New("lfs: no matching locks found")
+	// errLockAmbiguous is an error returned when multiple matching locks
+	// were found
+	errLockAmbiguous = errors.New("lfs: multiple locks found; ambiguous")
+)
+
+// Lock attempts to lock a file on the given remote name
+// path must be relative to the root of the repository
+// Returns the lock id if successful, or an error
+func Lock(path, remote string) (id string, e error) {
+	// TODO: API currently relies on config.Config but should really pass to client in future
+	savedRemote := config.Config.CurrentRemote
+	config.Config.CurrentRemote = remote
+	defer func() { config.Config.CurrentRemote = savedRemote }()
+
+	// TODO: this is not really the constraint we need to avoid merges, improve as per proposal
+	latest, err := git.CurrentRemoteRef()
+	if err != nil {
+		return "", err
+	}
+
+	s, resp := API.Locks.Lock(&api.LockRequest{
+		Path:               path,
+		Committer:          api.CurrentCommitter(),
+		LatestRemoteCommit: latest.Sha,
+	})
+
+	if _, err := API.Do(s); err != nil {
+		return "", fmt.Errorf("Error communicating with LFS API: %v", err)
+	}
+
+	if len(resp.Err) > 0 {
+		return "", fmt.Errorf("Server unable to create lock: %v", resp.Err)
+	}
+
+	if err := cacheLock(resp.Lock.Path, resp.Lock.Id); err != nil {
+		return "", fmt.Errorf("Error caching lock information: %v", err)
+	}
+
+	return resp.Lock.Id, nil
+}
+
+// Unlock attempts to unlock a file on the given remote name
+// path must be relative to the root of the repository
+// Force causes the file to be unlocked from other users as well
+func Unlock(path, remote string, force bool) error {
+	// TODO: API currently relies on config.Config but should really pass to client in future
+	savedRemote := config.Config.CurrentRemote
+	config.Config.CurrentRemote = remote
+	defer func() { config.Config.CurrentRemote = savedRemote }()
+
+	id, err := lockIdFromPath(path)
+	if err != nil {
+		return fmt.Errorf("Unable to get lock id: %v", err)
+	}
+
+	return UnlockById(id, remote, force)
+
+}
+
+// Unlock attempts to unlock a lock with a given id on the remote
+// Force causes the file to be unlocked from other users as well
+func UnlockById(id, remote string, force bool) error {
+	s, resp := API.Locks.Unlock(id, force)
+
+	if _, err := API.Do(s); err != nil {
+		return fmt.Errorf("Error communicating with LFS API: %v", err)
+	}
+
+	if len(resp.Err) > 0 {
+		return fmt.Errorf("Server unable to unlock lock: %v", resp.Err)
+	}
+
+	if err := cacheUnlockById(id); err != nil {
+		return fmt.Errorf("Error caching unlock information: %v", err)
+	}
+
+	return nil
+}
+
+// ChannelWrapper for lock search to more easily return async error data via Wait()
+// See NewPointerChannelWrapper for construction / use
+type LockChannelWrapper struct {
+	*tools.BaseChannelWrapper
+	Results <-chan api.Lock
+}
+
+// Construct a new channel wrapper for api.Lock
+// Caller can use s.Results directly for normal processing then call Wait() to finish & check for errors
+func NewLockChannelWrapper(lockChan <-chan api.Lock, errChan <-chan error) *LockChannelWrapper {
+	return &LockChannelWrapper{tools.NewBaseChannelWrapper(errChan), lockChan}
+}
+
+// SearchLocks returns a channel of locks which match the given name/value filter
+// If limit > 0 then search stops at that number of locks
+func SearchLocks(remote string, filter map[string]string, limit int) *LockChannelWrapper {
+	// TODO: API currently relies on config.Config but should really pass to client in future
+	savedRemote := config.Config.CurrentRemote
+	config.Config.CurrentRemote = remote
+	errChan := make(chan error, 5) // can be multiple errors below
+	lockChan := make(chan api.Lock, 10)
+	c := NewLockChannelWrapper(lockChan, errChan)
+	go func() {
+		defer func() {
+			close(lockChan)
+			close(errChan)
+			// Only reinstate the remote after we're done
+			config.Config.CurrentRemote = savedRemote
+		}()
+
+		apifilters := make([]api.Filter, 0, len(filter))
+		for k, v := range filter {
+			apifilters = append(apifilters, api.Filter{k, v})
+		}
+		lockCount := 0
+		query := &api.LockSearchRequest{Filters: apifilters}
+	QueryLoop:
+		for {
+			s, resp := API.Locks.Search(query)
+			if _, err := API.Do(s); err != nil {
+				errChan <- fmt.Errorf("Error communicating with LFS API: %v", err)
+				break
+			}
+
+			if resp.Err != "" {
+				errChan <- fmt.Errorf("Error response from LFS API: %v", resp.Err)
+				break
+			}
+
+			for _, l := range resp.Locks {
+				lockChan <- l
+				lockCount++
+				if limit > 0 && lockCount >= limit {
+					// Exit outer loop too
+					break QueryLoop
+				}
+			}
+
+			if resp.NextCursor != "" {
+				query.Cursor = resp.NextCursor
+			} else {
+				break
+			}
+		}
+
+	}()
+
+	return c
+
+}
+
+// lockIdFromPath makes a call to the LFS API and resolves the ID for the locked
+// locked at the given path.
+//
+// If the API call failed, an error will be returned. If multiple locks matched
+// the given path (should not happen during real-world usage), an error will be
+// returnd. If no locks matched the given path, an error will be returned.
+//
+// If the API call is successful, and only one lock matches the given filepath,
+// then its ID will be returned, along with a value of "nil" for the error.
+func lockIdFromPath(path string) (string, error) {
+	s, resp := API.Locks.Search(&api.LockSearchRequest{
+		Filters: []api.Filter{
+			{"path", path},
+		},
+	})
+
+	if _, err := API.Do(s); err != nil {
+		return "", err
+	}
+
+	switch len(resp.Locks) {
+	case 0:
+		return "", errNoMatchingLocks
+	case 1:
+		return resp.Locks[0].Id, nil
+	default:
+		return "", errLockAmbiguous
+	}
+}


### PR DESCRIPTION
Re-implementation of #1625. Based on PR feedback (except config changes which are still pending). Channel wrappers are gone & so is much of complexity, simpler for clients (and added local `Lock` struct so remove dependency on `api.Lock`). 

Merge target is `locking-master` to denote that this isn't a finished API yet but to enable reviewing in bite-size chunks.
