### PR TITLE
commands,lfs: handle malformed pointers

### DIFF
--- a/commands/command_filter_process.go
+++ b/commands/command_filter_process.go
@@ -83,7 +83,7 @@ func filterCommand(cmd *cobra.Command, args []string) {
 	}
 
 	if len(malformed) > 0 {
-		fmt.Fprintf(os.Stderr, "Encountered %d files that should have been pointers, but weren't:\n", len(malformed))
+		fmt.Fprintf(os.Stderr, "Encountered %d file(s) that should have been pointers, but weren't:\n", len(malformed))
 		for _, m := range malformed {
 			fmt.Fprintf(os.Stderr, "\t%s\n", m)
 		}

--- a/commands/command_filter_process.go
+++ b/commands/command_filter_process.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 
 	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/filepathfilter"
@@ -85,7 +84,9 @@ func filterCommand(cmd *cobra.Command, args []string) {
 
 	if len(malformed) > 0 {
 		fmt.Fprintf(os.Stderr, "Encountered %d files that should have been pointers, but weren't:\n", len(malformed))
-		fmt.Fprintf(os.Stderr, "%s\n", strings.Join(malformed, ", "))
+		for _, m := range malformed {
+			fmt.Fprintf(os.Stderr, "\t%s\n", m)
+		}
 	}
 
 	if err := s.Err(); err != nil && err != io.EOF {

--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -29,14 +28,9 @@ var (
 // were non-fatal, otherwise execution will halt and the process will be
 // terminated by using the `commands.Panic()` func.
 func smudge(to io.Writer, from io.Reader, filename string, skip bool, filter *filepathfilter.Filter) error {
-	pbuf, more, ptr, perr := lfs.DecodeFromHasMore(from)
+	ptr, pbuf, perr := lfs.DecodeFrom(from)
 	if perr != nil {
-		var r io.Reader = bytes.NewReader(pbuf)
-		if more {
-			r = io.MultiReader(r, from)
-		}
-
-		if _, err := io.Copy(to, r); err != nil {
+		if _, err := io.Copy(to, pbuf); err != nil {
 			return errors.Wrap(err, perr.Error())
 		}
 

--- a/lfs/pointer.go
+++ b/lfs/pointer.go
@@ -116,20 +116,20 @@ func DecodePointer(reader io.Reader) (*Pointer, error) {
 // blob's data will be returned, along with a parse error.
 func DecodeFrom(reader io.Reader) (*Pointer, io.Reader, error) {
 	buf := make([]byte, blobSizeCutoff)
-	written, rerr := reader.Read(buf)
-	output := buf[0:written]
+	n, err := reader.Read(buf)
+	buf = buf[:n]
 
-	var buffer io.Reader = bytes.NewReader(output)
-	if rerr != io.EOF {
-		buffer = io.MultiReader(buffer, reader)
+	var contents io.Reader = bytes.NewReader(buf)
+	if err != io.EOF {
+		contents = io.MultiReader(contents, reader)
 	}
 
-	if rerr != nil && rerr != io.EOF {
-		return nil, buffer, rerr
+	if err != nil && err != io.EOF {
+		return nil, contents, err
 	}
 
-	p, err := decodeKV(bytes.TrimSpace(output))
-	return p, buffer, err
+	p, err := decodeKV(bytes.TrimSpace(buf))
+	return p, contents, err
 }
 
 func verifyVersion(version string) error {

--- a/lfs/pointer_clean.go
+++ b/lfs/pointer_clean.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"io"
+	"io/ioutil"
 	"os"
 
 	"github.com/git-lfs/git-lfs/config"
@@ -76,8 +77,9 @@ func copyToTemp(reader io.Reader, fileSize int64, cb progress.CopyCallback) (oid
 		cb = nil
 	}
 
-	by, ptr, err := DecodeFrom(reader)
-	if err == nil && len(by) < 512 {
+	ptr, buf, err := DecodeFrom(reader)
+	by, rerr := ioutil.ReadAll(buf)
+	if rerr != nil || (err == nil && len(by) < 512) {
 		err = errors.NewCleanPointerError(ptr, by)
 		return
 	}

--- a/lfs/pointer_test.go
+++ b/lfs/pointer_test.go
@@ -3,6 +3,7 @@ package lfs
 import (
 	"bufio"
 	"bytes"
+	"io/ioutil"
 	"reflect"
 	"strings"
 	"testing"
@@ -168,11 +169,13 @@ size 12345`
 }
 
 func TestDecodeFromEmptyReader(t *testing.T) {
-	by, p, err := DecodeFrom(strings.NewReader(""))
+	p, buf, err := DecodeFrom(strings.NewReader(""))
+	by, rerr := ioutil.ReadAll(buf)
 
+	assert.Nil(t, rerr)
 	assert.EqualError(t, err, "Pointer file error: invalid header")
 	assert.Nil(t, p)
-	assert.Empty(t, string(by))
+	assert.Empty(t, by)
 }
 
 func TestDecodeInvalid(t *testing.T) {

--- a/test/test-filter-branch.sh
+++ b/test/test-filter-branch.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+. "test/testlib.sh"
+
+begin_test "filter-branch (git-lfs/git-lfs#1773)"
+(
+  set -e
+
+  reponame="filter-branch"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  contents_a="contents (a)"
+  printf "$contents_a" > a.dat
+  git add a.dat
+  git commit -m "add a.dat"
+
+  contents_b="contents (b)"
+  printf "$contents_b" > b.dat
+  git add b.dat
+  git commit -m "add b.dat"
+
+  contents_c="contents (c)"
+  printf "$contents_c" > c.dat
+  git add c.dat
+  git commit -m "add c.dat"
+
+  git filter-branch -f --prune-empty \
+    --tree-filter '
+      echo >&2 "---"
+      git rm --cached -r -q .
+      git lfs track "*.dat"
+      git add .
+    ' --tag-name-filter cat -- --all
+
+
+  assert_pointer "master" "a.dat" "$(calc_oid "$contents_a")" 12
+  assert_pointer "master" "b.dat" "$(calc_oid "$contents_b")" 12
+  assert_pointer "master" "c.dat" "$(calc_oid "$contents_c")" 12
+)
+end_test

--- a/test/test-malformed-pointers.sh
+++ b/test/test-malformed-pointers.sh
@@ -30,6 +30,10 @@ begin_test "malformed pointers"
   pushd .. >/dev/null
     clone_repo "$reponame" "$reponame-assert"
 
+    grep "malformed_small.dat" clone.log
+    grep "malformed_exact.dat" clone.log
+    grep "malformed_large.dat" clone.log
+
     expected_small="$(cat ../$reponame/malformed_small.dat)"
     expected_exact="$(cat ../$reponame/malformed_exact.dat)"
     expected_large="$(cat ../$reponame/malformed_large.dat)"

--- a/test/test-malformed-pointers.sh
+++ b/test/test-malformed-pointers.sh
@@ -20,7 +20,7 @@ begin_test "malformed pointers"
 
   git \
     -c "filter.lfs.process=" \
-    -c "filter.lfs.clean=" \
+    -c "filter.lfs.clean=cat" \
     -c "filter.lfs.required=false" \
     add *.dat
   git commit -m "add malformed pointer"

--- a/test/test-malformed-pointers.sh
+++ b/test/test-malformed-pointers.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+. "test/testlib.sh"
+
+begin_test "malformed pointers"
+(
+  set -e
+
+  reponame="malformed-pointers"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  base64 /dev/urandom | head -c 1023 > malformed_small.dat
+  base64 /dev/urandom | head -c 1024 > malformed_exact.dat
+  base64 /dev/urandom | head -c 1025 > malformed_large.dat
+
+  git \
+    -c "filter.lfs.process=" \
+    -c "filter.lfs.clean=" \
+    -c "filter.lfs.required=false" \
+    add *.dat
+  git commit -m "add malformed pointer"
+
+  git push origin master
+
+  pushd .. >/dev/null
+    clone_repo "$reponame" "$reponame-assert"
+
+    expected_small="$(cat ../$reponame/malformed_small.dat)"
+    expected_exact="$(cat ../$reponame/malformed_exact.dat)"
+    expected_large="$(cat ../$reponame/malformed_large.dat)"
+
+    actual_small="$(cat malformed_small.dat)"
+    actual_exact="$(cat malformed_exact.dat)"
+    actual_large="$(cat malformed_large.dat)"
+
+    [ "$expected_small" = "$actual_small" ]
+    [ "$expected_exact" = "$actual_exact" ]
+    [ "$expected_large" = "$actual_large" ]
+  popd >/dev/null
+)
+end_test


### PR DESCRIPTION
This pull-request fixes #1729 by streaming out the entire contents of a malformed pointer, instead of truncating the first 1024 bytes.

Previously, if LFS was unable to parse file that it thought was a pointer, it would "smudge" the file by just emitting it as is. The catch, however, was that the only data that it could hold onto was the first 1024 bytes. Since `(*git.PktlineReader) Read()`s block if there is no data on the pipe, buffering a fixed amount of data was the best that we could do. There were two cases:

1. `len(pbuf) < 1024`: We received the entire contents, no join necessary.
2. `len(pbuf) == 1024`: We _might_ have received the entire contents, or there were more than 1024 bytes and we just read the first 1024 of them. 

To handle this better, I introduced `lfs.DecodePointerHasMore` which mimics `lfs.DecodePointer`, but returns an additional `bool`, dictating whether or not more data is available to be read (in other words, where the `(*git.PktlineReader) Read()` error was `== io.EOF` or not). When using this in the `commands` package, we just check if there was `more` data, and join the reader as necessary:

```go
var r io.Reader = bytes.NewBuffer(pbuf)
if more {
        r = io.MultiReader(r, src)
}
```

As an added bonus, I added some warning messages that get printed to `os.Stderr` and include the filenames of all malformed pointers. When using `filter.lfs.process`, the files are collected together and printed once at the end. When using the `filter.lfs.clean` mode, we print out an error once per file, instead of bundling them up. Short of storing the list on disk in `.git/`, this is the best that we can do.

To wrap things up, I audited all uses of `lfs.DecodePointer`, `lfs.DecodeFromFile`, et. al., and determined that there were no other instances in the code where we would only output partially buffered data.

Hooray!

---

Here's a quick break-down of what was done:

1. cfcba6f: Introduce `lfs.DecodePointerHasMore` and use it in `commands.smudge()` to determine when to correctly join and copy the readers.
2. b3bab24: Keep track of the malformed pointers seen in a given pull/checkout/clone and emit them at the end (or once per file, if we're using `filter.lfs.clean` instead of the process filter).

---

/cc @git-lfs/core #1729 