### PR TITLE
lfs,cmd: remove lfs.New{Downloadable,Uploadable}

### DIFF
--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -327,8 +327,7 @@ func fetchAndReportToChan(allpointers []*lfs.WrappedPointer, filter *filepathfil
 	for _, p := range pointers {
 		tracerx.Printf("fetch %v [%v]", p.Name, p.Oid)
 
-		d := lfs.NewDownloadable(p)
-		q.Add(d.Name, d.Path, d.Oid, d.Size)
+		q.Add(downloadTransfer(p))
 	}
 
 	processQueue := time.Now()

--- a/commands/command_prune.go
+++ b/commands/command_prune.go
@@ -149,10 +149,10 @@ func prune(fetchPruneConfig config.FetchPruneConfig, verifyRemote, dryRun, verbo
 
 			if verifyRemote {
 				tracerx.Printf("VERIFYING: %v", file.Oid)
-				pointer := lfs.NewPointer(file.Oid, file.Size, nil)
 
-				d := lfs.NewDownloadable(&lfs.WrappedPointer{Pointer: pointer})
-				verifyQueue.Add(d.Name, d.Path, d.Oid, d.Size)
+				verifyQueue.Add(downloadTransfer(&lfs.WrappedPointer{
+					Pointer: lfs.NewPointer(file.Oid, file.Size, nil),
+				}))
 			}
 		}
 	}

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -73,6 +73,68 @@ func downloadTransfer(p *lfs.WrappedPointer) (name, path, oid string, size int64
 	return p.Name, path, p.Oid, p.Size
 }
 
