### PR TITLE
fix ssh endpoint parsing

### DIFF
--- a/config/endpoint.go
+++ b/config/endpoint.go
@@ -56,7 +56,7 @@ func NewEndpointWithConfig(rawurl string, c *Configuration) Endpoint {
 	rawurl = c.ReplaceUrlAlias(rawurl)
 	u, err := url.Parse(rawurl)
 	if err != nil {
-		return Endpoint{Url: EndpointUrlUnknown}
+		return endpointFromBareSshUrl(rawurl)
 	}
 
 	switch u.Scheme {
@@ -67,7 +67,7 @@ func NewEndpointWithConfig(rawurl string, c *Configuration) Endpoint {
 	case "git":
 		return endpointFromGitUrl(u, c)
 	case "":
-		return endpointFromBareSshUrl(u)
+		return endpointFromBareSshUrl(u.String())
 	default:
 		// Just passthrough to preserve
 		return Endpoint{Url: rawurl}
@@ -78,11 +78,11 @@ func NewEndpointWithConfig(rawurl string, c *Configuration) Endpoint {
 //
 //   user@host.com:path/to/repo.git
 //
-func endpointFromBareSshUrl(u *url.URL) Endpoint {
-	parts := strings.Split(u.Path, ":")
+func endpointFromBareSshUrl(rawurl string) Endpoint {
+	parts := strings.Split(rawurl, ":")
 	partsLen := len(parts)
 	if partsLen < 2 {
-		return Endpoint{Url: u.String()}
+		return Endpoint{Url: rawurl}
 	}
 
 	// Treat presence of ':' as a bare URL


### PR DESCRIPTION
The `url.Parse()` func on go 1.8 fails to handle ssh remotes like `git@foo.com:user/path.git`. Instead of returning a `*url.URL` where the `Path` property is the entire raw url, it now returns an error: "first path segment in URL cannot contain colon".

This now attempts to parse the bare ssh url in case `url.Parse` returns a URL, working on both go1.8 and go.1.7.