### PR TITLE
tq: implement `*tq.Queue` type

### DIFF
--- a/tq/queue.go
+++ b/tq/queue.go
@@ -1,0 +1,115 @@
+package tq
+
+import "sync"
+
+// Queue organizes and distributes work on OIDs against a set of available
+// workers (represented by a *workerQueue). Any failed items returned back by
+// that `*workerQueue` will be prioritized into the next batch.
+type Queue struct {
+	// incoming serves as the barrier between new calls to `Add()` and
+	// accumulating the next batch of items to be sent into the worker
+	// queue.
+	//
+	// incoming has a finite non-zero buffer equal to the size of a batch
+	// such that one extra batch of data can be buffered before applying
+	// back-pressure to callers.
+	incoming chan string
+	// workers maintains a handle on the *workerQueue instance used to
+	// distribute batched sets of OIDs
+	workers *workerQueue
+
+	// wg holds onto the run() goroutine and latches only after the
+	// goroutine has terminated, enabling safe shutdowns.
+	wg *sync.WaitGroup
+}
+
+// New instantiates a new `*tq.Queue` type with a given batch size "size",
+// number of workers "workers", and a function to do that work, "fn".
+//
+// Once returned, the `*Queue` will be active and able to accept new writes.
+func New(size, workers int, fn WorkerFn) *Queue {
+	q := &Queue{
+		incoming: make(chan string, size),
+		workers:  newWorkerQueue(workers, fn),
+
+		wg: new(sync.WaitGroup),
+	}
+
+	q.wg.Add(1)
+	go q.run()
+
+	return q
+}
+
+// run accumulates new items into a batch for sending to the pool of available
+// workers, prioritizing retried objects over new objects.
+//
+// The function executes as follows:
+//
+//   1. Allocate a new batch of items for sending to the worker pool.
+//   2. Accept as many writes as we can before overfilling the batch from the
+//      `q.incoming` channel. If the channel closes, mark that we are closing
+//      and continue.
+//   3. Send the batch to the worker pool
+//   4. Empty the batch, begin re-filling it with items from the retry channel
+//      until the channel is closed.
+//   5. If closing, and the batch is empty, return.
+//   6. Otherwise, go to step 2.
+//
+// run runs in its own goroutine.
+func (q *Queue) run() {
+	defer q.wg.Done()
+
+	var closing bool
+
+	batch := make([]string, 0, cap(q.incoming))
+
+	for {
+		for !closing && (len(batch) < cap(q.incoming)) {
+			oid, ok := <-q.incoming
+			if !ok {
+				closing = true
+				break
+			}
+
+			batch = append(batch, oid)
+		}
+
+		retries := q.workers.Add(batch)
+		batch = make([]string, 0, cap(q.incoming))
+
+		for retry := range retries {
+			batch = append(batch, retry)
+		}
+
+		if closing && len(batch) == 0 {
+			return
+		}
+	}
+}
+
+// Add enqueues a new item for entry into the next available batch of items. If
+// the batch is already full and one more full batch's worth of items has been
+// Add()-ed already, this function will block.
+//
+// Add cannot be called after the `*Queue` has been marked as `Wait()`-ing.
+func (q *Queue) Add(oid string) {
+	// TODO(taylor): potentially store whether or not we're closing and
+	// check that before writing to a closed channel? Not sure what to do
+	// with that "oid" though... drop it? Return an error? Panic? All seem
+	// uniquely bad...
+
+	q.incoming <- oid
+}
+
+// Wait marks the queue for shutting down. After calling this function, the
+// queue will process all queued new items after processing all of the retried
+// items.
+//
+// Once the queue is marked as closing and a single empty batch is detected, the
+// queue will be shut down completely, and this function will return.
+func (q *Queue) Wait() {
+	close(q.incoming)
+
+	q.wg.Wait()
+}

