### PR TITLE
Manifest config attempt 2

### DIFF
--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -291,7 +291,7 @@ func fetchAndReportToChan(allpointers []*lfs.WrappedPointer, filter *filepathfil
 	}
 
 	ready, pointers, meter := readyAndMissingPointers(allpointers, filter)
-	q := lfs.NewDownloadQueue(tq.WithProgress(meter))
+	q := newDownloadQueue(tq.WithProgress(meter))
 
 	if out != nil {
 		// If we already have it, or it won't be fetched

--- a/commands/command_prune.go
+++ b/commands/command_prune.go
@@ -122,7 +122,7 @@ func prune(fetchPruneConfig config.FetchPruneConfig, verifyRemote, dryRun, verbo
 	if verifyRemote {
 		cfg.CurrentRemote = fetchPruneConfig.PruneRemoteName
 		// build queue now, no estimates or progress output
-		verifyQueue = lfs.NewDownloadCheckQueue()
+		verifyQueue = newDownloadCheckQueue()
 		verifiedObjects = tools.NewStringSetWithCapacity(len(localObjects) / 2)
 
 		// this channel is filled with oids for which Check() succeeded & Transfer() was called

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -242,6 +242,24 @@ func logPanicToWriter(w io.Writer, loggedError error) {
 	}
 }
 
+// newDownloadCheckQueue builds a checking queue, checks that objects are there but doesn't download
+func newDownloadCheckQueue(options ...tq.Option) *tq.TransferQueue {
+	allOptions := make([]tq.Option, len(options), len(options)+1)
+	allOptions = append(allOptions, options...)
+	allOptions = append(allOptions, tq.DryRun(true))
+	return newDownloadQueue(allOptions...)
+}
+
+// newDownloadQueue builds a DownloadQueue, allowing concurrent downloads.
+func newDownloadQueue(options ...tq.Option) *tq.TransferQueue {
+	return tq.NewTransferQueue(tq.Download, TransferManifest(), options...)
+}
+
+// newUploadQueue builds an UploadQueue, allowing `workers` concurrent uploads.
+func newUploadQueue(options ...tq.Option) *tq.TransferQueue {
+	return tq.NewTransferQueue(tq.Upload, TransferManifest(), options...)
+}
+
 func buildFilepathFilter(config *config.Configuration, includeArg, excludeArg *string) *filepathfilter.Filter {
 	inc, exc := determineIncludeExcludePaths(config, includeArg, excludeArg)
 	return filepathfilter.New(inc, exc)

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -75,7 +75,7 @@ func (c *uploadContext) prepareUpload(unfiltered []*lfs.WrappedPointer) (*tq.Tra
 
 	// build the TransferQueue, automatically skipping any missing objects that
 	// the server already has.
-	uploadQueue := lfs.NewUploadQueue(tq.WithProgress(meter), tq.DryRun(c.DryRun))
+	uploadQueue := newUploadQueue(tq.WithProgress(meter), tq.DryRun(c.DryRun))
 	for _, p := range missingLocalObjects {
 		if c.HasUploaded(p.Oid) {
 			// if the server already has this object, call Skip() on
@@ -99,7 +99,7 @@ func (c *uploadContext) checkMissing(missing []*lfs.WrappedPointer, missingSize 
 		return
 	}
 
-	checkQueue := lfs.NewDownloadCheckQueue()
+	checkQueue := newDownloadCheckQueue()
 	transferCh := checkQueue.Watch()
 
 	done := make(chan int)

--- a/lfs/download_queue.go
+++ b/lfs/download_queue.go
@@ -1,6 +1,10 @@
 package lfs
 
-import "github.com/git-lfs/git-lfs/api"
+import (
+	"github.com/git-lfs/git-lfs/api"
+	"github.com/git-lfs/git-lfs/config"
+	"github.com/git-lfs/git-lfs/tq"
+)
 
 type Downloadable struct {
 	pointer *WrappedPointer
@@ -34,4 +38,17 @@ func (d *Downloadable) SetObject(o *api.ObjectResource) {
 
 func NewDownloadable(p *WrappedPointer) *Downloadable {
 	return &Downloadable{pointer: p}
+}
+
+// NewDownloadCheckQueue builds a checking queue, checks that objects are there but doesn't download
+func NewDownloadCheckQueue(cfg *config.Configuration, options ...tq.Option) *tq.TransferQueue {
+	allOptions := make([]tq.Option, len(options), len(options)+1)
+	allOptions = append(allOptions, options...)
+	allOptions = append(allOptions, tq.DryRun(true))
+	return NewDownloadQueue(cfg, allOptions...)
+}
+
+// NewDownloadQueue builds a DownloadQueue, allowing concurrent downloads.
+func NewDownloadQueue(cfg *config.Configuration, options ...tq.Option) *tq.TransferQueue {
+	return tq.NewTransferQueue(tq.Download, TransferManifest(cfg), options...)
 }

--- a/lfs/download_queue.go
+++ b/lfs/download_queue.go
@@ -1,9 +1,6 @@
 package lfs
 
-import (
-	"github.com/git-lfs/git-lfs/api"
-	"github.com/git-lfs/git-lfs/tq"
-)
+import "github.com/git-lfs/git-lfs/api"
 
 type Downloadable struct {
 	pointer *WrappedPointer
@@ -37,14 +34,4 @@ func (d *Downloadable) SetObject(o *api.ObjectResource) {
 
 func NewDownloadable(p *WrappedPointer) *Downloadable {
 	return &Downloadable{pointer: p}
-}
-
-// NewDownloadCheckQueue builds a checking queue, checks that objects are there but doesn't download
-func NewDownloadCheckQueue(options ...tq.Option) *tq.TransferQueue {
-	return tq.NewTransferQueue(tq.Download, options...)
-}
-
-// NewDownloadQueue builds a DownloadQueue, allowing concurrent downloads.
-func NewDownloadQueue(options ...tq.Option) *tq.TransferQueue {
-	return tq.NewTransferQueue(tq.Download, options...)
 }

--- a/lfs/lfs.go
+++ b/lfs/lfs.go
@@ -118,6 +118,11 @@ func Environ(cfg *config.Configuration, manifest *tq.Manifest) []string {
 	return env
 }
 
+// TransferManifest builds a tq.Manifest using the given cfg.
+func TransferManifest(cfg *config.Configuration) *tq.Manifest {
+	return tq.ConfigureManifest(tq.NewManifest(), cfg)
+}
+
 func InRepo() bool {
 	return config.LocalGitDir != ""
 }

--- a/lfs/lfs.go
+++ b/lfs/lfs.go
@@ -120,11 +120,7 @@ func Environ(cfg *config.Configuration, manifest *tq.Manifest) []string {
 
 // TransferManifest builds a tq.Manifest using the given cfg.
 func TransferManifest(cfg *config.Configuration) *tq.Manifest {
-	m := tq.NewManifestWithGitEnv(cfg.Git)
-	if cfg.NtlmAccess("download") {
-		m.ConcurrentTransfers = 1
-	}
-	return m
+	return tq.NewManifestWithGitEnv(cfg.Access("download"), cfg.Git)
 }
 
 func InRepo() bool {

--- a/lfs/lfs.go
+++ b/lfs/lfs.go
@@ -120,17 +120,10 @@ func Environ(cfg *config.Configuration, manifest *tq.Manifest) []string {
 
 // TransferManifest builds a tq.Manifest using the given cfg.
 func TransferManifest(cfg *config.Configuration) *tq.Manifest {
-	m := tq.NewManifest()
-	if err := cfg.Unmarshal(m); err != nil {
-		tracerx.Printf("manifest: error parsing config, falling back to default values...: %v", err)
-		m.MaxRetries = 1
-	}
-
+	m := tq.NewManifestWithGitEnv(cfg.Git)
 	if cfg.NtlmAccess("download") {
 		m.ConcurrentTransfers = 1
 	}
-
-	m.InitCustomAdaptersFromGit(cfg.Git)
 	return m
 }
 

--- a/lfs/manifest_test.go
+++ b/lfs/manifest_test.go
@@ -14,7 +14,19 @@ func TestManifestIsConfigurable(t *testing.T) {
 		},
 	})
 	m := TransferManifest(cfg)
-	assert.Equal(t, 3, m.MaxRetries)
+	assert.Equal(t, 3, m.MaxRetries())
+}
+
+func TestManifestChecksNTLM(t *testing.T) {
+	cfg := config.NewFrom(config.Values{
+		Git: map[string]string{
+			"lfs.url":                 "http://foo",
+			"lfs.http://foo.access":   "ntlm",
+			"lfs.concurrenttransfers": "3",
+		},
+	})
+	m := TransferManifest(cfg)
+	assert.Equal(t, 1, m.MaxRetries())
 }
 
 func TestManifestClampsValidValues(t *testing.T) {
@@ -24,7 +36,7 @@ func TestManifestClampsValidValues(t *testing.T) {
 		},
 	})
 	m := TransferManifest(cfg)
-	assert.Equal(t, 1, m.MaxRetries)
+	assert.Equal(t, 1, m.MaxRetries())
 }
 
 func TestManifestIgnoresNonInts(t *testing.T) {
@@ -34,5 +46,5 @@ func TestManifestIgnoresNonInts(t *testing.T) {
 		},
 	})
 	m := TransferManifest(cfg)
-	assert.Equal(t, 1, m.MaxRetries)
+	assert.Equal(t, 1, m.MaxRetries())
 }

--- a/lfs/manifest_test.go
+++ b/lfs/manifest_test.go
@@ -1,0 +1,38 @@
+package lfs
+
+import (
+	"testing"
+
+	"github.com/git-lfs/git-lfs/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestManifestIsConfigurable(t *testing.T) {
+	cfg := config.NewFrom(config.Values{
+		Git: map[string]string{
+			"lfs.transfer.maxretries": "3",
+		},
+	})
+	m := TransferManifest(cfg)
+	assert.Equal(t, 3, m.MaxRetries)
+}
+
+func TestManifestClampsValidValues(t *testing.T) {
+	cfg := config.NewFrom(config.Values{
+		Git: map[string]string{
+			"lfs.transfer.maxretries": "-1",
+		},
+	})
+	m := TransferManifest(cfg)
+	assert.Equal(t, 1, m.MaxRetries)
+}
+
+func TestManifestIgnoresNonInts(t *testing.T) {
+	cfg := config.NewFrom(config.Values{
+		Git: map[string]string{
+			"lfs.transfer.maxretries": "not_an_int",
+		},
+	})
+	m := TransferManifest(cfg)
+	assert.Equal(t, 1, m.MaxRetries)
+}

--- a/lfs/upload_queue.go
+++ b/lfs/upload_queue.go
@@ -8,6 +8,7 @@ import (
 	"github.com/git-lfs/git-lfs/api"
 	"github.com/git-lfs/git-lfs/config"
 	"github.com/git-lfs/git-lfs/errors"
+	"github.com/git-lfs/git-lfs/tq"
 )
 
 // Uploadable describes a file that can be uploaded.
@@ -100,4 +101,9 @@ func ensureFile(smudgePath, cleanPath string) error {
 	}
 
 	return nil
+}
+
+// NewUploadQueue builds an UploadQueue, allowing `workers` concurrent uploads.
+func NewUploadQueue(cfg *config.Configuration, options ...tq.Option) *tq.TransferQueue {
+	return tq.NewTransferQueue(tq.Upload, TransferManifest(cfg), options...)
 }

--- a/lfs/upload_queue.go
+++ b/lfs/upload_queue.go
@@ -8,7 +8,6 @@ import (
 	"github.com/git-lfs/git-lfs/api"
 	"github.com/git-lfs/git-lfs/config"
 	"github.com/git-lfs/git-lfs/errors"
-	"github.com/git-lfs/git-lfs/tq"
 )
 
 // Uploadable describes a file that can be uploaded.
@@ -64,11 +63,6 @@ func NewUploadable(oid, filename string) (*Uploadable, error) {
 	}
 
 	return &Uploadable{oid: oid, OidPath: localMediaPath, Filename: filename, size: fi.Size()}, nil
-}
-
-// NewUploadQueue builds an UploadQueue, allowing `workers` concurrent uploads.
-func NewUploadQueue(options ...tq.Option) *tq.TransferQueue {
-	return tq.NewTransferQueue(tq.Upload, options...)
 }
 
 // ensureFile makes sure that the cleanPath exists before pushing it.  If it

--- a/test/git-lfs-test-server-api/main.go
+++ b/test/git-lfs-test-server-api/main.go
@@ -159,7 +159,8 @@ func buildTestData() (oidsExist, oidsMissing []TestObject, err error) {
 	outputs := repo.AddCommits([]*test.CommitInput{&commit})
 
 	// now upload
-	uploadQueue := lfs.NewUploadQueue(tq.WithProgress(meter))
+	manifest := tq.ConfigureManifest(tq.NewManifest(), config.Config)
+	uploadQueue := tq.NewTransferQueue(tq.Upload, manifest, tq.WithProgress(meter))
 	for _, f := range outputs[0].Files {
 		oidsExist = append(oidsExist, TestObject{Oid: f.Oid, Size: f.Size})
 

--- a/test/git-lfs-test-server-api/main.go
+++ b/test/git-lfs-test-server-api/main.go
@@ -159,8 +159,7 @@ func buildTestData() (oidsExist, oidsMissing []TestObject, err error) {
 	outputs := repo.AddCommits([]*test.CommitInput{&commit})
 
 	// now upload
-	manifest := tq.ConfigureManifest(tq.NewManifest(), config.Config)
-	uploadQueue := tq.NewTransferQueue(tq.Upload, manifest, tq.WithProgress(meter))
+	uploadQueue := lfs.NewUploadQueue(config.Config, tq.WithProgress(meter))
 	for _, f := range outputs[0].Files {
 		oidsExist = append(oidsExist, TestObject{Oid: f.Oid, Size: f.Size})
 

--- a/tq/custom.go
+++ b/tq/custom.go
@@ -347,7 +347,7 @@ func newCustomAdapter(name string, dir Direction, path, args string, concurrent 
 }
 
 // Initialise custom adapters based on current config
-func configureCustomAdapters(git env, m *Manifest) {
+func configureCustomAdapters(git Env, m *Manifest) {
 	pathRegex := regexp.MustCompile(`lfs.customtransfer.([^.]+).path`)
 	for k, v := range git.All() {
 		match := pathRegex.FindStringSubmatch(k)

--- a/tq/custom.go
+++ b/tq/custom.go
@@ -347,9 +347,9 @@ func newCustomAdapter(name string, dir Direction, path, args string, concurrent 
 }
 
 // Initialise custom adapters based on current config
-func configureCustomAdapters(cfg *config.Configuration, m *Manifest) {
+func configureCustomAdapters(git env, m *Manifest) {
 	pathRegex := regexp.MustCompile(`lfs.customtransfer.([^.]+).path`)
-	for k, v := range cfg.Git.All() {
+	for k, v := range git.All() {
 		match := pathRegex.FindStringSubmatch(k)
 		if match == nil {
 			continue
@@ -358,9 +358,9 @@ func configureCustomAdapters(cfg *config.Configuration, m *Manifest) {
 		name := match[1]
 		path := v
 		// retrieve other values
-		args, _ := cfg.Git.Get(fmt.Sprintf("lfs.customtransfer.%s.args", name))
-		concurrent := cfg.Git.Bool(fmt.Sprintf("lfs.customtransfer.%s.concurrent", name), true)
-		direction, _ := cfg.Git.Get(fmt.Sprintf("lfs.customtransfer.%s.direction", name))
+		args, _ := git.Get(fmt.Sprintf("lfs.customtransfer.%s.args", name))
+		concurrent := git.Bool(fmt.Sprintf("lfs.customtransfer.%s.concurrent", name), true)
+		direction, _ := git.Get(fmt.Sprintf("lfs.customtransfer.%s.direction", name))
 		if len(direction) == 0 {
 			direction = "both"
 		} else {

--- a/tq/custom_test.go
+++ b/tq/custom_test.go
@@ -13,7 +13,8 @@ func TestCustomTransferBasicConfig(t *testing.T) {
 		Git: map[string]string{"lfs.customtransfer.testsimple.path": path},
 	})
 
-	m := ConfigureManifest(NewManifest(), cfg)
+	m := NewManifest()
+	m.InitCustomAdaptersFromGit(cfg.Git)
 
 	u := m.NewUploadAdapter("testsimple")
 	assert.NotNil(t, u, "Upload adapter should be present")
@@ -44,7 +45,8 @@ func TestCustomTransferDownloadConfig(t *testing.T) {
 		},
 	})
 
-	m := ConfigureManifest(NewManifest(), cfg)
+	m := NewManifest()
+	m.InitCustomAdaptersFromGit(cfg.Git)
 
 	u := m.NewUploadAdapter("testdownload")
 	assert.NotNil(t, u, "Upload adapter should always be created")
@@ -72,7 +74,8 @@ func TestCustomTransferUploadConfig(t *testing.T) {
 		},
 	})
 
-	m := ConfigureManifest(NewManifest(), cfg)
+	m := NewManifest()
+	m.InitCustomAdaptersFromGit(cfg.Git)
 
 	d := m.NewDownloadAdapter("testupload")
 	assert.NotNil(t, d, "Download adapter should always be created")
@@ -100,7 +103,8 @@ func TestCustomTransferBothConfig(t *testing.T) {
 		},
 	})
 
-	m := ConfigureManifest(NewManifest(), cfg)
+	m := NewManifest()
+	m.InitCustomAdaptersFromGit(cfg.Git)
 
 	d := m.NewDownloadAdapter("testboth")
 	assert.NotNil(t, d, "Download adapter should be present")

--- a/tq/custom_test.go
+++ b/tq/custom_test.go
@@ -13,9 +13,7 @@ func TestCustomTransferBasicConfig(t *testing.T) {
 		Git: map[string]string{"lfs.customtransfer.testsimple.path": path},
 	})
 
-	m := NewManifest()
-	m.InitCustomAdaptersFromGit(cfg.Git)
-
+	m := NewManifestWithGitEnv(cfg.Git)
 	u := m.NewUploadAdapter("testsimple")
 	assert.NotNil(t, u, "Upload adapter should be present")
 	cu, _ := u.(*customAdapter)
@@ -45,9 +43,7 @@ func TestCustomTransferDownloadConfig(t *testing.T) {
 		},
 	})
 
-	m := NewManifest()
-	m.InitCustomAdaptersFromGit(cfg.Git)
-
+	m := NewManifestWithGitEnv(cfg.Git)
 	u := m.NewUploadAdapter("testdownload")
 	assert.NotNil(t, u, "Upload adapter should always be created")
 	cu, _ := u.(*customAdapter)
@@ -74,9 +70,7 @@ func TestCustomTransferUploadConfig(t *testing.T) {
 		},
 	})
 
-	m := NewManifest()
-	m.InitCustomAdaptersFromGit(cfg.Git)
-
+	m := NewManifestWithGitEnv(cfg.Git)
 	d := m.NewDownloadAdapter("testupload")
 	assert.NotNil(t, d, "Download adapter should always be created")
 	cd, _ := d.(*customAdapter)
@@ -103,9 +97,7 @@ func TestCustomTransferBothConfig(t *testing.T) {
 		},
 	})
 
-	m := NewManifest()
-	m.InitCustomAdaptersFromGit(cfg.Git)
-
+	m := NewManifestWithGitEnv(cfg.Git)
 	d := m.NewDownloadAdapter("testboth")
 	assert.NotNil(t, d, "Download adapter should be present")
 	cd, _ := d.(*customAdapter)

--- a/tq/custom_test.go
+++ b/tq/custom_test.go
@@ -13,7 +13,7 @@ func TestCustomTransferBasicConfig(t *testing.T) {
 		Git: map[string]string{"lfs.customtransfer.testsimple.path": path},
 	})
 
-	m := NewManifestWithGitEnv(cfg.Git)
+	m := NewManifestWithGitEnv("", cfg.Git)
 	u := m.NewUploadAdapter("testsimple")
 	assert.NotNil(t, u, "Upload adapter should be present")
 	cu, _ := u.(*customAdapter)
@@ -43,7 +43,7 @@ func TestCustomTransferDownloadConfig(t *testing.T) {
 		},
 	})
 
-	m := NewManifestWithGitEnv(cfg.Git)
+	m := NewManifestWithGitEnv("", cfg.Git)
 	u := m.NewUploadAdapter("testdownload")
 	assert.NotNil(t, u, "Upload adapter should always be created")
 	cu, _ := u.(*customAdapter)
@@ -70,7 +70,7 @@ func TestCustomTransferUploadConfig(t *testing.T) {
 		},
 	})
 
