### PR TITLE
tq: implement `*tq.WorkerQueue` type

### DIFF
--- a/tq/worker_queue.go
+++ b/tq/worker_queue.go
@@ -1,0 +1,116 @@
+package tq
+
+import "sync"
+
+// WorkerFn is a function type, held by a `*WorkerQueue`, which is called
+// anytime there is work to be done. The parameter of the function "oid" is
+// given as the OID of the object to transfer. The return value dictates whether
+// or not the object was transferred successfully, true if so, false if
+// otherwise.
+type WorkerFn func(oid string) bool
+
+type WorkerQueue struct {
+	// tasks holds `*task`s to be worked upon by `WorkerFn`s. It is written
+	// to from a single source (see: `Add(batch []string)` below), and
+	// consumed from many workers.
+	tasks chan *task
+	// fn is the WorkerFn that executes when an OID is available to be
+	// processed. If the function returns true, then the OID is marked as
+	// successfully processed, and no retries are enqueued. Otherwise, the
+	// items is marked as having failed, and a retry is enqueued by writing
+	// the OID to the returned `retries` channel.
+	fn WorkerFn
+
+	// wg waits for all items given in an `Add()` call to be processed
+	// _completely_ by a worker. After latching, the given retries channel
+	// will be closed.
+	wg *sync.WaitGroup
+	// wwg waits for all workers to terminate after the `tasks` channel
+	// closes, and is a terminating condition of the Wait() function below.
+	wwg *sync.WaitGroup
+}
+
+// task encapsulates the necessary information to perform work on an object.
+type task struct {
+	// Oid is the object ID to be worked upon.
+	Oid string
+
+	// retry is a channel written to when the object is marked as having failed.
+	retry chan<- string
+	// wg is a *sync.WaitGroup that is incremented when new tasks are
+	// created, and decremented when tasks are completed (whether or not
+	// they are successful is a different matter).
+	wg *sync.WaitGroup
+}
+
+// MarkForRetry places the task's object ID on the retry channel.
+func (t *task) MarkForRetry() {
+	t.retry <- t.Oid
+}
+
+// Done signals that work on this object has completed in either a successful or
+// failed state.
+func (t *task) Done() {
+	t.wg.Done()
+}
+
+// NewWorkerQueue creates a new `*WorkerQueue` with `count` workers, each
+// executing the `WorkerFn` "fn".
+func NewWorkerQueue(count int, fn WorkerFn) *WorkerQueue {
+	q := &WorkerQueue{
+		tasks: make(chan *task),
+		fn:    fn,
+
+		wg:  new(sync.WaitGroup),
+		wwg: new(sync.WaitGroup),
+	}
+
+	for i := 0; i < count; i++ {
+		q.wwg.Add(1)
+
+		go func() {
+			defer q.wwg.Done()
+
+			for task := range q.tasks {
+				if ok := q.fn(task.Oid); !ok {
+					task.MarkForRetry()
+				}
+
+				task.Done()
+			}
+		}()
+	}
+
+	return q
+}
+
+// Add adds a batch of items to a queue of items to be processed, and then
+// distributes those items across the available workers. It immediately returns
+// a channel that object IDs are written to when those IDs need to be retried.
+// That channel is closed when work has completed on the entire batch.
+func (q *WorkerQueue) Add(batch []string) <-chan string {
+	q.wg.Add(len(batch))
+	retries := make(chan string, len(batch))
+
+	go func(wg *sync.WaitGroup, retries chan<- string) {
+		defer close(retries)
+
+		for _, oid := range batch {
+			q.tasks <- &task{oid, retries, wg}
+		}
+
+		wg.Wait()
+	}(q.wg, retries)
+
+	return retries
+}
+
+// Wait waits for all workers to finish processing active OIDs, then closes the
+// incoming items channel and therefore all living workers. After waiting for
+// the transitioning workers to completely transition from an alive to dead
+// state, this function returns.
+func (q *WorkerQueue) Wait() {
+	q.wg.Wait()
+	close(q.tasks)
+	q.wwg.Wait()
+}

--- a/tq/worker_queue.go
+++ b/tq/worker_queue.go
@@ -92,15 +92,15 @@ func (q *WorkerQueue) Add(batch []string) <-chan string {
 	q.wg.Add(len(batch))
 	retries := make(chan string, len(batch))
 
-	go func(wg *sync.WaitGroup, retries chan<- string) {
+	go func() {
 		defer close(retries)
 
 		for _, oid := range batch {
-			q.tasks <- &task{oid, retries, wg}
+			q.tasks <- &task{oid, retries, q.wg}
 		}
 
-		wg.Wait()
-	}(q.wg, retries)
+		q.wg.Wait()
+	}()
 
 	return retries
 }

