### PR TITLE
Add test to prove set operator [] works in filter matching

### DIFF
--- a/filepathfilter/filepathfilter_test.go
+++ b/filepathfilter/filepathfilter_test.go
@@ -78,6 +78,7 @@ func TestFilterAllows(t *testing.T) {
 		filterTest{true, []string{"test/fil*"}, nil},
 		filterTest{false, []string{"test/g*"}, nil},
 		filterTest{true, []string{"tes*/*"}, nil},
+		filterTest{true, []string{"[Tt]est/[Ff]ilename.dat"}, nil},
 		// Exclusion
 		filterTest{false, nil, []string{"*.dat"}},
 		filterTest{false, nil, []string{"file*.dat"}},
@@ -96,6 +97,7 @@ func TestFilterAllows(t *testing.T) {
 		filterTest{false, nil, []string{"test/fil*"}},
 		filterTest{true, nil, []string{"test/g*"}},
 		filterTest{false, nil, []string{"tes*/*"}},
+		filterTest{false, nil, []string{"[Tt]est/[Ff]ilename.dat"}},
 
 		// Both
 		filterTest{true, []string{"test/filename.dat"}, []string{"test/notfilename.dat"}},


### PR DESCRIPTION
Related: #1750 

Just a tiny PR to add tests for set support in filter e.g. `[Dd]ebug`. This is supported by .gitignore even though it's not very explicit in the git docs. I thought it might be an explanation for the issue above but it wasn't, this test just proves that.