### PR TITLE
backport filepathfilter to v1.5.x

### DIFF
--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/git-lfs/git-lfs/filepathfilter"
 	"github.com/git-lfs/git-lfs/localstorage"
 	"github.com/git-lfs/git-lfs/subprocess"
 	"github.com/git-lfs/git-lfs/tools/longpathos"
@@ -70,19 +71,18 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 	}
 
 	includeArg, excludeArg := getIncludeExcludeArgs(cmd)
-	include, exclude := determineIncludeExcludePaths(cfg, includeArg, excludeArg)
+	filter := filepathfilter.New(determineIncludeExcludePaths(cfg, includeArg, excludeArg))
 	if cloneFlags.NoCheckout || cloneFlags.Bare {
 		// If --no-checkout or --bare then we shouldn't check out, just fetch instead
-		fetchRef("HEAD", include, exclude)
+		fetchRef("HEAD", filter)
 	} else {
-		pull(include, exclude)
+		pull(filter)
 
 		err := postCloneSubmodules(args)
 		if err != nil {
 			Exit("Error performing 'git lfs pull' for submodules: %v", err)
 		}
 	}
-
 }
 
 func postCloneSubmodules(args []string) error {

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 
+	"github.com/git-lfs/git-lfs/filepathfilter"
 	"github.com/git-lfs/git-lfs/git"
 	"github.com/spf13/cobra"
 )
@@ -27,20 +28,18 @@ func pullCommand(cmd *cobra.Command, args []string) {
 	}
 
 	includeArg, excludeArg := getIncludeExcludeArgs(cmd)
-	pull(determineIncludeExcludePaths(cfg, includeArg, excludeArg))
+	pull(filepathfilter.New(determineIncludeExcludePaths(cfg, includeArg, excludeArg)))
 
 }
 
