### PR TITLE
Fix Install in root problems

### DIFF
--- a/commands/command_install.go
+++ b/commands/command_install.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/git-lfs/git-lfs/lfs"
+	"github.com/git-lfs/git-lfs/localstorage"
 	"github.com/spf13/cobra"
 )
 
@@ -41,6 +42,7 @@ func installCommand(cmd *cobra.Command, args []string) {
 	}
 
 	if localInstall || lfs.InRepo() {
+		localstorage.InitStorageOrFail()
 		installHooksCommand(cmd, args)
 	}
 
@@ -59,5 +61,6 @@ func init() {
 		cmd.Flags().BoolVarP(&systemInstall, "system", "", false, "Set the Git LFS config in system-wide scope.")
 		cmd.Flags().BoolVarP(&skipSmudgeInstall, "skip-smudge", "s", false, "Skip automatic downloading of objects on clone or pull.")
 		cmd.AddCommand(NewCommand("hooks", installHooksCommand))
+		cmd.PreRun = setupLocalStorage
 	})
 }

--- a/commands/command_uninstall.go
+++ b/commands/command_uninstall.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"github.com/git-lfs/git-lfs/lfs"
+	"github.com/git-lfs/git-lfs/localstorage"
 	"github.com/spf13/cobra"
 )
 
@@ -14,6 +15,7 @@ func uninstallCommand(cmd *cobra.Command, args []string) {
 	Print("Global Git LFS configuration has been removed.")
 
 	if lfs.InRepo() {
+		localstorage.InitStorageOrFail()
 		uninstallHooksCommand(cmd, args)
 	}
 }
