### PR TITLE
script/packagecloud: release LFS on fedora/25

### DIFF
--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -36,6 +36,7 @@ $distro_name_map = {
     fedora/22
     fedora/23
     fedora/24
+    fedora/25
   ),
   "debian/7" => %w(
     debian/wheezy


### PR DESCRIPTION
This pull-request adds `fedora/25` to our list of targets for Packagecloud, which will make all future builds available on the latest release of Fedora.

In addition to this, I re-built and released Git LFS v1.5.3 under the `centos_7` Docker image, and pushed that release out to just the Fedora 25 target.

---

/cc @git-lfs/core https://github.com/git-lfs/git-lfs/issues/1795