### PR TITLE
commands: convert push, pre-push to use async gitscanner

### DIFF
--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -76,7 +76,7 @@ func prePushCommand(cmd *cobra.Command, args []string) {
 			continue
 		}
 
-		if err := scanLeftOrAll(gitscanner, ctx, left); err != nil {
+		if err := uploadLeftOrAll(gitscanner, ctx, left); err != nil {
 			Print("Error scanning for Git LFS files in %q", left)
 			ExitWithError(err)
 		}

--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -84,6 +84,8 @@ func prePushCommand(cmd *cobra.Command, args []string) {
 		}
 		uploadPointers(ctx, pointers)
 	}
+
+	ctx.Await()
 }
 
 func scanLeft(g *lfs.GitScanner, ref string) ([]*lfs.WrappedPointer, error) {

--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"bufio"
-	"fmt"
 	"os"
 	"strings"
 
@@ -84,29 +83,6 @@ func prePushCommand(cmd *cobra.Command, args []string) {
 	}
 
 	ctx.Await()
-}
-
-func scanLeft(g *lfs.GitScanner, ref string) ([]*lfs.WrappedPointer, error) {
-	var pointers []*lfs.WrappedPointer
-	var multiErr error
-	cb := func(p *lfs.WrappedPointer, err error) {
-		if err != nil {
-			if multiErr != nil {
-				multiErr = fmt.Errorf("%v\n%v", multiErr, err)
-			} else {
-				multiErr = err
-			}
-			return
-		}
-
-		pointers = append(pointers, p)
-	}
-
-	if err := g.ScanLeftToRemote(ref, cb); err != nil {
-		return pointers, err
-	}
-
-	return pointers, multiErr
 }
 
 // decodeRefs pulls the sha1s out of the line read from the pre-push

--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -77,12 +77,10 @@ func prePushCommand(cmd *cobra.Command, args []string) {
 			continue
 		}
 
-		pointers, err := scanLeftOrAll(gitscanner, left)
-		if err != nil {
+		if err := scanLeftOrAll(gitscanner, ctx, left); err != nil {
 			Print("Error scanning for Git LFS files in %q", left)
 			ExitWithError(err)
 		}
-		uploadPointers(ctx, pointers...)
 	}
 
 	ctx.Await()

--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -82,7 +82,7 @@ func prePushCommand(cmd *cobra.Command, args []string) {
 			Print("Error scanning for Git LFS files in %q", left)
 			ExitWithError(err)
 		}
-		uploadPointers(ctx, pointers)
+		uploadPointers(ctx, pointers...)
 	}
 
 	ctx.Await()

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -74,11 +74,11 @@ func scanLeftOrAll(g *lfs.GitScanner, ref string) ([]*lfs.WrappedPointer, error)
 }
 
 func uploadsWithObjectIDs(ctx *uploadContext, oids []string) {
-	pointers := make([]*lfs.WrappedPointer, len(oids))
-	for idx, oid := range oids {
-		pointers[idx] = &lfs.WrappedPointer{Pointer: &lfs.Pointer{Oid: oid}}
+	for _, oid := range oids {
+		uploadPointers(ctx, &lfs.WrappedPointer{
+			Pointer: &lfs.Pointer{Oid: oid},
+		})
 	}
-	uploadPointers(ctx, pointers...)
 
 	ctx.Await()
 }

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -40,7 +40,7 @@ func uploadsBetweenRefAndRemote(ctx *uploadContext, refnames []string) {
 			Print("Error scanning for Git LFS files in the %q ref", ref.Name)
 			ExitWithError(err)
 		}
-		uploadPointers(ctx, pointers)
+		uploadPointers(ctx, pointers...)
 	}
 
 	ctx.Await()
