### PR TITLE
Backport #1797 for v1.5.x: script/packagecloud: release LFS on fedora/25

### DIFF
--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -36,6 +36,7 @@ $distro_name_map = {
     fedora/22
     fedora/23
     fedora/24
+    fedora/25
   ),
   "debian/7" => %w(
     debian/wheezy


### PR DESCRIPTION
This backports #1797.