-func pull(includePaths, excludePaths []string) {
-
+func pull(filter *filepathfilter.Filter) {
 	ref, err := git.CurrentRef()
 	if err != nil {
 		Panic(err, "Could not pull")
 	}
 
-	c := fetchRefToChan(ref.Sha, includePaths, excludePaths)
-	checkoutFromFetchChan(includePaths, excludePaths, c)
-
+	c := fetchRefToChan(ref.Sha, filter)
+	checkoutFromFetchChan(filter, c)
 }
 
 func init() {

--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 
 	"github.com/git-lfs/git-lfs/errors"
+	"github.com/git-lfs/git-lfs/filepathfilter"
 	"github.com/git-lfs/git-lfs/lfs"
-	"github.com/git-lfs/git-lfs/tools"
 	"github.com/git-lfs/git-lfs/tools/longpathos"
 	"github.com/spf13/cobra"
 )
@@ -42,7 +42,8 @@ func smudge(to io.Writer, ptr *lfs.Pointer, filename string, skip bool) error {
 		return err
 	}
 
-	download := tools.FilenamePassesIncludeExcludeFilter(filename, cfg.FetchIncludePaths(), cfg.FetchExcludePaths())
+	filter := filepathfilter.New(cfg.FetchIncludePaths(), cfg.FetchExcludePaths())
+	download := filter.Allows(filename)
 
 	if skip || cfg.Os.Bool("GIT_LFS_SKIP_SMUDGE", false) {
 		download = false

--- a/filepathfilter/filepathfilter.go
+++ b/filepathfilter/filepathfilter.go
@@ -1,0 +1,155 @@
+package filepathfilter
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+type Pattern interface {
+	Match(filename string) bool
+}
+
+type Filter struct {
+	include []Pattern
+	exclude []Pattern
+}
+
+func NewFromPatterns(include, exclude []Pattern) *Filter {
+	return &Filter{include: include, exclude: exclude}
+}
+
+func New(include, exclude []string) *Filter {
+	return NewFromPatterns(convertToPatterns(include), convertToPatterns(exclude))
+}
+
+func (f *Filter) Allows(filename string) bool {
+	if f == nil {
+		return true
+	}
+
+	if len(f.include)+len(f.exclude) == 0 {
+		return true
+	}
+
+	cleanedName := filepath.Clean(filename)
+
+	if len(f.include) > 0 {
+		matched := false
+		for _, inc := range f.include {
+			matched = inc.Match(cleanedName)
+			if matched {
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+
+	if len(f.exclude) > 0 {
+		for _, ex := range f.exclude {
+			if ex.Match(cleanedName) {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+func NewPattern(rawpattern string) Pattern {
+	cleanpattern := filepath.Clean(rawpattern)
+
+	// Special case local dir, matches all (inc subpaths)
+	if _, local := localDirSet[cleanpattern]; local {
+		return noOpMatcher{}
+	}
+
+	hasPathSep := strings.Contains(cleanpattern, string(filepath.Separator))
+
+	// special case * when there are no path separators
+	// filepath.Match never allows * to match a path separator, which is correct
+	// for gitignore IF the pattern includes a path separator, but not otherwise
+	// So *.txt should match in any subdir, as should test*, but sub/*.txt would
+	// only match directly in the sub dir
+	// Don't need to test cross-platform separators as both cleaned above
+	if !hasPathSep && strings.Contains(cleanpattern, "*") {
+		pattern := regexp.QuoteMeta(cleanpattern)
+		regpattern := fmt.Sprintf("^%s$", strings.Replace(pattern, "\\*", ".*", -1))
+		return &pathlessWildcardPattern{
+			rawPattern: cleanpattern,
+			wildcardRE: regexp.MustCompile(regpattern),
+		}
+		// Also support ** with path separators
+	} else if hasPathSep && strings.Contains(cleanpattern, "**") {
+		pattern := regexp.QuoteMeta(cleanpattern)
+		regpattern := fmt.Sprintf("^%s$", strings.Replace(pattern, "\\*\\*", ".*", -1))
+		return &doubleWildcardPattern{
+			rawPattern: cleanpattern,
+			wildcardRE: regexp.MustCompile(regpattern),
+		}
+	} else {
+		return &basicPattern{rawPattern: cleanpattern}
+	}
+}
+
+func convertToPatterns(rawpatterns []string) []Pattern {
+	patterns := make([]Pattern, len(rawpatterns))
+	for i, raw := range rawpatterns {
+		patterns[i] = NewPattern(raw)
+	}
+	return patterns
+}
+
+type basicPattern struct {
+	rawPattern string
+}
+
+// Match is a revised version of filepath.Match which makes it behave more
+// like gitignore
+func (p *basicPattern) Match(name string) bool {
+	matched, _ := filepath.Match(p.rawPattern, name)
+	// Also support matching a parent directory without a wildcard
+	return matched || strings.HasPrefix(name, p.rawPattern+string(filepath.Separator))
+}
+
+type pathlessWildcardPattern struct {
+	rawPattern string
+	wildcardRE *regexp.Regexp
+}
+
+// Match is a revised version of filepath.Match which makes it behave more
+// like gitignore
+func (p *pathlessWildcardPattern) Match(name string) bool {
+	matched, _ := filepath.Match(p.rawPattern, name)
+	// Match the whole of the base name but allow matching in folders if no path
+	return matched || p.wildcardRE.MatchString(filepath.Base(name))
+}
+
+type doubleWildcardPattern struct {
+	rawPattern string
+	wildcardRE *regexp.Regexp
+}
+
+// Match is a revised version of filepath.Match which makes it behave more
+// like gitignore
+func (p *doubleWildcardPattern) Match(name string) bool {
+	matched, _ := filepath.Match(p.rawPattern, name)
+	// Match the whole of the base name but allow matching in folders if no path
+	return matched || p.wildcardRE.MatchString(name)
+}
+
+type noOpMatcher struct {
+}
+
+func (n noOpMatcher) Match(name string) bool {
+	return true
+}
+
+var localDirSet = map[string]struct{}{
+	".":   struct{}{},
+	"./":  struct{}{},
+	".\\": struct{}{},
+}

--- a/filepathfilter/filepathfilter_test.go
+++ b/filepathfilter/filepathfilter_test.go
@@ -1,0 +1,124 @@
+package filepathfilter
+
+import (
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPatternMatch(t *testing.T) {
+	assert.True(t, patternMatch("filename.txt", "filename.txt"))
+	assert.True(t, patternMatch("*.txt", "filename.txt"))
+	assert.False(t, patternMatch("*.tx", "filename.txt"))
+	assert.True(t, patternMatch("f*.txt", "filename.txt"))
+	assert.False(t, patternMatch("g*.txt", "filename.txt"))
+	assert.True(t, patternMatch("file*", "filename.txt"))
+	assert.False(t, patternMatch("file", "filename.txt"))
+
+	// With no path separators, should match in subfolders
+	assert.True(t, patternMatch("*.txt", "sub/filename.txt"))
+	assert.False(t, patternMatch("*.tx", "sub/filename.txt"))
+	assert.True(t, patternMatch("f*.txt", "sub/filename.txt"))
+	assert.False(t, patternMatch("g*.txt", "sub/filename.txt"))
+	assert.True(t, patternMatch("file*", "sub/filename.txt"))
+	assert.False(t, patternMatch("file", "sub/filename.txt"))
+	// Needs wildcard for exact filename
+	assert.True(t, patternMatch("**/filename.txt", "sub/sub/sub/filename.txt"))
+
+	// Should not match dots to subparts
+	assert.False(t, patternMatch("*.ign", "sub/shouldignoreme.txt"))
+
+	// Path specific
+	assert.True(t, patternMatch("sub", "sub/filename.txt"))
+	assert.False(t, patternMatch("sub", "subfilename.txt"))
+
+	// Absolute
+	assert.True(t, patternMatch("*.dat", "/path/to/sub/.git/test.dat"))
+	assert.True(t, patternMatch("**/.git", "/path/to/sub/.git"))
+
+	// Match anything
+	assert.True(t, patternMatch(".", "path.txt"))
+	assert.True(t, patternMatch("./", "path.txt"))
+	assert.True(t, patternMatch(".\\", "path.txt"))
+}
+
+func patternMatch(pattern, filename string) bool {
+	return NewPattern(pattern).Match(filepath.Clean(filename))
+}
+
+type filterTest struct {
+	expectedResult bool
+	includes       []string
+	excludes       []string
+}
+
+func TestFilterAllows(t *testing.T) {
+	cases := []filterTest{
+		// Null case
+		filterTest{true, nil, nil},
+		// Inclusion
+		filterTest{true, []string{"*.dat"}, nil},
+		filterTest{true, []string{"file*.dat"}, nil},
+		filterTest{true, []string{"file*"}, nil},
+		filterTest{true, []string{"*name.dat"}, nil},
+		filterTest{false, []string{"/*.dat"}, nil},
+		filterTest{false, []string{"otherfolder/*.dat"}, nil},
+		filterTest{false, []string{"*.nam"}, nil},
+		filterTest{true, []string{"test/filename.dat"}, nil},
+		filterTest{true, []string{"test/filename.dat"}, nil},
+		filterTest{false, []string{"blank", "something", "foo"}, nil},
+		filterTest{false, []string{"test/notfilename.dat"}, nil},
+		filterTest{true, []string{"test"}, nil},
+		filterTest{true, []string{"test/*"}, nil},
+		filterTest{false, []string{"nottest"}, nil},
+		filterTest{false, []string{"nottest/*"}, nil},
+		filterTest{true, []string{"test/fil*"}, nil},
+		filterTest{false, []string{"test/g*"}, nil},
+		filterTest{true, []string{"tes*/*"}, nil},
+		filterTest{true, []string{"[Tt]est/[Ff]ilename.dat"}, nil},
+		// Exclusion
+		filterTest{false, nil, []string{"*.dat"}},
+		filterTest{false, nil, []string{"file*.dat"}},
+		filterTest{false, nil, []string{"file*"}},
+		filterTest{false, nil, []string{"*name.dat"}},
+		filterTest{true, nil, []string{"/*.dat"}},
+		filterTest{true, nil, []string{"otherfolder/*.dat"}},
+		filterTest{false, nil, []string{"test/filename.dat"}},
+		filterTest{false, nil, []string{"blank", "something", "test/filename.dat", "foo"}},
+		filterTest{true, nil, []string{"blank", "something", "foo"}},
+		filterTest{true, nil, []string{"test/notfilename.dat"}},
+		filterTest{false, nil, []string{"test"}},
+		filterTest{false, nil, []string{"test/*"}},
+		filterTest{true, nil, []string{"nottest"}},
+		filterTest{true, nil, []string{"nottest/*"}},
+		filterTest{false, nil, []string{"test/fil*"}},
+		filterTest{true, nil, []string{"test/g*"}},
+		filterTest{false, nil, []string{"tes*/*"}},
+		filterTest{false, nil, []string{"[Tt]est/[Ff]ilename.dat"}},
+
+		// Both
+		filterTest{true, []string{"test/filename.dat"}, []string{"test/notfilename.dat"}},
+		filterTest{false, []string{"test"}, []string{"test/filename.dat"}},
+		filterTest{true, []string{"test/*"}, []string{"test/notfile*"}},
+		filterTest{false, []string{"test/*"}, []string{"test/file*"}},
+		filterTest{false, []string{"another/*", "test/*"}, []string{"test/notfilename.dat", "test/filename.dat"}},
+	}
+
+	for _, c := range cases {
+		result := New(c.includes, c.excludes).Allows("test/filename.dat")
+		assert.Equal(t, c.expectedResult, result, "includes: %v excludes: %v", c.includes, c.excludes)
+		if runtime.GOOS == "windows" {
+			// also test with \ path separators, tolerate mixed separators
+			for i, inc := range c.includes {
+				c.includes[i] = strings.Replace(inc, "/", "\\", -1)
+			}
+			for i, ex := range c.excludes {
+				c.excludes[i] = strings.Replace(ex, "/", "\\", -1)
+			}
+			assert.Equal(t, c.expectedResult, New(c.includes, c.excludes).Allows("test/filename.dat"), c)
+		}
+	}
+}

--- a/filepathfilter/filepathfilterbench/bench_test.go
+++ b/filepathfilter/filepathfilterbench/bench_test.go
@@ -1,0 +1,66 @@
+package filepathfilterbench
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/git-lfs/git-lfs/filepathfilter"
+	"github.com/git-lfs/git-lfs/tools"
+)
+
+func BenchmarkFilterIncludeWildcardOnly(b *testing.B) {
+	files := benchmarkTree(b)
+	filter := filepathfilter.New([]string{"*.go"}, nil)
+	for i := 0; i < b.N; i++ {
+		for _, f := range files {
+			filter.Allows(f)
+		}
+	}
+}
+
+func BenchmarkFilterIncludeDoubleAsterisk(b *testing.B) {
+	files := benchmarkTree(b)
+	filter := filepathfilter.New([]string{"**/README.md"}, nil)
+	for i := 0; i < b.N; i++ {
+		for _, f := range files {
+			filter.Allows(f)
+		}
+	}
+}
+
+var (
+	benchmarkFiles []string
+	benchmarkMu    sync.Mutex
+)
+
+func benchmarkTree(b *testing.B) []string {
+	benchmarkMu.Lock()
+	defer benchmarkMu.Unlock()
+
+	if benchmarkFiles != nil {
+		return benchmarkFiles
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	hasErrors := false
+	tools.FastWalkGitRepo(filepath.Dir(wd), func(parent string, info os.FileInfo, err error) {
+		if err != nil {
+			hasErrors = true
+			b.Error(err)
+			return
+		}
+		benchmarkFiles = append(benchmarkFiles, filepath.Join(parent, info.Name()))
+	})
+
+	if hasErrors {
+		b.Fatal("has errors :(")
+	}
+
+	return benchmarkFiles
+}

--- a/tools/filetools.go
+++ b/tools/filetools.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/git-lfs/git-lfs/filepathfilter"
 	"github.com/git-lfs/git-lfs/tools/longpathos"
 )
 
@@ -211,60 +212,65 @@ func FileMatch(pattern, name string) bool {
 
 }
 
+// FastWalkCallback is the signature for the callback given to FastWalkGitRepo()
+type FastWalkCallback func(parentDir string, info os.FileInfo, err error)
+
+// FastWalkGitRepo is a more optimal implementation of filepath.Walk for a Git
+// repo. The callback guaranteed to be called sequentially. The function returns
+// once all files and errors have triggered callbacks.
+// It differs in the following ways:
+//  * Uses goroutines to parallelise large dirs and descent into subdirs
+//  * Does not provide sorted output; parents will always be before children but
+//    there are no other guarantees. Use parentDir argument in the callback to
+//    determine absolute path rather than tracking it yourself
+//  * Automatically ignores any .git directories
+//  * Respects .gitignore contents and skips ignored files/dirs
+func FastWalkGitRepo(dir string, cb FastWalkCallback) {
+	// Ignore all git metadata including subrepos
+	excludePaths := []filepathfilter.Pattern{
+		filepathfilter.NewPattern(".git"),
+		filepathfilter.NewPattern(filepath.Join("**", ".git")),
+	}
+
+	fileCh := fastWalkWithExcludeFiles(dir, ".gitignore", excludePaths)
+	for file := range fileCh {
+		cb(file.ParentDir, file.Info, file.Err)
+	}
+}
+
 // Returned from FastWalk with parent directory context
 // This is needed because FastWalk can provide paths out of order so the
 // parent dir cannot be implied
-type FastWalkInfo struct {
+type fastWalkInfo struct {
 	ParentDir string
 	Info      os.FileInfo
+	Err       error
 }
 
 // fastWalkWithExcludeFiles walks the contents of a dir, respecting
 // include/exclude patterns and also loading new exlude patterns from files
 // named excludeFilename in directories walked
 func fastWalkWithExcludeFiles(dir, excludeFilename string,
-	includePaths, excludePaths []string) (<-chan FastWalkInfo, <-chan error) {
-	fiChan := make(chan FastWalkInfo, 256)
-	errChan := make(chan error, 10)
-
-	go fastWalkFromRoot(dir, excludeFilename, includePaths, excludePaths, fiChan, errChan)
-
-	return fiChan, errChan
-}
-
-// FastWalkGitRepo is a more optimal implementation of filepath.Walk for a Git repo
-// It differs in the following ways:
-//  * Provides a channel of information instead of using a callback func
-//  * Uses goroutines to parallelise large dirs and descent into subdirs
-//  * Does not provide sorted output; parents will always be before children but
-//    there are no other guarantees. Use parentDir in the FastWalkInfo struct to
-//    determine absolute path rather than tracking it yourself like filepath.Walk
-//  * Automatically ignores any .git directories
-//  * Respects .gitignore contents and skips ignored files/dirs
-func FastWalkGitRepo(dir string) (<-chan FastWalkInfo, <-chan error) {
-	// Ignore all git metadata including subrepos
-	excludePaths := []string{".git", filepath.Join("**", ".git")}
-	return fastWalkWithExcludeFiles(dir, ".gitignore", nil, excludePaths)
+	excludePaths []filepathfilter.Pattern) <-chan fastWalkInfo {
+	fiChan := make(chan fastWalkInfo, 256)
+	go fastWalkFromRoot(dir, excludeFilename, excludePaths, fiChan)
+	return fiChan
 }
 
 func fastWalkFromRoot(dir string, excludeFilename string,
-	includePaths, excludePaths []string, fiChan chan<- FastWalkInfo, errChan chan<- error) {
+	excludePaths []filepathfilter.Pattern, fiChan chan<- fastWalkInfo) {
 
-	dirFi, err := longpathos.Stat(dir)
+	dirFi, err := os.Stat(dir)
 	if err != nil {
-		errChan <- err
+		fiChan <- fastWalkInfo{Err: err}
 		return
 	}
 
 	// This waitgroup will be incremented for each nested goroutine
 	var waitg sync.WaitGroup
-
-	fastWalkFileOrDir(filepath.Dir(dir), dirFi, excludeFilename, includePaths, excludePaths, fiChan, errChan, &waitg)
-
+	fastWalkFileOrDir(filepath.Dir(dir), dirFi, excludeFilename, excludePaths, fiChan, &waitg)
 	waitg.Wait()
 	close(fiChan)
-	close(errChan)
-
 }
 
 // fastWalkFileOrDir is the main recursive implementation of fast walk
@@ -274,16 +280,15 @@ func fastWalkFromRoot(dir string, excludeFilename string,
 // Also splits large directories into multiple goroutines.
 // Increments waitg.Add(1) for each new goroutine launched internally
 func fastWalkFileOrDir(parentDir string, itemFi os.FileInfo, excludeFilename string,
-	includePaths, excludePaths []string, fiChan chan<- FastWalkInfo, errChan chan<- error,
-	waitg *sync.WaitGroup) {
+	excludePaths []filepathfilter.Pattern, fiChan chan<- fastWalkInfo, waitg *sync.WaitGroup) {
 
 	fullPath := filepath.Join(parentDir, itemFi.Name())
 
-	if !FilenamePassesIncludeExcludeFilter(fullPath, includePaths, excludePaths) {
+	if !filepathfilter.NewFromPatterns(nil, excludePaths).Allows(fullPath) {
 		return
 	}
 
-	fiChan <- FastWalkInfo{ParentDir: parentDir, Info: itemFi}
+	fiChan <- fastWalkInfo{ParentDir: parentDir, Info: itemFi}
 
 	if !itemFi.IsDir() {
 		// Nothing more to do if this is not a dir
@@ -292,12 +297,10 @@ func fastWalkFileOrDir(parentDir string, itemFi os.FileInfo, excludeFilename str
 
 	if len(excludeFilename) > 0 {
 		possibleExcludeFile := filepath.Join(fullPath, excludeFilename)
-		if FileExists(possibleExcludeFile) {
-			var err error
-			excludePaths, err = loadExcludeFilename(possibleExcludeFile, fullPath, excludePaths)
-			if err != nil {
-				errChan <- err
-			}
+		var err error
+		excludePaths, err = loadExcludeFilename(possibleExcludeFile, fullPath, excludePaths)
+		if err != nil {
+			fiChan <- fastWalkInfo{Err: err}
 		}
 	}
 
@@ -305,12 +308,13 @@ func fastWalkFileOrDir(parentDir string, itemFi os.FileInfo, excludeFilename str
 	// still need the Stat() to know whether something is a dir, so use
 	// File.Readdir instead. Means we can provide os.FileInfo to callers like
 	// filepath.Walk as a bonus.
-	df, err := longpathos.Open(fullPath)
+	df, err := os.Open(fullPath)
 	if err != nil {
-		errChan <- err
+		fiChan <- fastWalkInfo{Err: err}
 		return
 	}
 	defer df.Close()
+
 	// The number of items in a dir we process in each goroutine
 	jobSize := 100
 	for children, err := df.Readdir(jobSize); err == nil; children, err = df.Readdir(jobSize) {
@@ -318,25 +322,27 @@ func fastWalkFileOrDir(parentDir string, itemFi os.FileInfo, excludeFilename str
 		waitg.Add(1)
 		go func(subitems []os.FileInfo) {
 			for _, childFi := range subitems {
-				fastWalkFileOrDir(fullPath, childFi, excludeFilename, includePaths, excludePaths, fiChan, errChan, waitg)
+				fastWalkFileOrDir(fullPath, childFi, excludeFilename, excludePaths, fiChan, waitg)
 			}
 			waitg.Done()
 		}(children)
 
 	}
 	if err != nil && err != io.EOF {
-		errChan <- err
+		fiChan <- fastWalkInfo{Err: err}
 	}
-
 }
 
 // loadExcludeFilename reads the given file in gitignore format and returns a
 // revised array of exclude paths if there are any changes.
 // If any changes are made a copy of the array is taken so the original is not
 // modified
-func loadExcludeFilename(filename, parentDir string, excludePaths []string) ([]string, error) {
-	f, err := longpathos.OpenFile(filename, os.O_RDONLY, 0644)
+func loadExcludeFilename(filename, parentDir string, excludePaths []filepathfilter.Pattern) ([]filepathfilter.Pattern, error) {
+	f, err := os.OpenFile(filename, os.O_RDONLY, 0644)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return excludePaths, nil
+		}
 		return excludePaths, err
 	}
 	defer f.Close()
@@ -354,7 +360,7 @@ func loadExcludeFilename(filename, parentDir string, excludePaths []string) ([]s
 
 		if !modified {
 			// copy on write
-			retPaths = make([]string, len(excludePaths))
+			retPaths = make([]filepathfilter.Pattern, len(excludePaths))
 			copy(retPaths, excludePaths)
 			modified = true
 		}
@@ -366,9 +372,8 @@ func loadExcludeFilename(filename, parentDir string, excludePaths []string) ([]s
 			!strings.Contains(path, "*") {
 			path = filepath.Join(parentDir, line)
 		}
-		retPaths = append(retPaths, path)
+		retPaths = append(retPaths, filepathfilter.NewPattern(path))
 	}
 
 	return retPaths, nil
-
 }


### PR DESCRIPTION
This backports the `filepathfilter` package, which should improve `git lfs track` times. /cc #1750