@@ -78,7 +78,7 @@ func uploadsWithObjectIDs(ctx *uploadContext, oids []string) {
 	for idx, oid := range oids {
 		pointers[idx] = &lfs.WrappedPointer{Pointer: &lfs.Pointer{Oid: oid}}
 	}
-	uploadPointers(ctx, pointers)
+	uploadPointers(ctx, pointers...)
 
 	ctx.Await()
 }

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -64,9 +64,10 @@ func uploadLeftOrAll(g *lfs.GitScanner, ctx *uploadContext, ref string) error {
 		if err := g.ScanRefWithDeleted(ref, cb); err != nil {
 			return err
 		}
-	}
-	if err := g.ScanLeftToRemote(ref, cb); err != nil {
-		return err
+	} else {
+		if err := g.ScanLeftToRemote(ref, cb); err != nil {
+			return err
+		}
 	}
 
 	return multiErr

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -42,6 +42,8 @@ func uploadsBetweenRefAndRemote(ctx *uploadContext, refnames []string) {
 		}
 		uploadPointers(ctx, pointers)
 	}
+
+	ctx.Await()
 }
 
 func scanLeftOrAll(g *lfs.GitScanner, ref string) ([]*lfs.WrappedPointer, error) {
@@ -77,6 +79,8 @@ func uploadsWithObjectIDs(ctx *uploadContext, oids []string) {
 		pointers[idx] = &lfs.WrappedPointer{Pointer: &lfs.Pointer{Oid: oid}}
 	}
 	uploadPointers(ctx, pointers)
+
+	ctx.Await()
 }
 
 func refsByNames(refnames []string) ([]*git.Ref, error) {

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -35,7 +35,7 @@ func uploadsBetweenRefAndRemote(ctx *uploadContext, refnames []string) {
 	}
 
 	for _, ref := range refs {
-		if err = scanLeftOrAll(gitscanner, ctx, ref.Name); err != nil {
+		if err = uploadLeftOrAll(gitscanner, ctx, ref.Name); err != nil {
 			Print("Error scanning for Git LFS files in the %q ref", ref.Name)
 			ExitWithError(err)
 		}
@@ -44,7 +44,7 @@ func uploadsBetweenRefAndRemote(ctx *uploadContext, refnames []string) {
 	ctx.Await()
 }
 
-func scanLeftOrAll(g *lfs.GitScanner, ctx *uploadContext, ref string) error {
+func uploadLeftOrAll(g *lfs.GitScanner, ctx *uploadContext, ref string) error {
 	var multiErr error
 	cb := func(p *lfs.WrappedPointer, err error) {
 		if err != nil {

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/git"
 	"github.com/git-lfs/git-lfs/lfs"
 	"github.com/rubyist/tracerx"
@@ -73,8 +74,22 @@ func uploadLeftOrAll(g *lfs.GitScanner, ctx *uploadContext, ref string) error {
 
 func uploadsWithObjectIDs(ctx *uploadContext, oids []string) {
 	for _, oid := range oids {
+		mp, err := lfs.LocalMediaPath(oid)
+		if err != nil {
+			ExitWithError(errors.Wrap(err, "Unable to find local media path:"))
+		}
+
+		stat, err := os.Stat(mp)
+		if err != nil {
+			ExitWithError(errors.Wrap(err, "Unable to stat local media path"))
+		}
+
 		uploadPointers(ctx, &lfs.WrappedPointer{
-			Pointer: &lfs.Pointer{Oid: oid},
+			Name: mp,
+			Pointer: &lfs.Pointer{
+				Oid:  oid,
+				Size: stat.Size(),
+			},
 		})
 	}
 

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -50,7 +50,7 @@ func (c *uploadContext) HasUploaded(oid string) bool {
 	return c.uploadedOids.Contains(oid)
 }
 
-func (c *uploadContext) prepareUpload(unfiltered []*lfs.WrappedPointer) (*tq.TransferQueue, []*lfs.WrappedPointer) {
+func (c *uploadContext) prepareUpload(unfiltered ...*lfs.WrappedPointer) (*tq.TransferQueue, []*lfs.WrappedPointer) {
 	numUnfiltered := len(unfiltered)
 	uploadables := make([]*lfs.WrappedPointer, 0, numUnfiltered)
 	missingLocalObjects := make([]*lfs.WrappedPointer, 0, numUnfiltered)
@@ -137,7 +137,7 @@ func (c *uploadContext) checkMissing(missing []*lfs.WrappedPointer, missingSize 
 	<-done
 }
 
-func uploadPointers(c *uploadContext, unfiltered []*lfs.WrappedPointer) {
+func uploadPointers(c *uploadContext, unfiltered ...*lfs.WrappedPointer) {
 	if c.DryRun {
 		for _, p := range unfiltered {
 			if c.HasUploaded(p.Oid) {
@@ -151,7 +151,7 @@ func uploadPointers(c *uploadContext, unfiltered []*lfs.WrappedPointer) {
 		return
 	}
 
-	q, pointers := c.prepareUpload(unfiltered)
+	q, pointers := c.prepareUpload(unfiltered...)
 	for _, p := range pointers {
 		t, err := uploadTransfer(p.Oid, p.Name)
 		if err != nil {

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -189,7 +189,7 @@ begin_test "pre-push with missing pointer not on server"
     git lfs pre-push origin "$GITSERVER/$reponame" 2>&1 |
     tee push.log
   set -e
-  grep "7aa7a5359173d05b63cfd682e3c38487f3cb4f7f1d60659fe59fab1505977d4c does not exist in .git/lfs/objects. Tried new.dat, which matches 7aa7a5359173d05b63cfd682e3c38487f3cb4f7f1d60659fe59fab1505977d4c." push.log
+  grep "Unable to find object (7aa7a5359173d05b63cfd682e3c38487f3cb4f7f1d60659fe59fab1505977d4c) locally." push.log
 )
 end_test
 

--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -132,7 +132,7 @@ begin_test "push --all (no ref args)"
   [ $(grep -c "push" < push.log) -eq 6 ]
 
   git push --all origin 2>&1 | tee push.log
-  [ $(grep -c "(3 of 3 files)" push.log) -eq 2 ]
+  [ $(grep -c "(6 of 6 files)" push.log) -eq 1 ]
   assert_server_object "$reponame-$suffix" "$oid1"
   assert_server_object "$reponame-$suffix" "$oid2"
   assert_server_object "$reponame-$suffix" "$oid3"
@@ -162,10 +162,9 @@ begin_test "push --all (no ref args)"
   [ $(grep -c "push" push.log) -eq 6 ]
 
   git push --all origin 2>&1 | tee push.log
-  grep "(2 of 2 files, 1 skipped)" push.log
-  grep "(3 of 3 files)" push.log
-  [ $(grep -c "files)" push.log) -eq 1 ]
-  [ $(grep -c "skipped)" push.log) -eq 1 ]
+  grep "(5 of 5 files, 1 skipped)" push.log
+  [ $(grep -c "files" push.log) -eq 1 ]
+  [ $(grep -c "skipped" push.log) -eq 1 ]
   assert_server_object "$reponame-$suffix-2" "$oid2"
   assert_server_object "$reponame-$suffix-2" "$oid3"
   assert_server_object "$reponame-$suffix-2" "$oid4"

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -1,6 +1,7 @@
 package tq
 
 import (
+	"os"
 	"sort"
 	"sync"
 
@@ -298,7 +299,6 @@ func (q *TransferQueue) enqueueAndCollectRetriesFor(batch batch) (batch, error) 
 				next = append(next, t)
 			} else {
 				q.sendNotifications(t.Oid, false)
-				q.wait.Done()
 			}
 		}
 
@@ -404,22 +404,60 @@ func (q *TransferQueue) addToAdapter(e lfsapi.Endpoint, pending []*Transfer) <-c
 		return retries
 	}
 
+	present, missingResults := q.partitionTransfers(pending)
+
 	go func() {
 		defer close(retries)
 
 		var results <-chan TransferResult
 		if q.dryRun {
-			results = q.makeDryRunResults(pending)
+			results = q.makeDryRunResults(present)
 		} else {
-			results = q.adapter.Add(pending...)
+			results = q.adapter.Add(present...)
 		}
 
+		for _, res := range missingResults {
+			q.handleTransferResult(res, retries)
+		}
 		for res := range results {
 			q.handleTransferResult(res, retries)
 		}
 	}()
 
 	return retries
+}
+
+func (q *TransferQueue) partitionTransfers(transfers []*Transfer) (present []*Transfer, results []TransferResult) {
+	if q.direction != Upload {
+		return transfers, nil
+	}
+
+	present = make([]*Transfer, 0, len(transfers))
+	results = make([]TransferResult, 0, len(transfers))
+
+	for _, t := range transfers {
+		var err error
+
+		if t.Size < 0 {
+			err = errors.Errorf("Git LFS: object %q has invalid size (got: %d)", t.Oid, t.Size)
+		} else {
+			fd, serr := os.Stat(t.Path)
+			if serr != nil || fd.Size() != t.Size {
+				err = errors.Errorf("Unable to find object (%s) locally.", t.Oid)
+			}
+		}
+
+		if err != nil {
+			results = append(results, TransferResult{
+				Transfer: t,
+				Error:    err,
+			})
+		} else {
+			present = append(present, t)
+		}
+	}
+
+	return
 }
 
 // makeDryRunResults returns a channel populated immediately with "successful"

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -294,6 +294,8 @@ func (q *TransferQueue) enqueueAndCollectRetriesFor(batch batch) (batch, error) 
 				q.rc.Increment(t.Oid)
 
 				next = append(next, t)
+			} else {
+				q.wait.Done()
 			}
 		}
 

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -83,6 +83,8 @@ func (b batch) Len() int           { return len(b) }
 func (b batch) Less(i, j int) bool { return b[i].Size < b[j].Size }
 func (b batch) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
 
+type NotifyFn func(oid string, ok bool)
+
 // TransferQueue organises the wider process of uploading and downloading,
 // including calling the API, passing the actual transfer request to transfer
 // adapters, and dealing with progress, errors and retries.
@@ -103,6 +105,7 @@ type TransferQueue struct {
 	incoming      chan *objectTuple
 	errorc        chan error // Channel for processing errors
 	watchers      []chan string
+	notify        []NotifyFn
 	trMutex       *sync.Mutex
 	startProgress sync.Once
 	collectorWait sync.WaitGroup
@@ -294,6 +297,7 @@ func (q *TransferQueue) enqueueAndCollectRetriesFor(batch batch) (batch, error) 
 
 				next = append(next, t)
 			} else {
+				q.sendNotifications(t.Oid, false)
 				q.wait.Done()
 			}
 		}
@@ -314,6 +318,7 @@ func (q *TransferQueue) enqueueAndCollectRetriesFor(batch batch) (batch, error) 
 		if o.Error != nil {
 			q.errorc <- errors.Wrapf(o.Error, "[%v] %v", o.Oid, o.Error.Message)
 			q.Skip(o.Size)
+			q.sendNotifications(o.Oid, false)
 			q.wait.Done()
 
 			continue
@@ -330,6 +335,7 @@ func (q *TransferQueue) enqueueAndCollectRetriesFor(batch batch) (batch, error) 
 			q.errorc <- errors.Errorf("[%v] The server returned an unknown OID.", o.Oid)
 
 			q.Skip(o.Size)
+			q.sendNotifications(o.Oid, false)
 			q.wait.Done()
 		} else {
 			tr := newTransfer(o, t.Name, t.Path)
@@ -348,6 +354,7 @@ func (q *TransferQueue) enqueueAndCollectRetriesFor(batch batch) (batch, error) 
 					}
 
 					q.Skip(o.Size)
+					q.sendNotifications(tr.Oid, false)
 					q.wait.Done()
 				}
 
@@ -390,6 +397,7 @@ func (q *TransferQueue) addToAdapter(e lfsapi.Endpoint, pending []*Transfer) <-c
 		q.errorc <- err
 		for _, t := range pending {
 			q.Skip(t.Size)
+			q.sendNotifications(t.Oid, false)
 			q.wait.Done()
 		}
 
@@ -459,14 +467,13 @@ func (q *TransferQueue) handleTransferResult(
 			// the retry channel, and the error will be reported
 			// immediately.
 			q.errorc <- res.Error
+			q.sendNotifications(oid, false)
 			q.wait.Done()
 		}
 	} else {
 		// Otherwise, if the transfer was successful, notify all of the
 		// watchers, and mark it as finished.
-		for _, c := range q.watchers {
-			c <- oid
-		}
+		q.sendNotifications(oid, true)
 
 		q.meter.FinishTransfer(res.Transfer.Name)
 		q.wait.Done()
@@ -567,6 +574,22 @@ func (q *TransferQueue) Watch() chan string {
 	c := make(chan string, q.batchSize)
 	q.watchers = append(q.watchers, c)
 	return c
+}
+
+func (q *TransferQueue) Notify(cb NotifyFn) {
+	q.notify = append(q.notify, cb)
+}
+
+func (q *TransferQueue) sendNotifications(oid string, ok bool) {
+	if ok {
+		for _, c := range q.watchers {
+			c <- oid
+		}
+	}
+
+	for _, cb := range q.notify {
+		cb(oid, ok)
+	}
 }
 
 // This goroutine collects errors returned from transfers


### PR DESCRIPTION
This pull-request teaches the `push` and `pre-push` commands how to use the new `gitscanner` without accumulating potentially large slices of `*lfs.WrappedPointers`.

Previously, in order to push a set of LFS objects to a remote, the pusher needed to have explicit knowledge of all objects they were going to push. In many cases, this isn't a problem, since usually the number of objects is manageable. During initial or large pushes, however, the number of objects to push can grow prohibitively large, causing a problem.

This pull-request applies the work that @technoweenie has done with the `gitscanner` type and applies it to the `push` and `pre-push` commands. Here's a breakdown of what happened:

1. 4d4f808: since the commands will now call `uploadPointers()` more than once, re-use the `*tq.TransferQueue` instance across invocations to prevent needless re-allocation and to take full advantage of batching.
2. 64a643e: since the `uploadPointers()` calls can place objects across multiple batches and thus do not guarantee that all objects in the call have been uploaded, introduce `Await()` to ensure that the `*tq.TransferQueue` is done before exiting LFS.
3. [`a58e91f^1...f1380bd`][1]: teach calling code how to asynchronously call `uploadPointers`.
4. [`028facf^1...430f5a7`][2]: :nail_care:
5. 7af9281: fix small bug in `lfs.NewDownloadCheckQueue` which created `n` empty elements in the options array (where `n` is equal to the length of options provided)
6. 15673a4: since the download check queue is used many times instead of all at once, do some preparation work to make it reusable. In this commit, provide a mechanism for callers to find out about failed transfers so that calling code can accurately determine when all given items have been checked.
7. b169435: Wire-up the download check queue to be reused in `*commands.uploadContext`.

[1]: https://github.com/git-lfs/git-lfs/compare/a58e91f%5E1...f1380bd
[2]: https://github.com/git-lfs/git-lfs/compare/028facf%5E1...430f5a7

---

One thing I'd like to investigate before merging is the use of the download check queue in b169435. Prior to that commit, the queue was re-instantiated each time the scanner reported items. This would be OK if the scanner reported items in small batches, since we'd be able to take advantage of the batching functionality of the `*tq.TransferQueue`, however it does not. What this means is that we have to perform an expensive object allocation (not to mention all of the internal `chan`s, `map`s, etc.) _each time a pointer is read from the gitscanner_.

To mitigate this, I did work in [`15673a4^1...b169435`][3] to avoid this expensive and repeated allocation. However, as a consequence, the download check queue needs to report synchronously whether or not the server has items that are missing locally in `.git/lfs/objects`. What this means is a batch size of 1, so that we're not waiting indefinitely to hear of the status a set of items with cardinality less than the batch size.

[3]: https://github.com/git-lfs/git-lfs/compare/15673a4%5E1...b169435

This may be fine, since I think it's a safe assumption to assume the number of items that needs to go through this check queue `(i.e., the number of objects missing from `.git/lfs/objects` needed to push) is sufficiently small. If not, it may be worth pursuing alternatives that remove the need for single-length batches.

One option we could pursue is using a second transfer queue to keep track of the items that are not present in `.git/lfs/objects`, or using the `*lfs.Batcher` type to batch it ourselves. I'm not sure if this is advantageous or not, since it does carry with it additional complexity. I'd love to hear additional thoughts on this.

---

/cc @git-lfs/core 