### PR TITLE
filepathfilter: remove `*bench` subpackage

### DIFF
--- a/filepathfilter/bench_test.go
+++ b/filepathfilter/bench_test.go
@@ -1,4 +1,4 @@
-package filepathfilterbench
+package filepathfilter_test
 
 import (
 	"os"


### PR DESCRIPTION
This pull-request removes the sub-package: `github.com/git-lfs/git-lfs/filepathfilter/filepathfilterbench`, which caused builds on Debian 7 & 8 to fail under `dh_golang`.

When trying to build the v1.5.4 release of LFS, `dh_golang` would not successfully preform the `go install -v` of all Go/LFS packages necessary to build LFS. When inspecting a diff of the build log between the v1.5.3 and v1.5.4 tree, I noticed the following line:

```
go build github.com/git-lfs/git-lfs/filepathfilter/filepathfilterbench: no buildable Go source files in /tmp/docker_run/src/github.com/git-lfs/git-lfs/i386/obj-i486-linux-gnu/src/github.com/git-lfs/git-lfs/filepathfilter/filepathfilterbench
```

`go build` exits in a dirty state after trying to build a path with no source files in it, as is the case with the `filepathfilterbench` sub-package.

As a short-term solution, I am moving the `bench_test.go` file into the parent package, `filepathfilter`. This follows standard Go testing conventions, and will allow us to build LFS using `dh_golang` again. As a precautionary measure, I moved the file into the `filepathfilter_test` pseudo-package so that this change will not affect the public API, nor will it make importing `filepathfilter` any heavier.

```diff
--- a/filepathfilter/bench_test.go
+++ b/filepathfilter/filepathfilterbench/bench_test.go
@@ -1,4 +1,4 @@
-package filepathfilter_test
+package filepathfilterbench
```

Looking at a long-term solution, I'd like to:

1. Figure out why this problem doesn't occur on Centos builds, and
2. Submit a patch upstream to `dh_golang` to skip building import paths with no build-able source files.

---

/cc @git-lfs/core 