### PR TITLE
Change Adapter Begin() signature to accept an AdapterConfig interface

### DIFF
--- a/lfs/pointer_smudge.go
+++ b/lfs/pointer_smudge.go
@@ -72,6 +72,14 @@ func PointerSmudge(writer io.Writer, ptr *Pointer, workingfile string, download 
 	return nil
 }
 
+type tempAdapterConfig struct {
+	concurrentTransfers int
+}
+
+func (c tempAdapterConfig) ConcurrentTransfers() int {
+	return c.concurrentTransfers
+}
+
 func downloadFile(writer io.Writer, ptr *Pointer, workingfile, mediafile string, manifest *tq.Manifest, cb progress.CopyCallback) error {
 	fmt.Fprintf(os.Stderr, "Downloading %s (%s)\n", workingfile, pb.FormatBytes(ptr.Size))
 
@@ -93,7 +101,7 @@ func downloadFile(writer io.Writer, ptr *Pointer, workingfile, mediafile string,
 		}
 	}
 	// Single download
-	err = adapter.Begin(1, tcb)
+	err = adapter.Begin(tempAdapterConfig{concurrentTransfers: 1}, tcb)
 	if err != nil {
 		return err
 	}

--- a/test/test-custom-transfers.sh
+++ b/test/test-custom-transfers.sh
@@ -28,7 +28,7 @@ begin_test "custom-transfer-wrong-path"
   GIT_TRACE=1 git push origin master 2>&1 | tee pushcustom.log
   # use PIPESTATUS otherwise we get exit code from tee
   res=${PIPESTATUS[0]}
-  grep "xfer: Custom transfer adapter" pushcustom.log
+  grep "xfer: adapter \"testcustom\" Begin()" pushcustom.log
   grep "Failed to start custom transfer command" pushcustom.log
   if [ "$res" = "0" ]; then
     echo "Push should have failed because of an incorrect custom transfer path."
@@ -101,9 +101,8 @@ begin_test "custom-transfer-upload-download"
 
   grep "xfer: started custom adapter process" fetchcustom.log
   grep "xfer\[lfstest-customadapter\]:" fetchcustom.log
-  grep "11 of 11 files" fetchcustom.log  
+  grep "11 of 11 files" fetchcustom.log
   [ `find .git/lfs/objects -type f | wc -l` = 11 ]
 
 )
 end_test
-

--- a/tq/adapterbase.go
+++ b/tq/adapterbase.go
@@ -60,9 +60,10 @@ func (a *adapterBase) Direction() Direction {
 	return a.direction
 }
 
-func (a *adapterBase) Begin(maxConcurrency int, cb ProgressCallback) error {
+func (a *adapterBase) Begin(cfg AdapterConfig, cb ProgressCallback) error {
 	a.cb = cb
 	a.jobChan = make(chan *job, 100)
+	maxConcurrency := cfg.ConcurrentTransfers()
 
 	tracerx.Printf("xfer: adapter %q Begin() with %d workers", a.Name(), maxConcurrency)
 

--- a/tq/transfer.go
+++ b/tq/transfer.go
@@ -161,6 +161,10 @@ type NewAdapterFunc func(name string, dir Direction) Adapter
 
 type ProgressCallback func(name string, totalSize, readSoFar int64, readSinceLast int) error
 
+type AdapterConfig interface {
+	ConcurrentTransfers() int
+}
+
 // Adapter is implemented by types which can upload and/or download LFS
 // file content to a remote store. Each Adapter accepts one or more requests
 // which it may schedule and parallelise in whatever way it chooses, clients of
@@ -185,7 +189,7 @@ type Adapter interface {
 	// one or more Add calls. maxConcurrency controls the number of transfers
 	// that may be done at once. The passed in callback will receive updates on
 	// progress. Either argument may be nil if not required by the client.
-	Begin(maxConcurrency int, cb ProgressCallback) error
+	Begin(cfg AdapterConfig, cb ProgressCallback) error
 	// Add queues a download/upload, which will complete asynchronously and
 	// notify the callbacks given to Begin()
 	Add(transfers ...*Transfer) (results <-chan TransferResult)

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -530,7 +530,7 @@ func (q *TransferQueue) ensureAdapterBegun() error {
 	}
 
 	tracerx.Printf("tq: starting transfer adapter %q", q.adapter.Name())
-	err := q.adapter.Begin(q.manifest.ConcurrentTransfers(), cb)
+	err := q.adapter.Begin(q.manifest, cb)
 	if err != nil {
 		return err
 	}

--- a/tq/transfer_test.go
+++ b/tq/transfer_test.go
@@ -21,7 +21,7 @@ func (a *testAdapter) Direction() Direction {
 	return a.dir
 }
 
-func (a *testAdapter) Begin(maxConcurrency int, cb ProgressCallback) error {
+func (a *testAdapter) Begin(cfg AdapterConfig, cb ProgressCallback) error {
 	return nil
 }
 


### PR DESCRIPTION
This implements my [suggested change](https://github.com/git-lfs/git-lfs/issues/1764#issuecomment-266901659) of the adapter `Begin()` interface, to accept a configuration object interface, instead of a `maxConcurrency int` argument. This gives us flexibility to add more properties if needed without breaking the public interface. If we decided to add something like `MaxSchmeckles() int`, adapters would keep working without ever having to deal with schmeckles if they don't need to.

The PR is currently based on #1772, which is about to merge. Once merged, the base will change to `tq-master`.