### PR TITLE
Teach tq.Manifest about tq.Environment interface

### DIFF
--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -291,7 +291,10 @@ func fetchAndReportToChan(allpointers []*lfs.WrappedPointer, filter *filepathfil
 	}
 
 	ready, pointers, meter := readyAndMissingPointers(allpointers, filter)
-	q := lfs.NewDownloadQueue(tq.WithProgress(meter))
+	q := lfs.NewDownloadQueue(
+		tq.WithGitEnv(cfg.Git),
+		tq.WithProgress(meter),
+	)
 
 	if out != nil {
 		// If we already have it, or it won't be fetched

--- a/commands/command_prune.go
+++ b/commands/command_prune.go
@@ -122,7 +122,7 @@ func prune(fetchPruneConfig config.FetchPruneConfig, verifyRemote, dryRun, verbo
 	if verifyRemote {
 		cfg.CurrentRemote = fetchPruneConfig.PruneRemoteName
 		// build queue now, no estimates or progress output
-		verifyQueue = lfs.NewDownloadCheckQueue()
+		verifyQueue = lfs.NewDownloadCheckQueue(tq.WithGitEnv(cfg.Git))
 		verifiedObjects = tools.NewStringSetWithCapacity(len(localObjects) / 2)
 
 		// this channel is filled with oids for which Check() succeeded & Transfer() was called

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -44,7 +44,7 @@ var (
 // TransferManifest builds a tq.Manifest from the commands package global
 // cfg var.
 func TransferManifest() *tq.Manifest {
-	return tq.ConfigureManifest(tq.NewManifest(), cfg)
+	return tq.ConfigureManifest(tq.NewManifest(), cfg.Git)
 }
 
 // Error prints a formatted message to Stderr.  It also gets printed to the

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -75,7 +75,12 @@ func (c *uploadContext) prepareUpload(unfiltered []*lfs.WrappedPointer) (*tq.Tra
 
 	// build the TransferQueue, automatically skipping any missing objects that
 	// the server already has.
-	uploadQueue := lfs.NewUploadQueue(tq.WithProgress(meter), tq.DryRun(c.DryRun))
+	uploadQueue := lfs.NewUploadQueue(
+		tq.WithGitEnv(cfg.Git),
+		tq.WithProgress(meter),
+		tq.DryRun(c.DryRun),
+	)
+
 	for _, p := range missingLocalObjects {
 		if c.HasUploaded(p.Oid) {
 			// if the server already has this object, call Skip() on
@@ -99,7 +104,7 @@ func (c *uploadContext) checkMissing(missing []*lfs.WrappedPointer, missingSize 
 		return
 	}
 
-	checkQueue := lfs.NewDownloadCheckQueue()
+	checkQueue := lfs.NewDownloadCheckQueue(tq.WithGitEnv(cfg.Git))
 	transferCh := checkQueue.Watch()
 
 	done := make(chan int)

--- a/tq/custom.go
+++ b/tq/custom.go
@@ -347,7 +347,7 @@ func newCustomAdapter(name string, dir Direction, path, args string, concurrent 
 }
 
 // Initialise custom adapters based on current config
-func configureCustomAdapters(gitEnv config.Environment, m *Manifest) {
+func configureCustomAdapters(gitEnv Environment, m *Manifest) {
 	pathRegex := regexp.MustCompile(`lfs.customtransfer.([^.]+).path`)
 	for k, v := range gitEnv.All() {
 		match := pathRegex.FindStringSubmatch(k)

--- a/tq/custom.go
+++ b/tq/custom.go
@@ -347,9 +347,9 @@ func newCustomAdapter(name string, dir Direction, path, args string, concurrent 
 }
 
 // Initialise custom adapters based on current config
-func configureCustomAdapters(cfg *config.Configuration, m *Manifest) {
+func configureCustomAdapters(gitEnv config.Environment, m *Manifest) {
 	pathRegex := regexp.MustCompile(`lfs.customtransfer.([^.]+).path`)
-	for k, v := range cfg.Git.All() {
+	for k, v := range gitEnv.All() {
 		match := pathRegex.FindStringSubmatch(k)
 		if match == nil {
 			continue
@@ -358,9 +358,9 @@ func configureCustomAdapters(cfg *config.Configuration, m *Manifest) {
 		name := match[1]
 		path := v
 		// retrieve other values
-		args, _ := cfg.Git.Get(fmt.Sprintf("lfs.customtransfer.%s.args", name))
-		concurrent := cfg.Git.Bool(fmt.Sprintf("lfs.customtransfer.%s.concurrent", name), true)
-		direction, _ := cfg.Git.Get(fmt.Sprintf("lfs.customtransfer.%s.direction", name))
+		args, _ := gitEnv.Get(fmt.Sprintf("lfs.customtransfer.%s.args", name))
+		concurrent := gitEnv.Bool(fmt.Sprintf("lfs.customtransfer.%s.concurrent", name), true)
+		direction, _ := gitEnv.Get(fmt.Sprintf("lfs.customtransfer.%s.direction", name))
 		if len(direction) == 0 {
 			direction = "both"
 		} else {

--- a/tq/custom_test.go
+++ b/tq/custom_test.go
@@ -13,7 +13,7 @@ func TestCustomTransferBasicConfig(t *testing.T) {
 		Git: map[string]string{"lfs.customtransfer.testsimple.path": path},
 	})
 
-	m := ConfigureManifest(NewManifest(), cfg)
+	m := ConfigureManifest(NewManifest(), cfg.Git)
 
 	u := m.NewUploadAdapter("testsimple")
 	assert.NotNil(t, u, "Upload adapter should be present")
@@ -44,7 +44,7 @@ func TestCustomTransferDownloadConfig(t *testing.T) {
 		},
 	})
 
-	m := ConfigureManifest(NewManifest(), cfg)
+	m := ConfigureManifest(NewManifest(), cfg.Git)
 
 	u := m.NewUploadAdapter("testdownload")
 	assert.NotNil(t, u, "Upload adapter should always be created")
@@ -72,7 +72,7 @@ func TestCustomTransferUploadConfig(t *testing.T) {
 		},
 	})
 
-	m := ConfigureManifest(NewManifest(), cfg)
+	m := ConfigureManifest(NewManifest(), cfg.Git)
 
 	d := m.NewDownloadAdapter("testupload")
 	assert.NotNil(t, d, "Download adapter should always be created")
@@ -100,7 +100,7 @@ func TestCustomTransferBothConfig(t *testing.T) {
 		},
 	})
 
-	m := ConfigureManifest(NewManifest(), cfg)
+	m := ConfigureManifest(NewManifest(), cfg.Git)
 
 	d := m.NewDownloadAdapter("testboth")
 	assert.NotNil(t, d, "Download adapter should be present")

--- a/tq/env.go
+++ b/tq/env.go
@@ -1,0 +1,9 @@
+package tq
+
+// copy of config.Environment. Removes forced coupling with config pkg.
+type Environment interface {
+	Get(key string) (val string, ok bool)
+	Bool(key string, def bool) (val bool)
+	Int(key string, def int) (val int)
+	All() map[string]string
+}

--- a/tq/manifest.go
+++ b/tq/manifest.go
@@ -21,15 +21,14 @@ func NewManifest() *Manifest {
 	}
 }
 
-func ConfigureManifest(m *Manifest, cfg *config.Configuration) *Manifest {
-	m.basicTransfersOnly = cfg.BasicTransfersOnly()
-
+func ConfigureManifest(m *Manifest, gitEnv config.Environment) *Manifest {
+	m.basicTransfersOnly = gitEnv.Bool("lfs.basictransfersonly", false)
 	configureBasicDownloadAdapter(m)
 	configureBasicUploadAdapter(m)
-	if cfg.TusTransfersAllowed() {
+	if gitEnv.Bool("lfs.tustransfers", false) {
 		configureTusAdapter(m)
 	}
-	configureCustomAdapters(cfg, m)
+	configureCustomAdapters(gitEnv, m)
 	return m
 }
 

--- a/tq/manifest.go
+++ b/tq/manifest.go
@@ -3,7 +3,6 @@ package tq
 import (
 	"sync"
 
-	"github.com/git-lfs/git-lfs/config"
 	"github.com/rubyist/tracerx"
 )
 
@@ -21,7 +20,7 @@ func NewManifest() *Manifest {
 	}
 }
 
-func ConfigureManifest(m *Manifest, gitEnv config.Environment) *Manifest {
+func ConfigureManifest(m *Manifest, gitEnv Environment) *Manifest {
 	m.basicTransfersOnly = gitEnv.Bool("lfs.basictransfersonly", false)
 	configureBasicDownloadAdapter(m)
 	configureBasicUploadAdapter(m)

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -139,7 +139,7 @@ func WithBufferDepth(depth int) Option {
 	return func(tq *TransferQueue) { tq.bufferDepth = depth }
 }
 
-func WithGitEnv(gitEnv config.Environment) Option {
+func WithGitEnv(gitEnv Environment) Option {
 	return func(tq *TransferQueue) {
 		ConfigureManifest(tq.manifest, gitEnv)
 
@@ -278,15 +278,13 @@ func (q *TransferQueue) collectBatches() {
 // enqueueAndCollectRetriesFor blocks until the entire Batch "batch" has been
 // processed.
 func (q *TransferQueue) enqueueAndCollectRetriesFor(batch Batch) (Batch, error) {
-	cfg := config.Config
-
 	next := q.makeBatch()
 	transferAdapterNames := q.manifest.GetAdapterNames(q.direction)
 
 	tracerx.Printf("tq: sending batch of size %d", len(batch))
 
 	objs, adapterName, err := api.Batch(
-		cfg, batch.ApiObjects(), q.transferKind(), transferAdapterNames,
+		config.Config, batch.ApiObjects(), q.transferKind(), transferAdapterNames,
 	)
 	if err != nil {
 		// If there was an error making the batch API call, mark all of

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -172,7 +172,7 @@ func NewTransferQueue(dir Direction, options ...Option) *TransferQueue {
 		errorc:        make(chan error),
 		transferables: make(map[string]Transferable),
 		trMutex:       &sync.Mutex{},
-		manifest:      ConfigureManifest(NewManifest(), config.Config),
+		manifest:      ConfigureManifest(NewManifest(), config.Config.Git),
 		rc:            newRetryCounter(config.Config),
 	}
 

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -165,6 +165,12 @@ func WithBufferDepth(depth int) Option {
 	return func(tq *TransferQueue) { tq.bufferDepth = depth }
 }
 
+func WithGitEnv(gitEnv config.Environment) Option {
+	return func(tq *TransferQueue) {
+		ConfigureManifest(tq.manifest, gitEnv)
+	}
+}
+
 // NewTransferQueue builds a TransferQueue, direction and underlying mechanism determined by adapter
 func NewTransferQueue(dir Direction, options ...Option) *TransferQueue {
 	q := &TransferQueue{
@@ -172,7 +178,7 @@ func NewTransferQueue(dir Direction, options ...Option) *TransferQueue {
 		errorc:        make(chan error),
 		transferables: make(map[string]Transferable),
 		trMutex:       &sync.Mutex{},
-		manifest:      ConfigureManifest(NewManifest(), config.Config.Git),
+		manifest:      NewManifest(),
 		rc:            newRetryCounter(config.Config),
 	}
 

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -36,6 +36,13 @@ type retryCounter struct {
 	count map[string]int
 }
 
+func newRetryCounter() *retryCounter {
+	return &retryCounter{
+		MaxRetries: defaultMaxRetries,
+		count:      make(map[string]int),
+	}
+}
+
 // Increment increments the number of retries for a given OID. It is safe to
 // call across multiple goroutines.
 func (r *retryCounter) Increment(oid string) {

--- a/tq/transfer_queue_test.go
+++ b/tq/transfer_queue_test.go
@@ -8,55 +8,54 @@ import (
 )
 
 func TestRetryCounterDefaultsToFixedRetries(t *testing.T) {
-	rc := newRetryCounter(config.NewFrom(config.Values{}))
-
+	rc := newRetryCounter()
 	assert.Equal(t, 1, rc.MaxRetries)
 }
 
 func TestRetryCounterIsConfigurable(t *testing.T) {
-	rc := newRetryCounter(config.NewFrom(config.Values{
+	cfg := config.NewFrom(config.Values{
 		Git: map[string]string{
 			"lfs.transfer.maxretries": "3",
 		},
-	}))
+	})
 
-	assert.Equal(t, 3, rc.MaxRetries)
+	tr := NewTransferQueue(Download, WithGitEnv(cfg.Git))
+	assert.Equal(t, 3, tr.rc.MaxRetries)
 }
 
 func TestRetryCounterClampsValidValues(t *testing.T) {
-	rc := newRetryCounter(config.NewFrom(config.Values{
+	cfg := config.NewFrom(config.Values{
 		Git: map[string]string{
 			"lfs.transfer.maxretries": "-1",
 		},
-	}))
+	})
 
-	assert.Equal(t, 1, rc.MaxRetries)
+	tr := NewTransferQueue(Download, WithGitEnv(cfg.Git))
+	assert.Equal(t, 1, tr.rc.MaxRetries)
 }
 
 func TestRetryCounterIgnoresNonInts(t *testing.T) {
-	rc := newRetryCounter(config.NewFrom(config.Values{
+	cfg := config.NewFrom(config.Values{
 		Git: map[string]string{
 			"lfs.transfer.maxretries": "not_an_int",
 		},
-	}))
+	})
 
-	assert.Equal(t, 1, rc.MaxRetries)
+	tr := NewTransferQueue(Download, WithGitEnv(cfg.Git))
+	assert.Equal(t, 1, tr.rc.MaxRetries)
 }
 
 func TestRetryCounterIncrementsObjects(t *testing.T) {
-	rc := newRetryCounter(config.NewFrom(config.Values{}))
-
+	rc := newRetryCounter()
 	rc.Increment("oid")
-
 	assert.Equal(t, 1, rc.CountFor("oid"))
 }
 
 func TestRetryCounterCanNotRetryAfterExceedingRetryCount(t *testing.T) {
-	rc := newRetryCounter(config.NewFrom(config.Values{}))
-
+	rc := newRetryCounter()
 	rc.Increment("oid")
-	count, canRetry := rc.CanRetry("oid")
 
+	count, canRetry := rc.CanRetry("oid")
 	assert.Equal(t, 1, count)
 	assert.False(t, canRetry)
 }

--- a/tq/transfer_test.go
+++ b/tq/transfer_test.go
@@ -46,7 +46,7 @@ func newRenamedTestAdapter(name string, dir Direction) Adapter {
 
 func testBasicAdapterExists(t *testing.T) {
 	cfg := config.New()
-	m := ConfigureManifest(NewManifest(), cfg)
+	m := ConfigureManifest(NewManifest(), cfg.Git)
 
 	assert := assert.New(t)
 
@@ -74,7 +74,7 @@ func testBasicAdapterExists(t *testing.T) {
 
 func testAdapterRegAndOverride(t *testing.T) {
 	cfg := config.New()
-	m := ConfigureManifest(NewManifest(), cfg)
+	m := ConfigureManifest(NewManifest(), cfg.Git)
 	assert := assert.New(t)
 
 	assert.Nil(m.NewDownloadAdapter("test"))
@@ -123,7 +123,7 @@ func testAdapterRegButBasicOnly(t *testing.T) {
 	cfg := config.NewFrom(config.Values{
 		Git: map[string]string{"lfs.basictransfersonly": "yes"},
 	})
-	m := ConfigureManifest(NewManifest(), cfg)
+	m := ConfigureManifest(NewManifest(), cfg.Git)
 
 	assert := assert.New(t)
 


### PR DESCRIPTION
This copies `config.Environment` to `tq.Environment`, and removes explicit coupling with `*config.Configuration` in `tq.NewTransferQueue()`. Instead, they depend on possibly receiving a `config.Environment` in a `tq.WithGitEnv()` option.  I opted to export `tq.Environment` so the `WithGitEnv()` signature makes sense to end users.

I'm not sold on this approach yet. I have another idea that I wanna experiment with first. 