### PR TITLE
git: parse filter process header values containing '=' properly

### DIFF
--- a/git/filter_process_scanner.go
+++ b/git/filter_process_scanner.go
@@ -177,7 +177,7 @@ func (o *FilterProcessScanner) readRequest() (*Request, error) {
 	}
 
 	for _, pair := range requestList {
-		v := strings.Split(pair, "=")
+		v := strings.SplitN(pair, "=", 2)
 		req.Header[v[0]] = v[1]
 	}
 

--- a/git/filter_process_scanner_test.go
+++ b/git/filter_process_scanner_test.go
@@ -102,7 +102,7 @@ func TestFilterProcessScannerReadsRequestHeadersAndPayload(t *testing.T) {
 	pl := newPktline(nil, &from)
 	// Headers
 	require.Nil(t, pl.writePacketList([]string{
-		"foo=bar", "other=woot",
+		"foo=bar", "other=woot", "crazy='sq',\\$x=.bin",
 	}))
 	// Multi-line packet
 	require.Nil(t, pl.writePacketText("first"))
@@ -114,6 +114,7 @@ func TestFilterProcessScannerReadsRequestHeadersAndPayload(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, req.Header["foo"], "bar")
 	assert.Equal(t, req.Header["other"], "woot")
+	assert.Equal(t, req.Header["crazy"], "'sq',\\$x=.bin")
 
 	payload, err := ioutil.ReadAll(req.Payload)
 	assert.Nil(t, err)


### PR DESCRIPTION
A filter process key-value pair must be split at the first '=' character
into into at most two substrings. The value *can* contain a '='
character. The key *must never* contain a '=' character.

Should fix https://github.com/git-lfs/git-lfs/issues/1730