### PR TITLE
locking: add pre-commit hook to detect inappropriately modified files

### DIFF
--- a/commands/command_pre_commit.go
+++ b/commands/command_pre_commit.go
@@ -20,7 +20,8 @@ func preCommitCommand(cmd *cobra.Command, args []string) {
 
 	lockSet, err := findLocks(lc, nil, 0, false)
 	if err != nil {
-		Exit("error finding locks: %s", err)
+		Print("could not find locks, proceeding anyway: %s", err)
+		os.Exit(0)
 	}
 
 	files, err := git.StagedFiles()

--- a/commands/command_pre_commit.go
+++ b/commands/command_pre_commit.go
@@ -1,0 +1,50 @@
+package commands
+
+import (
+	"os"
+
+	"github.com/git-lfs/git-lfs/git"
+	"github.com/git-lfs/git-lfs/locking"
+	"github.com/spf13/cobra"
+)
+
+func preCommitCommand(cmd *cobra.Command, args []string) {
+	requireGitVersion()
+
+	name, email := cfg.CurrentCommitter()
+	lc, err := locking.NewClient(cfg)
+	if err != nil {
+		Exit("Unable to create lock system: %v", err.Error())
+	}
+	defer lc.Close()
+
+	lockSet, err := findLocks(lc, nil, 0, false)
+	if err != nil {
+		Exit("error finding locks: %s", err)
+	}
+
+	files, err := git.StagedFiles()
+	if err != nil {
+		Exit("error finding staged files: %s", err)
+	}
+
+	lockConflicts := make([]string, 0, len(lockSet))
+
+	for _, f := range files {
+		if l, ok := lockSet[f]; ok && !(l.Name == name && l.Email == email) {
+			lockConflicts = append(lockConflicts, f)
+		}
+	}
+
+	if len(lockConflicts) > 0 {
+		Error("Some files are locked")
+		for _, file := range lockConflicts {
+			Error("* %s", file)
+		}
+		os.Exit(1)
+	}
+}
+
+func init() {
+	RegisterCommand("pre-commit", preCommitCommand, nil)
+}

--- a/commands/command_update.go
+++ b/commands/command_update.go
@@ -48,7 +48,7 @@ func updateCommand(cmd *cobra.Command, args []string) {
 			Error(err.Error())
 			Exit("To resolve this, either:\n  1: run `git lfs update --manual` for instructions on how to merge hooks.\n  2: run `git lfs update --force` to overwrite your hook.")
 		} else {
-			Print("Updated pre-push hook.")
+			Print("Updated hook(s).")
 		}
 	}
 

--- a/docs/man/git-lfs-pre-commit.1.ronn
+++ b/docs/man/git-lfs-pre-commit.1.ronn
@@ -1,0 +1,17 @@
+git-lfs-pre-commit(1) -- Git pre-commit hook implementation
+=======================================================
+
+## SYNOPSIS
+
+`git lfs pre-commit`
+
+## DESCRIPTION
+
+Responds to Git pre-commit events.
+
+For all locked files currently staged, contained within the refs given, error if
+staging a file locked by someone other than the current committer.
+
+## SEE ALSO
+
+Part of the git-lfs(1) suite.

--- a/git/git.go
+++ b/git/git.go
@@ -310,6 +310,26 @@ func UpdateIndex(file string) error {
 	return err
 }
 
+func StagedFiles() ([]string, error) {
+	cmd := subprocess.ExecCommand("git", "diff", "--cached", "--name-only", "--diff-filter=ACM")
+
+	outp, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to call git diff: %v", err)
+	}
+	cmd.Start()
+	defer cmd.Wait()
+
+	scanner := bufio.NewScanner(outp)
+
+	var ret []string
+	for scanner.Scan() {
+		ret = append(ret, strings.TrimSpace(scanner.Text()))
+	}
+
+	return ret, nil
+}
+
 type gitConfig struct {
 	gitVersion string
 	mu         sync.Mutex

--- a/lfs/setup.go
+++ b/lfs/setup.go
@@ -19,8 +19,14 @@ var (
 		},
 	}
 