--- a/tq/queue.go
+++ b/tq/queue.go
@@ -133,13 +133,9 @@ func (q *Queue) run() {
 // the batch is already full and one more full batch's worth of items has been
 // Add()-ed already, this function will block.
 //
-// Add cannot be called after the `*Queue` has been marked as `Wait()`-ing.
+// Add cannot be called after the `*Queue` has been marked as `Wait()`-ing,
+// otherwise the function will panic.
 func (q *Queue) Add(oid string) {
-	// TODO(taylor): potentially store whether or not we're closing and
-	// check that before writing to a closed channel? Not sure what to do
-	// with that "oid" though... drop it? Return an error? Panic? All seem
-	// uniquely bad...
-
 	q.incoming <- oid
 }
 

--- a/tq/queue_test.go
+++ b/tq/queue_test.go
@@ -12,7 +12,7 @@ import (
 func TestQueueProcessesNewItems(t *testing.T) {
 	var seen uint32
 
-	q := tq.New(1, 1, func(oid string) bool {
+	q := tq.New(1, func(oid string) bool {
 		if oid == "some-oid" {
 			atomic.AddUint32(&seen, 1)
 		}
@@ -29,7 +29,7 @@ func TestQueueProcessesNewItems(t *testing.T) {
 func TestQueueRetriesFailedItems(t *testing.T) {
 	var seen uint32
 
-	q := tq.New(1, 1, func(oid string) bool {
+	q := tq.New(1, func(oid string) bool {
 		if oid == "some-oid" {
 			atomic.AddUint32(&seen, 1)
 		}
@@ -47,14 +47,14 @@ func TestQueueProcessesRetriedItemsBeforeNewItems(t *testing.T) {
 	var order []string
 	var retries uint32
 
-	q := tq.New(3, 1, func(oid string) bool {
+	q := tq.New(1, func(oid string) bool {
 		order = append(order, oid)
 
 		if strings.HasSuffix(oid, "retry") {
 			return atomic.AddUint32(&retries, 1) > 3
 		}
 		return true
-	})
+	}, tq.WithBatchSize(3), tq.WithBufferDepth(4))
 
 	q.Add("first-retry")
 	q.Add("second-retry")

--- a/tq/queue_test.go
+++ b/tq/queue_test.go
@@ -1,0 +1,71 @@
+package tq_test
+
+import (
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/git-lfs/git-lfs/tq"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQueueProcessesNewItems(t *testing.T) {
+	var seen uint32
+
+	q := tq.New(1, 1, func(oid string) bool {
+		if oid == "some-oid" {
+			atomic.AddUint32(&seen, 1)
+		}
+
+		return true
+	})
+
+	q.Add("some-oid")
+	q.Wait()
+
+	assert.EqualValues(t, 1, seen)
+}
+
+func TestQueueRetriesFailedItems(t *testing.T) {
+	var seen uint32
+
+	q := tq.New(1, 1, func(oid string) bool {
+		if oid == "some-oid" {
+			atomic.AddUint32(&seen, 1)
+		}
+
+		return atomic.LoadUint32(&seen) == 2
+	})
+
+	q.Add("some-oid")
+	q.Wait()
+
+	assert.EqualValues(t, 2, seen)
+}
+
+func TestQueueProcessesRetriedItemsBeforeNewItems(t *testing.T) {
+	var order []string
+	var retries uint32
+
+	q := tq.New(3, 1, func(oid string) bool {
+		order = append(order, oid)
+
+		if strings.HasSuffix(oid, "retry") {
+			return atomic.AddUint32(&retries, 1) > 3
+		}
+		return true
+	})
+
+	q.Add("first-retry")
+	q.Add("second-retry")
+	q.Add("third-retry")
+	q.Add("fourth-oid")
+
+	q.Wait()
+
+	assert.Equal(t, []string{
+		"first-retry", "second-retry", "third-retry",
+		"first-retry", "second-retry", "third-retry",
+		"fourth-oid",
+	}, order)
+}


### PR DESCRIPTION
~~⚠️  this PR is based against the [`tq-worker-queue`][1] tree to make the diff easier to view. Once [that PR][2] is merged into `tq-master`, I'll update the base of this to point at `tq-master` as well.~~

---

This pull-request implements a type similar to `*lfs.TransferQueue` as `*tq.Queue`. This type serves as a conduit between a stream of OIDs (i.e., the `*lfs.gitscanner`) and a pool of available workers (represented by the `*tq.WorkerQueue`). 

Though the public API between `*tq.Queue` and `*tq.WorkerQueue` is similar (both have `Add(oid string)` and `Wait()` funcs), their underlying purpose is different. While the `*tq.WorkerQueue` is responsible for distributing work and reporting failures, the `*tq.Queue` is responsible for batching units of work and including retries back into that batch _before_ new items.

Couple of neat things going on:

1. **Buffered channels**: One thing we can do to make sure batches are more readily available is wait until we have one _extra_ batch's worth of data buffered before applying back-pressure to the caller. This is done through channels alone by [buffering the incoming channel][3] to the desired size of a batch so that 
2. **Priority retries**: By waiting for a batch to complete, we can process retried items into the batch first before accepting new writes. That means that even if _all_ of the items fail in a batch, we can just skip reading new items, and immediately kick off that batch in the next iteration of the loop, since it'll already be full by that time.

Couple of things to consider:

1. As noted in #1742, we _have_ to wait for one batch to completely finish processing before sending off items for the next batch into the worker pool. I don't think this will be a huge deal, unless we have batches of _drastically_ different sizes (i.e., 99 objects <5MB, and a single 2GB object). I think there are a few things we can do to handle this better:
   - One thing we can do is kick off multiple batches and check retries before we send the batch off, pushing back new items in favor of retried ones.
   - Another thing we could do is sort the batches by size of item, prioritizing larger items first, so we have less of a chance of having to wait on them at the end. This could be interesting, and would also be fairly easy to implement.
2. Should we address [this][4] comment and do something meaningful if a caller tries to call `Add()` after `Wait()`-ing? Currently, the function will panic after trying to send on the now-closed `q.incoming` channel. I figure we could store the state in an `atomic`-managed `uint32`, but I'm not sure about what we can do when we _are_ closing and will reject the write other than log it and drop the OID on the floor. That may be good enough, but I'd love to hear your thoughts on this.

---

/cc @git-lfs/core 

[1]: https://github.com/git-lfs/git-lfs/tree/tq-worker-queue
[2]: https://github.com/git-lfs/git-lfs/pull/1742
[3]: https://github.com/git-lfs/git-lfs/pull/1744/commits/24fc67f8554573d74cbadbe594b71965234c1765#diff-aa8152c7da8b9e591de386d91ba55952R32
[4]: https://github.com/git-lfs/git-lfs/pull/1744/commits/24fc67f8554573d74cbadbe594b71965234c1765#diff-aa8152c7da8b9e591de386d91ba55952R97