### PR TITLE
Gitscanner callbacks

### DIFF
--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -34,7 +34,7 @@ func checkoutCommand(cmd *cobra.Command, args []string) {
 	close(inchan)
 
 	filter := filepathfilter.New(rootedpaths, nil)
-	gitscanner := lfs.NewGitScanner()
+	gitscanner := lfs.NewGitScanner(nil)
 	defer gitscanner.Close()
 	checkoutWithIncludeExclude(gitscanner, filter)
 }

--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -49,8 +49,7 @@ func checkoutFromFetchChan(gitscanner *lfs.GitScanner, filter *filepathfilter.Fi
 	// Need to ScanTree to identify multiple files with the same content (fetch will only report oids once)
 	// use new gitscanner so mapping has all the scanned pointers before continuing
 	mapping := make(map[string][]*lfs.WrappedPointer)
-	chgitscanner := lfs.NewGitScanner(nil)
-	err = chgitscanner.ScanTree(ref.Sha, func(p *lfs.WrappedPointer, err error) {
+	chgitscanner := lfs.NewGitScanner(func(p *lfs.WrappedPointer, err error) {
 		if err != nil {
 			Panic(err, "Could not scan for Git LFS files")
 			return
@@ -61,7 +60,7 @@ func checkoutFromFetchChan(gitscanner *lfs.GitScanner, filter *filepathfilter.Fi
 		}
 	})
 
-	if err != nil {
+	if err := chgitscanner.ScanTree(ref.Sha, nil); err != nil {
 		ExitWithError(err)
 	}
 

--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -44,23 +45,27 @@ func checkoutFromFetchChan(gitscanner *lfs.GitScanner, filter *filepathfilter.Fi
 	if err != nil {
 		Panic(err, "Could not checkout")
 	}
+
 	// Need to ScanTree to identify multiple files with the same content (fetch will only report oids once)
-	pointerCh, err := gitscanner.ScanTree(ref.Sha)
+	// use new gitscanner so mapping has all the scanned pointers before continuing
+	mapping := make(map[string][]*lfs.WrappedPointer)
+	chgitscanner := lfs.NewGitScanner(nil)
+	err = chgitscanner.ScanTree(ref.Sha, func(p *lfs.WrappedPointer, err error) {
+		if err != nil {
+			Panic(err, "Could not scan for Git LFS files")
+			return
+		}
+
+		if filter.Allows(p.Name) {
+			mapping[p.Oid] = append(mapping[p.Oid], p)
+		}
+	})
+
 	if err != nil {
 		ExitWithError(err)
 	}
-	pointers, err := collectPointers(pointerCh)
-	if err != nil {
-		Panic(err, "Could not scan for Git LFS files")
-	}
 
-	// Map oid to multiple pointers
-	mapping := make(map[string][]*lfs.WrappedPointer)
-	for _, pointer := range pointers {
-		if filter.Allows(pointer.Name) {
-			mapping[pointer.Oid] = append(mapping[pointer.Oid], pointer)
-		}
-	}
+	chgitscanner.Close()
 
 	// Launch git update-index
 	c := make(chan *lfs.WrappedPointer)
@@ -90,14 +95,29 @@ func checkoutWithIncludeExclude(gitscanner *lfs.GitScanner, filter *filepathfilt
 		Panic(err, "Could not checkout")
 	}
 
-	pointerCh, err := gitscanner.ScanTree(ref.Sha)
-	if err != nil {
+	// this func has to load all pointers into memory
+	var pointers []*lfs.WrappedPointer
+	var multiErr error
+	chgitscanner := lfs.NewGitScanner(func(p *lfs.WrappedPointer, err error) {
+		if err != nil {
+			if multiErr != nil {
+				multiErr = fmt.Errorf("%v\n%v", multiErr, err)
+			} else {
+				multiErr = err
+			}
+			return
+		}
+
+		pointers = append(pointers, p)
+	})
+
+	if err := chgitscanner.ScanTree(ref.Sha, nil); err != nil {
 		ExitWithError(err)
 	}
+	chgitscanner.Close()
 
-	pointers, err := collectPointers(pointerCh)
-	if err != nil {
-		Panic(err, "Could not scan for Git LFS files")
+	if multiErr != nil {
+		Panic(multiErr, "Could not scan for Git LFS files")
 	}
 
 	var wait sync.WaitGroup

--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -71,7 +71,7 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 
 	includeArg, excludeArg := getIncludeExcludeArgs(cmd)
 	filter := buildFilepathFilter(cfg, includeArg, excludeArg)
-	gitscanner := lfs.NewGitScanner()
+	gitscanner := lfs.NewGitScanner(nil)
 	defer gitscanner.Close()
 	if cloneFlags.NoCheckout || cloneFlags.Bare {
 		// If --no-checkout or --bare then we shouldn't check out, just fetch instead

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -156,8 +156,7 @@ func fetchRef(gitscanner *lfs.GitScanner, ref string, filter *filepathfilter.Fil
 func fetchPreviousVersions(gitscanner *lfs.GitScanner, ref string, since time.Time, filter *filepathfilter.Filter) bool {
 	var pointers []*lfs.WrappedPointer
 
-	tempgitscanner := lfs.NewGitScanner(nil)
-	err := tempgitscanner.ScanPreviousVersions(ref, since, func(p *lfs.WrappedPointer, err error) {
+	tempgitscanner := lfs.NewGitScanner(func(p *lfs.WrappedPointer, err error) {
 		if err != nil {
 			Panic(err, "Could not scan for Git LFS previous versions")
 			return
@@ -166,7 +165,7 @@ func fetchPreviousVersions(gitscanner *lfs.GitScanner, ref string, since time.Ti
 		pointers = append(pointers, p)
 	})
 
-	if err != nil {
+	if err := tempgitscanner.ScanPreviousVersions(ref, since, nil); err != nil {
 		ExitWithError(err)
 	}
 

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -61,7 +61,7 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 	}
 
 	success := true
-	gitscanner := lfs.NewGitScanner()
+	gitscanner := lfs.NewGitScanner(nil)
 	defer gitscanner.Close()
 
 	include, exclude := getIncludeExcludeArgs(cmd)

--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -29,7 +29,7 @@ func doFsck() (bool, error) {
 	// All we care about is the pointer OID and file name
 	pointerIndex := make(map[string]string)
 
-	gitscanner := lfs.NewGitScanner()
+	gitscanner := lfs.NewGitScanner(nil)
 	defer gitscanner.Close()
 	pointerCh, err := gitscanner.ScanRefWithDeleted(ref.Sha)
 	if err != nil {

--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -112,7 +112,7 @@ func getPointersFromRef(ref string) (map[string]string, error) {
 		return pointerIndex, err
 	}
 
-	if err := gitscanner.ScanIndex("HEAD"); err != nil {
+	if err := gitscanner.ScanIndex("HEAD", nil); err != nil {
 		return pointerIndex, err
 	}
 

--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -99,16 +99,7 @@ func getPointersFromRef(ref string) (map[string]string, error) {
 	})
 
 	defer gitscanner.Close()
-	pointerCh, err := gitscanner.ScanRefWithDeleted(ref)
-	if err != nil {
-		return pointerIndex, err
-	}
-
-	for p := range pointerCh.Results {
-		pointerIndex[p.Oid] = p.Name
-	}
-
-	if err := pointerCh.Wait(); err != nil {
+	if err := gitscanner.ScanRefWithDeleted(ref, nil); err != nil {
 		return pointerIndex, err
 	}
 

--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -16,7 +16,6 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 	requireInRepo()
 
 	var ref string
-	var err error
 
 	if len(args) == 1 {
 		ref = args[0]
@@ -33,19 +32,17 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 		showOidLen = 64
 	}
 
-	gitscanner := lfs.NewGitScanner(nil)
+	gitscanner := lfs.NewGitScanner(func(p *lfs.WrappedPointer, err error) {
+		if err != nil {
+			Exit("Could not scan for Git LFS tree: %s", err)
+			return
+		}
+
+		Print("%s %s %s", p.Oid[0:showOidLen], lsFilesMarker(p), p.Name)
+	})
 	defer gitscanner.Close()
 
-	pointerCh, err := gitscanner.ScanTree(ref)
-	if err != nil {
-		Exit("Could not scan for Git LFS tree: %s", err)
-	}
-
-	for p := range pointerCh.Results {
-		Print("%s %s %s", p.Oid[0:showOidLen], lsFilesMarker(p), p.Name)
-	}
-
-	if err := pointerCh.Wait(); err != nil {
+	if err := gitscanner.ScanTree(ref, nil); err != nil {
 		Exit("Could not scan for Git LFS tree: %s", err)
 	}
 }

--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -33,7 +33,7 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 		showOidLen = 64
 	}
 
-	gitscanner := lfs.NewGitScanner()
+	gitscanner := lfs.NewGitScanner(nil)
 	defer gitscanner.Close()
 
 	pointerCh, err := gitscanner.ScanTree(ref)

--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -54,7 +54,7 @@ func prePushCommand(cmd *cobra.Command, args []string) {
 	cfg.CurrentRemote = args[0]
 	ctx := newUploadContext(prePushDryRun)
 
-	gitscanner := lfs.NewGitScanner()
+	gitscanner := lfs.NewGitScanner(nil)
 	if err := gitscanner.RemoteForPush(cfg.CurrentRemote); err != nil {
 		ExitWithError(err)
 	}

--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"bufio"
+	"fmt"
 	"os"
 	"strings"
 
@@ -77,12 +78,35 @@ func prePushCommand(cmd *cobra.Command, args []string) {
 			continue
 		}
 
-		pointerCh, err := gitscanner.ScanLeftToRemote(left)
+		pointers, err := scanLeftOrAll(gitscanner, left)
 		if err != nil {
-			Panic(err, "Error scanning for Git LFS files")
+			Print("Error scanning for Git LFS files in %q", left)
+			ExitWithError(err)
 		}
-		upload(ctx, pointerCh)
+		uploadPointers(ctx, pointers)
 	}
+}
+
+func scanLeft(g *lfs.GitScanner, ref string) ([]*lfs.WrappedPointer, error) {
+	var pointers []*lfs.WrappedPointer
+	var multiErr error
+	cb := func(p *lfs.WrappedPointer, err error) {
+		if err != nil {
+			if multiErr != nil {
+				multiErr = fmt.Errorf("%v\n%v", multiErr, err)
+			} else {
+				multiErr = err
+			}
+			return
+		}
+
+		pointers = append(pointers, p)
+	}
+
+	if err := g.ScanLeftToRemote(ref, cb); err != nil {
+		return pointers, err
+	}
+	return pointers, multiErr
 }
 
 // decodeRefs pulls the sha1s out of the line read from the pre-push

--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -106,6 +106,7 @@ func scanLeft(g *lfs.GitScanner, ref string) ([]*lfs.WrappedPointer, error) {
 	if err := g.ScanLeftToRemote(ref, cb); err != nil {
 		return pointers, err
 	}
+
 	return pointers, multiErr
 }
 

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -30,7 +30,7 @@ func pullCommand(cmd *cobra.Command, args []string) {
 
 	includeArg, excludeArg := getIncludeExcludeArgs(cmd)
 	filter := buildFilepathFilter(cfg, includeArg, excludeArg)
-	gitscanner := lfs.NewGitScanner()
+	gitscanner := lfs.NewGitScanner(nil)
 	defer gitscanner.Close()
 	pull(gitscanner, filter)
 }

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/git-lfs/git-lfs/git"
@@ -34,19 +35,40 @@ func uploadsBetweenRefAndRemote(ctx *uploadContext, refnames []string) {
 	}
 
 	for _, ref := range refs {
-		pointerCh, err := scanLeftOrAll(gitscanner, ref.Name)
+		pointers, err := scanLeftOrAll(gitscanner, ref.Name)
 		if err != nil {
-			Panic(err, "Error scanning for Git LFS files in the %q ref", ref.Name)
+			Print("Error scanning for Git LFS files in the %q ref", ref.Name)
+			ExitWithError(err)
 		}
-		upload(ctx, pointerCh)
+		uploadPointers(ctx, pointers)
 	}
 }
 
-func scanLeftOrAll(g *lfs.GitScanner, ref string) (*lfs.PointerChannelWrapper, error) {
-	if pushAll {
-		return g.ScanRefWithDeleted(ref)
+func scanLeftOrAll(g *lfs.GitScanner, ref string) ([]*lfs.WrappedPointer, error) {
+	var pointers []*lfs.WrappedPointer
+	var multiErr error
+	cb := func(p *lfs.WrappedPointer, err error) {
+		if err != nil {
+			if multiErr != nil {
+				multiErr = fmt.Errorf("%v\n%v", multiErr, err)
+			} else {
+				multiErr = err
+			}
+			return
+		}
+
+		pointers = append(pointers, p)
 	}
-	return g.ScanLeftToRemote(ref)
+
+	if pushAll {
+		if err := g.ScanRefWithDeleted(ref, cb); err != nil {
+			return pointers, err
+		}
+	}
+	if err := g.ScanLeftToRemote(ref, cb); err != nil {
+		return pointers, err
+	}
+	return pointers, multiErr
 }
 
 func uploadsWithObjectIDs(ctx *uploadContext, oids []string) {
@@ -77,7 +99,7 @@ func refsByNames(refnames []string) ([]*git.Ref, error) {
 		if ref, ok := reflookup[name]; ok {
 			refs[i] = ref
 		} else {
-			refs[i] = &git.Ref{name, git.RefTypeOther, name}
+			refs[i] = &git.Ref{Name: name, Type: git.RefTypeOther, Sha: name}
 		}
 	}
 

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -21,7 +21,7 @@ var (
 func uploadsBetweenRefAndRemote(ctx *uploadContext, refnames []string) {
 	tracerx.Printf("Upload refs %v to remote %v", refnames, cfg.CurrentRemote)
 
-	gitscanner := lfs.NewGitScanner()
+	gitscanner := lfs.NewGitScanner(nil)
 	if err := gitscanner.RemoteForPush(cfg.CurrentRemote); err != nil {
 		ExitWithError(err)
 	}

--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -12,6 +12,28 @@ var (
 	porcelain = false
 )
 
+func porcelainStagedPointers(ref string) {
+	gitscanner := lfs.NewGitScanner(func(p *lfs.WrappedPointer, err error) {
+		if err != nil {
+			ExitWithError(err)
+		}
+
+		switch p.Status {
+		case "R", "C":
+			Print("%s  %s -> %s %d", p.Status, p.SrcName, p.Name, p.Size)
+		case "M":
+			Print(" %s %s %d", p.Status, p.Name, p.Size)
+		default:
+			Print("%s  %s %d", p.Status, p.Name, p.Size)
+		}
+	})
+	defer gitscanner.Close()
+
+	if err := gitscanner.ScanIndex(ref); err != nil {
+		ExitWithError(err)
+	}
+}
+
 func statusCommand(cmd *cobra.Command, args []string) {
 	requireInRepo()
 
@@ -26,26 +48,8 @@ func statusCommand(cmd *cobra.Command, args []string) {
 		scanIndexAt = git.RefBeforeFirstCommit
 	}
 
-	stagedPointers, err := gitscanner.ScanIndex(scanIndexAt)
-	if err != nil {
-		Panic(err, "Could not scan staging for Git LFS objects")
-	}
-
 	if porcelain {
-		for p := range stagedPointers.Results {
-			switch p.Status {
-			case "R", "C":
-				Print("%s  %s -> %s %d", p.Status, p.SrcName, p.Name, p.Size)
-			case "M":
-				Print(" %s %s %d", p.Status, p.Name, p.Size)
-			default:
-				Print("%s  %s %d", p.Status, p.Name, p.Size)
-			}
-		}
-
-		if err := stagedPointers.Wait(); err != nil {
-			ExitWithError(err)
-		}
+		porcelainStagedPointers(scanIndexAt)
 		return
 	}
 
@@ -71,8 +75,14 @@ func statusCommand(cmd *cobra.Command, args []string) {
 	}
 
 	Print("\nGit LFS objects to be committed:\n")
+
 	var unstagedPointers []*lfs.WrappedPointer
-	for p := range stagedPointers.Results {
+	indexScanner := lfs.NewGitScanner(func(p *lfs.WrappedPointer, err error) {
+		if err != nil {
+			ExitWithError(err)
+			return
+		}
+
 		switch p.Status {
 		case "R", "C":
 			Print("\t%s -> %s (%s)", p.SrcName, p.Name, humanizeBytes(p.Size))
@@ -81,7 +91,13 @@ func statusCommand(cmd *cobra.Command, args []string) {
 		default:
 			Print("\t%s (%s)", p.Name, humanizeBytes(p.Size))
 		}
+	})
+
+	if err := indexScanner.ScanIndex(scanIndexAt); err != nil {
+		ExitWithError(err)
 	}
+
+	indexScanner.Close()
 
 	Print("\nGit LFS objects not staged for commit:\n")
 	for _, p := range unstagedPointers {
@@ -90,11 +106,7 @@ func statusCommand(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	if err := stagedPointers.Wait(); err != nil {
-		ExitWithError(err)
-	} else {
-		Print("")
-	}
+	Print("")
 }
 
 var byteUnits = []string{"B", "KB", "MB", "GB", "TB"}

--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -18,7 +18,7 @@ func statusCommand(cmd *cobra.Command, args []string) {
 	// tolerate errors getting ref so this works before first commit
 	ref, _ := git.CurrentRef()
 
-	gitscanner := lfs.NewGitScanner()
+	gitscanner := lfs.NewGitScanner(nil)
 	defer gitscanner.Close()
 
 	scanIndexAt := "HEAD"

--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -29,7 +29,7 @@ func porcelainStagedPointers(ref string) {
 	})
 	defer gitscanner.Close()
 
-	if err := gitscanner.ScanIndex(ref); err != nil {
+	if err := gitscanner.ScanIndex(ref, nil); err != nil {
 		ExitWithError(err)
 	}
 }
@@ -93,7 +93,7 @@ func statusCommand(cmd *cobra.Command, args []string) {
 		}
 	})
 
-	if err := indexScanner.ScanIndex(scanIndexAt); err != nil {
+	if err := indexScanner.ScanIndex(scanIndexAt, nil); err != nil {
 		ExitWithError(err)
 	}
 

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -126,19 +126,6 @@ func (c *uploadContext) checkMissing(missing []*lfs.WrappedPointer, missingSize 
 	<-done
 }
 
-func upload(c *uploadContext, pointerCh *lfs.PointerChannelWrapper) {
-	var pointers []*lfs.WrappedPointer
-	for p := range pointerCh.Results {
-		pointers = append(pointers, p)
-	}
-
-	if err := pointerCh.Wait(); err != nil {
-		ExitWithError(err)
-	}
-
-	uploadPointers(c, pointers)
-}
-
 func uploadPointers(c *uploadContext, unfiltered []*lfs.WrappedPointer) {
 	if c.DryRun {
 		for _, p := range unfiltered {

--- a/lfs/gitscanner.go
+++ b/lfs/gitscanner.go
@@ -122,8 +122,8 @@ func (s *GitScanner) ScanPreviousVersions(ref string, since time.Time) (*Pointer
 }
 
 // ScanIndex scans the git index for modified LFS objects.
-func (s *GitScanner) ScanIndex(ref string) (*PointerChannelWrapper, error) {
-	return scanIndex(ref)
+func (s *GitScanner) ScanIndex(ref string) error {
+	return scanIndex(s.callback, ref)
 }
 
 func (s *GitScanner) opts(mode ScanningMode) *ScanRefsOptions {

--- a/lfs/gitscanner.go
+++ b/lfs/gitscanner.go
@@ -10,6 +10,14 @@ import (
 	"github.com/rubyist/tracerx"
 )
 
+var missingCallbackErr = errors.New("No callback given")
+
+// CallbackMissing returns a boolean indicating whether the error is reporting
+// that a GitScanner is missing a required GitScannerCallback.
+func CallbackMissing(err error) bool {
+	return err == missingCallbackErr
+}
+
 // GitScanner scans objects in a Git repository for LFS pointers.
 type GitScanner struct {
 	Filter      *filepathfilter.Filter
@@ -182,7 +190,7 @@ func firstGitScannerCallback(callbacks ...GitScannerCallback) (GitScannerCallbac
 		return cb, nil
 	}
 
-	return nil, errors.New("No callback given")
+	return nil, missingCallbackErr
 }
 
 type ScanningMode int

--- a/lfs/gitscanner.go
+++ b/lfs/gitscanner.go
@@ -12,9 +12,9 @@ import (
 
 var missingCallbackErr = errors.New("No callback given")
 
-// CallbackMissing returns a boolean indicating whether the error is reporting
+// IsCallbackMissing returns a boolean indicating whether the error is reporting
 // that a GitScanner is missing a required GitScannerCallback.
-func CallbackMissing(err error) bool {
+func IsCallbackMissing(err error) bool {
 	return err == missingCallbackErr
 }
 

--- a/lfs/gitscanner.go
+++ b/lfs/gitscanner.go
@@ -104,8 +104,12 @@ func (s *GitScanner) ScanAll() (*PointerChannelWrapper, error) {
 // ScanTree takes a ref and returns WrappedPointer objects in the tree at that
 // ref. Differs from ScanRefs in that multiple files in the tree with the same
 // content are all reported.
-func (s *GitScanner) ScanTree(ref string) (*PointerChannelWrapper, error) {
-	return runScanTree(ref)
+func (s *GitScanner) ScanTree(ref string, cb GitScannerCallback) error {
+	callback, err := firstGitScannerCallback(cb, s.callback)
+	if err != nil {
+		return err
+	}
+	return runScanTree(callback, ref)
 }
 
 // ScanUnpushed scans history for all LFS pointers which have been added but not

--- a/lfs/gitscanner.go
+++ b/lfs/gitscanner.go
@@ -122,8 +122,12 @@ func (s *GitScanner) ScanUnpushed(remote string, cb GitScannerCallback) error {
 // Returns channel of pointers for *previous* versions that overlap that time.
 // Does not include pointers which were still in use at ref (use ScanRefsToChan
 // for that)
-func (s *GitScanner) ScanPreviousVersions(ref string, since time.Time) (*PointerChannelWrapper, error) {
-	return logPreviousSHAs(ref, since)
+func (s *GitScanner) ScanPreviousVersions(ref string, since time.Time, cb GitScannerCallback) error {
+	callback, err := firstGitScannerCallback(cb, s.callback)
+	if err != nil {
+		return err
+	}
+	return logPreviousSHAs(callback, ref, since)
 }
 
 // ScanIndex scans the git index for modified LFS objects.

--- a/lfs/gitscanner_log.go
+++ b/lfs/gitscanner_log.go
@@ -58,12 +58,15 @@ func scanUnpushed(cb GitScannerCallback, remote string) error {
 		return err
 	}
 
-	cmd.Stdin.Close()
+	parseScannerLogOutput(cb, LogDiffAdditions, cmd)
+	return nil
+}
 
+func parseScannerLogOutput(cb GitScannerCallback, direction LogDiffDirection, cmd *wrappedCmd) {
 	ch := make(chan gitscannerResult, chanBufSize)
 
 	go func() {
-		scanner := newLogScanner(LogDiffAdditions, cmd.Stdout)
+		scanner := newLogScanner(direction, cmd.Stdout)
 		for scanner.Scan() {
 			if p := scanner.Pointer(); p != nil {
 				ch <- gitscannerResult{Pointer: p}
@@ -77,16 +80,15 @@ func scanUnpushed(cb GitScannerCallback, remote string) error {
 		close(ch)
 	}()
 
+	cmd.Stdin.Close()
 	for result := range ch {
 		cb(result.Pointer, result.Err)
 	}
-
-	return nil
 }
 
 // logPreviousVersions scans history for all previous versions of LFS pointers
 // from 'since' up to (but not including) the final state at ref
-func logPreviousSHAs(ref string, since time.Time) (*PointerChannelWrapper, error) {
+func logPreviousSHAs(cb GitScannerCallback, ref string, since time.Time) error {
 	logArgs := []string{"log",
 		fmt.Sprintf("--since=%v", git.FormatGitDate(since)),
 	}
@@ -97,29 +99,11 @@ func logPreviousSHAs(ref string, since time.Time) (*PointerChannelWrapper, error
 
 	cmd, err := startCommand("git", logArgs...)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	cmd.Stdin.Close()
-
-	pchan := make(chan *WrappedPointer, chanBufSize)
-	errchan := make(chan error, 1)
-
-	// we pull out deletions, since we want the previous SHAs at commits in the range
-	// this means we pick up all previous versions that could have been checked
-	// out in the date range, not just if the commit which *introduced* them is in the range
-	go func() {
-		parseLogOutputToPointers(cmd.Stdout, LogDiffDeletions, nil, nil, pchan)
-		stderr, _ := ioutil.ReadAll(cmd.Stderr)
-		err := cmd.Wait()
-		if err != nil {
-			errchan <- fmt.Errorf("Error in git log: %v %v", err, string(stderr))
-		}
-		close(pchan)
-		close(errchan)
-	}()
-
-	return NewPointerChannelWrapper(pchan, errchan), nil
+	parseScannerLogOutput(cb, LogDiffDeletions, cmd)
+	return nil
 }
 
 func parseLogOutputToPointers(log io.Reader, dir LogDiffDirection,

--- a/lfs/scanner_git_test.go
+++ b/lfs/scanner_git_test.go
@@ -104,7 +104,7 @@ func scanUnpushed(remoteName string) ([]*WrappedPointer, error) {
 		pointers = append(pointers, p)
 	})
 
-	if err := gitscanner.ScanUnpushed(remoteName); err != nil {
+	if err := gitscanner.ScanUnpushed(remoteName, nil); err != nil {
 		return nil, err
 	}
 

--- a/test/test-fsck.sh
+++ b/test/test-fsck.sh
@@ -38,20 +38,14 @@ begin_test "fsck default"
 
   echo "CORRUPTION" >> .git/lfs/objects/$aOid12/$aOid34/$aOid
 
-  moved=$(native_path "$TRASHDIR/$reponame/.git/lfs/bad/$aOid")
+  moved=$(native_path "$TRASHDIR/$reponame/.git/lfs/bad")
   expected="$(printf 'Object a.dat (%s) is corrupt
-  moved to %s' "$aOid" "$moved")"
+Moving corrupt objects to %s' "$aOid" "$moved")"
   [ "$expected" = "$(git lfs fsck)" ]
 
-  if [ -e .git/lfs/objects/$aOid12/$aOid34/$aOid ]; then
-    echo "Expected a.dat to be cleared for being corrupt"
-    exit 1
-  fi
-
-  if [ "$bOid" != "$(calc_oid_file .git/lfs/objects/$bOid12/$bOid34/$bOid)" ]; then
-    echo "oid for b.dat does not match"
-    exit 1
-  fi
+  [ -e ".git/lfs/bad/$aOid" ]
+  [ ! -e ".git/lfs/objects/$aOid12/$aOid34/$aOid" ]
+  [ "$bOid" = "$(calc_oid_file .git/lfs/objects/$bOid12/$bOid34/$bOid)" ]
 )
 end_test
 


### PR DESCRIPTION
This changes the `gitscanner` API to use callbacks, instead of returning a `PointerChannelWrapper`. See [the fsck command](https://github.com/git-lfs/git-lfs/compare/fast-walk-no-channels...gitscanner-callbacks?expand=1#diff-3b7fa953c43592e4af73f324813e6c2fR35) for an _ideal_ usage of it:

```go
gitscanner := lfs.NewGitScanner(func(p *lfs.WrappedPointer, err error) {
  // handle pointers or scan errors
})

if err := gitscanner.ScanRefWithDeleted(ref.Sha, nil); err != nil {
  // handle cmd error
}

gitscanner.Close()
```

You can now pass a callback to `NewGitScanner()` for all the `.Scan*()` funcs, or pass a callback to individual functions if you want those pointers to be handled differently.

Unfortunately, this introduces some ugly code in the core push/pull/checkout related commands. A lot of code still expects to receive a `[]*lfs.WrappedPointer` after the scan has completed. This cleanup will have to happen in future PRs. The main blockers are the progress meter and transfer queues need to accept a stream of pointers.

My hunch is that the transfer queue is all ready setup for this, but our _use_ of it prefers receiving a `[]*lfs.WrappedPointer`. However, the progress meter definitely expects to receive the total number and size of the pointers up front. Since this process is becoming async, updating the progress meter stuff is my next target.

Also, I was a doofus and did most of this work on top of #1710, so I have to wait for that to be merged before merging this :)

* [ ] merge #1710
* [ ] reset base to `master`