--- a/tq/worker_queue_test.go
+++ b/tq/worker_queue_test.go
@@ -1,0 +1,103 @@
+package tq_test
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/git-lfs/git-lfs/tq"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWorkerQueueProcessesBatchedItems(t *testing.T) {
+	var called uint32
+
+	wq := tq.NewWorkerQueue(1, func(oid string) bool {
+		if oid == "some-oid" {
+			atomic.AddUint32(&called, 1)
+		}
+
+		return true
+	})
+
+	retries := wq.Add([]string{"some-oid"})
+	wq.Wait()
+
+	assertChannelEmpty(t, retries, 100*time.Millisecond)
+	assert.EqualValues(t, 1, called)
+}
+
+func TestWorkerQueueReturnsRetriedItems(t *testing.T) {
+	retried := make(map[string]bool)
+
+	wq := tq.NewWorkerQueue(1, func(oid string) bool {
+		retried[oid] = false
+
+		return false
+	})
+
+	retries := wq.Add([]string{"first-oid", "second-oid"})
+	wq.Wait()
+
+L:
+	for {
+		select {
+		case retry, ok := <-retries:
+			if !ok {
+				break L
+			}
+
+			retried[retry] = true
+		case <-time.After(100 * time.Millisecond):
+			t.Errorf("tq: expected `retries` to be closed, wasn't after 100msec")
+
+			break L
+		}
+	}
+
+	assert.Len(t, retried, 2)
+	assert.True(t, retried["first-oid"])
+	assert.True(t, retried["second-oid"])
+}
+
+func TestWorkerQueueDistributesItemsAcrossManyWorkers(t *testing.T) {
+	seen := make(map[string]bool)
+
+	wg := new(sync.WaitGroup)
+	wg.Add(2)
+
+	wq := tq.NewWorkerQueue(2, func(oid string) bool {
+		wg.Done()
+		wg.Wait()
+
+		seen[oid] = true
+
+		return true
+	})
+
+	retries := wq.Add([]string{"first-oid", "second-oid"})
+	wq.Wait()
+
+	assertChannelEmpty(t, retries, 100*time.Millisecond)
+
+	assert.Len(t, seen, 2)
+	assert.True(t, seen["first-oid"])
+	assert.True(t, seen["second-oid"])
+}
+
+func assertChannelEmpty(t *testing.T, from <-chan string, after time.Duration) {
+L:
+	for {
+		select {
+		case v, ok := <-from:
+			if !ok {
+				break L
+			}
+
+			t.Errorf("tq: expected channel to be empty, got '%+v'", v)
+		case <-time.After(after):
+			t.Errorf("tq: expected channel to be closed after %s, wasn't", after)
+		}
+	}
+}

--- a/tq/worker_queue_test.go
+++ b/tq/worker_queue_test.go
@@ -1,4 +1,4 @@
-package tq_test
+package tq
 
 import (
 	"sync"
@@ -6,14 +6,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/git-lfs/git-lfs/tq"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestWorkerQueueProcessesBatchedItems(t *testing.T) {
 	var called uint32
 
-	wq := tq.NewWorkerQueue(1, func(oid string) bool {
+	wq := newWorkerQueue(1, func(oid string) bool {
 		if oid == "some-oid" {
 			atomic.AddUint32(&called, 1)
 		}
@@ -31,7 +30,7 @@ func TestWorkerQueueProcessesBatchedItems(t *testing.T) {
 func TestWorkerQueueReturnsRetriedItems(t *testing.T) {
 	retried := make(map[string]bool)
 
-	wq := tq.NewWorkerQueue(1, func(oid string) bool {
+	wq := newWorkerQueue(1, func(oid string) bool {
 		retried[oid] = false
 
 		return false
@@ -67,7 +66,7 @@ func TestWorkerQueueDistributesItemsAcrossManyWorkers(t *testing.T) {
 	wg := new(sync.WaitGroup)
 	wg.Add(2)
 
-	wq := tq.NewWorkerQueue(2, func(oid string) bool {
+	wq := newWorkerQueue(2, func(oid string) bool {
 		wg.Done()
 		wg.Wait()
 


### PR DESCRIPTION
This pull-request implements the `*tq.WorkerQueue` type, responsible for distributing work among an available set of workers.

## What

Functionally, this type is very similar to the existing [`*transfer.adapterBase`][1] type, but I chose to re-implement in this new package for a few reasons:

1. **Model of execution**. This implementation has slightly different conditions for deciding when workers are available, and when new work can be assigned to the queue. Since this is an "all or nothing" scenario, where these execution changes have to be implemented atomically, I figured it'd be easier to start with something similar and port over functionality as necessary.
2. **New package**. This is going in a new package, `tq`, so at the very least I'd be duplicating the `transfer.adapterBase` type as `tq.adapterBase` and making changes there. I figure there won't be a huge difference in time spent whether I port over functionality up front or as needed. My immediate next step is going to be to make the existing interface and functionality from the `transfer` package work in the new `tq` package, so we should know pretty soon whether or not there are major flaws.

## How

This `*tq.WorkerQueue` has design invariants that make it easy to satisfy our goals for new work done in the `*tq.TransferQueue`. One of those goals is prioritizing retries to happen immediately to avoid a large amount of buffering, and in order for that to happen, we need to know about retries as soon as possible. 

This queue reports "failed" items that need to be retried through the retry channel that it returns in response to an `Add()` call:

```go
func (q *WorkerQueue) Add(batch []string) (retries <-chan string) { ... }
```

Callers of this method (namely, the `*tq.TransferQueue`) can read items from this channel until it closes and prioritize those items in the next batch of items. In fact, this is exactly what the new transfer queue will do, in a pull-request that I'll push shortly.

One downside of this method is that we have to wait for work to _completely_ finish in a batch before accumulating the next one. Right now, I'm not convinced that this is yet a showstopper, but just something that we need to keep our 👀  on. Implementing this new transfer queue in a new package will allow us to have clear boundaries of functional types that we can change in isolation should this behavior become prohibitive to operation. 

## Misc

Following @sinbad's lead, I've based this PR off of `tq-master`, the de-facto "master" branch for the transfer queue refactorings. This means I can avoid the nasty PR chain that was the filter-process project, while still making these fairly short/easy to review.

Once the project is done, we'll fast-forward master to include all the changes from `tq-master`.

---

/cc @git-lfs/core  

[1]: https://github.com/git-lfs/git-lfs/blob/7ffac54d7662d0ca3f919ec68d481d604970cea7/transfer/adapterbase.go