### PR TITLE
progress: guard negative padding width, panic in `strings.Repeat`

### DIFF
--- a/progress/spinner.go
+++ b/progress/spinner.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/git-lfs/git-lfs/tools"
 	"github.com/olekukonko/ts"
 )
 
@@ -54,7 +55,7 @@ func (s *Spinner) update(out io.Writer, prefix, msg string) {
 	if err == nil {
 		width = size.Col()
 	}
-	padding := strings.Repeat(" ", width-len(str))
+	padding := strings.Repeat(" ", tools.MaxInt(0, width-len(str)))
 
 	fmt.Fprintf(out, "\r%v%v", str, padding)
 

--- a/progress/spinner.go
+++ b/progress/spinner.go
@@ -6,7 +6,6 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/git-lfs/git-lfs/tools"
 	"github.com/olekukonko/ts"
 )
 
@@ -55,7 +54,7 @@ func (s *Spinner) update(out io.Writer, prefix, msg string) {
 	if err == nil {
 		width = size.Col()
 	}
-	padding := strings.Repeat(" ", tools.MaxInt(0, width-len(str)))
+	padding := strings.Repeat(" ", maxInt(0, width-len(str)))
 
 	fmt.Fprintf(out, "\r%v%v", str, padding)
 
@@ -63,4 +62,15 @@ func (s *Spinner) update(out io.Writer, prefix, msg string) {
 
 func NewSpinner() *Spinner {
 	return &Spinner{}
+}
+
+// maxInt returns the greater of two `int`s, "a", or "b". This function
+// originally comes from `github.com/git-lfs/git-lfs/tools#MaxInt`, but would
+// introduce an import cycle if depended on directly.
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+
+	return b
 }

--- a/progress/spinner.go
+++ b/progress/spinner.go
@@ -4,9 +4,6 @@ import (
 	"fmt"
 	"io"
 	"runtime"
-	"strings"
-
-	"github.com/olekukonko/ts"
 )
 
 // Indeterminate progress indicator 'spinner'
@@ -46,31 +43,9 @@ func (s *Spinner) Finish(out io.Writer, finishMsg string) {
 }
 
 func (s *Spinner) update(out io.Writer, prefix, msg string) {
-
-	str := fmt.Sprintf("%v %v", prefix, msg)
-
-	width := 80 // default to 80 chars wide if ts.GetSize() fails
-	size, err := ts.GetSize()
-	if err == nil {
-		width = size.Col()
-	}
-	padding := strings.Repeat(" ", maxInt(0, width-len(str)))
-
-	fmt.Fprintf(out, "\r%v%v", str, padding)
-
+	fmt.Fprintf(out, "\r%v", pad(fmt.Sprintf("%v %v", prefix, msg)))
 }
 
 func NewSpinner() *Spinner {
 	return &Spinner{}
-}
-
-// maxInt returns the greater of two `int`s, "a", or "b". This function
-// originally comes from `github.com/git-lfs/git-lfs/tools#MaxInt`, but would
-// introduce an import cycle if depended on directly.
-func maxInt(a, b int) int {
-	if a > b {
-		return a
-	}
-
-	return b
 }


### PR DESCRIPTION
This pull-request prevents the `len(padding)` used in the progress meter from ever being less than zero. This prevents the panic from `strings.Repeat` trying to [allocate a slice][1] with a [`len < 0`][2] as seen in #1803.

Previously, LFS printed a number of number of padding characters to the terminal when displaying progress meter updates, so that the terminal's cursor would be in the correct position to fill the entire line after printing the CR character, `\r`, as such:

```
       |-----------------------padding---------------------|
message                                                    
                                                           ^- cursor position
```

However, if the message's length is greater than the terminal width, `width-len(str)` is a negative number, causing the panic as shown above. This check with `tools.MaxInt(0, width-len(str))` prevents that from happening by forcing the padding to be an empty string.

This is a safe change, since we'll be outside of the terminal's assumed width, leaving the cursor in an OK position to rewrite the entire line. This would leave a remaining number of characters trailing off the line, but this only happens when the `ts` library can't accurately determine the tty's width, and we default back to 80. 

---

/cc @git-lfs/core #1803

[1]: https://github.com/golang/go/blob/go1.7.3/src/strings/strings.go#L420
[2]: https://github.com/golang/go/blob/go1.7.3/src/runtime/slice.go#L47-L50