### PR TITLE
Backport #1796 for v1.5.x: commands,lfs: handle malformed pointers

### DIFF
--- a/commands/command_filter_process.go
+++ b/commands/command_filter_process.go
@@ -1,11 +1,12 @@
 package commands
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"os"
 
+	"github.com/git-lfs/git-lfs/errors"
+	"github.com/git-lfs/git-lfs/filepathfilter"
 	"github.com/git-lfs/git-lfs/git"
 	"github.com/git-lfs/git-lfs/lfs"
 	"github.com/spf13/cobra"
@@ -29,37 +30,6 @@ const (
 // in the working tree.
 var filterSmudgeSkip bool
 
-// filterSmudge is a gateway to the `smudge()` function and serves to bail out
-// immediately if the pointer decoded from "from" has no data (i.e., is empty).
-// This function, unlike the implementation found in the legacy smudge command,
-// only combines the `io.Reader`s when necessary, since the implementation
-// found in `*git.PacketReader` blocks while waiting for the following packet.
-func filterSmudge(to io.Writer, from io.Reader, filename string) error {
-	var pbuf bytes.Buffer
-	from = io.TeeReader(from, &pbuf)
-
-	ptr, err := lfs.DecodePointer(from)
-	if err != nil {
-		// If we tried to decode a pointer out of the data given to us,
-		// and the file was _empty_, write out an empty file in
-		// response. This occurs because when the clean filter
-		// encounters an empty file, and writes out an empty file,
-		// instead of a pointer.
-		if pbuf.Len() == 0 {
-			if _, cerr := io.Copy(to, &pbuf); cerr != nil {
-				Panic(cerr, "Error writing data to stdout:")
-			}
-			return nil
-		}
-
-		return err
-	}
-
-	lfs.LinkOrCopyFromReference(ptr.Oid, ptr.Size)
-
-	return smudge(to, ptr, filename, filterSmudgeSkip)
-}
-
 func filterCommand(cmd *cobra.Command, args []string) {
 	requireStdin("This command should be run by the Git filter process")
 	lfs.InstallHooks(false)
@@ -72,6 +42,11 @@ func filterCommand(cmd *cobra.Command, args []string) {
 	if err := s.NegotiateCapabilities(); err != nil {
 		ExitWithError(err)
 	}
+
+	skip := filterSmudgeSkip || cfg.Os.Bool("GIT_LFS_SKIP_SMUDGE", false)
+	filter := filepathfilter.New(cfg.FetchIncludePaths(), cfg.FetchExcludePaths())
+
+	var malformed []string
 
 	for s.Scan() {
 		var err error
@@ -87,9 +62,14 @@ func filterCommand(cmd *cobra.Command, args []string) {
 			err = clean(w, req.Payload, req.Header["pathname"])
 		case "smudge":
 			w = git.NewPktlineWriter(os.Stdout, smudgeFilterBufferCapacity)
-			err = filterSmudge(w, req.Payload, req.Header["pathname"])
+			err = smudge(w, req.Payload, req.Header["pathname"], skip, filter)
 		default:
 			ExitWithError(fmt.Errorf("Unknown command %q", req.Header["command"]))
+		}
+
+		if errors.IsNotAPointerError(err) {
+			malformed = append(malformed, req.Header["pathname"])
+			err = nil
 		}
 
 		var status string
@@ -100,6 +80,13 @@ func filterCommand(cmd *cobra.Command, args []string) {
 		}
 
 		s.WriteStatus(status)
+	}
+
+	if len(malformed) > 0 {
+		fmt.Fprintf(os.Stderr, "Encountered %d file(s) that should have been pointers, but weren't:\n", len(malformed))
+		for _, m := range malformed {
+			fmt.Fprintf(os.Stderr, "\t%s\n", m)
+		}
 	}
 
 	if err := s.Err(); err != nil && err != io.EOF {

--- a/lfs/pointer.go
+++ b/lfs/pointer.go
@@ -105,21 +105,32 @@ func DecodePointerFromFile(file string) (*Pointer, error) {
 	return DecodePointer(f)
 }
 func DecodePointer(reader io.Reader) (*Pointer, error) {
-	_, p, err := DecodeFrom(reader)
+	p, _, err := DecodeFrom(reader)
 	return p, err
 }
 
-func DecodeFrom(reader io.Reader) ([]byte, *Pointer, error) {
+// DecodeFrom decodes an *lfs.Pointer from the given io.Reader, "reader".
+// If the pointer encoded in the reader could successfully be read and decoded,
+// it will be returned with a nil error.
+//
+// If the pointer could not be decoded, an io.Reader containing the entire
+// blob's data will be returned, along with a parse error.
+func DecodeFrom(reader io.Reader) (*Pointer, io.Reader, error) {
 	buf := make([]byte, blobSizeCutoff)
-	written, err := reader.Read(buf)
-	output := buf[0:written]
+	n, err := reader.Read(buf)
+	buf = buf[:n]
 
-	if err != nil && err != io.EOF {
-		return output, nil, err
+	var contents io.Reader = bytes.NewReader(buf)
+	if err != io.EOF {
+		contents = io.MultiReader(contents, reader)
 	}
 
-	p, err := decodeKV(bytes.TrimSpace(output))
-	return output, p, err
+	if err != nil && err != io.EOF {
+		return nil, contents, err
+	}
+
+	p, err := decodeKV(bytes.TrimSpace(buf))
+	return p, contents, err
 }
 
 func verifyVersion(version string) error {

--- a/lfs/pointer_clean.go
+++ b/lfs/pointer_clean.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"io"
+	"io/ioutil"
 	"os"
 
 	"github.com/git-lfs/git-lfs/config"
@@ -77,8 +78,9 @@ func copyToTemp(reader io.Reader, fileSize int64, cb progress.CopyCallback) (oid
 		cb = nil
 	}
 
-	by, ptr, err := DecodeFrom(reader)
-	if err == nil && len(by) < 512 {
+	ptr, buf, err := DecodeFrom(reader)
+	by, rerr := ioutil.ReadAll(buf)
+	if rerr != nil || (err == nil && len(by) < 512) {
 		err = errors.NewCleanPointerError(ptr, by)
 		return
 	}

--- a/lfs/pointer_test.go
+++ b/lfs/pointer_test.go
@@ -3,6 +3,7 @@ package lfs
 import (
 	"bufio"
 	"bytes"
+	"io/ioutil"
 	"reflect"
 	"strings"
 	"testing"
@@ -168,11 +169,13 @@ size 12345`
 }
 
 func TestDecodeFromEmptyReader(t *testing.T) {
-	by, p, err := DecodeFrom(strings.NewReader(""))
+	p, buf, err := DecodeFrom(strings.NewReader(""))
+	by, rerr := ioutil.ReadAll(buf)
 
+	assert.Nil(t, rerr)
 	assert.EqualError(t, err, "Pointer file error: invalid header")
 	assert.Nil(t, p)
-	assert.Empty(t, string(by))
+	assert.Empty(t, by)
 }
 
 func TestDecodeInvalid(t *testing.T) {

--- a/test/test-filter-branch.sh
+++ b/test/test-filter-branch.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+. "test/testlib.sh"
+
+begin_test "filter-branch (git-lfs/git-lfs#1773)"
+(
+  set -e
+
+  reponame="filter-branch"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  contents_a="contents (a)"
+  printf "$contents_a" > a.dat
+  git add a.dat
+  git commit -m "add a.dat"
+
+  contents_b="contents (b)"
+  printf "$contents_b" > b.dat
+  git add b.dat
+  git commit -m "add b.dat"
+
+  contents_c="contents (c)"
+  printf "$contents_c" > c.dat
+  git add c.dat
+  git commit -m "add c.dat"
+
+  git filter-branch -f --prune-empty \
+    --tree-filter '
+      echo >&2 "---"
+      git rm --cached -r -q .
+      git lfs track "*.dat"
+      git add .
+    ' --tag-name-filter cat -- --all
+
+
+  assert_pointer "master" "a.dat" "$(calc_oid "$contents_a")" 12
+  assert_pointer "master" "b.dat" "$(calc_oid "$contents_b")" 12
+  assert_pointer "master" "c.dat" "$(calc_oid "$contents_c")" 12
+)
+end_test

--- a/test/test-malformed-pointers.sh
+++ b/test/test-malformed-pointers.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+. "test/testlib.sh"
+
+begin_test "malformed pointers"
+(
+  set -e
+
+  reponame="malformed-pointers"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  base64 /dev/urandom | head -c 1023 > malformed_small.dat
+  base64 /dev/urandom | head -c 1024 > malformed_exact.dat
+  base64 /dev/urandom | head -c 1025 > malformed_large.dat
+
+  git \
+    -c "filter.lfs.process=" \
+    -c "filter.lfs.clean=cat" \
+    -c "filter.lfs.required=false" \
+    add *.dat
+  git commit -m "add malformed pointer"
+
+  git push origin master
+
+  pushd .. >/dev/null
+    clone_repo "$reponame" "$reponame-assert"
+
+    grep "malformed_small.dat" clone.log
+    grep "malformed_exact.dat" clone.log
+    grep "malformed_large.dat" clone.log
+
+    expected_small="$(cat ../$reponame/malformed_small.dat)"
+    expected_exact="$(cat ../$reponame/malformed_exact.dat)"
+    expected_large="$(cat ../$reponame/malformed_large.dat)"
+
+    actual_small="$(cat malformed_small.dat)"
+    actual_exact="$(cat malformed_exact.dat)"
+    actual_large="$(cat malformed_large.dat)"
+
+    [ "$expected_small" = "$actual_small" ]
+    [ "$expected_exact" = "$actual_exact" ]
+    [ "$expected_large" = "$actual_large" ]
+  popd >/dev/null
+)
+end_test


### PR DESCRIPTION
This backports #1796.

Conflicting files:
- commands/command_filter_process.go
- commands/command_smudge.go