### PR TITLE
test/locks: update lock assertions to include missing reponame

### DIFF
--- a/test/test-lock.sh
+++ b/test/test-lock.sh
@@ -21,13 +21,14 @@ begin_test "creating a lock (--json)"
 (
   set -e
 
-  setup_remote_repo_with_file "lock_create_simple_json" "a_json.dat"
+  reponame="lock_create_simple_json"
+  setup_remote_repo_with_file "$reponame" "a_json.dat"
 
   GITLFSLOCKSENABLED=1 git lfs lock --json "a_json.dat" | tee lock.log
   grep "\"path\":\"a_json.dat\"" lock.log
 
   id=$(grep -o "\"id\":\".*\"" lock.log | cut -d \" -f 4)
-  assert_server_lock $id
+  assert_server_lock "$reponame" "$id"
 )
 end_test
 

--- a/test/test-locks.sh
+++ b/test/test-locks.sh
@@ -24,12 +24,13 @@ begin_test "list a single lock (--json)"
 (
   set -e
 
-  setup_remote_repo_with_file "locks_list_single_json" "f_json.dat"
+  reponame="locks_list_single_json"
+  setup_remote_repo_with_file "$reponame" "f_json.dat"
 
   GITLFSLOCKSENABLED=1 git lfs lock "f_json.dat" | tee lock.log
 
   id=$(grep -oh "\((.*)\)" lock.log | tr -d "()")
-  assert_server_lock $id
+  assert_server_lock "$reponame" "$id"
 
   GITLFSLOCKSENABLED=1 git lfs locks --json --path "f_json.dat" | tee locks.log
   grep "\"path\":\"f_json.dat\"" locks.log

--- a/test/test-unlock.sh
+++ b/test/test-unlock.sh
@@ -23,17 +23,18 @@ begin_test "unlocking a lock (--json)"
 (
   set -e
 
-  setup_remote_repo_with_file "unlock_by_path_json" "c_json.dat"
+  reponame="unlock_by_path_json"
+  setup_remote_repo_with_file "$reponame" "c_json.dat"
 
   GITLFSLOCKSENABLED=1 git lfs lock "c_json.dat" | tee lock.log
 
   id=$(grep -oh "\((.*)\)" lock.log | tr -d "()")
-  assert_server_lock $id
+  assert_server_lock "$reponame" "$id"
 
   GITLFSLOCKSENABLED=1 git lfs unlock --json "c_json.dat" 2>&1 | tee unlock.log
   grep "\"unlocked\":true" unlock.log
 
-  refute_server_lock $id
+  refute_server_lock "$reponame" "$id"
 )
 end_test
 


### PR DESCRIPTION
This pull-request updates the assertions added in #1814 (`assert_server_lock`, `refute_server_lock`) to include the `"$reponame"` argument, as added in #1818.

---

/cc @git-lfs/core #1820 