### PR TITLE
locking: add `--json` flag

### DIFF
--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -40,6 +41,13 @@ func lockCommand(cmd *cobra.Command, args []string) {
 	lock, err := lockClient.LockFile(path)
 	if err != nil {
 		Exit("Lock failed: %v", err)
+	}
+
+	if locksCmdFlags.JSON {
+		if err := json.NewEncoder(os.Stdout).Encode(lock); err != nil {
+			Error(err.Error())
+		}
+		return
 	}
 
 	Print("\n'%s' was locked (%s)", args[0], lock.Id)
@@ -91,5 +99,6 @@ func init() {
 
 	RegisterCommand("lock", lockCommand, func(cmd *cobra.Command) {
 		cmd.Flags().StringVarP(&lockRemote, "remote", "r", cfg.CurrentRemote, lockRemoteHelp)
+		cmd.Flags().BoolVarP(&locksCmdFlags.JSON, "json", "", false, "print output in json")
 	})
 }

--- a/commands/command_locks.go
+++ b/commands/command_locks.go
@@ -1,7 +1,11 @@
 package commands
 
 import (
+	"encoding/json"
+	"os"
+
 	"github.com/git-lfs/git-lfs/locking"
+
 	"github.com/spf13/cobra"
 )
 
@@ -10,7 +14,6 @@ var (
 )
 
 func locksCommand(cmd *cobra.Command, args []string) {
-
 	filters, err := locksCmdFlags.Filters()
 	if err != nil {
 		Exit("Error building filters: %v", err)
@@ -27,6 +30,14 @@ func locksCommand(cmd *cobra.Command, args []string) {
 	var lockCount int
 	locks, err := lockClient.SearchLocks(filters, locksCmdFlags.Limit, locksCmdFlags.Local)
 	// Print any we got before exiting
+
+	if locksCmdFlags.JSON {
+		if err := json.NewEncoder(os.Stdout).Encode(locks); err != nil {
+			Error(err.Error())
+		}
+		return
+	}
+
 	for _, lock := range locks {
 		Print("%s\t%s <%s>", lock.Path, lock.Name, lock.Email)
 		lockCount++
@@ -35,7 +46,6 @@ func locksCommand(cmd *cobra.Command, args []string) {
 	if err != nil {
 		Exit("Error while retrieving locks: %v", err)
 	}
-
 	Print("\n%d lock(s) matched query.", lockCount)
 }
 
@@ -54,6 +64,8 @@ type locksFlags struct {
 	// local limits the scope of lock reporting to the locally cached record
 	// of locks for the current user & doesn't query the server
 	Local bool
+	// JSON is an optional parameter to output data in json format.
+	JSON bool
 }
 
 // Filters produces a filter based on locksFlags instance.
@@ -86,5 +98,6 @@ func init() {
 		cmd.Flags().StringVarP(&locksCmdFlags.Id, "id", "i", "", "filter locks results matching a particular ID")
 		cmd.Flags().IntVarP(&locksCmdFlags.Limit, "limit", "l", 0, "optional limit for number of results to return")
 		cmd.Flags().BoolVarP(&locksCmdFlags.Local, "local", "", false, "only list cached local record of own locks")
+		cmd.Flags().BoolVarP(&locksCmdFlags.JSON, "json", "", false, "print output in json")
 	})
 }

--- a/commands/command_unlock.go
+++ b/commands/command_unlock.go
@@ -1,8 +1,10 @@
 package commands
 
 import (
-	"github.com/git-lfs/git-lfs/locking"
+	"encoding/json"
+	"os"
 
+	"github.com/git-lfs/git-lfs/locking"
 	"github.com/spf13/cobra"
 )
 
@@ -21,7 +23,6 @@ type unlockFlags struct {
 }
 
 func unlockCommand(cmd *cobra.Command, args []string) {
-
 	if len(lockRemote) > 0 {
 		cfg.CurrentRemote = lockRemote
 	}
@@ -50,6 +51,14 @@ func unlockCommand(cmd *cobra.Command, args []string) {
 		Error("Usage: git lfs unlock (--id my-lock-id | <path>)")
 	}
 
+	if locksCmdFlags.JSON {
+		if err := json.NewEncoder(os.Stdout).Encode(struct {
+			Unlocked bool `json:"unlocked"`
+		}{true}); err != nil {
+			Error(err.Error())
+		}
+		return
+	}
 	Print("'%s' was unlocked", args[0])
 }
 
@@ -62,5 +71,6 @@ func init() {
 		cmd.Flags().StringVarP(&lockRemote, "remote", "r", cfg.CurrentRemote, lockRemoteHelp)
 		cmd.Flags().StringVarP(&unlockCmdFlags.Id, "id", "i", "", "unlock a lock by its ID")
 		cmd.Flags().BoolVarP(&unlockCmdFlags.Force, "force", "f", false, "forcibly break another user's lock(s)")
+		cmd.Flags().BoolVarP(&locksCmdFlags.JSON, "json", "", false, "print output in json")
 	})
 }

--- a/locking/locks.go
+++ b/locking/locks.go
@@ -126,16 +126,16 @@ func (c *Client) UnlockFileById(id string, force bool) error {
 type Lock struct {
 	// Id is the unique identifier corresponding to this particular Lock. It
 	// must be consistent with the local copy, and the server's copy.
-	Id string
+	Id string `json:"id"`
 	// Path is an absolute path to the file that is locked as a part of this
 	// lock.
-	Path string
+	Path string `json:"path"`
 	// Name is the name of the person holding this lock
-	Name string
+	Name string `json:"name"`
 	// Email address of the person holding this lock
-	Email string
+	Email string `json:"email"`
 	// LockedAt is the time at which this lock was acquired.
-	LockedAt time.Time
+	LockedAt time.Time `json:"locked_at"`
 }
 
 func (c *Client) newLockFromApi(a api.Lock) Lock {

--- a/test/test-lock.sh
+++ b/test/test-lock.sh
@@ -16,6 +16,20 @@ begin_test "creating a lock"
 )
 end_test
 
+begin_test "creating a lock (--json)"
+(
+  set -e
+
+  setup_remote_repo_with_file "lock_create_simple_json" "a_json.dat"
+
+  GITLFSLOCKSENABLED=1 git lfs lock --json "a_json.dat" | tee lock.log
+  grep "\"path\":\"a_json.dat\"" lock.log
+
+  id=$(grep -o "\"id\":\".*\"" lock.log | cut -d \" -f 4)
+  assert_server_lock $id
+)
+end_test
+
 begin_test "locking a previously locked file"
 (
   set -e

--- a/test/test-locks.sh
+++ b/test/test-locks.sh
@@ -19,6 +19,22 @@ begin_test "list a single lock"
 )
 end_test
 
+begin_test "list a single lock (--json)"
+(
+  set -e
+
+  setup_remote_repo_with_file "locks_list_single_json" "f_json.dat"
+
+  GITLFSLOCKSENABLED=1 git lfs lock "f_json.dat" | tee lock.log
+
+  id=$(grep -oh "\((.*)\)" lock.log | tr -d "()")
+  assert_server_lock $id
+
+  GITLFSLOCKSENABLED=1 git lfs locks --json --path "f_json.dat" | tee locks.log
+  grep "\"path\":\"f_json.dat\"" locks.log
+)
+end_test
+
 begin_test "list locks with a limit"
 (
   set -e

--- a/test/test-unlock.sh
+++ b/test/test-unlock.sh
@@ -18,6 +18,24 @@ begin_test "unlocking a lock by path"
 )
 end_test
 
+begin_test "unlocking a lock (--json)"
+(
+  set -e
+
+  setup_remote_repo_with_file "unlock_by_path_json" "c_json.dat"
+
+  GITLFSLOCKSENABLED=1 git lfs lock "c_json.dat" | tee lock.log
+
+  id=$(grep -oh "\((.*)\)" lock.log | tr -d "()")
+  assert_server_lock $id
+
+  GITLFSLOCKSENABLED=1 git lfs unlock --json "c_json.dat" 2>&1 | tee unlock.log
+  grep "\"unlocked\":true" unlock.log
+
+  refute_server_lock $id
+)
+end_test
+
 begin_test "unlocking a lock by id"
 (
   set -e


### PR DESCRIPTION
This pull-request backports an internal change made to the various locking commands adding the `--json` flag.

To allow 3rd party tools written in languages that do not interoperate with Go to integrate with LFS , a `--json` flag is used to share a standard encoding format. This allows other programs to shell out to LFS and expect an exact data format in return over stdout.

As a caveat, the `Error()`'d messages are not encoded in JSON. This behavior should be OK, since programs can expect that JSON parse errors should be treated as LFS errors and can treat the contents of stdout as the error message.

---

While working on this PR, I noticed that none of the three locking commands (`locks`, `lock`, and `unlock`) have manpage documentation. Before removing the `GITLFSLOCKSENABLED` environment flag, manpages should be written, and they should include notes about the `--json` flag.

---

/cc @git-lfs/core