### PR TITLE
locking: add post-merge hook to unlock locks

### DIFF
--- a/commands/command_post_merge.go
+++ b/commands/command_post_merge.go
@@ -1,0 +1,61 @@
+package commands
+
+import (
+	"strings"
+
+	"github.com/git-lfs/git-lfs/lfs"
+	"github.com/git-lfs/git-lfs/locking"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+func postMergeCommand(cmd *cobra.Command, args []string) {
+	gitscanner := lfs.NewGitScanner(nil)
+	if err := gitscanner.RemoteForPush("master@{1}"); err != nil {
+		ExitWithError(err)
+	}
+
+	defer gitscanner.Close()
+
+	pointers, err := scanLeftOrAll(gitscanner, "master")
+	if err != nil {
+		Exit("Error scanning Git LFS files: %+v", err)
+	}
+
+	lc, err := locking.NewClient(cfg)
+	if err != nil {
+		Exit("Unable to create lock system: %v", err.Error())
+	}
+	defer lc.Close()
+
+	lockSet, err := findLocks(lc, nil, 0, false)
+	if err != nil && !strings.Contains(err.Error(), "Not Found") {
+		Exit("error finding locks: %s", err)
+	}
+
+	name, email := cfg.CurrentCommitter()
+
+	myLocks := make(map[string]struct{})
+	for _, p := range pointers {
+		if l, ok := lockSet[p.Name]; ok && l.Name == name && l.Email == email {
+			myLocks[p.Name] = struct{}{}
+		}
+	}
+
+	if len(myLocks) == 0 {
+		return
+	}
+
+	Print("Unlocking %d files", len(myLocks))
+	for filename, _ := range myLocks {
+		if err := lc.UnlockFile(filename, false); err != nil {
+			ExitWithError(errors.Wrap(err, "unable to unlock file"))
+		}
+
+		Print("* %s", filename)
+	}
+}
+
+func init() {
+	RegisterCommand("post-merge", postMergeCommand, nil)
+}

--- a/commands/command_post_merge.go
+++ b/commands/command_post_merge.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"strings"
 
+	"github.com/git-lfs/git-lfs/git"
 	"github.com/git-lfs/git-lfs/lfs"
 	"github.com/git-lfs/git-lfs/locking"
 	"github.com/pkg/errors"
@@ -16,6 +17,16 @@ func postMergeCommand(cmd *cobra.Command, args []string) {
 	}
 
 	defer gitscanner.Close()
+
+	ref, err := git.ResolveRef("HEAD")
+	if err != nil {
+		Exit("Unable to resolve HEAD ref: %v", err)
+	}
+
+	// only unlock files when merging to master
+	if ref.Name != "master" {
+		return
+	}
 
 	pointers, err := scanLeftOrAll(gitscanner, "master")
 	if err != nil {

--- a/commands/command_update.go
+++ b/commands/command_update.go
@@ -48,7 +48,7 @@ func updateCommand(cmd *cobra.Command, args []string) {
 			Error(err.Error())
 			Exit("To resolve this, either:\n  1: run `git lfs update --manual` for instructions on how to merge hooks.\n  2: run `git lfs update --force` to overwrite your hook.")
 		} else {
-			Print("Updated pre-push hook.")
+			Print("Updated hook(s).")
 		}
 	}
 

--- a/docs/man/git-lfs-post-merge.1.ronn
+++ b/docs/man/git-lfs-post-merge.1.ronn
@@ -1,0 +1,15 @@
+git-lfs-post-merge(1) -- Git post-merge hook implementation
+=======================================================
+
+## SYNOPSIS
+
+`git lfs post-merge`
+
+## DESCRIPTION
+
+For all files merged in the last successful merged with locks owned by the
+current committer, unlock those files.
+
+## SEE ALSO
+
+Part of the git-lfs(1) suite.

--- a/lfs/setup.go
+++ b/lfs/setup.go
@@ -19,8 +19,14 @@ var (
 		},
 	}
 
