### PR TITLE
docs/api: object size must be positive

### DIFF
--- a/docs/api/batch.md
+++ b/docs/api/batch.md
@@ -31,7 +31,7 @@ that the client has configured. If omitted, the `basic` transfer adapter MUST
 be assumed by the server.
 * `objects` - An Array of objects to download.
   * `oid` - String OID of the LFS object.
-  * `size` - Integer byte size of the LFS object.
+  * `size` - Integer byte size of the LFS object. Must be at least zero.
 
 Note: Git LFS currently only supports the `basic` transfer adapter. This
 property was added for future compatibility with some experimental transfer
@@ -70,7 +70,7 @@ client will use the `basic` transfer adapter if the `transfer` property is
 omitted.
 * `objects` - An Array of objects to download.
   * `oid` - String OID of the LFS object.
-  * `size` - Integer byte size of the LFS object.
+  * `size` - Integer byte size of the LFS object. Must be at least zero.
   * `authenticated` - Optional boolean specifying whether the request for this
   specific object is authenticated. If omitted or false, Git LFS will attempt
   to [find credentials for this URL](./authentication.md).

--- a/docs/api/schemas/http-batch-request-schema.json
+++ b/docs/api/schemas/http-batch-request-schema.json
@@ -21,7 +21,8 @@
             "type": "string"
           },
           "size": {
-            "type": "number"
+            "type": "number",
+            "minimum": 0
           },
           "authenticated": {
             "type": "boolean"


### PR DESCRIPTION
This pull-request makes more clear that object sizes sent to and returned from the server must be positive.

This information was originally added in https://github.com/git-lfs/git-lfs/pull/1371, but only changed the legacy and v1 schemas, which were removed as of https://github.com/git-lfs/git-lfs/pull/1641. Now they're back :-)

---

/cc @git-lfs/core #1778