### PR TITLE
Fixed file paths on cygwin.

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -576,12 +576,10 @@ func GetCommitSummary(commit string) (*CommitSummary, error) {
 func isCygwin() bool {
 	cmd := subprocess.ExecCommand("uname")
 	out, err := cmd.Output()
-	output := string(out)
-	if (err == nil) && (strings.Contains(output, "CYGWIN")) {
-		return true
-	} else {
+	if err != nil {
 		return false
 	}
+	return bytes.Contains(out, []byte("CYGWIN"))
 }
 
 func translateCygwinPath(path string) (string, error) {
@@ -589,8 +587,7 @@ func translateCygwinPath(path string) (string, error) {
 	buf := &bytes.Buffer{}
 	cmd.Stderr = buf
 	out, err := cmd.Output()
-	output := string(out)
-	output = strings.TrimSpace(output)
+	output := strings.TrimSpace(string(out))
 	if err != nil {
 		return path, fmt.Errorf("Failed to translate path from cygwin to windows: %s", buf.String())
 	}

--- a/git/git.go
+++ b/git/git.go
@@ -573,6 +573,32 @@ func GetCommitSummary(commit string) (*CommitSummary, error) {
 	}
 }
 
+func isCygwin() bool {
+	cmd := subprocess.ExecCommand("uname")
+	buf := &bytes.Buffer{}
+	cmd.Stderr = buf
+	out, err := cmd.Output()
+	output := string(out)
+	if (err == nil) && (strings.Contains(output, "CYGWIN")) {
+		return true
+	} else {
+		return false
+	}
+}
+
+func translateCygwinPath(path string) (string, error) {
+	cmd := subprocess.ExecCommand("cygpath", "-w", path)
+	buf := &bytes.Buffer{}
+	cmd.Stderr = buf
+	out, err := cmd.Output()
+	output := string(out)
+	output = strings.TrimSpace(output)
+	if err != nil {
+		return path, fmt.Errorf("Failed to translate path from cygwin to windows")
+	}
+	return output, nil
+}
+
 func GitAndRootDirs() (string, string, error) {
 	cmd := subprocess.ExecCommand("git", "rev-parse", "--git-dir", "--show-toplevel")
 	buf := &bytes.Buffer{}
@@ -586,6 +612,12 @@ func GitAndRootDirs() (string, string, error) {
 
 	paths := strings.Split(output, "\n")
 	pathLen := len(paths)
+
+	if isCygwin() {
+		for i := 0; i < pathLen; i++ {
+			paths[i], err = translateCygwinPath(paths[i])
+		}
+	}
 
 	if pathLen == 0 {
 		return "", "", fmt.Errorf("Bad git rev-parse output: %q", output)
@@ -612,6 +644,9 @@ func RootDir() (string, error) {
 	}
 
 	path := strings.TrimSpace(string(out))
+	if isCygwin() {
+		path, err = translateCygwinPath(path)
+	}
 	if len(path) > 0 {
 		return filepath.Abs(path)
 	}

--- a/git/git.go
+++ b/git/git.go
@@ -575,8 +575,6 @@ func GetCommitSummary(commit string) (*CommitSummary, error) {
 
 func isCygwin() bool {
 	cmd := subprocess.ExecCommand("uname")
-	buf := &bytes.Buffer{}
-	cmd.Stderr = buf
 	out, err := cmd.Output()
 	output := string(out)
 	if (err == nil) && (strings.Contains(output, "CYGWIN")) {
@@ -594,7 +592,7 @@ func translateCygwinPath(path string) (string, error) {
 	output := string(out)
 	output = strings.TrimSpace(output)
 	if err != nil {
-		return path, fmt.Errorf("Failed to translate path from cygwin to windows")
+		return path, fmt.Errorf("Failed to translate path from cygwin to windows: %s", buf.String())
 	}
 	return output, nil
 }


### PR DESCRIPTION
Fixes git-lfs/git-lfs#865.  These are the changes that @marcrossinyol created.  Tested against v1.5.4 on cygwin.  Can't test against master because master doesn't build on cygwin:

```
$ ./script/bootstrap
Installing goversioninfo to embed resources into Windows executables...
Creating the resource.syso version information file...
git-lfs.go:1: running "goversioninfo": exec: "goversioninfo": executable file not found in %PATH%
```