+	postMergeHook = &Hook{
+		Type:     "post-merge",
+		Contents: "#!/bin/sh\ncommand -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/post-merge.\\n\"; exit 2; }\ngit lfs post-merge \"$@\"",
+	}
+
 	hooks = []*Hook{
 		prePushHook,
+		postMergeHook,
 	}
 
 	filters = &Attribute{

--- a/test/test-install-custom-hooks-path-unsupported.sh
+++ b/test/test-install-custom-hooks-path-unsupported.sh
@@ -21,7 +21,7 @@ begin_test "install with unsupported core.hooksPath"
   git config --local core.hooksPath "$hooks_dir"
 
   git lfs install 2>&1 | tee install.log
-  grep "Updated pre-push hook" install.log
+  grep "Updated hook(s)" install.log
 
   [ ! -e "$hooks_dir/pre-push" ]
   [ -e ".git/hooks/pre-push" ]

--- a/test/test-install-custom-hooks-path.sh
+++ b/test/test-install-custom-hooks-path.sh
@@ -21,7 +21,7 @@ begin_test "install with supported core.hooksPath"
   git config --local core.hooksPath "$hooks_dir"
 
   git lfs install 2>&1 | tee install.log
-  grep "Updated pre-push hook" install.log
+  grep "Updated hook(s)" install.log
 
   [ -e "$hooks_dir/pre-push" ]
   [ ! -e ".git/pre-push" ]

--- a/test/test-install.sh
+++ b/test/test-install.sh
@@ -76,7 +76,7 @@ begin_test "install updates repo hooks"
 command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/pre-push.\\n\"; exit 2; }
 git lfs pre-push \"\$@\""
 
-  [ "Updated pre-push hook.
+  [ "Updated hook(s).
 Git LFS initialized." = "$(git lfs install)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
@@ -84,7 +84,7 @@ Git LFS initialized." = "$(git lfs install)" ]
   # more-comprehensive hook update tests are in test-update.sh
   echo "#!/bin/sh
 git lfs push --stdin \$*" > .git/hooks/pre-push
-  [ "Updated pre-push hook.
+  [ "Updated hook(s).
 Git LFS initialized." = "$(git lfs install)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
@@ -112,7 +112,7 @@ To resolve this, either:
   set -e
 
   # force replace unexpected hook
-  [ "Updated pre-push hook.
+  [ "Updated hook(s).
 Git LFS initialized." = "$(git lfs install --force)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 

--- a/test/test-post-merge.sh
+++ b/test/test-post-merge.sh
@@ -47,3 +47,49 @@ begin_test "post-merge with owned locks (into master)"
   refute_server_lock "$lock_id"
 )
 end_test
+
+begin_test "post-merge with owned locks (into non-master)"
+(
+  set -e
+
+  reponame="post-merge-owned-non-master"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  printf "contents" > locked_pmo1.dat
+  git add locked_pmo1.dat
+  git commit -m "add locked file"
+
+  git push origin master
+
+  GITLFSLOCKSENABLED=1 git lfs lock "locked_pmo1.dat" | tee lock.log
+  grep "'locked_pmo1.dat' was locked" lock.log
+
+  lock_id=$(grep -oh "\((.*)\)" lock.log | tr -d "()")
+  assert_server_lock $lock_id
+
+  git checkout -b my-feature
+  git checkout -b my-sub-feature
+
+  printf "(more) contents" >> locked_pmo1.dat
+  git add locked_pmo1.dat
+  git commit -m "change locked file"
+
+  git push origin my-sub-feature
+
+  assert_server_lock $lock_id
+
+  git checkout my-feature
+
+  git merge my-sub-feature 2>&1 | tee merge.log
+  [ "0" -eq "$(grep -c "Unlocking" merge.log)" ]
+
+  git push origin my-feature
+
+  assert_server_lock "$lock_id"
+)
+end_test

--- a/test/test-update.sh
+++ b/test/test-update.sh
@@ -14,49 +14,49 @@ git lfs pre-push \"\$@\""
   cd without-pre-push
   git init
 
-  [ "Updated pre-push hook." = "$(git lfs update)" ]
+  [ "Updated hook(s)." = "$(git lfs update)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
   # run it again
-  [ "Updated pre-push hook." = "$(git lfs update)" ]
+  [ "Updated hook(s)." = "$(git lfs update)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
   # replace old hook 1
   echo "#!/bin/sh
 git lfs push --stdin \$*" > .git/hooks/pre-push
-  [ "Updated pre-push hook." = "$(git lfs update)" ]
+  [ "Updated hook(s)." = "$(git lfs update)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
   # replace old hook 2
   echo "#!/bin/sh
 git lfs push --stdin \"\$@\"" > .git/hooks/pre-push
-  [ "Updated pre-push hook." = "$(git lfs update)" ]
+  [ "Updated hook(s)." = "$(git lfs update)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
   # replace old hook 3
   echo "#!/bin/sh
 git lfs pre-push \"\$@\"" > .git/hooks/pre-push
-  [ "Updated pre-push hook." = "$(git lfs update)" ]
+  [ "Updated hook(s)." = "$(git lfs update)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
   # replace blank hook
   rm .git/hooks/pre-push
   touch .git/hooks/pre-push
-  [ "Updated pre-push hook." = "$(git lfs update)" ]
+  [ "Updated hook(s)." = "$(git lfs update)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
   # replace old hook 4
   echo "#!/bin/sh
 command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository has been set up with Git LFS but Git LFS is not installed.\\n\"; exit 0; }
 git lfs pre-push \"$@\""
-  [ "Updated pre-push hook." = "$(git lfs update)" ]
+  [ "Updated hook(s)." = "$(git lfs update)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
   # replace old hook 5
   echo "#!/bin/sh
 command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository has been set up with Git LFS but Git LFS is not installed.\\n\"; exit 2; }
 git lfs pre-push \"$@\""
-  [ "Updated pre-push hook." = "$(git lfs update)" ]
+  [ "Updated hook(s)." = "$(git lfs update)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
   # don't replace unexpected hook
@@ -92,7 +92,7 @@ git lfs pre-push \"\$@\""
   [ "test" = "$(cat .git/hooks/pre-push)" ]
 
   # force replace unexpected hook
-  [ "Updated pre-push hook." = "$(git lfs update --force)" ]
+  [ "Updated hook(s)." = "$(git lfs update --force)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
   has_test_dir || exit 0
@@ -125,7 +125,7 @@ begin_test "update lfs.{url}.access"
   [ "basic" = "$(git config lfs.https://example2.com.access)" ]
   [ "other" = "$(git config lfs.https://example3.com.access)" ]
 
-  expected="Updated pre-push hook.
+  expected="Updated hook(s).
 Updated http://example.com access from private to basic.
 Updated https://example.com access from private to basic.
 Removed invalid https://example3.com access of other."

--- a/test/test-update.sh
+++ b/test/test-update.sh
@@ -86,7 +86,12 @@ To resolve this, either:
 
 #!/bin/sh
 command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/pre-push.\n\"; exit 2; }
-git lfs pre-push \"\$@\""
+git lfs pre-push \"\$@\"
+Add the following to .git/hooks/post-merge :
+
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/post-merge.\n\"; exit 2; }
+git lfs post-merge \"\$@\""
 
   [ "$expected" = "$(git lfs update --manual 2>&1)" ]
   [ "test" = "$(cat .git/hooks/pre-push)" ]


### PR DESCRIPTION
This pull-request implements a post-merge hook to unlock all locked (owned) files merged back into the `master` branch of a repository.

Here's a breakdown of what happened:

1. 1598acb...111046d: implement the `post-merge` hook
2. decf27e: Install the `post-merge` hook
3. 63b5143...77e2311: add integration tests covering this behavior
4. 0fbfbba...213577e: fix `git-lfs update` command to use generic message
5. cd796b6: add a man-page entry for post-merge

Some things I'd like to consider before merging:

- Should there be a configurable option to specify a default branch (or set of branches) to check, instead of just `master`?
- ~~What should happen if the merge is done using the `--no-verify` option, skipping the `pre-commit` hook and merging a file locked by someone other than the current committer?~~

---

/cc @git-lfs/core  