### PR TITLE
ensure you're in the correct directory when installing

### DIFF
--- a/script/install.sh.example
+++ b/script/install.sh.example
@@ -10,11 +10,13 @@ elif [ "${BOXEN_HOME:-}" != "" ] ; then
 fi
 
 mkdir -p $prefix/bin
-
 rm -rf $prefix/bin/git-lfs*
-for g in git*; do
-  install $g "$prefix/bin/$g"
-done
+
+pushd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null
+  for g in git*; do
+    install $g "$prefix/bin/$g"
+  done
+popd > /dev/null
 
 PATH+=:$prefix/bin
 git lfs install


### PR DESCRIPTION
Implements the suggestion in #1792, using `pushd` and `popd` so the user's `pwd` doesn't change after running the command.