### PR TITLE
Backport #1810 for v1.5.x: filepathfilter: remove `*bench` subpackage

### DIFF
--- a/filepathfilter/bench_test.go
+++ b/filepathfilter/bench_test.go
@@ -1,4 +1,4 @@
-package filepathfilterbench
+package filepathfilter_test
 
 import (
 	"os"


### PR DESCRIPTION
This backports #1810.