-	m := NewManifestWithGitEnv(cfg.Git)
+	m := NewManifestWithGitEnv("", cfg.Git)
 	d := m.NewDownloadAdapter("testupload")
 	assert.NotNil(t, d, "Download adapter should always be created")
 	cd, _ := d.(*customAdapter)
@@ -97,7 +97,7 @@ func TestCustomTransferBothConfig(t *testing.T) {
 		},
 	})
 
-	m := NewManifestWithGitEnv(cfg.Git)
+	m := NewManifestWithGitEnv("", cfg.Git)
 	d := m.NewDownloadAdapter("testboth")
 	assert.NotNil(t, d, "Download adapter should be present")
 	cd, _ := d.(*customAdapter)

--- a/tq/manifest.go
+++ b/tq/manifest.go
@@ -28,7 +28,7 @@ func NewManifest() *Manifest {
 	return NewManifestWithGitEnv(nil)
 }
 
-func NewManifestWithGitEnv(git env) *Manifest {
+func NewManifestWithGitEnv(git Env) *Manifest {
 	m := &Manifest{
 		downloadAdapterFuncs: make(map[string]NewAdapterFunc),
 		uploadAdapterFuncs:   make(map[string]NewAdapterFunc),
@@ -37,7 +37,7 @@ func NewManifestWithGitEnv(git env) *Manifest {
 	return m
 }
 
-func initManifest(m *Manifest, git env) {
+func initManifest(m *Manifest, git Env) {
 	var tusAllowed bool
 
 	if git != nil {
@@ -160,7 +160,8 @@ func (m *Manifest) NewUploadAdapter(name string) Adapter {
 	return m.NewAdapterOrDefault(name, Upload)
 }
 
-type env interface {
+// Env is any object with a config.Environment interface.
+type Env interface {
 	Get(key string) (val string, ok bool)
 	Bool(key string, def bool) (val bool)
 	Int(key string, def int) (val int)

--- a/tq/manifest.go
+++ b/tq/manifest.go
@@ -10,7 +10,8 @@ import (
 type Manifest struct {
 	// MaxRetries is the maximum number of retries a single object can
 	// attempt to make before it will be dropped.
-	MaxRetries int `git:"lfs.transfer.maxretries"`
+	MaxRetries          int `git:"lfs.transfer.maxretries"`
+	ConcurrentTransfers int `git:"lfs.concurrenttransfers"`
 
 	basicTransfersOnly   bool
 	downloadAdapterFuncs map[string]NewAdapterFunc
@@ -29,6 +30,10 @@ func ConfigureManifest(m *Manifest, cfg *config.Configuration) *Manifest {
 	if err := cfg.Unmarshal(m); err != nil {
 		tracerx.Printf("manifest: error parsing config, falling back to default values...: %v", err)
 		m.MaxRetries = 1
+	}
+
+	if cfg.NtlmAccess("download") {
+		m.ConcurrentTransfers = 1
 	}
 
 	if m.MaxRetries < 1 {

--- a/tq/manifest.go
+++ b/tq/manifest.go
@@ -40,13 +40,8 @@ func NewManifestWithGitEnv(access string, git Env) *Manifest {
 		downloadAdapterFuncs: make(map[string]NewAdapterFunc),
 		uploadAdapterFuncs:   make(map[string]NewAdapterFunc),
 	}
-	initManifest(m, access, git)
-	return m
-}
 
-func initManifest(m *Manifest, access string, git Env) {
 	var tusAllowed bool
-
 	if git != nil {
 		if v := git.Int("lfs.transfer.maxretries", 0); v > 0 {
 			m.maxRetries = v
@@ -74,6 +69,7 @@ func initManifest(m *Manifest, access string, git Env) {
 	if tusAllowed {
 		configureTusAdapter(m)
 	}
+	return m
 }
 
 // GetAdapterNames returns a list of the names of adapters available to be created

--- a/tq/manifest.go
+++ b/tq/manifest.go
@@ -32,13 +32,14 @@ func ConfigureManifest(m *Manifest, cfg *config.Configuration) *Manifest {
 		m.MaxRetries = 1
 	}
 
-	if cfg.NtlmAccess("download") {
-		m.ConcurrentTransfers = 1
+	if m.MaxRetries < 1 {
+		m.MaxRetries = defaultMaxRetries
 	}
 
-	if m.MaxRetries < 1 {
-		tracerx.Printf("manifest: invalid retry count: %d, defaulting to %d", m.MaxRetries, 1)
-		m.MaxRetries = 1
+	if cfg.NtlmAccess("download") {
+		m.ConcurrentTransfers = 1
+	} else if m.ConcurrentTransfers < 1 {
+		m.ConcurrentTransfers = 3
 	}
 
 	m.basicTransfersOnly = cfg.BasicTransfersOnly()

--- a/tq/manifest.go
+++ b/tq/manifest.go
@@ -29,7 +29,7 @@ func ConfigureManifest(m *Manifest, cfg *config.Configuration) *Manifest {
 	if cfg.TusTransfersAllowed() {
 		configureTusAdapter(m)
 	}
-	configureCustomAdapters(cfg, m)
+	configureCustomAdapters(cfg.Git, m)
 	return m
 }
 
@@ -125,4 +125,11 @@ func (m *Manifest) NewDownloadAdapter(name string) Adapter {
 // Create a new upload adapter by name, or BasicAdapterName if doesn't exist
 func (m *Manifest) NewUploadAdapter(name string) Adapter {
 	return m.NewAdapterOrDefault(name, Upload)
+}
+
+type env interface {
+	Get(key string) (val string, ok bool)
+	Bool(key string, def bool) (val bool)
+	Int(key string, def int) (val int)
+	All() map[string]string
 }

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -12,8 +12,7 @@ import (
 )
 
 const (
-	defaultBatchSize  = 100
-	defaultMaxRetries = 1
+	defaultBatchSize = 100
 )
 
 type Transferable interface {

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -164,7 +164,7 @@ func NewTransferQueue(dir Direction, manifest *Manifest, options ...Option) *Tra
 		opt(q)
 	}
 
-	q.rc.MaxRetries = q.manifest.MaxRetries
+	q.rc.MaxRetries = q.manifest.maxRetries
 
 	if q.batchSize <= 0 {
 		q.batchSize = defaultBatchSize
@@ -522,7 +522,7 @@ func (q *TransferQueue) ensureAdapterBegun() error {
 	}
 
 	tracerx.Printf("tq: starting transfer adapter %q", q.adapter.Name())
-	err := q.adapter.Begin(q.manifest.ConcurrentTransfers, cb)
+	err := q.adapter.Begin(q.manifest.ConcurrentTransfers(), cb)
 	if err != nil {
 		return err
 	}

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -523,7 +523,7 @@ func (q *TransferQueue) ensureAdapterBegun() error {
 	}
 
 	tracerx.Printf("tq: starting transfer adapter %q", q.adapter.Name())
-	err := q.adapter.Begin(config.Config.ConcurrentTransfers(), cb)
+	err := q.adapter.Begin(q.manifest.ConcurrentTransfers, cb)
 	if err != nil {
 		return err
 	}

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -151,13 +151,13 @@ func WithBufferDepth(depth int) Option {
 }
 
 // NewTransferQueue builds a TransferQueue, direction and underlying mechanism determined by adapter
-func NewTransferQueue(dir Direction, options ...Option) *TransferQueue {
+func NewTransferQueue(dir Direction, manifest *Manifest, options ...Option) *TransferQueue {
 	q := &TransferQueue{
 		direction:     dir,
 		errorc:        make(chan error),
 		transferables: make(map[string]Transferable),
 		trMutex:       &sync.Mutex{},
-		manifest:      ConfigureManifest(NewManifest(), config.Config),
+		manifest:      manifest,
 		rc:            newRetryCounter(),
 	}
 

--- a/tq/transfer_queue_test.go
+++ b/tq/transfer_queue_test.go
@@ -3,44 +3,11 @@ package tq
 import (
 	"testing"
 
-	"github.com/git-lfs/git-lfs/config"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestManifestDefaultsToFixedRetries(t *testing.T) {
-	cfg := config.NewFrom(config.Values{})
-	m := ConfigureManifest(NewManifest(), cfg)
-	assert.Equal(t, 1, m.MaxRetries)
-}
-
-func TestManifestIsConfigurable(t *testing.T) {
-	cfg := config.NewFrom(config.Values{
-		Git: map[string]string{
-			"lfs.transfer.maxretries": "3",
-		},
-	})
-	m := ConfigureManifest(NewManifest(), cfg)
-	assert.Equal(t, 3, m.MaxRetries)
-}
-
-func TestManifestClampsValidValues(t *testing.T) {
-	cfg := config.NewFrom(config.Values{
-		Git: map[string]string{
-			"lfs.transfer.maxretries": "-1",
-		},
-	})
-	m := ConfigureManifest(NewManifest(), cfg)
-	assert.Equal(t, 1, m.MaxRetries)
-}
-
-func TestManifestIgnoresNonInts(t *testing.T) {
-	cfg := config.NewFrom(config.Values{
-		Git: map[string]string{
-			"lfs.transfer.maxretries": "not_an_int",
-		},
-	})
-	m := ConfigureManifest(NewManifest(), cfg)
-	assert.Equal(t, 1, m.MaxRetries)
+	assert.Equal(t, 1, NewManifest().MaxRetries)
 }
 
 func TestRetryCounterDefaultsToFixedRetries(t *testing.T) {

--- a/tq/transfer_queue_test.go
+++ b/tq/transfer_queue_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestManifestDefaultsToFixedRetries(t *testing.T) {
-	assert.Equal(t, 1, NewManifest().MaxRetries)
+	assert.Equal(t, 1, NewManifest().MaxRetries())
 }
 
 func TestRetryCounterDefaultsToFixedRetries(t *testing.T) {

--- a/tq/transfer_queue_test.go
+++ b/tq/transfer_queue_test.go
@@ -7,56 +7,58 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRetryCounterDefaultsToFixedRetries(t *testing.T) {
-	rc := newRetryCounter(config.NewFrom(config.Values{}))
-
-	assert.Equal(t, 1, rc.MaxRetries)
+func TestManifestDefaultsToFixedRetries(t *testing.T) {
+	cfg := config.NewFrom(config.Values{})
+	m := ConfigureManifest(NewManifest(), cfg)
+	assert.Equal(t, 1, m.MaxRetries)
 }
 
-func TestRetryCounterIsConfigurable(t *testing.T) {
-	rc := newRetryCounter(config.NewFrom(config.Values{
+func TestManifestIsConfigurable(t *testing.T) {
+	cfg := config.NewFrom(config.Values{
 		Git: map[string]string{
 			"lfs.transfer.maxretries": "3",
 		},
-	}))
-
-	assert.Equal(t, 3, rc.MaxRetries)
+	})
+	m := ConfigureManifest(NewManifest(), cfg)
+	assert.Equal(t, 3, m.MaxRetries)
 }
 
-func TestRetryCounterClampsValidValues(t *testing.T) {
-	rc := newRetryCounter(config.NewFrom(config.Values{
+func TestManifestClampsValidValues(t *testing.T) {
+	cfg := config.NewFrom(config.Values{
 		Git: map[string]string{
 			"lfs.transfer.maxretries": "-1",
 		},
-	}))
-
-	assert.Equal(t, 1, rc.MaxRetries)
+	})
+	m := ConfigureManifest(NewManifest(), cfg)
+	assert.Equal(t, 1, m.MaxRetries)
 }
 
-func TestRetryCounterIgnoresNonInts(t *testing.T) {
-	rc := newRetryCounter(config.NewFrom(config.Values{
+func TestManifestIgnoresNonInts(t *testing.T) {
+	cfg := config.NewFrom(config.Values{
 		Git: map[string]string{
 			"lfs.transfer.maxretries": "not_an_int",
 		},
-	}))
+	})
+	m := ConfigureManifest(NewManifest(), cfg)
+	assert.Equal(t, 1, m.MaxRetries)
+}
 
+func TestRetryCounterDefaultsToFixedRetries(t *testing.T) {
+	rc := newRetryCounter()
 	assert.Equal(t, 1, rc.MaxRetries)
 }
 
 func TestRetryCounterIncrementsObjects(t *testing.T) {
-	rc := newRetryCounter(config.NewFrom(config.Values{}))
-
+	rc := newRetryCounter()
 	rc.Increment("oid")
-
 	assert.Equal(t, 1, rc.CountFor("oid"))
 }
 
 func TestRetryCounterCanNotRetryAfterExceedingRetryCount(t *testing.T) {
-	rc := newRetryCounter(config.NewFrom(config.Values{}))
-
+	rc := newRetryCounter()
 	rc.Increment("oid")
-	count, canRetry := rc.CanRetry("oid")
 
+	count, canRetry := rc.CanRetry("oid")
 	assert.Equal(t, 1, count)
 	assert.False(t, canRetry)
 }

--- a/tq/transfer_test.go
+++ b/tq/transfer_test.go
@@ -45,9 +45,7 @@ func newRenamedTestAdapter(name string, dir Direction) Adapter {
 }
 
 func testBasicAdapterExists(t *testing.T) {
-	cfg := config.New()
 	m := NewManifest()
-	m.InitCustomAdaptersFromGit(cfg.Git)
 
 	assert := assert.New(t)
 
@@ -74,9 +72,7 @@ func testBasicAdapterExists(t *testing.T) {
 }
 
 func testAdapterRegAndOverride(t *testing.T) {
-	cfg := config.New()
 	m := NewManifest()
-	m.InitCustomAdaptersFromGit(cfg.Git)
 	assert := assert.New(t)
 
 	assert.Nil(m.NewDownloadAdapter("test"))
@@ -125,8 +121,7 @@ func testAdapterRegButBasicOnly(t *testing.T) {
 	cfg := config.NewFrom(config.Values{
 		Git: map[string]string{"lfs.basictransfersonly": "yes"},
 	})
-	m := NewManifest()
-	m.InitCustomAdaptersFromGit(cfg.Git)
+	m := NewManifestWithGitEnv(cfg.Git)
 
 	assert := assert.New(t)
 

--- a/tq/transfer_test.go
+++ b/tq/transfer_test.go
@@ -46,7 +46,8 @@ func newRenamedTestAdapter(name string, dir Direction) Adapter {
 
 func testBasicAdapterExists(t *testing.T) {
 	cfg := config.New()
-	m := ConfigureManifest(NewManifest(), cfg)
+	m := NewManifest()
+	m.InitCustomAdaptersFromGit(cfg.Git)
 
 	assert := assert.New(t)
 
@@ -74,7 +75,8 @@ func testBasicAdapterExists(t *testing.T) {
 
 func testAdapterRegAndOverride(t *testing.T) {
 	cfg := config.New()
-	m := ConfigureManifest(NewManifest(), cfg)
+	m := NewManifest()
+	m.InitCustomAdaptersFromGit(cfg.Git)
 	assert := assert.New(t)
 
 	assert.Nil(m.NewDownloadAdapter("test"))
@@ -123,7 +125,8 @@ func testAdapterRegButBasicOnly(t *testing.T) {
 	cfg := config.NewFrom(config.Values{
 		Git: map[string]string{"lfs.basictransfersonly": "yes"},
 	})
-	m := ConfigureManifest(NewManifest(), cfg)
+	m := NewManifest()
+	m.InitCustomAdaptersFromGit(cfg.Git)
 
 	assert := assert.New(t)
 

--- a/tq/transfer_test.go
+++ b/tq/transfer_test.go
@@ -121,7 +121,7 @@ func testAdapterRegButBasicOnly(t *testing.T) {
 	cfg := config.NewFrom(config.Values{
 		Git: map[string]string{"lfs.basictransfersonly": "yes"},
 	})
-	m := NewManifestWithGitEnv(cfg.Git)
+	m := NewManifestWithGitEnv("", cfg.Git)
 
 	assert := assert.New(t)
 


### PR DESCRIPTION
This is a slightly different approach to #1766. Instead of introducing a new `tq.WithGitEnv()` option, this assumes that the caller will configure the `*tq.Manifest`, which is now a required argument for `NewTransferQueue()`. I was able to remove all `config` references inside the `tq` package except for the internal uses (which is tied to internal api methods still using it). Nothing in the exported interface uses `config` anymore though.

I like this approach, it gets us closer to @sinbad's idea of a config object per package. Could even rename `*tq.Manifest` to `*tq.Config` if you think that'd make more sense.

Notes:

* <del>Had to export `BasicTransfersOnly` and `TusTransfersAllowed` allowed, because `Unmarshal()` can only set exported properties. I'd rather not export these though.</del> -- not the case, see below
* Discovered that I dropped the dry run setting from `NewDownloadCheckQueue` in https://github.com/git-lfs/git-lfs/pull/1746/files#diff-1b73a9b301d9b5f76392f5818dd2ab15L43, it was re-added.
* Dropped the `ConcurrentTransfers()` call too.