### PR TITLE
Implement local lock cache, support querying it

### DIFF
--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -37,12 +37,12 @@ func lockCommand(cmd *cobra.Command, args []string) {
 		Exit("Unable to create lock system: %v", err.Error())
 	}
 	defer lockClient.Close()
-	id, err := lockClient.LockFile(path)
+	lock, err := lockClient.LockFile(path)
 	if err != nil {
 		Exit("Lock failed: %v", err)
 	}
 
-	Print("\n'%s' was locked (%s)", args[0], id)
+	Print("\n'%s' was locked (%s)", args[0], lock.Id)
 }
 
 // lockPaths relativizes the given filepath such that it is relative to the root

--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -36,6 +36,7 @@ func lockCommand(cmd *cobra.Command, args []string) {
 	if err != nil {
 		Exit("Unable to create lock system: %v", err.Error())
 	}
+	defer lockClient.Close()
 	id, err := lockClient.LockFile(path)
 	if err != nil {
 		Exit("Lock failed: %v", err)

--- a/commands/command_locks.go
+++ b/commands/command_locks.go
@@ -25,7 +25,7 @@ func locksCommand(cmd *cobra.Command, args []string) {
 	}
 	defer lockClient.Close()
 	var lockCount int
-	locks, err := lockClient.SearchLocks(filters, locksCmdFlags.Limit)
+	locks, err := lockClient.SearchLocks(filters, locksCmdFlags.Limit, locksCmdFlags.Local)
 	// Print any we got before exiting
 	for _, lock := range locks {
 		Print("%s\t%s <%s>", lock.Path, lock.Name, lock.Email)
@@ -51,6 +51,9 @@ type locksFlags struct {
 	// limit is an optional request parameter sent to the server used to
 	// limit the
 	Limit int
+	// local limits the scope of lock reporting to the locally cached record
+	// of locks for the current user & doesn't query the server
+	Local bool
 }
 
 // Filters produces a filter based on locksFlags instance.
@@ -82,5 +85,6 @@ func init() {
 		cmd.Flags().StringVarP(&locksCmdFlags.Path, "path", "p", "", "filter locks results matching a particular path")
 		cmd.Flags().StringVarP(&locksCmdFlags.Id, "id", "i", "", "filter locks results matching a particular ID")
 		cmd.Flags().IntVarP(&locksCmdFlags.Limit, "limit", "l", 0, "optional limit for number of results to return")
+		cmd.Flags().BoolVarP(&locksCmdFlags.Local, "local", "", false, "only list cached local record of own locks")
 	})
 }

--- a/commands/command_locks.go
+++ b/commands/command_locks.go
@@ -23,6 +23,7 @@ func locksCommand(cmd *cobra.Command, args []string) {
 	if err != nil {
 		Exit("Unable to create lock system: %v", err.Error())
 	}
+	defer lockClient.Close()
 	var lockCount int
 	locks, err := lockClient.SearchLocks(filters, locksCmdFlags.Limit)
 	// Print any we got before exiting

--- a/commands/command_unlock.go
+++ b/commands/command_unlock.go
@@ -30,6 +30,7 @@ func unlockCommand(cmd *cobra.Command, args []string) {
 	if err != nil {
 		Exit("Unable to create lock system: %v", err.Error())
 	}
+	defer lockClient.Close()
 	if len(args) != 0 {
 		path, err := lockPath(args[0])
 		if err != nil {

--- a/locking/cache.go
+++ b/locking/cache.go
@@ -44,7 +44,7 @@ func (c *LockCache) isIdKey(key string) bool {
 }
 
 // Cache a successful lock for faster local lookup later
-func (c *LockCache) CacheLock(l Lock) error {
+func (c *LockCache) Add(l Lock) error {
 	// Store reference in both directions
 	// Path -> Lock
 	c.kv.Set(l.Path, &l)
@@ -54,7 +54,7 @@ func (c *LockCache) CacheLock(l Lock) error {
 }
 
 // Remove a cached lock by path becuase it's been relinquished
-func (c *LockCache) CacheUnlockByPath(filePath string) error {
+func (c *LockCache) RemoveByPath(filePath string) error {
 	ilock := c.kv.Get(filePath)
 	if lock, ok := ilock.(*Lock); ok && lock != nil {
 		c.kv.Remove(lock.Path)
@@ -65,7 +65,7 @@ func (c *LockCache) CacheUnlockByPath(filePath string) error {
 }
 
 // Remove a cached lock by id because it's been relinquished
-func (c *LockCache) CacheUnlockById(id string) error {
+func (c *LockCache) RemoveById(id string) error {
 	// Id as key is encoded
 	idkey := c.encodeIdKey(id)
 	ilock := c.kv.Get(idkey)
@@ -77,7 +77,7 @@ func (c *LockCache) CacheUnlockById(id string) error {
 }
 
 // Get the list of cached locked files
-func (c *LockCache) CachedLocks() []Lock {
+func (c *LockCache) Locks() []Lock {
 	var locks []Lock
 	c.kv.Visit(func(key string, val interface{}) bool {
 		// Only report file->id entries not reverse

--- a/locking/cache.go
+++ b/locking/cache.go
@@ -56,8 +56,7 @@ func (c *LockCache) CacheLock(l Lock) error {
 // Remove a cached lock by path becuase it's been relinquished
 func (c *LockCache) CacheUnlockByPath(filePath string) error {
 	ilock := c.kv.Get(filePath)
-	if ilock != nil {
-		lock := ilock.(*Lock)
+	if lock, ok := ilock.(*Lock); ok && lock != nil {
 		c.kv.Remove(lock.Path)
 		// Id as key is encoded
 		c.kv.Remove(c.encodeIdKey(lock.Id))
@@ -70,8 +69,7 @@ func (c *LockCache) CacheUnlockById(id string) error {
 	// Id as key is encoded
 	idkey := c.encodeIdKey(id)
 	ilock := c.kv.Get(idkey)
-	if ilock != nil {
-		lock := ilock.(*Lock)
+	if lock, ok := ilock.(*Lock); ok && lock != nil {
 		c.kv.Remove(idkey)
 		c.kv.Remove(lock.Path)
 	}

--- a/locking/cache.go
+++ b/locking/cache.go
@@ -1,0 +1,103 @@
+package locking
+
+import (
+	"strings"
+
+	"github.com/git-lfs/git-lfs/tools/kv"
+)
+
+const (
+	// We want to use a single cache file for integrity, but to make it easy to
+	// list all locks, prefix the id->path map in a way we can identify (something
+	// that won't be in a path)
+	idKeyPrefix string = "*id*://"
+)
+
+type LockCache struct {
+	kv *kv.Store
+}
+
+func NewLockCache(filepath string) (*LockCache, error) {
+	kv, err := kv.NewStore(filepath)
+	if err != nil {
+		return nil, err
+	}
+	return &LockCache{kv}, nil
+}
+
+func (c *LockCache) encodeIdKey(id string) string {
+	// Safety against accidents
+	if !c.isIdKey(id) {
+		return idKeyPrefix + id
+	}
+	return id
+}
+func (c *LockCache) decodeIdKey(key string) string {
+	// Safety against accidents
+	if c.isIdKey(key) {
+		return key[len(idKeyPrefix):]
+	}
+	return key
+}
+func (c *LockCache) isIdKey(key string) bool {
+	return strings.HasPrefix(key, idKeyPrefix)
+}
+
+// Cache a successful lock for faster local lookup later
+func (c *LockCache) CacheLock(l Lock) error {
+	// Store reference in both directions
+	// Path -> Lock
+	c.kv.Set(l.Path, &l)
+	// EncodedId -> Lock (encoded so we can easily identify)
+	c.kv.Set(c.encodeIdKey(l.Id), &l)
+	return nil
+}
+
+// Remove a cached lock by path becuase it's been relinquished
+func (c *LockCache) CacheUnlockByPath(filePath string) error {
+	ilock := c.kv.Get(filePath)
+	if ilock != nil {
+		lock := ilock.(*Lock)
+		c.kv.Remove(lock.Path)
+		// Id as key is encoded
+		c.kv.Remove(c.encodeIdKey(lock.Id))
+	}
+	return nil
+}
+
+// Remove a cached lock by id because it's been relinquished
+func (c *LockCache) CacheUnlockById(id string) error {
+	// Id as key is encoded
+	idkey := c.encodeIdKey(id)
+	ilock := c.kv.Get(idkey)
+	if ilock != nil {
+		lock := ilock.(*Lock)
+		c.kv.Remove(idkey)
+		c.kv.Remove(lock.Path)
+	}
+	return nil
+}
+
+// Get the list of cached locked files
+func (c *LockCache) CachedLocks() []Lock {
+	var locks []Lock
+	c.kv.Visit(func(key string, val interface{}) bool {
+		// Only report file->id entries not reverse
+		if !c.isIdKey(key) {
+			lock := val.(*Lock)
+			locks = append(locks, *lock)
+		}
+		return true // continue
+	})
+	return locks
+}
+
+// Clear the cache
+func (c *LockCache) Clear() {
+	c.kv.RemoveAll()
+}
+
+// Save the cache
+func (c *LockCache) Save() error {
+	return c.kv.Save()
+}

--- a/locking/cache_test.go
+++ b/locking/cache_test.go
@@ -1,0 +1,61 @@
+package locking
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLockCache(t *testing.T) {
+	var err error
+
+	tmpf, err := ioutil.TempFile("", "testCacheLock")
+	assert.Nil(t, err)
+	defer func() {
+		os.Remove(tmpf.Name())
+	}()
+	tmpf.Close()
+
+	cache, err := NewLockCache(tmpf.Name())
+	assert.Nil(t, err)
+
+	testLocks := []Lock{
+		Lock{Path: "folder/test1.dat", Id: "101"},
+		Lock{Path: "folder/test2.dat", Id: "102"},
+		Lock{Path: "root.dat", Id: "103"},
+	}
+
+	for _, l := range testLocks {
+		err = cache.CacheLock(l)
+		assert.Nil(t, err)
+	}
+
+	locks := cache.CachedLocks()
+	for _, l := range testLocks {
+		assert.Contains(t, locks, l)
+	}
+	assert.Equal(t, len(testLocks), len(locks))
+
+	err = cache.CacheUnlockByPath("folder/test2.dat")
+	assert.Nil(t, err)
+
+	locks = cache.CachedLocks()
+	// delete item 1 from test locls
+	testLocks = append(testLocks[:1], testLocks[2:]...)
+	for _, l := range testLocks {
+		assert.Contains(t, locks, l)
+	}
+	assert.Equal(t, len(testLocks), len(locks))
+
+	err = cache.CacheUnlockById("101")
+	assert.Nil(t, err)
+
+	locks = cache.CachedLocks()
+	testLocks = testLocks[1:]
+	for _, l := range testLocks {
+		assert.Contains(t, locks, l)
+	}
+	assert.Equal(t, len(testLocks), len(locks))
+}

--- a/locking/cache_test.go
+++ b/locking/cache_test.go
@@ -28,20 +28,20 @@ func TestLockCache(t *testing.T) {
 	}
 
 	for _, l := range testLocks {
-		err = cache.CacheLock(l)
+		err = cache.Add(l)
 		assert.Nil(t, err)
 	}
 
-	locks := cache.CachedLocks()
+	locks := cache.Locks()
 	for _, l := range testLocks {
 		assert.Contains(t, locks, l)
 	}
 	assert.Equal(t, len(testLocks), len(locks))
 
-	err = cache.CacheUnlockByPath("folder/test2.dat")
+	err = cache.RemoveByPath("folder/test2.dat")
 	assert.Nil(t, err)
 
-	locks = cache.CachedLocks()
+	locks = cache.Locks()
 	// delete item 1 from test locls
 	testLocks = append(testLocks[:1], testLocks[2:]...)
 	for _, l := range testLocks {
@@ -49,10 +49,10 @@ func TestLockCache(t *testing.T) {
 	}
 	assert.Equal(t, len(testLocks), len(locks))
 
-	err = cache.CacheUnlockById("101")
+	err = cache.RemoveById("101")
 	assert.Nil(t, err)
 
-	locks = cache.CachedLocks()
+	locks = cache.Locks()
 	testLocks = testLocks[1:]
 	for _, l := range testLocks {
 		assert.Contains(t, locks, l)

--- a/locking/locks.go
+++ b/locking/locks.go
@@ -250,7 +250,7 @@ func (c *Client) lockIdFromPath(path string) (string, error) {
 
 // Fetch locked files for the current committer and cache them locally
 // This can be used to sync up locked files when moving machines
-func (c *Client) fetchLocksToCache() error {
+func (c *Client) refreshLockCache() error {
 	// TODO: filters don't seem to currently define how to search for a
 	// committer's email. Is it "committer.email"? For now, just iterate
 	locks, err := c.SearchLocks(nil, 0, false)

--- a/locking/locks.go
+++ b/locking/locks.go
@@ -30,6 +30,8 @@ type Client struct {
 }
 
 // NewClient creates a new locking client with the given configuration
+// You must call the returned object's `Close` method when you are finished with
+// it
 func NewClient(cfg *config.Configuration) (*Client, error) {
 
 	apiClient := api.NewClient(api.NewHttpLifecycle(cfg))
@@ -45,6 +47,11 @@ func NewClient(cfg *config.Configuration) (*Client, error) {
 		return nil, err
 	}
 	return &Client{cfg, apiClient, store}, nil
+}
+
+// Close this client instance; must be called to dispose of resources
+func (c *Client) Close() error {
+	return c.cache.Save()
 }
 
 // LockFile attempts to lock a file on the current remote

--- a/locking/locks.go
+++ b/locking/locks.go
@@ -178,12 +178,12 @@ func (c *Client) SearchLocks(filter map[string]string, limit int, localOnly bool
 }
 
 func (c *Client) searchCachedLocks(filter map[string]string, limit int) ([]Lock, error) {
-	locks := c.cachedLocks()
+	cachedlocks := c.cachedLocks()
 	path, filterByPath := filter["path"]
 	id, filterById := filter["id"]
 	lockCount := 0
-
-	for _, l := range locks {
+	locks := make([]Lock, 0, len(cachedlocks))
+	for _, l := range cachedlocks {
 		// Manually filter by Path/Id
 		if (filterByPath && path != l.Path) ||
 			(filterById && id != l.Id) {

--- a/locking/locks.go
+++ b/locking/locks.go
@@ -124,8 +124,6 @@ func (c *Client) UnlockFileById(id string, force bool) error {
 }
 
 // Lock is a record of a locked file
-// TODO SJS: review this struct and api equivalent
-//           deliberately duplicated to make this API self-contained, could be simpler
 type Lock struct {
 	// Id is the unique identifier corresponding to this particular Lock. It
 	// must be consistent with the local copy, and the server's copy.
@@ -137,31 +135,17 @@ type Lock struct {
 	Name string
 	// Email address of the person holding this lock
 	Email string
-	// CommitSHA is the commit that this Lock was created against. It is
-	// strictly equal to the SHA of the minimum commit negotiated in order
-	// to create this lock.
-	CommitSHA string
-	// LockedAt is a required parameter that represents the instant in time
-	// that this lock was created. For most server implementations, this
-	// should be set to the instant at which the lock was initially
-	// received.
+	// LockedAt tells you when this lock was acquired.
 	LockedAt time.Time
-	// ExpiresAt is an optional parameter that represents the instant in
-	// time that the lock stopped being active. If the lock is still active,
-	// the server can either a) not send this field, or b) send the
-	// zero-value of time.Time.
-	UnlockedAt time.Time
 }
 
 func (c *Client) newLockFromApi(a api.Lock) Lock {
 	return Lock{
-		Id:         a.Id,
-		Path:       a.Path,
-		Name:       a.Committer.Name,
-		Email:      a.Committer.Email,
-		CommitSHA:  a.CommitSHA,
-		LockedAt:   a.LockedAt,
-		UnlockedAt: a.UnlockedAt,
+		Id:       a.Id,
+		Path:     a.Path,
+		Name:     a.Committer.Name,
+		Email:    a.Committer.Email,
+		LockedAt: a.LockedAt,
 	}
 }
 

--- a/locking/locks.go
+++ b/locking/locks.go
@@ -81,7 +81,7 @@ func (c *Client) LockFile(path string) (Lock, error) {
 
 	lock := c.newLockFromApi(*resp.Lock)
 
-	if err := c.cache.CacheLock(lock); err != nil {
+	if err := c.cache.Add(lock); err != nil {
 		return Lock{}, fmt.Errorf("Error caching lock information: %v", err)
 	}
 
@@ -115,7 +115,7 @@ func (c *Client) UnlockFileById(id string, force bool) error {
 		return fmt.Errorf("Server unable to unlock lock: %v", resp.Err)
 	}
 
-	if err := c.cache.CacheUnlockById(id); err != nil {
+	if err := c.cache.RemoveById(id); err != nil {
 		return fmt.Errorf("Error caching unlock information: %v", err)
 	}
 
@@ -161,7 +161,7 @@ func (c *Client) SearchLocks(filter map[string]string, limit int, localOnly bool
 }
 
 func (c *Client) searchCachedLocks(filter map[string]string, limit int) ([]Lock, error) {
-	cachedlocks := c.cache.CachedLocks()
+	cachedlocks := c.cache.Locks()
 	path, filterByPath := filter["path"]
 	id, filterById := filter["id"]
 	lockCount := 0
@@ -264,7 +264,7 @@ func (c *Client) fetchLocksToCache() error {
 	_, email := c.cfg.CurrentCommitter()
 	for _, l := range locks {
 		if l.Email == email {
-			c.cache.CacheLock(l)
+			c.cache.Add(l)
 		}
 	}
 

--- a/locking/locks_test.go
+++ b/locking/locks_test.go
@@ -1,0 +1,139 @@
+package locking
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/git-lfs/git-lfs/api"
+	"github.com/git-lfs/git-lfs/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLockCache(t *testing.T) {
+	var err error
+
+	oldStore := config.LocalGitStorageDir
+	config.LocalGitStorageDir, err = ioutil.TempDir("", "testCacheLock")
+	assert.Nil(t, err)
+	defer func() {
+		os.RemoveAll(config.LocalGitStorageDir)
+		config.LocalGitStorageDir = oldStore
+	}()
+
+	client, err := NewClient(config.NewFrom(config.Values{}))
+	assert.Nil(t, err)
+
+	testLocks := []Lock{
+		Lock{Path: "folder/test1.dat", Id: "101"},
+		Lock{Path: "folder/test2.dat", Id: "102"},
+		Lock{Path: "root.dat", Id: "103"},
+	}
+
+	for _, l := range testLocks {
+		err = client.cacheLock(l)
+		assert.Nil(t, err)
+	}
+
+	locks := client.cachedLocks()
+	for _, l := range testLocks {
+		assert.Contains(t, locks, l)
+	}
+	assert.Equal(t, len(testLocks), len(locks))
+
+	err = client.cacheUnlockByPath("folder/test2.dat")
+	assert.Nil(t, err)
+
+	locks = client.cachedLocks()
+	// delete item 1 from test locls
+	testLocks = append(testLocks[:1], testLocks[2:]...)
+	for _, l := range testLocks {
+		assert.Contains(t, locks, l)
+	}
+	assert.Equal(t, len(testLocks), len(locks))
+
+	err = client.cacheUnlockById("101")
+	assert.Nil(t, err)
+
+	locks = client.cachedLocks()
+	testLocks = testLocks[1:]
+	for _, l := range testLocks {
+		assert.Contains(t, locks, l)
+	}
+	assert.Equal(t, len(testLocks), len(locks))
+}
+
+type TestLifecycle struct {
+}
+
+func (l *TestLifecycle) Build(schema *api.RequestSchema) (*http.Request, error) {
+	return http.NewRequest("GET", "http://dummy", nil)
+}
+
+func (l *TestLifecycle) Execute(req *http.Request, into interface{}) (api.Response, error) {
+	// Return test data including other users
+	locks := api.LockList{Locks: []api.Lock{
+		api.Lock{Id: "99", Path: "folder/test3.dat", Committer: api.Committer{Name: "Alice", Email: "alice@wonderland.com"}},
+		api.Lock{Id: "101", Path: "folder/test1.dat", Committer: api.Committer{Name: "Fred", Email: "fred@bloggs.com"}},
+		api.Lock{Id: "102", Path: "folder/test2.dat", Committer: api.Committer{Name: "Fred", Email: "fred@bloggs.com"}},
+		api.Lock{Id: "103", Path: "root.dat", Committer: api.Committer{Name: "Fred", Email: "fred@bloggs.com"}},
+		api.Lock{Id: "199", Path: "other/test1.dat", Committer: api.Committer{Name: "Charles", Email: "charles@incharge.com"}},
+	}}
+	locksJson, _ := json.Marshal(locks)
+	r := &http.Response{
+		Status:     "200 OK",
+		StatusCode: 200,
+		Proto:      "HTTP/1.0",
+		Body:       ioutil.NopCloser(bytes.NewReader(locksJson)),
+	}
+	if into != nil {
+		decoder := json.NewDecoder(r.Body)
+		if err := decoder.Decode(into); err != nil {
+			return nil, err
+		}
+	}
+	return api.WrapHttpResponse(r), nil
+}
+func (l *TestLifecycle) Cleanup(resp api.Response) error {
+	return resp.Body().Close()
+}
+
+func TestRefreshCache(t *testing.T) {
+	var err error
+	oldStore := config.LocalGitStorageDir
+	config.LocalGitStorageDir, err = ioutil.TempDir("", "testCacheLock")
+	assert.Nil(t, err)
+	defer func() {
+		os.RemoveAll(config.LocalGitStorageDir)
+		config.LocalGitStorageDir = oldStore
+	}()
+
+	cfg := config.NewFrom(config.Values{
+		Git: map[string]string{"user.name": "Fred", "user.email": "fred@bloggs.com"}})
+	client, err := NewClient(cfg)
+	assert.Nil(t, err)
+	// Override api client for testing
+	client.apiClient = api.NewClient(&TestLifecycle{})
+
+	// Should start with no cached items
+	locks := client.cachedLocks()
+	assert.Empty(t, locks)
+
+	// Should load from test data, just Fred's
+	err = client.fetchLocksToCache()
+	assert.Nil(t, err)
+
+	locks = client.cachedLocks()
+	// Need to include zero time in structure for equal to work
+	zeroTime := time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC)
+	assert.Equal(t, []Lock{
+		Lock{Path: "folder/test1.dat", Id: "101", Name: "Fred", Email: "fred@bloggs.com", LockedAt: zeroTime, UnlockedAt: zeroTime},
+		Lock{Path: "folder/test2.dat", Id: "102", Name: "Fred", Email: "fred@bloggs.com", LockedAt: zeroTime, UnlockedAt: zeroTime},
+		Lock{Path: "root.dat", Id: "103", Name: "Fred", Email: "fred@bloggs.com", LockedAt: zeroTime, UnlockedAt: zeroTime},
+	}, locks)
+
+}

--- a/locking/locks_test.go
+++ b/locking/locks_test.go
@@ -131,9 +131,9 @@ func TestRefreshCache(t *testing.T) {
 	// Need to include zero time in structure for equal to work
 	zeroTime := time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC)
 	assert.Equal(t, []Lock{
-		Lock{Path: "folder/test1.dat", Id: "101", Name: "Fred", Email: "fred@bloggs.com", LockedAt: zeroTime, UnlockedAt: zeroTime},
-		Lock{Path: "folder/test2.dat", Id: "102", Name: "Fred", Email: "fred@bloggs.com", LockedAt: zeroTime, UnlockedAt: zeroTime},
-		Lock{Path: "root.dat", Id: "103", Name: "Fred", Email: "fred@bloggs.com", LockedAt: zeroTime, UnlockedAt: zeroTime},
+		Lock{Path: "folder/test1.dat", Id: "101", Name: "Fred", Email: "fred@bloggs.com", LockedAt: zeroTime},
+		Lock{Path: "folder/test2.dat", Id: "102", Name: "Fred", Email: "fred@bloggs.com", LockedAt: zeroTime},
+		Lock{Path: "root.dat", Id: "103", Name: "Fred", Email: "fred@bloggs.com", LockedAt: zeroTime},
 	}, locks)
 
 }

--- a/locking/locks_test.go
+++ b/locking/locks_test.go
@@ -79,7 +79,7 @@ func TestRefreshCache(t *testing.T) {
 	assert.Empty(t, locks)
 
 	// Should load from test data, just Fred's
-	err = client.fetchLocksToCache()
+	err = client.refreshLockCache()
 	assert.Nil(t, err)
 
 	locks, err = client.SearchLocks(nil, 0, true)

--- a/tools/kv/keyvaluestore_test.go
+++ b/tools/kv/keyvaluestore_test.go
@@ -66,6 +66,29 @@ func TestStoreSimple(t *testing.T) {
 	n = kvs2.Get("noValue")
 	assert.Nil(t, n)
 
+	// Test remove all
+	kvs2.RemoveAll()
+	s = kvs2.Get("stringVal")
+	assert.Nil(t, s)
+	i = kvs2.Get("intVal")
+	assert.Nil(t, i)
+	f = kvs2.Get("floatVal")
+	assert.Nil(t, f)
+	c = kvs2.Get("structVal")
+	assert.Nil(t, c)
+
+	err = kvs2.Save()
+	assert.Nil(t, err)
+	kvs2 = nil
+
+	// Now confirm that we can read blank & get nothing
+	kvs, err = NewStore(filename)
+	kvs.Visit(func(k string, v interface{}) bool {
+		// Should not be called
+		assert.Fail(t, "Should be no entries")
+		return true
+	})
+
 }
 
 func TestStoreOptimisticConflict(t *testing.T) {


### PR DESCRIPTION
The next incremental rewrite of the locking work; this time we're using our key value store to locally cache locks for the current user for more efficient access. This will be used in the next PR to provide efficient support for marking files read-only on checkout if not locked.

Also adds some minor API improvements such as returning a full `Lock` structure on acquiring a lock rather than just an Id.