### PR TITLE
Teach gitscanner how to filter in ScanTree()

### DIFF
--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -38,7 +38,7 @@ func checkoutCommand(cmd *cobra.Command, args []string) {
 	checkoutWithIncludeExclude(filter)
 }
 
-func checkoutFromFetchChan(in chan *lfs.WrappedPointer) {
+func checkoutFromFetchChan(in chan *lfs.WrappedPointer, filter *filepathfilter.Filter) {
 	ref, err := git.CurrentRef()
 	if err != nil {
 		Panic(err, "Could not checkout")
@@ -54,6 +54,7 @@ func checkoutFromFetchChan(in chan *lfs.WrappedPointer) {
 		}
 		mapping[p.Oid] = append(mapping[p.Oid], p)
 	})
+	chgitscanner.Filter = filter
 
 	if err := chgitscanner.ScanTree(ref.Sha, nil); err != nil {
 		ExitWithError(err)

--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/git-lfs/git-lfs/lfs"
 	"github.com/git-lfs/git-lfs/localstorage"
 	"github.com/git-lfs/git-lfs/subprocess"
 
@@ -71,13 +70,11 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 
 	includeArg, excludeArg := getIncludeExcludeArgs(cmd)
 	filter := buildFilepathFilter(cfg, includeArg, excludeArg)
-	gitscanner := lfs.NewGitScanner(nil)
-	defer gitscanner.Close()
 	if cloneFlags.NoCheckout || cloneFlags.Bare {
 		// If --no-checkout or --bare then we shouldn't check out, just fetch instead
-		fetchRef(gitscanner, "HEAD", filter)
+		fetchRef("HEAD", filter)
 	} else {
-		pull(gitscanner, filter)
+		pull(filter)
 		err := postCloneSubmodules(args)
 		if err != nil {
 			Exit("Error performing 'git lfs pull' for submodules: %v", err)

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/git-lfs/git-lfs/filepathfilter"
 	"github.com/git-lfs/git-lfs/git"
-	"github.com/git-lfs/git-lfs/lfs"
 	"github.com/spf13/cobra"
 )
 
@@ -30,19 +29,17 @@ func pullCommand(cmd *cobra.Command, args []string) {
 
 	includeArg, excludeArg := getIncludeExcludeArgs(cmd)
 	filter := buildFilepathFilter(cfg, includeArg, excludeArg)
-	gitscanner := lfs.NewGitScanner(nil)
-	defer gitscanner.Close()
-	pull(gitscanner, filter)
+	pull(filter)
 }
 
-func pull(gitscanner *lfs.GitScanner, filter *filepathfilter.Filter) {
+func pull(filter *filepathfilter.Filter) {
 	ref, err := git.CurrentRef()
 	if err != nil {
 		Panic(err, "Could not pull")
 	}
 
-	c := fetchRefToChan(gitscanner, ref.Sha, filter)
-	checkoutFromFetchChan(gitscanner, filter, c)
+	c := fetchRefToChan(ref.Sha, filter)
+	checkoutFromFetchChan(c)
 }
 
 func init() {

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -39,7 +39,7 @@ func pull(filter *filepathfilter.Filter) {
 	}
 
 	c := fetchRefToChan(ref.Sha, filter)
-	checkoutFromFetchChan(c)
+	checkoutFromFetchChan(c, filter)
 }
 
 func init() {

--- a/lfs/gitscanner.go
+++ b/lfs/gitscanner.go
@@ -137,7 +137,7 @@ func (s *GitScanner) ScanTree(ref string, cb GitScannerCallback) error {
 	if err != nil {
 		return err
 	}
-	return runScanTree(callback, ref)
+	return runScanTree(callback, ref, s.Filter)
 }
 
 // ScanUnpushed scans history for all LFS pointers which have been added but not

--- a/test/test-clone.sh
+++ b/test/test-clone.sh
@@ -240,16 +240,20 @@ begin_test "clone (with include/exclude args)"
   contents_a="a"
   contents_a_oid=$(calc_oid "$contents_a")
   printf "$contents_a" > "a.dat"
+  printf "$contents_a" > "a-dupe.dat"
+  printf "$contents_a" > "dupe-a.dat"
 
   contents_b="b"
   contents_b_oid=$(calc_oid "$contents_b")
   printf "$contents_b" > "b.dat"
 
-  git add a.dat b.dat .gitattributes
+  git add *.dat .gitattributes
   git commit -m "add a.dat, b.dat" 2>&1 | tee commit.log
   grep "master (root-commit)" commit.log
-  grep "3 files changed" commit.log
+  grep "5 files changed" commit.log
   grep "create mode 100644 a.dat" commit.log
+  grep "create mode 100644 a-dupe.dat" commit.log
+  grep "create mode 100644 dupe-a.dat" commit.log
   grep "create mode 100644 b.dat" commit.log
   grep "create mode 100644 .gitattributes" commit.log
 
@@ -260,11 +264,13 @@ begin_test "clone (with include/exclude args)"
   cd "$TRASHDIR"
 
   local_reponame="clone_with_includes"
-  git lfs clone "$GITSERVER/$reponame" "$local_reponame" -I "a.dat"
+  git lfs clone "$GITSERVER/$reponame" "$local_reponame" -I "a*.dat"
   pushd "$local_reponame"
   assert_local_object "$contents_a_oid" 1
   refute_local_object "$contents_b_oid"
   [ "a" = "$(cat a.dat)" ]
+  [ "a" = "$(cat a-dupe.dat)" ]
+  [ "$(pointer $contents_a_oid 1)" = "$(cat dupe-a.dat)" ]
   [ "$(pointer $contents_b_oid 1)" = "$(cat b.dat)" ]
   popd
 

--- a/test/test-clone.sh
+++ b/test/test-clone.sh
@@ -55,9 +55,9 @@ begin_test "clone"
 
   # check a few file sizes to make sure pulled
   pushd "$newclonedir"
-  [ $(wc -c < "file1.dat") -eq 110 ] 
-  [ $(wc -c < "file2.dat") -eq 75 ] 
-  [ $(wc -c < "file3.dat") -eq 66 ] 
+  [ $(wc -c < "file1.dat") -eq 110 ]
+  [ $(wc -c < "file2.dat") -eq 75 ]
+  [ $(wc -c < "file3.dat") -eq 66 ]
   [ ! -e "lfs" ]
   popd
   # Now check clone with implied dir
@@ -71,9 +71,9 @@ begin_test "clone"
   # clone location should be implied
   [ -d "$reponame" ]
   pushd "$reponame"
-  [ $(wc -c < "file1.dat") -eq 110 ] 
-  [ $(wc -c < "file2.dat") -eq 75 ] 
-  [ $(wc -c < "file3.dat") -eq 66 ] 
+  [ $(wc -c < "file1.dat") -eq 110 ]
+  [ $(wc -c < "file2.dat") -eq 75 ]
+  [ $(wc -c < "file3.dat") -eq 66 ]
   [ ! -e "lfs" ]
   popd
 
@@ -127,9 +127,9 @@ begin_test "cloneSSL"
 
   # check a few file sizes to make sure pulled
   pushd "$newclonedir"
-  [ $(wc -c < "file1.dat") -eq 100 ] 
-  [ $(wc -c < "file2.dat") -eq 75 ] 
-  [ $(wc -c < "file3.dat") -eq 30 ] 
+  [ $(wc -c < "file1.dat") -eq 100 ]
+  [ $(wc -c < "file2.dat") -eq 75 ]
+  [ $(wc -c < "file3.dat") -eq 30 ]
   popd
 
 
@@ -162,7 +162,7 @@ begin_test "clone with flags"
   },
   {
     \"CommitDate\":\"$(get_date -7d)\",
-    \"NewBranch\":\"branch2\",    
+    \"NewBranch\":\"branch2\",
     \"Files\":[
       {\"Filename\":\"fileonbranch2.dat\",\"Size\":66}]
   },
@@ -217,7 +217,7 @@ begin_test "clone with flags"
 
   # specific test for --bare
   git lfs clone --bare "$GITSERVER/$reponame" "$newclonedir"
-  [ -d "$newclonedir/objects" ]  
+  [ -d "$newclonedir/objects" ]
 
   # short flags
   git lfs clone -l -v -n -s -b branch2 "$GITSERVER/$reponame" "$newclonedir"
@@ -264,6 +264,8 @@ begin_test "clone (with include/exclude args)"
   pushd "$local_reponame"
   assert_local_object "$contents_a_oid" 1
   refute_local_object "$contents_b_oid"
+  [ "a" = "$(cat a.dat)" ]
+  [ "$(pointer $contents_b_oid 1)" = "$(cat b.dat)" ]
   popd
 
   local_reponame="clone_with_excludes"
@@ -271,6 +273,8 @@ begin_test "clone (with include/exclude args)"
   pushd "$local_reponame"
   assert_local_object "$contents_b_oid" 1
   refute_local_object "$contents_a_oid"
+  [ "$(pointer $contents_a_oid 1)" = "$(cat a.dat)" ]
+  [ "b" = "$(cat b.dat)" ]
   popd
 )
 end_test
@@ -387,7 +391,7 @@ begin_test "clone with submodules"
   contents_sub2="Inception. Now, before you bother telling me it's impossible..."
   contents_sub2_oid=$(calc_oid "$contents_sub2")
   printf "$contents_sub2" > "sub2.dat"
-  git add sub2.dat .gitattributes 
+  git add sub2.dat .gitattributes
   git commit -m "Nested submodule level 2"
   git push origin master
 
@@ -402,7 +406,7 @@ begin_test "clone with submodules"
   # add submodule2 as submodule of submodule1
   git submodule add "$GITSERVER/$submodname2" sub2
   git submodule update
-  git add sub2 sub1.dat .gitattributes 
+  git add sub2 sub1.dat .gitattributes
   git commit -m "Nested submodule level 1"
   git push origin master
 
@@ -417,7 +421,7 @@ begin_test "clone with submodules"
   # add submodule1 as submodule of root
   git submodule add "$GITSERVER/$submodname1" sub1
   git submodule update
-  git add sub1 root.dat .gitattributes 
+  git add sub1 root.dat .gitattributes
   git commit -m "Root repo"
   git push origin master
 
@@ -430,14 +434,14 @@ begin_test "clone with submodules"
   cd $local_reponame
   # check LFS store and working copy
   assert_local_object "$contents_root_oid" "${#contents_root}"
-  [ $(wc -c < "root.dat") -eq ${#contents_root} ] 
+  [ $(wc -c < "root.dat") -eq ${#contents_root} ]
   # and so on for nested subs
   cd sub1
   assert_local_object "$contents_sub1_oid" "${#contents_sub1}"
-  [ $(wc -c < "sub1.dat") -eq ${#contents_sub1} ] 
+  [ $(wc -c < "sub1.dat") -eq ${#contents_sub1} ]
   cd sub2
   assert_local_object "$contents_sub2_oid" "${#contents_sub2}"
-  [ $(wc -c < "sub2.dat") -eq ${#contents_sub2} ] 
+  [ $(wc -c < "sub2.dat") -eq ${#contents_sub2} ]
 
 
   popd


### PR DESCRIPTION
This removes the inline filepathfilter checking from the `commands`, relying on the gitscanner to do it. 