### PR TITLE
api refactor: locking

### DIFF
--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -32,7 +32,7 @@ func lockCommand(cmd *cobra.Command, args []string) {
 		cfg.CurrentRemote = lockRemote
 	}
 
-	lockClient, err := locking.NewClient(cfg)
+	lockClient, err := locking.NewClient(lockRemote, APIClient(), cfg)
 	if err != nil {
 		Exit("Unable to create lock system: %v", err.Error())
 	}

--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/git-lfs/git-lfs/git"
-	"github.com/git-lfs/git-lfs/locking"
 	"github.com/spf13/cobra"
 )
 
@@ -27,15 +26,9 @@ func lockCommand(cmd *cobra.Command, args []string) {
 		Exit(err.Error())
 	}
 
-	if len(lockRemote) > 0 {
-		cfg.CurrentRemote = lockRemote
-	}
-
-	lockClient, err := locking.NewClient(lockRemote, APIClient())
-	if err != nil {
-		Exit("Unable to create lock system: %v", err.Error())
-	}
+	lockClient := LockClient(lockRemote)
 	defer lockClient.Close()
+
 	lock, err := lockClient.LockFile(path)
 	if err != nil {
 		Exit("Lock failed: %v", err)

--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -26,7 +26,7 @@ func lockCommand(cmd *cobra.Command, args []string) {
 		Exit(err.Error())
 	}
 
-	lockClient := LockClient(lockRemote)
+	lockClient := newLockClient(lockRemote)
 	defer lockClient.Close()
 
 	lock, err := lockClient.LockFile(path)

--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -17,7 +17,6 @@ var (
 )
 
 func lockCommand(cmd *cobra.Command, args []string) {
-
 	if len(args) == 0 {
 		Print("Usage: git lfs lock <path>")
 		return
@@ -32,7 +31,7 @@ func lockCommand(cmd *cobra.Command, args []string) {
 		cfg.CurrentRemote = lockRemote
 	}
 
-	lockClient, err := locking.NewClient(lockRemote, APIClient(), cfg)
+	lockClient, err := locking.NewClient(lockRemote, APIClient())
 	if err != nil {
 		Exit("Unable to create lock system: %v", err.Error())
 	}

--- a/commands/command_locks.go
+++ b/commands/command_locks.go
@@ -19,7 +19,7 @@ func locksCommand(cmd *cobra.Command, args []string) {
 	if len(lockRemote) > 0 {
 		cfg.CurrentRemote = lockRemote
 	}
-	lockClient, err := locking.NewClient(cfg)
+	lockClient, err := locking.NewClient(lockRemote, APIClient(), cfg)
 	if err != nil {
 		Exit("Unable to create lock system: %v", err.Error())
 	}

--- a/commands/command_locks.go
+++ b/commands/command_locks.go
@@ -1,9 +1,6 @@
 package commands
 
-import (
-	"github.com/git-lfs/git-lfs/locking"
-	"github.com/spf13/cobra"
-)
+import "github.com/spf13/cobra"
 
 var (
 	locksCmdFlags = new(locksFlags)
@@ -15,14 +12,9 @@ func locksCommand(cmd *cobra.Command, args []string) {
 		Exit("Error building filters: %v", err)
 	}
 
-	if len(lockRemote) > 0 {
-		cfg.CurrentRemote = lockRemote
-	}
-	lockClient, err := locking.NewClient(lockRemote, APIClient())
-	if err != nil {
-		Exit("Unable to create lock system: %v", err.Error())
-	}
+	lockClient := LockClient(lockRemote)
 	defer lockClient.Close()
+
 	var lockCount int
 	locks, err := lockClient.SearchLocks(filters, locksCmdFlags.Limit, locksCmdFlags.Local)
 	// Print any we got before exiting

--- a/commands/command_locks.go
+++ b/commands/command_locks.go
@@ -12,7 +12,7 @@ func locksCommand(cmd *cobra.Command, args []string) {
 		Exit("Error building filters: %v", err)
 	}
 
-	lockClient := LockClient(lockRemote)
+	lockClient := newLockClient(lockRemote)
 	defer lockClient.Close()
 
 	var lockCount int

--- a/commands/command_locks.go
+++ b/commands/command_locks.go
@@ -10,7 +10,6 @@ var (
 )
 
 func locksCommand(cmd *cobra.Command, args []string) {
-
 	filters, err := locksCmdFlags.Filters()
 	if err != nil {
 		Exit("Error building filters: %v", err)
@@ -19,7 +18,7 @@ func locksCommand(cmd *cobra.Command, args []string) {
 	if len(lockRemote) > 0 {
 		cfg.CurrentRemote = lockRemote
 	}
-	lockClient, err := locking.NewClient(lockRemote, APIClient(), cfg)
+	lockClient, err := locking.NewClient(lockRemote, APIClient())
 	if err != nil {
 		Exit("Unable to create lock system: %v", err.Error())
 	}

--- a/commands/command_unlock.go
+++ b/commands/command_unlock.go
@@ -26,7 +26,7 @@ func unlockCommand(cmd *cobra.Command, args []string) {
 		cfg.CurrentRemote = lockRemote
 	}
 
-	lockClient, err := locking.NewClient(cfg)
+	lockClient, err := locking.NewClient(lockRemote, APIClient(), cfg)
 	if err != nil {
 		Exit("Unable to create lock system: %v", err.Error())
 	}

--- a/commands/command_unlock.go
+++ b/commands/command_unlock.go
@@ -17,7 +17,7 @@ type unlockFlags struct {
 }
 
 func unlockCommand(cmd *cobra.Command, args []string) {
-	lockClient := LockClient(lockRemote)
+	lockClient := newLockClient(lockRemote)
 	defer lockClient.Close()
 
 	if len(args) != 0 {

--- a/commands/command_unlock.go
+++ b/commands/command_unlock.go
@@ -1,10 +1,6 @@
 package commands
 
-import (
-	"github.com/git-lfs/git-lfs/locking"
-
-	"github.com/spf13/cobra"
-)
+import "github.com/spf13/cobra"
 
 var (
 	unlockCmdFlags unlockFlags
@@ -21,15 +17,9 @@ type unlockFlags struct {
 }
 
 func unlockCommand(cmd *cobra.Command, args []string) {
-	if len(lockRemote) > 0 {
-		cfg.CurrentRemote = lockRemote
-	}
-
-	lockClient, err := locking.NewClient(lockRemote, APIClient())
-	if err != nil {
-		Exit("Unable to create lock system: %v", err.Error())
-	}
+	lockClient := LockClient(lockRemote)
 	defer lockClient.Close()
+
 	if len(args) != 0 {
 		path, err := lockPath(args[0])
 		if err != nil {

--- a/commands/command_unlock.go
+++ b/commands/command_unlock.go
@@ -21,12 +21,11 @@ type unlockFlags struct {
 }
 
 func unlockCommand(cmd *cobra.Command, args []string) {
-
 	if len(lockRemote) > 0 {
 		cfg.CurrentRemote = lockRemote
 	}
 
-	lockClient, err := locking.NewClient(lockRemote, APIClient(), cfg)
+	lockClient, err := locking.NewClient(lockRemote, APIClient())
 	if err != nil {
 		Exit("Unable to create lock system: %v", err.Error())
 	}

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -17,6 +17,7 @@ import (
 	"github.com/git-lfs/git-lfs/git"
 	"github.com/git-lfs/git-lfs/lfs"
 	"github.com/git-lfs/git-lfs/lfsapi"
+	"github.com/git-lfs/git-lfs/locking"
 	"github.com/git-lfs/git-lfs/progress"
 	"github.com/git-lfs/git-lfs/tools"
 	"github.com/git-lfs/git-lfs/tq"
@@ -43,6 +44,19 @@ func APIClient() *lfsapi.Client {
 		ExitWithError(err)
 	}
 	return c
+}
+
+func LockClient(remote string) *locking.Client {
+	lockClient, err := locking.NewClient(remote, APIClient())
+	if err == nil {
+		err = lockClient.SetupFileCache(filepath.Join(config.LocalGitStorageDir, "lfs"))
+	}
+
+	if err != nil {
+		Exit("Unable to create lock system: %v", err.Error())
+	}
+
+	return lockClient
 }
 
 // TransferManifest builds a tq.Manifest from the commands package global

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -16,6 +16,7 @@ import (
 	"github.com/git-lfs/git-lfs/filepathfilter"
 	"github.com/git-lfs/git-lfs/git"
 	"github.com/git-lfs/git-lfs/lfs"
+	"github.com/git-lfs/git-lfs/lfsapi"
 	"github.com/git-lfs/git-lfs/progress"
 	"github.com/git-lfs/git-lfs/tools"
 	"github.com/git-lfs/git-lfs/tq"
@@ -35,6 +36,14 @@ var (
 	includeArg string
 	excludeArg string
 )
+
+func APIClient() *lfsapi.Client {
+	c, err := lfsapi.NewClient(cfg.Os, cfg.Git)
+	if err != nil {
+		ExitWithError(err)
+	}
+	return c
+}
 
 // TransferManifest builds a tq.Manifest from the commands package global
 // cfg var.

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -38,7 +38,7 @@ var (
 	excludeArg string
 )
 
-func APIClient() *lfsapi.Client {
+func newAPIClient() *lfsapi.Client {
 	c, err := lfsapi.NewClient(cfg.Os, cfg.Git)
 	if err != nil {
 		ExitWithError(err)
@@ -46,8 +46,8 @@ func APIClient() *lfsapi.Client {
 	return c
 }
 
-func LockClient(remote string) *locking.Client {
-	lockClient, err := locking.NewClient(remote, APIClient())
+func newLockClient(remote string) *locking.Client {
+	lockClient, err := locking.NewClient(remote, newAPIClient())
 	if err == nil {
 		err = lockClient.SetupFileCache(filepath.Join(config.LocalGitStorageDir, "lfs"))
 	}

--- a/lfsapi/auth_test.go
+++ b/lfsapi/auth_test.go
@@ -74,7 +74,7 @@ func TestDoWithAuthApprove(t *testing.T) {
 	creds := newMockCredentialHelper()
 	c := &Client{
 		Credentials: creds,
-		Endpoints: NewEndpointFinder(testEnv(map[string]string{
+		Endpoints: NewEndpointFinder(Env(map[string]string{
 			"lfs.url": srv.URL + "/repo/lfs",
 		})),
 	}
@@ -144,7 +144,7 @@ func TestDoWithAuthReject(t *testing.T) {
 
 	c := &Client{
 		Credentials: creds,
-		Endpoints: NewEndpointFinder(testEnv(map[string]string{
+		Endpoints: NewEndpointFinder(Env(map[string]string{
 			"lfs.url": srv.URL,
 		})),
 	}
@@ -467,7 +467,7 @@ func TestGetCreds(t *testing.T) {
 			req.Header.Set(key, value)
 		}
 
-		ef := NewEndpointFinder(testEnv(test.Config))
+		ef := NewEndpointFinder(Env(test.Config))
 		endpoint, access, creds, credsURL, err := getCreds(credHelper, netrcFinder, ef, test.Remote, req)
 		if !assert.Nil(t, err) {
 			continue

--- a/lfsapi/certs_test.go
+++ b/lfsapi/certs_test.go
@@ -60,7 +60,7 @@ func TestCertFromSSLCAInfoConfig(t *testing.T) {
 	// Test http.<url>.sslcainfo
 	for _, hostName := range sslCAInfoConfigHostNames {
 		hostKey := fmt.Sprintf("http.https://%v.sslcainfo", hostName)
-		c, err := NewClient(nil, testEnv(map[string]string{
+		c, err := NewClient(nil, Env(map[string]string{
 			hostKey: tempfile.Name(),
 		}))
 		assert.Nil(t, err)
@@ -82,7 +82,7 @@ func TestCertFromSSLCAInfoConfig(t *testing.T) {
 	}
 
 	// Test http.sslcainfo
-	c, err := NewClient(nil, testEnv(map[string]string{
+	c, err := NewClient(nil, Env(map[string]string{
 		"http.sslcainfo": tempfile.Name(),
 	}))
 	assert.Nil(t, err)
@@ -103,7 +103,7 @@ func TestCertFromSSLCAInfoEnv(t *testing.T) {
 	assert.Nil(t, err, "Error writing temp cert file")
 	tempfile.Close()
 
-	c, err := NewClient(testEnv(map[string]string{
+	c, err := NewClient(Env(map[string]string{
 		"GIT_SSL_CAINFO": tempfile.Name(),
 	}), nil)
 	assert.Nil(t, err)
@@ -123,7 +123,7 @@ func TestCertFromSSLCAPathConfig(t *testing.T) {
 	err = ioutil.WriteFile(filepath.Join(tempdir, "cert1.pem"), []byte(testCert), 0644)
 	assert.Nil(t, err, "Error creating cert file")
 
-	c, err := NewClient(nil, testEnv(map[string]string{
+	c, err := NewClient(nil, Env(map[string]string{
 		"http.sslcapath": tempdir,
 	}))
 
@@ -144,7 +144,7 @@ func TestCertFromSSLCAPathEnv(t *testing.T) {
 	err = ioutil.WriteFile(filepath.Join(tempdir, "cert1.pem"), []byte(testCert), 0644)
 	assert.Nil(t, err, "Error creating cert file")
 
-	c, err := NewClient(testEnv(map[string]string{
+	c, err := NewClient(Env(map[string]string{
 		"GIT_SSL_CAPATH": tempdir,
 	}), nil)
 	assert.Nil(t, err)
@@ -164,7 +164,7 @@ func TestCertVerifyDisabledGlobalEnv(t *testing.T) {
 		assert.False(t, tr.TLSClientConfig.InsecureSkipVerify)
 	}
 
-	c, err := NewClient(testEnv(map[string]string{
+	c, err := NewClient(Env(map[string]string{
 		"GIT_SSL_NO_VERIFY": "1",
 	}), nil)
 
@@ -185,7 +185,7 @@ func TestCertVerifyDisabledGlobalConfig(t *testing.T) {
 		assert.False(t, tr.TLSClientConfig.InsecureSkipVerify)
 	}
 
-	c, err := NewClient(nil, testEnv(map[string]string{
+	c, err := NewClient(nil, Env(map[string]string{
 		"http.sslverify": "false",
 	}))
 	assert.Nil(t, err)
@@ -211,7 +211,7 @@ func TestCertVerifyDisabledHostConfig(t *testing.T) {
 		assert.False(t, tr.TLSClientConfig.InsecureSkipVerify)
 	}
 
-	c, err := NewClient(nil, testEnv(map[string]string{
+	c, err := NewClient(nil, Env(map[string]string{
 		"http.https://specifichost.com/.sslverify": "false",
 	}))
 	assert.Nil(t, err)

--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -15,6 +15,30 @@ import (
 
 var UserAgent = "git-lfs"
 
+func (c *Client) NewRequest(method string, e Endpoint, suffix string, body interface{}) (*http.Request, error) {
+	req, err := http.NewRequest(method, joinURL(e.Url, suffix), nil)
+	if err != nil {
+		return req, err
+	}
+
+	if body != nil {
+		if merr := MarshalToRequest(req, body); merr != nil {
+			return req, merr
+		}
+	}
+
+	return req, err
+}
+
+const slash = "/"
+
+func joinURL(prefix, suffix string) string {
+	if strings.HasSuffix(prefix, slash) {
+		return prefix + suffix
+	}
+	return prefix + slash + suffix
+}
+
 func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	req.Header.Set("User-Agent", UserAgent)
 

--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -94,11 +94,11 @@ func (c *Client) httpClient(host string) *http.Client {
 	defer c.clientMu.Unlock()
 
 	if c.gitEnv == nil {
-		c.gitEnv = make(testEnv)
+		c.gitEnv = make(Env)
 	}
 
 	if c.osEnv == nil {
-		c.osEnv = make(testEnv)
+		c.osEnv = make(Env)
 	}
 
 	if c.hostClients == nil {

--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -161,6 +161,12 @@ func (c *Client) httpClient(host string) *http.Client {
 	return httpClient
 }
 
+func (c *Client) CurrentUser() (string, string) {
+	userName, _ := c.gitEnv.Get("user.name")
+	userEmail, _ := c.gitEnv.Get("user.email")
+	return userName, userEmail
+}
+
 func newRequestForRetry(req *http.Request, location string) (*http.Request, error) {
 	newReq, err := http.NewRequest(req.Method, location, nil)
 	if err != nil {

--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -15,16 +15,21 @@ import (
 
 var UserAgent = "git-lfs"
 
+const MediaType = "application/vnd.git-lfs+json; charset=utf-8"
+
 func (c *Client) NewRequest(method string, e Endpoint, suffix string, body interface{}) (*http.Request, error) {
 	req, err := http.NewRequest(method, joinURL(e.Url, suffix), nil)
 	if err != nil {
 		return req, err
 	}
 
+	req.Header.Set("Accept", MediaType)
+
 	if body != nil {
 		if merr := MarshalToRequest(req, body); merr != nil {
 			return req, merr
 		}
+		req.Header.Set("Content-Type", MediaType)
 	}
 
 	return req, err

--- a/lfsapi/client_test.go
+++ b/lfsapi/client_test.go
@@ -99,7 +99,7 @@ func TestClientRedirect(t *testing.T) {
 }
 
 func TestNewClient(t *testing.T) {
-	c, err := NewClient(testEnv(map[string]string{}), testEnv(map[string]string{
+	c, err := NewClient(Env(map[string]string{}), Env(map[string]string{
 		"lfs.dialtimeout":         "151",
 		"lfs.keepalive":           "152",
 		"lfs.tlstimeout":          "153",
@@ -119,7 +119,7 @@ func TestNewClientWithGitSSLVerify(t *testing.T) {
 	assert.False(t, c.SkipSSLVerify)
 
 	for _, value := range []string{"true", "1", "t"} {
-		c, err = NewClient(testEnv(map[string]string{}), testEnv(map[string]string{
+		c, err = NewClient(Env(map[string]string{}), Env(map[string]string{
 			"http.sslverify": value,
 		}))
 		t.Logf("http.sslverify: %q", value)
@@ -128,7 +128,7 @@ func TestNewClientWithGitSSLVerify(t *testing.T) {
 	}
 
 	for _, value := range []string{"false", "0", "f"} {
-		c, err = NewClient(testEnv(map[string]string{}), testEnv(map[string]string{
+		c, err = NewClient(Env(map[string]string{}), Env(map[string]string{
 			"http.sslverify": value,
 		}))
 		t.Logf("http.sslverify: %q", value)
@@ -143,18 +143,18 @@ func TestNewClientWithOSSSLVerify(t *testing.T) {
 	assert.False(t, c.SkipSSLVerify)
 
 	for _, value := range []string{"false", "0", "f"} {
-		c, err = NewClient(testEnv(map[string]string{
+		c, err = NewClient(Env(map[string]string{
 			"GIT_SSL_NO_VERIFY": value,
-		}), testEnv(map[string]string{}))
+		}), Env(map[string]string{}))
 		t.Logf("GIT_SSL_NO_VERIFY: %q", value)
 		assert.Nil(t, err)
 		assert.False(t, c.SkipSSLVerify)
 	}
 
 	for _, value := range []string{"true", "1", "t"} {
-		c, err = NewClient(testEnv(map[string]string{
+		c, err = NewClient(Env(map[string]string{
 			"GIT_SSL_NO_VERIFY": value,
-		}), testEnv(map[string]string{}))
+		}), Env(map[string]string{}))
 		t.Logf("GIT_SSL_NO_VERIFY: %q", value)
 		assert.Nil(t, err)
 		assert.True(t, c.SkipSSLVerify)
@@ -170,7 +170,7 @@ func TestNewRequest(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		c, err := NewClient(nil, testEnv(map[string]string{
+		c, err := NewClient(nil, Env(map[string]string{
 			"lfs.url": test[0],
 		}))
 		require.Nil(t, err)

--- a/lfsapi/endpoint_finder_test.go
+++ b/lfsapi/endpoint_finder_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestEndpointDefaultsToOrigin(t *testing.T) {
-	finder := NewEndpointFinder(testEnv(map[string]string{
+	finder := NewEndpointFinder(Env(map[string]string{
 		"remote.origin.lfsurl": "abc",
 	}))
 
@@ -18,7 +18,7 @@ func TestEndpointDefaultsToOrigin(t *testing.T) {
 }
 
 func TestEndpointOverridesOrigin(t *testing.T) {
-	finder := NewEndpointFinder(testEnv(map[string]string{
+	finder := NewEndpointFinder(Env(map[string]string{
 		"lfs.url":              "abc",
 		"remote.origin.lfsurl": "def",
 	}))
@@ -30,7 +30,7 @@ func TestEndpointOverridesOrigin(t *testing.T) {
 }
 
 func TestEndpointNoOverrideDefaultRemote(t *testing.T) {
-	finder := NewEndpointFinder(testEnv(map[string]string{
+	finder := NewEndpointFinder(Env(map[string]string{
 		"remote.origin.lfsurl": "abc",
 		"remote.other.lfsurl":  "def",
 	}))
@@ -42,7 +42,7 @@ func TestEndpointNoOverrideDefaultRemote(t *testing.T) {
 }
 
 func TestEndpointUseAlternateRemote(t *testing.T) {
-	finder := NewEndpointFinder(testEnv(map[string]string{
+	finder := NewEndpointFinder(Env(map[string]string{
 		"remote.origin.lfsurl": "abc",
 		"remote.other.lfsurl":  "def",
 	}))
@@ -54,7 +54,7 @@ func TestEndpointUseAlternateRemote(t *testing.T) {
 }
 
 func TestEndpointAddsLfsSuffix(t *testing.T) {
-	finder := NewEndpointFinder(testEnv(map[string]string{
+	finder := NewEndpointFinder(Env(map[string]string{
 		"remote.origin.url": "https://example.com/foo/bar",
 	}))
 
@@ -65,7 +65,7 @@ func TestEndpointAddsLfsSuffix(t *testing.T) {
 }
 
 func TestBareEndpointAddsLfsSuffix(t *testing.T) {
-	finder := NewEndpointFinder(testEnv(map[string]string{
+	finder := NewEndpointFinder(Env(map[string]string{
 		"remote.origin.url": "https://example.com/foo/bar.git",
 	}))
 
@@ -76,7 +76,7 @@ func TestBareEndpointAddsLfsSuffix(t *testing.T) {
 }
 
 func TestEndpointSeparateClonePushUrl(t *testing.T) {
-	finder := NewEndpointFinder(testEnv(map[string]string{
+	finder := NewEndpointFinder(Env(map[string]string{
 		"remote.origin.url":     "https://example.com/foo/bar.git",
 		"remote.origin.pushurl": "https://readwrite.com/foo/bar.git",
 	}))
@@ -93,7 +93,7 @@ func TestEndpointSeparateClonePushUrl(t *testing.T) {
 }
 
 func TestEndpointOverriddenSeparateClonePushLfsUrl(t *testing.T) {
-	finder := NewEndpointFinder(testEnv(map[string]string{
+	finder := NewEndpointFinder(Env(map[string]string{
 		"remote.origin.url":        "https://example.com/foo/bar.git",
 		"remote.origin.pushurl":    "https://readwrite.com/foo/bar.git",
 		"remote.origin.lfsurl":     "https://examplelfs.com/foo/bar",
@@ -112,7 +112,7 @@ func TestEndpointOverriddenSeparateClonePushLfsUrl(t *testing.T) {
 }
 
 func TestEndpointGlobalSeparateLfsPush(t *testing.T) {
-	finder := NewEndpointFinder(testEnv(map[string]string{
+	finder := NewEndpointFinder(Env(map[string]string{
 		"lfs.url":     "https://readonly.com/foo/bar",
 		"lfs.pushurl": "https://write.com/foo/bar",
 	}))
@@ -129,7 +129,7 @@ func TestEndpointGlobalSeparateLfsPush(t *testing.T) {
 }
 
 func TestSSHEndpointOverridden(t *testing.T) {
-	finder := NewEndpointFinder(testEnv(map[string]string{
+	finder := NewEndpointFinder(Env(map[string]string{
 		"remote.origin.url":    "git@example.com:foo/bar",
 		"remote.origin.lfsurl": "lfs",
 	}))
@@ -142,7 +142,7 @@ func TestSSHEndpointOverridden(t *testing.T) {
 }
 
 func TestSSHEndpointAddsLfsSuffix(t *testing.T) {
-	finder := NewEndpointFinder(testEnv(map[string]string{
+	finder := NewEndpointFinder(Env(map[string]string{
 		"remote.origin.url": "ssh://git@example.com/foo/bar",
 	}))
 
@@ -154,7 +154,7 @@ func TestSSHEndpointAddsLfsSuffix(t *testing.T) {
 }
 
 func TestSSHCustomPortEndpointAddsLfsSuffix(t *testing.T) {
-	finder := NewEndpointFinder(testEnv(map[string]string{
+	finder := NewEndpointFinder(Env(map[string]string{
 		"remote.origin.url": "ssh://git@example.com:9000/foo/bar",
 	}))
 
@@ -166,7 +166,7 @@ func TestSSHCustomPortEndpointAddsLfsSuffix(t *testing.T) {
 }
 
 func TestBareSSHEndpointAddsLfsSuffix(t *testing.T) {
-	finder := NewEndpointFinder(testEnv(map[string]string{
+	finder := NewEndpointFinder(Env(map[string]string{
 		"remote.origin.url": "git@example.com:foo/bar.git",
 	}))
 
@@ -178,7 +178,7 @@ func TestBareSSHEndpointAddsLfsSuffix(t *testing.T) {
 }
 
 func TestSSHEndpointFromGlobalLfsUrl(t *testing.T) {
-	finder := NewEndpointFinder(testEnv(map[string]string{
+	finder := NewEndpointFinder(Env(map[string]string{
 		"lfs.url": "git@example.com:foo/bar.git",
 	}))
 
@@ -190,7 +190,7 @@ func TestSSHEndpointFromGlobalLfsUrl(t *testing.T) {
 }
 
 func TestHTTPEndpointAddsLfsSuffix(t *testing.T) {
-	finder := NewEndpointFinder(testEnv(map[string]string{
+	finder := NewEndpointFinder(Env(map[string]string{
 		"remote.origin.url": "http://example.com/foo/bar",
 	}))
 
@@ -202,7 +202,7 @@ func TestHTTPEndpointAddsLfsSuffix(t *testing.T) {
 }
 
 func TestBareHTTPEndpointAddsLfsSuffix(t *testing.T) {
-	finder := NewEndpointFinder(testEnv(map[string]string{
+	finder := NewEndpointFinder(Env(map[string]string{
 		"remote.origin.url": "http://example.com/foo/bar.git",
 	}))
 
@@ -214,7 +214,7 @@ func TestBareHTTPEndpointAddsLfsSuffix(t *testing.T) {
 }
 
 func TestGitEndpointAddsLfsSuffix(t *testing.T) {
-	finder := NewEndpointFinder(testEnv(map[string]string{
+	finder := NewEndpointFinder(Env(map[string]string{
 		"remote.origin.url": "git://example.com/foo/bar",
 	}))
 
@@ -226,7 +226,7 @@ func TestGitEndpointAddsLfsSuffix(t *testing.T) {
 }
 
 func TestGitEndpointAddsLfsSuffixWithCustomProtocol(t *testing.T) {
-	finder := NewEndpointFinder(testEnv(map[string]string{
+	finder := NewEndpointFinder(Env(map[string]string{
 		"remote.origin.url": "git://example.com/foo/bar",
 		"lfs.gitprotocol":   "http",
 	}))
@@ -239,7 +239,7 @@ func TestGitEndpointAddsLfsSuffixWithCustomProtocol(t *testing.T) {
 }
 
 func TestBareGitEndpointAddsLfsSuffix(t *testing.T) {
-	finder := NewEndpointFinder(testEnv(map[string]string{
+	finder := NewEndpointFinder(Env(map[string]string{
 		"remote.origin.url": "git://example.com/foo/bar.git",
 	}))
 
@@ -266,7 +266,7 @@ func TestAccessConfig(t *testing.T) {
 	}
 
 	for value, expected := range tests {
-		finder := NewEndpointFinder(testEnv(map[string]string{
+		finder := NewEndpointFinder(Env(map[string]string{
 			"lfs.url":                        "http://example.com",
 			"lfs.http://example.com.access":  value,
 			"lfs.https://example.com.access": "bad",
@@ -285,7 +285,7 @@ func TestAccessConfig(t *testing.T) {
 
 	// Test again but with separate push url
 	for value, expected := range tests {
-		finder := NewEndpointFinder(testEnv(map[string]string{
+		finder := NewEndpointFinder(Env(map[string]string{
 			"lfs.url":                           "http://example.com",
 			"lfs.pushurl":                       "http://examplepush.com",
 			"lfs.http://example.com.access":     value,
@@ -312,7 +312,7 @@ func TestAccessAbsentConfig(t *testing.T) {
 }
 
 func TestSetAccess(t *testing.T) {
-	finder := NewEndpointFinder(testEnv(map[string]string{}))
+	finder := NewEndpointFinder(Env(map[string]string{}))
 
 	assert.Equal(t, NoneAccess, finder.AccessFor("http://example.com"))
 	finder.SetAccess("http://example.com", NTLMAccess)
@@ -320,7 +320,7 @@ func TestSetAccess(t *testing.T) {
 }
 
 func TestChangeAccess(t *testing.T) {
-	finder := NewEndpointFinder(testEnv(map[string]string{
+	finder := NewEndpointFinder(Env(map[string]string{
 		"lfs.http://example.com.access": "basic",
 	}))
 
@@ -330,7 +330,7 @@ func TestChangeAccess(t *testing.T) {
 }
 
 func TestDeleteAccessWithNone(t *testing.T) {
-	finder := NewEndpointFinder(testEnv(map[string]string{
+	finder := NewEndpointFinder(Env(map[string]string{
 		"lfs.http://example.com.access": "basic",
 	}))
 
@@ -340,7 +340,7 @@ func TestDeleteAccessWithNone(t *testing.T) {
 }
 
 func TestDeleteAccessWithEmptyString(t *testing.T) {
-	finder := NewEndpointFinder(testEnv(map[string]string{
+	finder := NewEndpointFinder(Env(map[string]string{
 		"lfs.http://example.com.access": "basic",
 	}))
 

--- a/lfsapi/errors.go
+++ b/lfsapi/errors.go
@@ -30,7 +30,11 @@ func (c *Client) handleResponse(res *http.Response) error {
 	}
 
 	cliErr := &ClientError{}
-	err := decodeResponse(res, cliErr)
+	err := DecodeJSON(res, cliErr)
+	if IsDecodeTypeError(err) {
+		err = nil
+	}
+
 	if err == nil {
 		if len(cliErr.Message) == 0 {
 			err = defaultError(res)

--- a/lfsapi/lfsapi.go
+++ b/lfsapi/lfsapi.go
@@ -51,11 +51,11 @@ type Client struct {
 
 func NewClient(osEnv env, gitEnv env) (*Client, error) {
 	if osEnv == nil {
-		osEnv = make(testEnv)
+		osEnv = make(Env)
 	}
 
 	if gitEnv == nil {
-		gitEnv = make(testEnv)
+		gitEnv = make(Env)
 	}
 
 	netrc, err := ParseNetrc(osEnv)
@@ -114,14 +114,14 @@ type env interface {
 
 // basic config.Environment implementation. Only used in tests, or as a zero
 // value to NewClient().
-type testEnv map[string]string
+type Env map[string]string
 
-func (e testEnv) Get(key string) (string, bool) {
+func (e Env) Get(key string) (string, bool) {
 	v, ok := e[key]
 	return v, ok
 }
 
-func (e testEnv) Int(key string, def int) (val int) {
+func (e Env) Int(key string, def int) (val int) {
 	s, _ := e.Get(key)
 	if len(s) == 0 {
 		return def
@@ -135,7 +135,7 @@ func (e testEnv) Int(key string, def int) (val int) {
 	return i
 }
 
-func (e testEnv) Bool(key string, def bool) (val bool) {
+func (e Env) Bool(key string, def bool) (val bool) {
 	s, _ := e.Get(key)
 	if len(s) == 0 {
 		return def
@@ -151,6 +151,6 @@ func (e testEnv) Bool(key string, def bool) (val bool) {
 	}
 }
 
-func (e testEnv) All() map[string]string {
+func (e Env) All() map[string]string {
 	return e
 }

--- a/lfsapi/proxy_test.go
+++ b/lfsapi/proxy_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 func TestProxyFromGitConfig(t *testing.T) {
-	c, err := NewClient(testEnv(map[string]string{
+	c, err := NewClient(Env(map[string]string{
 		"HTTPS_PROXY": "https://proxy-from-env:8080",
-	}), testEnv(map[string]string{
+	}), Env(map[string]string{
 		"http.proxy": "https://proxy-from-git-config:8080",
 	}))
 	require.Nil(t, err)
@@ -25,9 +25,9 @@ func TestProxyFromGitConfig(t *testing.T) {
 }
 
 func TestHttpProxyFromGitConfig(t *testing.T) {
-	c, err := NewClient(testEnv(map[string]string{
+	c, err := NewClient(Env(map[string]string{
 		"HTTPS_PROXY": "https://proxy-from-env:8080",
-	}), testEnv(map[string]string{
+	}), Env(map[string]string{
 		"http.proxy": "http://proxy-from-git-config:8080",
 	}))
 	require.Nil(t, err)
@@ -41,7 +41,7 @@ func TestHttpProxyFromGitConfig(t *testing.T) {
 }
 
 func TestProxyFromEnvironment(t *testing.T) {
-	c, err := NewClient(testEnv(map[string]string{
+	c, err := NewClient(Env(map[string]string{
 		"HTTPS_PROXY": "https://proxy-from-env:8080",
 	}), nil)
 	require.Nil(t, err)
@@ -66,9 +66,9 @@ func TestProxyIsNil(t *testing.T) {
 }
 
 func TestProxyNoProxy(t *testing.T) {
-	c, err := NewClient(testEnv(map[string]string{
+	c, err := NewClient(Env(map[string]string{
 		"NO_PROXY": "some-host",
-	}), testEnv(map[string]string{
+	}), Env(map[string]string{
 		"http.proxy": "https://proxy-from-git-config:8080",
 	}))
 	require.Nil(t, err)

--- a/locking/api.go
+++ b/locking/api.go
@@ -1,0 +1,202 @@
+package locking
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/git-lfs/git-lfs/lfsapi"
+)
+
+type lockClient struct {
+	*lfsapi.Client
+}
+
+// LockRequest encapsulates the payload sent across the API when a client would
+// like to obtain a lock against a particular path on a given remote.
+type lockRequest struct {
+	// Path is the path that the client would like to obtain a lock against.
+	Path string `json:"path"`
+	// LatestRemoteCommit is the SHA of the last known commit from the
+	// remote that we are trying to create the lock against, as found in
+	// `.git/refs/origin/<name>`.
+	LatestRemoteCommit string `json:"latest_remote_commit"`
+	// Committer is the individual that wishes to obtain the lock.
+	Committer committer `json:"committer"`
+}
+
+// LockResponse encapsulates the information sent over the API in response to
+// a `LockRequest`.
+type lockResponse struct {
+	// Lock is the Lock that was optionally created in response to the
+	// payload that was sent (see above). If the lock already exists, then
+	// the existing lock is sent in this field instead, and the author of
+	// that lock remains the same, meaning that the client failed to obtain
+	// that lock. An HTTP status of "409 - Conflict" is used here.
+	//
+	// If the lock was unable to be created, this field will hold the
+	// zero-value of Lock and the Err field will provide a more detailed set
+	// of information.
+	//
+	// If an error was experienced in creating this lock, then the
+	// zero-value of Lock should be sent here instead.
+	Lock *Lock `json:"lock"`
+	// CommitNeeded holds the minimum commit SHA that client must have to
+	// obtain the lock.
+	CommitNeeded string `json:"commit_needed,omitempty"`
+	// Err is the optional error that was encountered while trying to create
+	// the above lock.
+	Err string `json:"error,omitempty"`
+}
+
+func (c *lockClient) Lock(remote string, lockReq *lockRequest) (*lockResponse, *http.Response, error) {
+	e := c.Endpoints.Endpoint("upload", remote)
+	req, err := c.NewRequest("POST", e, "locks", lockReq)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	res, err := c.DoWithAuth(remote, req)
+	if err != nil {
+		return nil, res, err
+	}
+
+	lockRes := &lockResponse{}
+	err = lfsapi.DecodeJSON(res, lockRes)
+	return lockRes, res, err
+}
+
+// UnlockRequest encapsulates the data sent in an API request to remove a lock.
+type unlockRequest struct {
+	// Id is the Id of the lock that the user wishes to unlock.
+	Id string `json:"id"`
+	// Force determines whether or not the lock should be "forcibly"
+	// unlocked; that is to say whether or not a given individual should be
+	// able to break a different individual's lock.
+	Force bool `json:"force"`
+}
+
+// UnlockResponse is the result sent back from the API when asked to remove a
+// lock.
+type unlockResponse struct {
+	// Lock is the lock corresponding to the asked-about lock in the
+	// `UnlockPayload` (see above). If no matching lock was found, this
+	// field will take the zero-value of Lock, and Err will be non-nil.
+	Lock *Lock `json:"lock"`
+	// Err is an optional field which holds any error that was experienced
+	// while removing the lock.
+	Err string `json:"error,omitempty"`
+}
+
+func (c *lockClient) Unlock(remote, id string, force bool) (*unlockResponse, *http.Response, error) {
+	e := c.Endpoints.Endpoint("upload", remote)
+	suffix := fmt.Sprintf("locks/%s/unlock", id)
+	req, err := c.NewRequest("POST", e, suffix, &unlockRequest{Id: id, Force: force})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	res, err := c.DoWithAuth(remote, req)
+	if err != nil {
+		return nil, res, err
+	}
+
+	unlockRes := &unlockResponse{}
+	err = lfsapi.DecodeJSON(res, unlockRes)
+	return unlockRes, res, err
+}
+
+// Filter represents a single qualifier to apply against a set of locks.
+type lockFilter struct {
+	// Property is the property to search against.
+	// Value is the value that the property must take.
+	Property, Value string
+}
+
+// LockSearchRequest encapsulates the request sent to the server when the client
+// would like a list of locks that match the given criteria.
+type lockSearchRequest struct {
+	// Filters is the set of filters to query against. If the client wishes
+	// to obtain a list of all locks, an empty array should be passed here.
+	Filters []lockFilter
+	// Cursor is an optional field used to tell the server which lock was
+	// seen last, if scanning through multiple pages of results.
+	//
+	// Servers must return a list of locks sorted in reverse chronological
+	// order, so the Cursor provides a consistent method of viewing all
+	// locks, even if more were created between two requests.
+	Cursor string
+	// Limit is the maximum number of locks to return in a single page.
+	Limit int
+}
+
+func (r *lockSearchRequest) QueryValues() map[string]string {
+	q := make(map[string]string)
+	for _, filter := range r.Filters {
+		q[filter.Property] = filter.Value
+	}
+
+	if len(r.Cursor) > 0 {
+		q["cursor"] = r.Cursor
+	}
+
+	if r.Limit > 0 {
+		q["limit"] = strconv.Itoa(r.Limit)
+	}
+
+	return q
+}
+
+// LockList encapsulates a set of Locks.
+type lockList struct {
+	// Locks is the set of locks returned back, typically matching the query
+	// parameters sent in the LockListRequest call. If no locks were matched
+	// from a given query, then `Locks` will be represented as an empty
+	// array.
+	Locks []Lock `json:"locks"`
+	// NextCursor returns the Id of the Lock the client should update its
+	// cursor to, if there are multiple pages of results for a particular
+	// `LockListRequest`.
+	NextCursor string `json:"next_cursor,omitempty"`
+	// Err populates any error that was encountered during the search. If no
+	// error was encountered and the operation was succesful, then a value
+	// of nil will be passed here.
+	Err string `json:"error,omitempty"`
+}
+
+func (c *lockClient) Search(remote string, searchReq *lockSearchRequest) (*lockList, *http.Response, error) {
+	e := c.Endpoints.Endpoint("upload", remote)
+	req, err := c.NewRequest("GET", e, "locks", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	q := req.URL.Query()
+	for key, value := range searchReq.QueryValues() {
+		q.Add(key, value)
+	}
+	req.URL.RawQuery = q.Encode()
+
+	res, err := c.DoWithAuth(remote, req)
+	if err != nil {
+		return nil, res, err
+	}
+
+	locks := &lockList{}
+	err = lfsapi.DecodeJSON(res, locks)
+	return locks, res, err
+}
+
+// Committer represents a "First Last <email@domain.com>" pair.
+type committer struct {
+	// Name is the name of the individual who would like to obtain the
+	// lock, for instance: "Rick Olson".
+	Name string `json:"name"`
+	// Email is the email assopsicated with the individual who would
+	// like to obtain the lock, for instance: "rick@github.com".
+	Email string `json:"email"`
+}
+
+func newCommitter(name, email string) committer {
+	return committer{Name: name, Email: email}
+}

--- a/locking/api_test.go
+++ b/locking/api_test.go
@@ -19,6 +19,8 @@ func TestAPILock(t *testing.T) {
 		}
 
 		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, lfsapi.MediaType, r.Header.Get("Accept"))
+		assert.Equal(t, lfsapi.MediaType, r.Header.Get("Content-Type"))
 
 		lockReq := &lockRequest{}
 		err := json.NewDecoder(r.Body).Decode(lockReq)
@@ -58,6 +60,8 @@ func TestAPIUnlock(t *testing.T) {
 		}
 
 		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, lfsapi.MediaType, r.Header.Get("Accept"))
+		assert.Equal(t, lfsapi.MediaType, r.Header.Get("Content-Type"))
 
 		unlockReq := &unlockRequest{}
 		err := json.NewDecoder(r.Body).Decode(unlockReq)
@@ -98,6 +102,9 @@ func TestAPISearch(t *testing.T) {
 		}
 
 		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, lfsapi.MediaType, r.Header.Get("Accept"))
+		assert.Equal(t, "", r.Header.Get("Content-Type"))
+
 		q := r.URL.Query()
 		assert.Equal(t, "A", q.Get("a"))
 		assert.Equal(t, "cursor", q.Get("cursor"))

--- a/locking/api_test.go
+++ b/locking/api_test.go
@@ -1,0 +1,135 @@
+package locking
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/git-lfs/git-lfs/lfsapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPILock(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/locks" {
+			w.WriteHeader(404)
+			return
+		}
+
+		assert.Equal(t, "POST", r.Method)
+
+		lockReq := &lockRequest{}
+		err := json.NewDecoder(r.Body).Decode(lockReq)
+		r.Body.Close()
+		assert.Nil(t, err)
+		assert.Equal(t, "request", lockReq.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		err = json.NewEncoder(w).Encode(&lockResponse{
+			Lock: &Lock{
+				Id:   "1",
+				Path: "response",
+			},
+		})
+		assert.Nil(t, err)
+	}))
+	defer srv.Close()
+
+	c, err := lfsapi.NewClient(nil, lfsapi.Env(map[string]string{
+		"lfs.url": srv.URL + "/api",
+	}))
+	require.Nil(t, err)
+
+	lc := &lockClient{Client: c}
+	lockRes, res, err := lc.Lock("", &lockRequest{Path: "request"})
+	require.Nil(t, err)
+	assert.Equal(t, 200, res.StatusCode)
+	assert.Equal(t, "1", lockRes.Lock.Id)
+	assert.Equal(t, "response", lockRes.Lock.Path)
+}
+
+func TestAPIUnlock(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/locks/123/unlock" {
+			w.WriteHeader(404)
+			return
+		}
+
+		assert.Equal(t, "POST", r.Method)
+
+		unlockReq := &unlockRequest{}
+		err := json.NewDecoder(r.Body).Decode(unlockReq)
+		r.Body.Close()
+		assert.Nil(t, err)
+		assert.Equal(t, "123", unlockReq.Id)
+		assert.True(t, unlockReq.Force)
+
+		w.Header().Set("Content-Type", "application/json")
+		err = json.NewEncoder(w).Encode(&unlockResponse{
+			Lock: &Lock{
+				Id:   "123",
+				Path: "response",
+			},
+		})
+		assert.Nil(t, err)
+	}))
+	defer srv.Close()
+
+	c, err := lfsapi.NewClient(nil, lfsapi.Env(map[string]string{
+		"lfs.url": srv.URL + "/api",
+	}))
+	require.Nil(t, err)
+
+	lc := &lockClient{Client: c}
+	unlockRes, res, err := lc.Unlock("", "123", true)
+	require.Nil(t, err)
+	assert.Equal(t, 200, res.StatusCode)
+	assert.Equal(t, "123", unlockRes.Lock.Id)
+	assert.Equal(t, "response", unlockRes.Lock.Path)
+}
+
+func TestAPISearch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/locks" {
+			w.WriteHeader(404)
+			return
+		}
+
+		assert.Equal(t, "GET", r.Method)
+		q := r.URL.Query()
+		assert.Equal(t, "A", q.Get("a"))
+		assert.Equal(t, "cursor", q.Get("cursor"))
+		assert.Equal(t, "5", q.Get("limit"))
+
+		w.Header().Set("Content-Type", "application/json")
+		err := json.NewEncoder(w).Encode(&lockList{
+			Locks: []Lock{
+				{Id: "1"},
+				{Id: "2"},
+			},
+		})
+		assert.Nil(t, err)
+	}))
+	defer srv.Close()
+
+	c, err := lfsapi.NewClient(nil, lfsapi.Env(map[string]string{
+		"lfs.url": srv.URL + "/api",
+	}))
+	require.Nil(t, err)
+
+	lc := &lockClient{Client: c}
+	locks, res, err := lc.Search("", &lockSearchRequest{
+		Filters: []lockFilter{
+			{Property: "a", Value: "A"},
+		},
+		Cursor: "cursor",
+		Limit:  5,
+	})
+	require.Nil(t, err)
+	assert.Equal(t, 200, res.StatusCode)
+	assert.Equal(t, 2, len(locks.Locks))
+	assert.Equal(t, "1", locks.Locks[0].Id)
+	assert.Equal(t, "2", locks.Locks[1].Id)
+}

--- a/locking/cache.go
+++ b/locking/cache.go
@@ -25,24 +25,6 @@ func NewLockCache(filepath string) (*LockCache, error) {
 	return &LockCache{kv}, nil
 }
 
-func (c *LockCache) encodeIdKey(id string) string {
-	// Safety against accidents
-	if !c.isIdKey(id) {
-		return idKeyPrefix + id
-	}
-	return id
-}
-func (c *LockCache) decodeIdKey(key string) string {
-	// Safety against accidents
-	if c.isIdKey(key) {
-		return key[len(idKeyPrefix):]
-	}
-	return key
-}
-func (c *LockCache) isIdKey(key string) bool {
-	return strings.HasPrefix(key, idKeyPrefix)
-}
-
 // Cache a successful lock for faster local lookup later
 func (c *LockCache) Add(l Lock) error {
 	// Store reference in both directions
@@ -98,4 +80,24 @@ func (c *LockCache) Clear() {
 // Save the cache
 func (c *LockCache) Save() error {
 	return c.kv.Save()
+}
+
+func (c *LockCache) encodeIdKey(id string) string {
+	// Safety against accidents
+	if !c.isIdKey(id) {
+		return idKeyPrefix + id
+	}
+	return id
+}
+
+func (c *LockCache) decodeIdKey(key string) string {
+	// Safety against accidents
+	if c.isIdKey(key) {
+		return key[len(idKeyPrefix):]
+	}
+	return key
+}
+
+func (c *LockCache) isIdKey(key string) bool {
+	return strings.HasPrefix(key, idKeyPrefix)
 }

--- a/locking/locks.go
+++ b/locking/locks.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/git-lfs/git-lfs/api"
 	"github.com/git-lfs/git-lfs/config"
 	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/git"
@@ -136,16 +135,6 @@ type Lock struct {
 	Email string
 	// LockedAt is the time at which this lock was acquired.
 	LockedAt time.Time
-}
-
-func (c *Client) newLockFromApi(a api.Lock) Lock {
-	return Lock{
-		Id:       a.Id,
-		Path:     a.Path,
-		Name:     a.Committer.Name,
-		Email:    a.Committer.Email,
-		LockedAt: a.LockedAt,
-	}
 }
 
 // SearchLocks returns a channel of locks which match the given name/value filter

--- a/locking/locks.go
+++ b/locking/locks.go
@@ -25,20 +25,16 @@ var (
 
 // Client is the main interface object for the locking package
 type Client struct {
-	Remote    string
-	client    *lockClient
-	cfg       *config.Configuration
-	apiClient *api.Client
-	cache     *LockCache
+	Remote string
+	client *lockClient
+	cfg    *config.Configuration
+	cache  *LockCache
 }
 
 // NewClient creates a new locking client with the given configuration
 // You must call the returned object's `Close` method when you are finished with
 // it
 func NewClient(remote string, lfsClient *lfsapi.Client, cfg *config.Configuration) (*Client, error) {
-
-	apiClient := api.NewClient(api.NewHttpLifecycle(cfg))
-
 	lockDir := filepath.Join(config.LocalGitStorageDir, "lfs")
 	err := os.MkdirAll(lockDir, 0755)
 	if err != nil {
@@ -51,11 +47,10 @@ func NewClient(remote string, lfsClient *lfsapi.Client, cfg *config.Configuratio
 	}
 
 	return &Client{
-		Remote:    remote,
-		client:    &lockClient{Client: lfsClient},
-		cfg:       cfg,
-		apiClient: apiClient,
-		cache:     cache,
+		Remote: remote,
+		client: &lockClient{Client: lfsClient},
+		cfg:    cfg,
+		cache:  cache,
 	}, nil
 }
 

--- a/locking/locks_test.go
+++ b/locking/locks_test.go
@@ -55,7 +55,7 @@ func TestRefreshCache(t *testing.T) {
 
 	client, err := NewClient("", lfsclient)
 	assert.Nil(t, err)
-	assert.Nil(t, client.SetupCache(tempDir))
+	assert.Nil(t, client.SetupFileCache(tempDir))
 
 	// Should start with no cached items
 	locks, err := client.SearchLocks(nil, 0, true)

--- a/locking/locks_test.go
+++ b/locking/locks_test.go
@@ -1,54 +1,20 @@
 package locking
 
 import (
-	"bytes"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"sort"
 	"testing"
 	"time"
 
-	"github.com/git-lfs/git-lfs/api"
 	"github.com/git-lfs/git-lfs/config"
+	"github.com/git-lfs/git-lfs/lfsapi"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
-
-type TestLifecycle struct {
-}
-
-func (l *TestLifecycle) Build(schema *api.RequestSchema) (*http.Request, error) {
-	return http.NewRequest("GET", "http://dummy", nil)
-}
-
-func (l *TestLifecycle) Execute(req *http.Request, into interface{}) (api.Response, error) {
-	// Return test data including other users
-	locks := api.LockList{Locks: []api.Lock{
-		api.Lock{Id: "99", Path: "folder/test3.dat", Committer: api.Committer{Name: "Alice", Email: "alice@wonderland.com"}},
-		api.Lock{Id: "101", Path: "folder/test1.dat", Committer: api.Committer{Name: "Fred", Email: "fred@bloggs.com"}},
-		api.Lock{Id: "102", Path: "folder/test2.dat", Committer: api.Committer{Name: "Fred", Email: "fred@bloggs.com"}},
-		api.Lock{Id: "103", Path: "root.dat", Committer: api.Committer{Name: "Fred", Email: "fred@bloggs.com"}},
-		api.Lock{Id: "199", Path: "other/test1.dat", Committer: api.Committer{Name: "Charles", Email: "charles@incharge.com"}},
-	}}
-	locksJson, _ := json.Marshal(locks)
-	r := &http.Response{
-		Status:     "200 OK",
-		StatusCode: 200,
-		Proto:      "HTTP/1.0",
-		Body:       ioutil.NopCloser(bytes.NewReader(locksJson)),
-	}
-	if into != nil {
-		decoder := json.NewDecoder(r.Body)
-		if err := decoder.Decode(into); err != nil {
-			return nil, err
-		}
-	}
-	return api.WrapHttpResponse(r), nil
-}
-func (l *TestLifecycle) Cleanup(resp api.Response) error {
-	return resp.Body().Close()
-}
 
 type LocksById []Lock
 
@@ -61,17 +27,41 @@ func TestRefreshCache(t *testing.T) {
 	oldStore := config.LocalGitStorageDir
 	config.LocalGitStorageDir, err = ioutil.TempDir("", "testCacheLock")
 	assert.Nil(t, err)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/locks", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		err = json.NewEncoder(w).Encode(lockList{
+			Locks: []Lock{
+				Lock{Id: "99", Path: "folder/test3.dat", Name: "Alice", Email: "alice@wonderland.com"},
+				Lock{Id: "101", Path: "folder/test1.dat", Name: "Fred", Email: "fred@bloggs.com"},
+				Lock{Id: "102", Path: "folder/test2.dat", Name: "Fred", Email: "fred@bloggs.com"},
+				Lock{Id: "103", Path: "root.dat", Name: "Fred", Email: "fred@bloggs.com"},
+				Lock{Id: "199", Path: "other/test1.dat", Name: "Charles", Email: "charles@incharge.com"},
+			},
+		})
+		assert.Nil(t, err)
+	}))
+
 	defer func() {
+		srv.Close()
 		os.RemoveAll(config.LocalGitStorageDir)
 		config.LocalGitStorageDir = oldStore
 	}()
 
 	cfg := config.NewFrom(config.Values{
 		Git: map[string]string{"user.name": "Fred", "user.email": "fred@bloggs.com"}})
-	client, err := NewClient(cfg)
+	lfsclient, err := lfsapi.NewClient(nil, lfsapi.Env(map[string]string{
+		"lfs.url":    srv.URL + "/api",
+		"user.name":  "Fred",
+		"user.email": "fred@bloggs.com",
+	}))
+	require.Nil(t, err)
+
+	client, err := NewClient("", lfsclient, cfg)
 	assert.Nil(t, err)
-	// Override api client for testing
-	client.apiClient = api.NewClient(&TestLifecycle{})
 
 	// Should start with no cached items
 	locks, err := client.SearchLocks(nil, 0, true)

--- a/locking/locks_test.go
+++ b/locking/locks_test.go
@@ -51,8 +51,6 @@ func TestRefreshCache(t *testing.T) {
 		config.LocalGitStorageDir = oldStore
 	}()
 
-	cfg := config.NewFrom(config.Values{
-		Git: map[string]string{"user.name": "Fred", "user.email": "fred@bloggs.com"}})
 	lfsclient, err := lfsapi.NewClient(nil, lfsapi.Env(map[string]string{
 		"lfs.url":    srv.URL + "/api",
 		"user.name":  "Fred",
@@ -60,7 +58,7 @@ func TestRefreshCache(t *testing.T) {
 	}))
 	require.Nil(t, err)
 
-	client, err := NewClient("", lfsclient, cfg)
+	client, err := NewClient("", lfsclient)
 	assert.Nil(t, err)
 
 	// Should start with no cached items

--- a/test/cmd/lfstest-gitserver.go
+++ b/test/cmd/lfstest-gitserver.go
@@ -859,6 +859,7 @@ func locksHandler(w http.ResponseWriter, r *http.Request) {
 			enc.Encode(ll)
 		}
 	case "POST":
+		w.Header().Set("Content-Type", "application/json")
 		if strings.HasSuffix(r.URL.Path, "unlock") {
 			var unlockRequest UnlockRequest
 			if err := dec.Decode(&unlockRequest); err != nil {


### PR DESCRIPTION
This updates the locking package to use the new `lfsapi.Client` from the `api-master` branch. As a result, this removes the dependencies on the `api` and `config` packages from `locking`, while adding `lfsapi` of course.