### PR TITLE
build: use Go 1.7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # http://docs.travis-ci.com/user/languages/go/
 language: go
 
-go: 1.7.1
+go: 1.7.4
 
 os:
   - linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,11 @@ environment:
 clone_folder: $(GOPATH)\src\github.com\git-lfs\git-lfs
 
 install:
+  - echo $(GOPATH)
+  - rd C:\Go /s /q
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.7.4.windows-amd64.zip
+  - 7z x go1.7.4.windows-amd64.zip -oC:\ >nul
+  - C:\go\bin\go version
   - cinst InnoSetup -y
   - set PATH="C:\Program Files (x86)\Inno Setup 5";%PATH%
 


### PR DESCRIPTION
This pull-request uses Go 1.7.4 on all of our build services. Go 1.7.4 matches what we ship with (after bumping the build dockers) and contains security fixes over 1.7.3.

- **TravisCI**: Bumped version.
- **CircleCI**: Uses latest version from Homebrew, already upgraded.
- **AppVeyor**: Doesn't ship their workers with 1.7.4 yet, working on installing it ourselves.

---

/cc @technoweenie 