### PR TITLE
teach the smudge filter how to use the transfer queue directly

### DIFF
--- a/lfs/pointer_smudge.go
+++ b/lfs/pointer_smudge.go
@@ -10,7 +10,6 @@ import (
 	"github.com/git-lfs/git-lfs/tools"
 	"github.com/git-lfs/git-lfs/tq"
 
-	"github.com/git-lfs/git-lfs/api"
 	"github.com/git-lfs/git-lfs/config"
 	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/progress"
@@ -75,33 +74,20 @@ func PointerSmudge(writer io.Writer, ptr *Pointer, workingfile string, download 
 func downloadFile(writer io.Writer, ptr *Pointer, workingfile, mediafile string, manifest *tq.Manifest, cb progress.CopyCallback) error {
 	fmt.Fprintf(os.Stderr, "Downloading %s (%s)\n", workingfile, pb.FormatBytes(ptr.Size))
 
-	xfers := manifest.GetDownloadAdapterNames()
-	obj, adapterName, err := api.BatchSingle(config.Config, &api.ObjectResource{Oid: ptr.Oid, Size: ptr.Size}, "download", xfers)
-	if err != nil {
-		return errors.Wrapf(err, "Error downloading %s: %s", filepath.Base(mediafile), err)
-	}
+	q := tq.NewTransferQueue(tq.Download, manifest)
+	q.Add(filepath.Base(workingfile), mediafile, ptr.Oid, ptr.Size)
+	q.Wait()
 
-	if ptr.Size == 0 {
-		ptr.Size = obj.Size
-	}
-
-	adapter := manifest.NewDownloadAdapter(adapterName)
-	var tcb tq.ProgressCallback
-	if cb != nil {
-		tcb = func(name string, totalSize, readSoFar int64, readSinceLast int) error {
-			return cb(totalSize, readSoFar, readSinceLast)
+	if errs := q.Errors(); len(errs) > 0 {
+		var multiErr error
+		for _, e := range errs {
+			if multiErr != nil {
+				multiErr = fmt.Errorf("%v\n%v", multiErr, e)
+			} else {
+				multiErr = e
+			}
+			return errors.Wrapf(multiErr, "Error downloading %s (%s)", workingfile, ptr.Oid)
 		}
-	}
-	// Single download
-	err = adapter.Begin(1, tcb)
-	if err != nil {
-		return err
-	}
-	res := <-adapter.Add(tq.NewTransfer(filepath.Base(workingfile), obj, mediafile))
-	adapter.End()
-
-	if res.Error != nil {
-		return errors.Wrapf(err, "Error buffering media file: %s", res.Error)
 	}
 
 	return readLocalFile(writer, ptr, mediafile, workingfile, nil)


### PR DESCRIPTION
This removes the only public usage of `tq.NewTransfer()`. That `multiErr` stuff should be pulled into some package....