+	preCommitHook = &Hook{
+		Type:     "pre-commit",
+		Contents: "#!/bin/sh\ncommand -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/pre-commit.\\n\"; exit 2; }\ngit lfs pre-commit \"$@\"",
+	}
+
 	hooks = []*Hook{
 		prePushHook,
+		preCommitHook,
 	}
 
 	filters = &Attribute{

--- a/test/test-install-custom-hooks-path-unsupported.sh
+++ b/test/test-install-custom-hooks-path-unsupported.sh
@@ -21,7 +21,7 @@ begin_test "install with unsupported core.hooksPath"
   git config --local core.hooksPath "$hooks_dir"
 
   git lfs install 2>&1 | tee install.log
-  grep "Updated pre-push hook" install.log
+  grep "Updated hook(s)" install.log
 
   [ ! -e "$hooks_dir/pre-push" ]
   [ -e ".git/hooks/pre-push" ]

--- a/test/test-install-custom-hooks-path.sh
+++ b/test/test-install-custom-hooks-path.sh
@@ -21,7 +21,7 @@ begin_test "install with supported core.hooksPath"
   git config --local core.hooksPath "$hooks_dir"
 
   git lfs install 2>&1 | tee install.log
-  grep "Updated pre-push hook" install.log
+  grep "Updated hook(s)" install.log
 
   [ -e "$hooks_dir/pre-push" ]
   [ ! -e ".git/pre-push" ]

--- a/test/test-install.sh
+++ b/test/test-install.sh
@@ -76,7 +76,7 @@ begin_test "install updates repo hooks"
 command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/pre-push.\\n\"; exit 2; }
 git lfs pre-push \"\$@\""
 
-  [ "Updated pre-push hook.
+  [ "Updated hook(s).
 Git LFS initialized." = "$(git lfs install)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
@@ -84,7 +84,7 @@ Git LFS initialized." = "$(git lfs install)" ]
   # more-comprehensive hook update tests are in test-update.sh
   echo "#!/bin/sh
 git lfs push --stdin \$*" > .git/hooks/pre-push
-  [ "Updated pre-push hook.
+  [ "Updated hook(s).
 Git LFS initialized." = "$(git lfs install)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
@@ -112,7 +112,7 @@ To resolve this, either:
   set -e
 
   # force replace unexpected hook
-  [ "Updated pre-push hook.
+  [ "Updated hook(s).
 Git LFS initialized." = "$(git lfs install --force)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 

--- a/test/test-pre-commit.sh
+++ b/test/test-pre-commit.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+. "test/testlib.sh"
+
+begin_test "pre-commit with own locked files"
+(
+  set -e
+
+  reponame="pre-commit-owned-locks"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  contents="locked contents"
+  printf "$contents" > locked_pc_auth.dat
+  git add locked_pc_auth.dat
+  git commit -m "add locked_pc_auth.dat"
+
+  git push origin master
+
+  GITLFSLOCKSENABLED=1 git lfs lock "locked_pc_auth.dat" | tee lock.log
+  grep "'locked_pc_auth.dat' was locked" lock.log
+
+  id=$(grep -oh "\((.*)\)" lock.log | tr -d "()")
+  assert_server_lock $id
+
+  printf "authorized changes" >> locked_pc_auth.dat
+  git add locked_pc_auth.dat
+  git commit -m "locked changes"
+)
+end_test

--- a/test/test-pre-commit.sh
+++ b/test/test-pre-commit.sh
@@ -32,3 +32,53 @@ begin_test "pre-commit with own locked files"
   git commit -m "locked changes"
 )
 end_test
+
+begin_test "pre-commit with unowned locked files"
+(
+  set -e
+
+  reponame="pre-commit-unowned-locks"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git config --local user.name "Example Locker"
+  git config --local user.email "locker@xample.com"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  contents="locked contents"
+  printf "$contents" > locked_pc_unauth.dat
+  git add locked_pc_unauth.dat
+  git commit -m "add locked_pc_unauth.dat"
+
+  git push origin master
+
+  GITLFSLOCKSENABLED=1 git lfs lock "locked_pc_unauth.dat" | tee lock.log
+  grep "'locked_pc_unauth.dat' was locked" lock.log
+
+  id=$(grep -oh "\((.*)\)" lock.log | tr -d "()")
+  assert_server_lock $id
+
+  pushd "$TRASHDIR" >/dev/null
+    clone_repo "$reponame" "$reponame-assert"
+
+    printf "authorized changes" >> locked_pc_unauth.dat
+    git add locked_pc_unauth.dat
+
+    set +e
+    git commit -m "locked_pc_unauth changes" 2>&1 | tee commit.log
+    ok="${PIPESTATUS[0]}"
+    set -e
+
+    if [ "0" -eq "$ok" ]; then
+      echo >&2 "ERR: expected \`git commit\` to fail, didn't..."
+      exit 1
+    fi
+
+    grep "Some files are locked" commit.log
+    grep "locked_pc_unauth.dat" commit.log
+  popd >/dev/null
+)
+end_test

--- a/test/test-update.sh
+++ b/test/test-update.sh
@@ -14,49 +14,49 @@ git lfs pre-push \"\$@\""
   cd without-pre-push
   git init
 
-  [ "Updated pre-push hook." = "$(git lfs update)" ]
+  [ "Updated hook(s)." = "$(git lfs update)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
   # run it again
-  [ "Updated pre-push hook." = "$(git lfs update)" ]
+  [ "Updated hook(s)." = "$(git lfs update)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
   # replace old hook 1
   echo "#!/bin/sh
 git lfs push --stdin \$*" > .git/hooks/pre-push
-  [ "Updated pre-push hook." = "$(git lfs update)" ]
+  [ "Updated hook(s)." = "$(git lfs update)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
   # replace old hook 2
   echo "#!/bin/sh
 git lfs push --stdin \"\$@\"" > .git/hooks/pre-push
-  [ "Updated pre-push hook." = "$(git lfs update)" ]
+  [ "Updated hook(s)." = "$(git lfs update)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
   # replace old hook 3
   echo "#!/bin/sh
 git lfs pre-push \"\$@\"" > .git/hooks/pre-push
-  [ "Updated pre-push hook." = "$(git lfs update)" ]
+  [ "Updated hook(s)." = "$(git lfs update)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
   # replace blank hook
   rm .git/hooks/pre-push
   touch .git/hooks/pre-push
-  [ "Updated pre-push hook." = "$(git lfs update)" ]
+  [ "Updated hook(s)." = "$(git lfs update)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
   # replace old hook 4
   echo "#!/bin/sh
 command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository has been set up with Git LFS but Git LFS is not installed.\\n\"; exit 0; }
 git lfs pre-push \"$@\""
-  [ "Updated pre-push hook." = "$(git lfs update)" ]
+  [ "Updated hook(s)." = "$(git lfs update)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
   # replace old hook 5
   echo "#!/bin/sh
 command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository has been set up with Git LFS but Git LFS is not installed.\\n\"; exit 2; }
 git lfs pre-push \"$@\""
-  [ "Updated pre-push hook." = "$(git lfs update)" ]
+  [ "Updated hook(s)." = "$(git lfs update)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
   # don't replace unexpected hook
@@ -97,7 +97,7 @@ git lfs pre-commit \"\$@\""
   [ "test" = "$(cat .git/hooks/pre-push)" ]
 
   # force replace unexpected hook
-  [ "Updated pre-push hook." = "$(git lfs update --force)" ]
+  [ "Updated hook(s)." = "$(git lfs update --force)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
   has_test_dir || exit 0
@@ -110,6 +110,23 @@ git lfs pre-commit \"\$@\""
   git lfs update
   ls -al hooks
   [ "$pre_push_hook" = "$(cat hooks/pre-push)" ]
+)
+end_test
+
+begin_test "update pre-commit hook"
+(
+  set -e
+
+  pre_commit_hook="#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/pre-commit.\\n\"; exit 2; }
+git lfs pre-commit \"\$@\""
+
+  mkdir without-pre-commit
+  cd without-pre-commit
+  git init
+
+  [ "Updated hook(s)." = "$(git lfs update)" ]
+  [ "$pre_commit_hook" = "$(cat .git/hooks/pre-commit)" ]
 )
 end_test
 
@@ -130,7 +147,7 @@ begin_test "update lfs.{url}.access"
   [ "basic" = "$(git config lfs.https://example2.com.access)" ]
   [ "other" = "$(git config lfs.https://example3.com.access)" ]
 
-  expected="Updated pre-push hook.
+  expected="Updated hook(s).
 Updated http://example.com access from private to basic.
 Updated https://example.com access from private to basic.
 Removed invalid https://example3.com access of other."

--- a/test/test-update.sh
+++ b/test/test-update.sh
@@ -86,7 +86,12 @@ To resolve this, either:
 
 #!/bin/sh
 command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/pre-push.\n\"; exit 2; }
-git lfs pre-push \"\$@\""
+git lfs pre-push \"\$@\"
+Add the following to .git/hooks/pre-commit :
+
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/pre-commit.\n\"; exit 2; }
+git lfs pre-commit \"\$@\""
 
   [ "$expected" = "$(git lfs update --manual 2>&1)" ]
   [ "test" = "$(cat .git/hooks/pre-push)" ]


### PR DESCRIPTION
This pull-request adds a `pre-commit` hook that detects and prevents commits changing locked files owned by someone other than the current committer.

This hook looks at the currently staged files when it is called (before the user is told to edit the `.git/COMMIT_EDITMSG`) and inspects each one of them to see if they are locked by someone other than the current committer. The current committer is used since it is the latest and most accurate information determinable about who will commit the file.

Here's a breakdown of the changes:

1. 4f40215...19eaad8: implement the `pre-commit` hook
2. c0843c7: install the `pre-commit` hook
3. 479f031...bf24886: add integration tests
4. 2958106: add a man-page entry for the `pre-commit` command

Some things that we should investigate before merging:

- How does this hook behave when changing history, i.e., with `filter-branch`, `rebase` or `commit --amend`?
- Should we stream the results of `git.StagedFiles()`, to better handle a case where there are _many_ staged files?

---

/cc @git-lfs/core 
