### PR TITLE
test: suppress cURL progress when shutting down the test server

### DIFF
--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -360,7 +360,7 @@ shutdown() {
     # only cleanup test/remote after script/integration done OR a single
     # test/test-*.sh file is run manually.
     if [ -s "$LFS_URL_FILE" ]; then
-      curl "$(cat "$LFS_URL_FILE")/shutdown"
+      curl -s "$(cat "$LFS_URL_FILE")/shutdown"
     fi
 
     [ -z "$KEEPTRASH" ] && rm -rf "$REMOTEDIR"


### PR DESCRIPTION
This pull-request suppresses the progress output that cURL generates at the end of running the integration suite, which can get rather annoying :-).

I intentionally didn't apply the `-s` flag to other `curl` invocations in the `testhelpers` file, since I think that output is useful when going through failure logs.

---

/cc @git-lfs/core 