@@ -30,5 +32,6 @@ func uninstallHooksCommand(cmd *cobra.Command, args []string) {
 func init() {
 	RegisterCommand("uninstall", uninstallCommand, func(cmd *cobra.Command) {
 		cmd.AddCommand(NewCommand("hooks", uninstallHooksCommand))
+		cmd.PreRun = setupLocalStorage
 	})
 }

--- a/commands/run.go
+++ b/commands/run.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/git-lfs/git-lfs/config"
 	"github.com/git-lfs/git-lfs/httputil"
 	"github.com/git-lfs/git-lfs/localstorage"
 	"github.com/spf13/cobra"
@@ -76,6 +77,10 @@ func gitlfsCommand(cmd *cobra.Command, args []string) {
 // will resolve the localstorage directories.
 func resolveLocalStorage(cmd *cobra.Command, args []string) {
 	localstorage.ResolveDirs()
+}
+
+func setupLocalStorage(cmd *cobra.Command, args []string) {
+	config.ResolveGitBasicDirs()
 }
 
 func helpCommand(cmd *cobra.Command, args []string) {

--- a/localstorage/currentstore.go
+++ b/localstorage/currentstore.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/git-lfs/git-lfs/config"
+	"github.com/git-lfs/git-lfs/errors"
 )
 
 const (
@@ -17,6 +18,7 @@ const (
 
 var (
 	objects        *LocalStorage
+	notInRepoErr   = errors.New("not in a repository")
 	TempDir        = filepath.Join(os.TempDir(), "git-lfs")
 	checkedTempDir string
 )
@@ -25,25 +27,44 @@ func Objects() *LocalStorage {
 	return objects
 }
 
-func ResolveDirs() {
+func InitStorage() error {
+	if len(config.LocalGitStorageDir) == 0 || len(config.LocalGitDir) == 0 {
+		return notInRepoErr
+	}
 
-	config.ResolveGitBasicDirs()
 	TempDir = filepath.Join(config.LocalGitDir, "lfs", "tmp") // temp files per worktree
-
 	objs, err := NewStorage(
 		filepath.Join(config.LocalGitStorageDir, "lfs", "objects"),
 		filepath.Join(TempDir, "objects"),
 	)
 
 	if err != nil {
-		panic(fmt.Sprintf("Error trying to init LocalStorage: %s", err))
+		return errors.Wrap(err, "init LocalStorage")
 	}
 
 	objects = objs
 	config.LocalLogDir = filepath.Join(objs.RootDir, "logs")
 	if err := os.MkdirAll(config.LocalLogDir, localLogDirPerms); err != nil {
-		panic(fmt.Errorf("Error trying to create log directory in '%s': %s", config.LocalLogDir, err))
+		return errors.Wrap(err, "create log dir")
 	}
+
+	return nil
+}
+
+func InitStorageOrFail() {
+	if err := InitStorage(); err != nil {
+		if err == notInRepoErr {
+			return
+		}
+
+		fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
+		os.Exit(1)
+	}
+}
+
+func ResolveDirs() {
+	config.ResolveGitBasicDirs()
+	InitStorageOrFail()
 }
 
 func TempFile(prefix string) (*os.File, error) {

--- a/test/test-install.sh
+++ b/test/test-install.sh
@@ -157,6 +157,9 @@ begin_test "install --skip-smudge"
 (
   set -e
 
+  mkdir install-skip-smudge-test
+  cd install-skip-smudge-test
+
   git lfs install
   [ "git-lfs clean -- %f" = "$(git config --global filter.lfs.clean)" ]
   [ "git-lfs smudge -- %f" = "$(git config --global filter.lfs.smudge)" ]
@@ -171,6 +174,8 @@ begin_test "install --skip-smudge"
   [ "git-lfs clean -- %f" = "$(git config --global filter.lfs.clean)" ]
   [ "git-lfs smudge -- %f" = "$(git config --global filter.lfs.smudge)" ]
   [ "git-lfs filter-process" = "$(git config --global filter.lfs.process)" ]
+
+  [ ! -e "lfs" ]
 )
 end_test
 
@@ -212,5 +217,23 @@ begin_test "install --local outside repository"
 
   [ "Not in a git repository." = "$(cat err.log)" ]
   [ "0" != "$res" ]
+)
+end_test
+
+begin_test "install in directory without access to .git/lfs"
+(
+  set -e
+  mkdir not-a-repo
+  cd not-a-repo
+  mkdir .git
+  touch .git/lfs
+  touch lfs
+
+  git config --global filter.lfs.clean whatevs
+  [ "whatevs" = "$(git config filter.lfs.clean)" ]
+
+  git lfs install --force
+
+  [ "git-lfs clean -- %f" = "$(git config filter.lfs.clean)" ]
 )
 end_test

--- a/test/test-uninstall.sh
+++ b/test/test-uninstall.sh
@@ -6,6 +6,9 @@ begin_test "uninstall outside repository"
 (
   set -e
 
+  mkdir uninstall-test
+  cd uninstall-test
+
   smudge="$(git config filter.lfs.smudge)"
   clean="$(git config filter.lfs.clean)"
   filter="$(git config filter.lfs.process)"
@@ -16,6 +19,9 @@ begin_test "uninstall outside repository"
 
   # uninstall multiple times to trigger https://github.com/git-lfs/git-lfs/issues/529
   git lfs uninstall
+
+  [ ! -e "lfs" ]
+
   git lfs install
   git lfs uninstall | tee uninstall.log
   grep "configuration has been removed" uninstall.log
@@ -28,6 +34,28 @@ begin_test "uninstall outside repository"
   [ "$(grep 'filter "lfs"' $HOME/.gitconfig -c)" = "0" ]
 )
 end_test
+
+begin_test "uninstall outside repository without access to .git/lfs"
+(
+  set -e
+
+  mkdir uninstall-no-lfs
+  cd uninstall-no-lfs
+
+  mkdir .git
+  touch .git/lfs
+  touch lfs
+
+  [ "" != "$(git config --global filter.lfs.smudge)" ]
+  [ "" != "$(git config --global filter.lfs.clean)" ]
+  [ "" != "$(git config --global filter.lfs.process)" ]
+
+  git lfs uninstall
+
+  [ "" = "$(git config --global filter.lfs.smudge)" ]
+  [ "" = "$(git config --global filter.lfs.clean)" ]
+  [ "" = "$(git config --global filter.lfs.process)" ]
+)
 
 begin_test "uninstall inside repository with default pre-push hook"
 (


### PR DESCRIPTION
Fixes #1717 by splitting `localstorage.ResolveDirs()` so that `install` and `uninstall` can do what they need if `lfs.InRepo()` is true.  This is meant to be a bug fix, and definitely doesn't try to fix any package design issues.  I want to backport this PR to v1.5.3, and explore a redesign of this code for 2.x.