+func uploadTransfer(oid, filename string) (*tq.Transfer, error) {
+	localMediaPath, err := lfs.LocalMediaPath(oid)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error uploading file %s (%s)", filename, oid)
+	}
+
+	if len(filename) > 0 {
+		if err = ensureFile(filename, localMediaPath); err != nil {
+			return nil, err
+		}
+	}
+
+	fi, err := os.Stat(localMediaPath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error uploading file %s (%s)", filename, oid)
+	}
+
+	return &tq.Transfer{
+		Name: filename,
+		Path: localMediaPath,
+		Oid:  oid,
+		Size: fi.Size(),
+	}, nil
+}
+
+// ensureFile makes sure that the cleanPath exists before pushing it.  If it
+// does not exist, it attempts to clean it by reading the file at smudgePath.
+func ensureFile(smudgePath, cleanPath string) error {
+	if _, err := os.Stat(cleanPath); err == nil {
+		return nil
+	}
+
+	expectedOid := filepath.Base(cleanPath)
+	localPath := filepath.Join(config.LocalWorkingDir, smudgePath)
+	file, err := os.Open(localPath)
+	if err != nil {
+		return err
+	}
+
+	defer file.Close()
+
+	stat, err := file.Stat()
+	if err != nil {
+		return err
+	}
+
+	cleaned, err := lfs.PointerClean(file, file.Name(), stat.Size(), nil)
+	if cleaned != nil {
+		cleaned.Teardown()
+	}
+
+	if err != nil {
+		return err
+	}
+
+	if expectedOid != cleaned.Oid {
+		return fmt.Errorf("Trying to push %q with OID %s.\nNot found in %s.", smudgePath, expectedOid, filepath.Dir(cleanPath))
+	}
+
+	return nil
+}
+
 // Error prints a formatted message to Stderr.  It also gets printed to the
 // panic log if one is created for this command.
 func Error(format string, args ...interface{}) {

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -67,6 +67,12 @@ func buildFilepathFilter(config *config.Configuration, includeArg, excludeArg *s
 	return filepathfilter.New(inc, exc)
 }
 
+func downloadTransfer(p *lfs.WrappedPointer) (name, path, oid string, size int64) {
+	path, _ = lfs.LocalMediaPath(p.Oid)
+
+	return p.Name, path, p.Oid, p.Size
+}
+
 // Error prints a formatted message to Stderr.  It also gets printed to the
 // panic log if one is created for this command.
 func Error(format string, args ...interface{}) {

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -113,8 +113,7 @@ func (c *uploadContext) checkMissing(missing []*lfs.WrappedPointer, missingSize 
 	}()
 
 	for _, p := range missing {
-		d := lfs.NewDownloadable(p)
-		checkQueue.Add(d.Name, d.Path, d.Oid, d.Size)
+		checkQueue.Add(downloadTransfer(p))
 	}
 
 	// Currently this is needed to flush the batch but is not enough to sync

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -140,7 +140,7 @@ func uploadPointers(c *uploadContext, unfiltered []*lfs.WrappedPointer) {
 
 	q, pointers := c.prepareUpload(unfiltered)
 	for _, p := range pointers {
-		u, err := lfs.NewUploadable(p.Oid, p.Name)
+		t, err := uploadTransfer(p.Oid, p.Name)
 		if err != nil {
 			if errors.IsCleanPointerError(err) {
 				Exit(uploadMissingErr, p.Oid, p.Name, errors.GetContext(err, "pointer").(*lfs.Pointer).Oid)
@@ -149,7 +149,7 @@ func uploadPointers(c *uploadContext, unfiltered []*lfs.WrappedPointer) {
 			}
 		}
 
-		q.Add(u.Name, u.Path, u.Oid, u.Size)
+		q.Add(t.Name, t.Path, t.Oid, t.Size)
 		c.SetUploaded(p.Oid)
 	}
 

--- a/lfs/download_queue.go
+++ b/lfs/download_queue.go
@@ -5,17 +5,6 @@ import (
 	"github.com/git-lfs/git-lfs/tq"
 )
 
-func NewDownloadable(p *WrappedPointer) *tq.Transfer {
-	path, _ := LocalMediaPath(p.Oid)
-
-	return &tq.Transfer{
-		Oid:  p.Oid,
-		Size: p.Size,
-		Name: p.Name,
-		Path: path,
-	}
-}
-
 // NewDownloadCheckQueue builds a checking queue, checks that objects are there but doesn't download
 func NewDownloadCheckQueue(cfg *config.Configuration, options ...tq.Option) *tq.TransferQueue {
 	allOptions := make([]tq.Option, len(options), len(options)+1)

--- a/lfs/upload_queue.go
+++ b/lfs/upload_queue.go
@@ -1,78 +1,9 @@
 package lfs
 
 import (
-	"fmt"
-	"os"
-	"path/filepath"
-
 	"github.com/git-lfs/git-lfs/config"
-	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/tq"
 )
-
-// NewUploadable builds the Uploadable from the given information.
-// "filename" can be empty if a raw object is pushed (see "object-id" flag in push command)/
-func NewUploadable(oid, filename string) (*tq.Transfer, error) {
-	localMediaPath, err := LocalMediaPath(oid)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Error uploading file %s (%s)", filename, oid)
-	}
-
-	if len(filename) > 0 {
-		if err := ensureFile(filename, localMediaPath); err != nil {
-			return nil, err
-		}
-	}
-
-	fi, err := os.Stat(localMediaPath)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Error uploading file %s (%s)", filename, oid)
-	}
-
-	return &tq.Transfer{
-		Name: filename,
-		Oid:  oid,
-		Size: fi.Size(),
-		Path: localMediaPath,
-	}, nil
-}
-
-// ensureFile makes sure that the cleanPath exists before pushing it.  If it
-// does not exist, it attempts to clean it by reading the file at smudgePath.
-func ensureFile(smudgePath, cleanPath string) error {
-	if _, err := os.Stat(cleanPath); err == nil {
-		return nil
-	}
-
-	expectedOid := filepath.Base(cleanPath)
-	localPath := filepath.Join(config.LocalWorkingDir, smudgePath)
-	file, err := os.Open(localPath)
-	if err != nil {
-		return err
-	}
-
-	defer file.Close()
-
-	stat, err := file.Stat()
-	if err != nil {
-		return err
-	}
-
-	cleaned, err := PointerClean(file, file.Name(), stat.Size(), nil)
-	if cleaned != nil {
-		cleaned.Teardown()
-	}
-
-	if err != nil {
-		return err
-	}
-
-	if expectedOid != cleaned.Oid {
-		return fmt.Errorf("Trying to push %q with OID %s.\nNot found in %s.", smudgePath, expectedOid, filepath.Dir(cleanPath))
-	}
-
-	return nil
-}
 
 // NewUploadQueue builds an UploadQueue, allowing `workers` concurrent uploads.
 func NewUploadQueue(cfg *config.Configuration, options ...tq.Option) *tq.TransferQueue {


### PR DESCRIPTION
This pull-request moves the `lfs.NewDownloadable` and `lfs.NewUploadable` functions into the `commands` package and un-exports them.

As an aside, the `NewUploadable` alternative had to be copied into the `test` package, since it was inaccessible as a private member of the `commands` package. I think this follows the Go-ism: "A little copy is better than a little dependency."

---

/cc @git-lfs/core 