### PR TITLE
tq: move api.ObjectResource to tq pkg

### DIFF
--- a/lfsapi/errors.go
+++ b/lfsapi/errors.go
@@ -13,7 +13,7 @@ type httpError interface {
 	HTTPResponse() *http.Response
 }
 
-func IsHTTPError(err error) (*http.Response, bool) {
+func IsHTTP(err error) (*http.Response, bool) {
 	if httpErr, ok := err.(httpError); ok {
 		return httpErr.HTTPResponse(), true
 	}

--- a/test/git-lfs-test-server-api/main.go
+++ b/test/git-lfs-test-server-api/main.go
@@ -265,7 +265,7 @@ func callBatchApi(manifest *tq.Manifest, dir tq.Direction, objs []TestObject) ([
 		apiobjs = append(apiobjs, &tq.Transfer{Oid: o.Oid, Size: o.Size})
 	}
 
-	return tq.Batch(dir, manifest, "origin", apiobjs)
+	return tq.Batch(manifest, dir, "origin", apiobjs)
 }
 
 // Combine 2 slices into one by "randomly" interleaving

--- a/test/git-lfs-test-server-api/main.go
+++ b/test/git-lfs-test-server-api/main.go
@@ -265,7 +265,11 @@ func callBatchApi(manifest *tq.Manifest, dir tq.Direction, objs []TestObject) ([
 		apiobjs = append(apiobjs, &tq.Transfer{Oid: o.Oid, Size: o.Size})
 	}
 
-	return tq.Batch(manifest, dir, "origin", apiobjs)
+	bres, err := tq.Batch(manifest, dir, "origin", apiobjs)
+	if err != nil {
+		return nil, err
+	}
+	return bres.Objects, nil
 }
 
 // Combine 2 slices into one by "randomly" interleaving

--- a/test/git-lfs-test-server-api/main.go
+++ b/test/git-lfs-test-server-api/main.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/git-lfs/git-lfs/api"
 	"github.com/git-lfs/git-lfs/config"
 	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/lfs"
@@ -28,7 +27,7 @@ type TestObject struct {
 
 type ServerTest struct {
 	Name string
-	F    func(oidsExist, oidsMissing []TestObject) error
+	F    func(m *tq.Manifest, oidsExist, oidsMissing []TestObject) error
 }
 
 var (
@@ -65,6 +64,11 @@ func testServerApi(cmd *cobra.Command, args []string) {
 	// Force loading of config before we alter it
 	config.Config.Git.All()
 
+	manifest, err := buildManifest()
+	if err != nil {
+		exit("error building tq.Manifest: " + err.Error())
+	}
+
 	// Configure the endpoint manually
 	var endp lfsapi.Endpoint
 	finder := lfsapi.NewEndpointFinder(config.Config.Git)
@@ -83,7 +87,7 @@ func testServerApi(cmd *cobra.Command, args []string) {
 	} else {
 		fmt.Printf("Creating test data (will upload to server)\n")
 		var err error
-		oidsExist, oidsMissing, err = buildTestData()
+		oidsExist, oidsMissing, err = buildTestData(manifest)
 		if err != nil {
 			exit("Failed to set up test data, aborting")
 		}
@@ -97,7 +101,7 @@ func testServerApi(cmd *cobra.Command, args []string) {
 
 	}
 
-	ok := runTests(oidsExist, oidsMissing)
+	ok := runTests(manifest, oidsExist, oidsMissing)
 	if !ok {
 		exit("One or more tests failed, see above")
 	}
@@ -136,13 +140,16 @@ func (*testDataCallback) Errorf(format string, args ...interface{}) {
 	fmt.Printf(format, args...)
 }
 
-func buildTestData() (oidsExist, oidsMissing []TestObject, err error) {
+func buildManifest() (*tq.Manifest, error) {
 	cfg := config.Config
 	apiClient, err := lfsapi.NewClient(cfg.Os, cfg.Git)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
+	return tq.NewManifestWithClient(apiClient), nil
+}
 
+func buildTestData(manifest *tq.Manifest) (oidsExist, oidsMissing []TestObject, err error) {
 	const oidCount = 50
 	oidsExist = make([]TestObject, 0, oidCount)
 	oidsMissing = make([]TestObject, 0, oidCount)
@@ -166,8 +173,7 @@ func buildTestData() (oidsExist, oidsMissing []TestObject, err error) {
 	outputs := repo.AddCommits([]*test.CommitInput{&commit})
 
 	// now upload
-	manifest := tq.NewManifestWithClient(apiClient)
-	uploadQueue := tq.NewTransferQueue(tq.Upload, manifest, "", tq.WithProgress(meter))
+	uploadQueue := tq.NewTransferQueue(tq.Upload, manifest, "origin", tq.WithProgress(meter))
 	for _, f := range outputs[0].Files {
 		oidsExist = append(oidsExist, TestObject{Oid: f.Oid, Size: f.Size})
 
@@ -211,12 +217,11 @@ func saveTestOids(filename string, objs []TestObject) {
 
 }
 
-func runTests(oidsExist, oidsMissing []TestObject) bool {
-
+func runTests(manifest *tq.Manifest, oidsExist, oidsMissing []TestObject) bool {
 	ok := true
 	fmt.Printf("Running %d tests...\n", len(tests))
 	for _, t := range tests {
-		err := runTest(t, oidsExist, oidsMissing)
+		err := runTest(t, manifest, oidsExist, oidsMissing)
 		if err != nil {
 			ok = false
 		}
@@ -224,7 +229,7 @@ func runTests(oidsExist, oidsMissing []TestObject) bool {
 	return ok
 }
 
-func runTest(t ServerTest, oidsExist, oidsMissing []TestObject) error {
+func runTest(t ServerTest, manifest *tq.Manifest, oidsExist, oidsMissing []TestObject) error {
 	const linelen = 70
 	line := t.Name
 	if len(line) > linelen {
@@ -234,7 +239,7 @@ func runTest(t ServerTest, oidsExist, oidsMissing []TestObject) error {
 	}
 	fmt.Printf("%s...\r", line)
 
-	err := t.F(oidsExist, oidsMissing)
+	err := t.F(manifest, oidsExist, oidsMissing)
 	if err != nil {
 		fmt.Printf("%s FAILED\n", line)
 		fmt.Println(err.Error())
@@ -250,21 +255,17 @@ func exit(format string, args ...interface{}) {
 	os.Exit(2)
 }
 
-func addTest(name string, f func(oidsExist, oidsMissing []TestObject) error) {
+func addTest(name string, f func(manifest *tq.Manifest, oidsExist, oidsMissing []TestObject) error) {
 	tests = append(tests, ServerTest{Name: name, F: f})
 }
 
-func callBatchApi(op string, objs []TestObject) ([]*api.ObjectResource, error) {
-
-	apiobjs := make([]*api.ObjectResource, 0, len(objs))
+func callBatchApi(manifest *tq.Manifest, dir tq.Direction, objs []TestObject) ([]*tq.Transfer, error) {
+	apiobjs := make([]*tq.Transfer, 0, len(objs))
 	for _, o := range objs {
-		apiobjs = append(apiobjs, &api.ObjectResource{Oid: o.Oid, Size: o.Size})
+		apiobjs = append(apiobjs, &tq.Transfer{Oid: o.Oid, Size: o.Size})
 	}
-	o, _, err := api.Batch(config.Config, apiobjs, op, []string{"basic"})
-	if err != nil {
-		return nil, err
-	}
-	return o, nil
+
+	return tq.Batch(dir, manifest, "origin", apiobjs)
 }
 
 // Combine 2 slices into one by "randomly" interleaving

--- a/test/git-lfs-test-server-api/testdownload.go
+++ b/test/git-lfs-test-server-api/testdownload.go
@@ -6,11 +6,12 @@ import (
 	"fmt"
 
 	"github.com/git-lfs/git-lfs/tools"
+	"github.com/git-lfs/git-lfs/tq"
 )
 
 // "download" - all present
-func downloadAllExist(oidsExist, oidsMissing []TestObject) error {
-	retobjs, err := callBatchApi("download", oidsExist)
+func downloadAllExist(manifest *tq.Manifest, oidsExist, oidsMissing []TestObject) error {
+	retobjs, err := callBatchApi(manifest, tq.Download, oidsExist)
 
 	if err != nil {
 		return err
@@ -36,8 +37,8 @@ func downloadAllExist(oidsExist, oidsMissing []TestObject) error {
 }
 
 // "download" - all missing (test includes 404 error entry)
-func downloadAllMissing(oidsExist, oidsMissing []TestObject) error {
-	retobjs, err := callBatchApi("download", oidsMissing)
+func downloadAllMissing(manifest *tq.Manifest, oidsExist, oidsMissing []TestObject) error {
+	retobjs, err := callBatchApi(manifest, tq.Download, oidsMissing)
 
 	if err != nil {
 		return err
@@ -54,7 +55,7 @@ func downloadAllMissing(oidsExist, oidsMissing []TestObject) error {
 			errbuf.WriteString(fmt.Sprintf("Download link should not exist for %s, was %s\n", o.Oid, link))
 		}
 		if o.Error == nil {
-			errbuf.WriteString(fmt.Sprintf("Download should include an error for missing object %s, was %s\n", o.Oid))
+			errbuf.WriteString(fmt.Sprintf("Download should include an error for missing object %s\n", o.Oid))
 		} else if o.Error.Code != 404 {
 			errbuf.WriteString(fmt.Sprintf("Download error code for missing object %s should be 404, got %d\n", o.Oid, o.Error.Code))
 		}
@@ -68,8 +69,7 @@ func downloadAllMissing(oidsExist, oidsMissing []TestObject) error {
 }
 
 // "download" - mixture
-func downloadMixed(oidsExist, oidsMissing []TestObject) error {
-
+func downloadMixed(manifest *tq.Manifest, oidsExist, oidsMissing []TestObject) error {
 	existSet := tools.NewStringSetWithCapacity(len(oidsExist))
 	for _, o := range oidsExist {
 		existSet.Add(o.Oid)
@@ -80,7 +80,7 @@ func downloadMixed(oidsExist, oidsMissing []TestObject) error {
 	}
 
 	calloids := interleaveTestData(oidsExist, oidsMissing)
-	retobjs, err := callBatchApi("download", calloids)
+	retobjs, err := callBatchApi(manifest, tq.Download, calloids)
 
 	if err != nil {
 		return err

--- a/test/git-lfs-test-server-api/testupload.go
+++ b/test/git-lfs-test-server-api/testupload.go
@@ -6,11 +6,12 @@ import (
 	"fmt"
 
 	"github.com/git-lfs/git-lfs/tools"
+	"github.com/git-lfs/git-lfs/tq"
 )
 
 // "upload" - all missing
-func uploadAllMissing(oidsExist, oidsMissing []TestObject) error {
-	retobjs, err := callBatchApi("upload", oidsMissing)
+func uploadAllMissing(manifest *tq.Manifest, oidsExist, oidsMissing []TestObject) error {
+	retobjs, err := callBatchApi(manifest, tq.Upload, oidsMissing)
 
 	if err != nil {
 		return err
@@ -37,8 +38,8 @@ func uploadAllMissing(oidsExist, oidsMissing []TestObject) error {
 }
 
 // "upload" - all present
-func uploadAllExists(oidsExist, oidsMissing []TestObject) error {
-	retobjs, err := callBatchApi("upload", oidsExist)
+func uploadAllExists(manifest *tq.Manifest, oidsExist, oidsMissing []TestObject) error {
+	retobjs, err := callBatchApi(manifest, tq.Upload, oidsExist)
 
 	if err != nil {
 		return err
@@ -64,8 +65,7 @@ func uploadAllExists(oidsExist, oidsMissing []TestObject) error {
 }
 
 // "upload" - mix of missing & present
-func uploadMixed(oidsExist, oidsMissing []TestObject) error {
-
+func uploadMixed(manifest *tq.Manifest, oidsExist, oidsMissing []TestObject) error {
 	existSet := tools.NewStringSetWithCapacity(len(oidsExist))
 	for _, o := range oidsExist {
 		existSet.Add(o.Oid)
@@ -76,7 +76,7 @@ func uploadMixed(oidsExist, oidsMissing []TestObject) error {
 	}
 
 	calloids := interleaveTestData(oidsExist, oidsMissing)
-	retobjs, err := callBatchApi("upload", calloids)
+	retobjs, err := callBatchApi(manifest, tq.Upload, calloids)
 
 	if err != nil {
 		return err
@@ -109,7 +109,7 @@ func uploadMixed(oidsExist, oidsMissing []TestObject) error {
 
 }
 
-func uploadEdgeCases(oidsExist, oidsMissing []TestObject) error {
+func uploadEdgeCases(manifest *tq.Manifest, oidsExist, oidsMissing []TestObject) error {
 	errorCases := make([]TestObject, 0, 5)
 	errorCodeMap := make(map[string]int, 5)
 	errorReasonMap := make(map[string]string, 5)
@@ -149,7 +149,7 @@ func uploadEdgeCases(oidsExist, oidsMissing []TestObject) error {
 	validReasonMap[sha] = "Zero size should be allowed"
 
 	calloids := interleaveTestData(errorCases, validCases)
-	retobjs, err := callBatchApi("upload", calloids)
+	retobjs, err := callBatchApi(manifest, tq.Upload, calloids)
 
 	if err != nil {
 		return err

--- a/tq/api.go
+++ b/tq/api.go
@@ -21,8 +21,8 @@ type batchRequest struct {
 
 type BatchResponse struct {
 	Objects             []*Transfer `json:"objects"`
+	TransferAdapterName string      `json:"transfer"`
 	endpoint            lfsapi.Endpoint
-	transferAdapterName string `json:"transfer"`
 }
 
 func Batch(m *Manifest, dir Direction, remote string, objects []*Transfer) (*BatchResponse, error) {

--- a/tq/api.go
+++ b/tq/api.go
@@ -25,6 +25,25 @@ type batchResponse struct {
 	Objects             []*Transfer `json:"objects"`
 }
 
+func Batch(dir Direction, m *Manifest, remote string, objects []*Transfer) ([]*Transfer, error) {
+	if len(objects) == 0 {
+		return nil, nil
+	}
+
+	breq := &batchRequest{
+		Operation:            string(dir),
+		Objects:              objects,
+		TransferAdapterNames: m.GetAdapterNames(dir),
+	}
+
+	cli := &tqClient{Client: m.APIClient()}
+	bres, _, err := cli.Batch(remote, breq)
+	if err != nil {
+		return nil, err
+	}
+	return bres.Objects, nil
+}
+
 func (c *tqClient) Batch(remote string, bReq *batchRequest) (*batchResponse, *http.Response, error) {
 	bRes := &batchResponse{}
 	if len(bReq.Objects) == 0 {

--- a/tq/api.go
+++ b/tq/api.go
@@ -25,13 +25,13 @@ type batchResponse struct {
 	Objects             []*Transfer `json:"objects"`
 }
 
-func Batch(dir Direction, m *Manifest, remote string, objects []*Transfer) ([]*Transfer, error) {
+func Batch(m *Manifest, dir Direction, remote string, objects []*Transfer) ([]*Transfer, error) {
 	if len(objects) == 0 {
 		return nil, nil
 	}
 
 	breq := &batchRequest{
-		Operation:            string(dir),
+		Operation:            dir.String(),
 		Objects:              objects,
 		TransferAdapterNames: m.GetAdapterNames(dir),
 	}

--- a/tq/api.go
+++ b/tq/api.go
@@ -36,8 +36,7 @@ func Batch(m *Manifest, dir Direction, remote string, objects []*Transfer) (*Bat
 		TransferAdapterNames: m.GetAdapterNames(dir),
 	}
 
-	cli := &tqClient{Client: m.APIClient()}
-	bres, _, err := cli.Batch(remote, breq)
+	bres, _, err := m.batchClient().Batch(remote, breq)
 	return bres, err
 }
 

--- a/tq/api.go
+++ b/tq/api.go
@@ -13,33 +13,16 @@ type tqClient struct {
 	*lfsapi.Client
 }
 
-type objectResource struct {
-	Oid           string             `json:"oid,omitempty"`
-	Size          int64              `json:"size"`
-	Authenticated bool               `json:"authenticated,omitempty"`
-	Actions       map[string]*Action `json:"actions,omitempty"`
-	Error         *ObjectError       `json:"error,omitempty"`
-}
-
-func (o *objectResource) Rel(name string) (*Action, bool) {
-	if o.Actions == nil {
-		return nil, false
-	}
-
-	rel, ok := o.Actions[name]
-	return rel, ok
-}
-
 type batchRequest struct {
-	Operation            string            `json:"operation"`
-	Objects              []*objectResource `json:"objects"`
-	TransferAdapterNames []string          `json:"transfers,omitempty"`
+	Operation            string      `json:"operation"`
+	Objects              []*Transfer `json:"objects"`
+	TransferAdapterNames []string    `json:"transfers,omitempty"`
 }
 
 type batchResponse struct {
 	Endpoint            lfsapi.Endpoint
-	TransferAdapterName string            `json:"transfer"`
-	Objects             []*objectResource `json:"objects"`
+	TransferAdapterName string      `json:"transfer"`
+	Objects             []*Transfer `json:"objects"`
 }
 
 func (c *tqClient) Batch(remote string, bReq *batchRequest) (*batchResponse, *http.Response, error) {

--- a/tq/api.go
+++ b/tq/api.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/git-lfs/git-lfs/api"
 	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/lfsapi"
 	"github.com/rubyist/tracerx"
@@ -14,16 +13,33 @@ type tqClient struct {
 	*lfsapi.Client
 }
 
+type objectResource struct {
+	Oid           string             `json:"oid,omitempty"`
+	Size          int64              `json:"size"`
+	Authenticated bool               `json:"authenticated,omitempty"`
+	Actions       map[string]*Action `json:"actions,omitempty"`
+	Error         *ObjectError       `json:"error,omitempty"`
+}
+
+func (o *objectResource) Rel(name string) (*Action, bool) {
+	if o.Actions == nil {
+		return nil, false
+	}
+
+	rel, ok := o.Actions[name]
+	return rel, ok
+}
+
 type batchRequest struct {
-	Operation            string                `json:"operation"`
-	Objects              []*api.ObjectResource `json:"objects"`
-	TransferAdapterNames []string              `json:"transfers,omitempty"`
+	Operation            string            `json:"operation"`
+	Objects              []*objectResource `json:"objects"`
+	TransferAdapterNames []string          `json:"transfers,omitempty"`
 }
 
 type batchResponse struct {
 	Endpoint            lfsapi.Endpoint
-	TransferAdapterName string                `json:"transfer"`
-	Objects             []*api.ObjectResource `json:"objects"`
+	TransferAdapterName string            `json:"transfer"`
+	Objects             []*objectResource `json:"objects"`
 }
 
 func (c *tqClient) Batch(remote string, bReq *batchRequest) (*batchResponse, *http.Response, error) {

--- a/tq/api_test.go
+++ b/tq/api_test.go
@@ -45,8 +45,8 @@ func TestAPIBatch(t *testing.T) {
 	tqc := &tqClient{Client: c}
 	bReq := &batchRequest{
 		TransferAdapterNames: []string{"basic", "whatev"},
-		Objects: []*objectResource{
-			&objectResource{Oid: "a", Size: 1},
+		Objects: []*Transfer{
+			&Transfer{Oid: "a", Size: 1},
 		},
 	}
 	bRes, res, err := tqc.Batch("remote", bReq)
@@ -91,8 +91,8 @@ func TestAPIBatchOnlyBasic(t *testing.T) {
 	tqc := &tqClient{Client: c}
 	bReq := &batchRequest{
 		TransferAdapterNames: []string{"basic"},
-		Objects: []*objectResource{
-			&objectResource{Oid: "a", Size: 1},
+		Objects: []*Transfer{
+			&Transfer{Oid: "a", Size: 1},
 		},
 	}
 	bRes, res, err := tqc.Batch("remote", bReq)

--- a/tq/api_test.go
+++ b/tq/api_test.go
@@ -49,9 +49,8 @@ func TestAPIBatch(t *testing.T) {
 			&Transfer{Oid: "a", Size: 1},
 		},
 	}
-	bRes, res, err := tqc.Batch("remote", bReq)
+	bRes, err := tqc.Batch("remote", bReq)
 	require.Nil(t, err)
-	assert.Equal(t, 200, res.StatusCode)
 	assert.Equal(t, "basic", bRes.TransferAdapterName)
 	if assert.Equal(t, 1, len(bRes.Objects)) {
 		assert.Equal(t, "a", bRes.Objects[0].Oid)
@@ -95,9 +94,8 @@ func TestAPIBatchOnlyBasic(t *testing.T) {
 			&Transfer{Oid: "a", Size: 1},
 		},
 	}
-	bRes, res, err := tqc.Batch("remote", bReq)
+	bRes, err := tqc.Batch("remote", bReq)
 	require.Nil(t, err)
-	assert.Equal(t, 200, res.StatusCode)
 	assert.Equal(t, "basic", bRes.TransferAdapterName)
 }
 
@@ -109,9 +107,8 @@ func TestAPIBatchEmptyObjects(t *testing.T) {
 	bReq := &batchRequest{
 		TransferAdapterNames: []string{"basic", "whatev"},
 	}
-	bRes, res, err := tqc.Batch("remote", bReq)
+	bRes, err := tqc.Batch("remote", bReq)
 	require.Nil(t, err)
-	assert.Nil(t, res)
 	assert.Equal(t, "", bRes.TransferAdapterName)
 	assert.Equal(t, 0, len(bRes.Objects))
 }

--- a/tq/api_test.go
+++ b/tq/api_test.go
@@ -31,7 +31,7 @@ func TestAPIBatch(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		err = json.NewEncoder(w).Encode(&BatchResponse{
-			transferAdapterName: "basic",
+			TransferAdapterName: "basic",
 			Objects:             bReq.Objects,
 		})
 	}))
@@ -52,7 +52,7 @@ func TestAPIBatch(t *testing.T) {
 	bRes, res, err := tqc.Batch("remote", bReq)
 	require.Nil(t, err)
 	assert.Equal(t, 200, res.StatusCode)
-	assert.Equal(t, "basic", bRes.transferAdapterName)
+	assert.Equal(t, "basic", bRes.TransferAdapterName)
 	if assert.Equal(t, 1, len(bRes.Objects)) {
 		assert.Equal(t, "a", bRes.Objects[0].Oid)
 	}
@@ -78,7 +78,7 @@ func TestAPIBatchOnlyBasic(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		err = json.NewEncoder(w).Encode(&BatchResponse{
-			transferAdapterName: "basic",
+			TransferAdapterName: "basic",
 		})
 	}))
 	defer srv.Close()
@@ -98,7 +98,7 @@ func TestAPIBatchOnlyBasic(t *testing.T) {
 	bRes, res, err := tqc.Batch("remote", bReq)
 	require.Nil(t, err)
 	assert.Equal(t, 200, res.StatusCode)
-	assert.Equal(t, "basic", bRes.transferAdapterName)
+	assert.Equal(t, "basic", bRes.TransferAdapterName)
 }
 
 func TestAPIBatchEmptyObjects(t *testing.T) {
@@ -112,6 +112,6 @@ func TestAPIBatchEmptyObjects(t *testing.T) {
 	bRes, res, err := tqc.Batch("remote", bReq)
 	require.Nil(t, err)
 	assert.Nil(t, res)
-	assert.Equal(t, "", bRes.transferAdapterName)
+	assert.Equal(t, "", bRes.TransferAdapterName)
 	assert.Equal(t, 0, len(bRes.Objects))
 }

--- a/tq/api_test.go
+++ b/tq/api_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/git-lfs/git-lfs/api"
 	"github.com/git-lfs/git-lfs/lfsapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -46,8 +45,8 @@ func TestAPIBatch(t *testing.T) {
 	tqc := &tqClient{Client: c}
 	bReq := &batchRequest{
 		TransferAdapterNames: []string{"basic", "whatev"},
-		Objects: []*api.ObjectResource{
-			&api.ObjectResource{Oid: "a", Size: 1},
+		Objects: []*objectResource{
+			&objectResource{Oid: "a", Size: 1},
 		},
 	}
 	bRes, res, err := tqc.Batch("remote", bReq)
@@ -92,8 +91,8 @@ func TestAPIBatchOnlyBasic(t *testing.T) {
 	tqc := &tqClient{Client: c}
 	bReq := &batchRequest{
 		TransferAdapterNames: []string{"basic"},
-		Objects: []*api.ObjectResource{
-			&api.ObjectResource{Oid: "a", Size: 1},
+		Objects: []*objectResource{
+			&objectResource{Oid: "a", Size: 1},
 		},
 	}
 	bRes, res, err := tqc.Batch("remote", bReq)

--- a/tq/api_test.go
+++ b/tq/api_test.go
@@ -30,8 +30,8 @@ func TestAPIBatch(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		err = json.NewEncoder(w).Encode(&batchResponse{
-			TransferAdapterName: "basic",
+		err = json.NewEncoder(w).Encode(&BatchResponse{
+			transferAdapterName: "basic",
 			Objects:             bReq.Objects,
 		})
 	}))
@@ -52,7 +52,7 @@ func TestAPIBatch(t *testing.T) {
 	bRes, res, err := tqc.Batch("remote", bReq)
 	require.Nil(t, err)
 	assert.Equal(t, 200, res.StatusCode)
-	assert.Equal(t, "basic", bRes.TransferAdapterName)
+	assert.Equal(t, "basic", bRes.transferAdapterName)
 	if assert.Equal(t, 1, len(bRes.Objects)) {
 		assert.Equal(t, "a", bRes.Objects[0].Oid)
 	}
@@ -77,8 +77,8 @@ func TestAPIBatchOnlyBasic(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		err = json.NewEncoder(w).Encode(&batchResponse{
-			TransferAdapterName: "basic",
+		err = json.NewEncoder(w).Encode(&BatchResponse{
+			transferAdapterName: "basic",
 		})
 	}))
 	defer srv.Close()
@@ -98,7 +98,7 @@ func TestAPIBatchOnlyBasic(t *testing.T) {
 	bRes, res, err := tqc.Batch("remote", bReq)
 	require.Nil(t, err)
 	assert.Equal(t, 200, res.StatusCode)
-	assert.Equal(t, "basic", bRes.TransferAdapterName)
+	assert.Equal(t, "basic", bRes.transferAdapterName)
 }
 
 func TestAPIBatchEmptyObjects(t *testing.T) {
@@ -112,6 +112,6 @@ func TestAPIBatchEmptyObjects(t *testing.T) {
 	bRes, res, err := tqc.Batch("remote", bReq)
 	require.Nil(t, err)
 	assert.Nil(t, res)
-	assert.Equal(t, "", bRes.TransferAdapterName)
+	assert.Equal(t, "", bRes.transferAdapterName)
 	assert.Equal(t, 0, len(bRes.Objects))
 }

--- a/tq/manifest.go
+++ b/tq/manifest.go
@@ -22,6 +22,7 @@ type Manifest struct {
 	downloadAdapterFuncs map[string]NewAdapterFunc
 	uploadAdapterFuncs   map[string]NewAdapterFunc
 	apiClient            *lfsapi.Client
+	tqClient             *tqClient
 	mu                   sync.Mutex
 }
 
@@ -37,6 +38,10 @@ func (m *Manifest) ConcurrentTransfers() int {
 	return m.concurrentTransfers
 }
 
+func (m *Manifest) batchClient() *tqClient {
+	return m.tqClient
+}
+
 func NewManifest() *Manifest {
 	cli, err := lfsapi.NewClient(nil, nil)
 	if err != nil {
@@ -50,6 +55,7 @@ func NewManifest() *Manifest {
 func NewManifestWithClient(apiClient *lfsapi.Client) *Manifest {
 	m := &Manifest{
 		apiClient:            apiClient,
+		tqClient:             &tqClient{Client: apiClient},
 		downloadAdapterFuncs: make(map[string]NewAdapterFunc),
 		uploadAdapterFuncs:   make(map[string]NewAdapterFunc),
 	}

--- a/tq/transfer.go
+++ b/tq/transfer.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/git-lfs/git-lfs/api"
 	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/lfsapi"
 )
@@ -33,8 +32,12 @@ type ObjectError struct {
 	Message string `json:"message"`
 }
 
+func (e *ObjectError) Error() string {
+	return fmt.Sprintf("[%d] %s", e.Code, e.Message)
+}
+
 // newTransfer creates a new Transfer instance
-func newTransfer(name string, obj *api.ObjectResource, path string) *Transfer {
+func newTransfer(name string, obj *objectResource, path string) *Transfer {
 	t := &Transfer{
 		Name:          name,
 		Oid:           obj.Oid,
@@ -60,7 +63,6 @@ func newTransfer(name string, obj *api.ObjectResource, path string) *Transfer {
 	}
 
 	return t
-
 }
 
 type Action struct {
@@ -121,32 +123,6 @@ func IsActionMissingError(err error) bool {
 		return true
 	}
 	return false
-}
-
-func toApiObject(t *Transfer) *api.ObjectResource {
-	o := &api.ObjectResource{
-		Oid:           t.Oid,
-		Size:          t.Size,
-		Authenticated: t.Authenticated,
-		Actions:       make(map[string]*api.LinkRelation),
-	}
-
-	for rel, a := range t.Actions {
-		o.Actions[rel] = &api.LinkRelation{
-			Href:      a.Href,
-			Header:    a.Header,
-			ExpiresAt: a.ExpiresAt,
-		}
-	}
-
-	if t.Error != nil {
-		o.Error = &api.ObjectError{
-			Code:    t.Error.Code,
-			Message: t.Error.Message,
-		}
-	}
-
-	return o
 }
 
 // NewAdapterFunc creates new instances of Adapter. Code that wishes

--- a/tq/transfer.go
+++ b/tq/transfer.go
@@ -10,12 +10,23 @@ import (
 	"github.com/git-lfs/git-lfs/lfsapi"
 )
 
-type Direction string
+type Direction int
 
 const (
-	Upload   = Direction("upload")
-	Download = Direction("download")
+	Upload   = Direction(iota)
+	Download = Direction(iota)
 )
+
+func (d Direction) String() string {
+	switch d {
+	case Download:
+		return "download"
+	case Upload:
+		return "upload"
+	default:
+		return "<unknown>"
+	}
+}
 
 type Transfer struct {
 	Name          string       `json:"name,omitempty"`

--- a/tq/transfer.go
+++ b/tq/transfer.go
@@ -10,11 +10,11 @@ import (
 	"github.com/git-lfs/git-lfs/lfsapi"
 )
 
-type Direction int
+type Direction string
 
 const (
-	Upload   = Direction(iota)
-	Download = Direction(iota)
+	Upload   = Direction("upload")
+	Download = Direction("download")
 )
 
 type Transfer struct {

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -282,13 +282,7 @@ func (q *TransferQueue) enqueueAndCollectRetriesFor(batch batch) (batch, error) 
 	next := q.makeBatch()
 	tracerx.Printf("tq: sending batch of size %d", len(batch))
 
-	bReq := &batchRequest{
-		Operation:            q.direction.String(),
-		Objects:              batch.ToTransfers(),
-		TransferAdapterNames: q.manifest.GetAdapterNames(q.direction),
-	}
-
-	bRes, _, err := q.client.Batch(q.remote, bReq)
+	bRes, err := Batch(q.manifest, q.direction, q.remote, batch.ToTransfers())
 	if err != nil {
 		// If there was an error making the batch API call, mark all of
 		// the objects for retry, and return them along with the error

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -311,7 +311,7 @@ func (q *TransferQueue) enqueueAndCollectRetriesFor(batch batch) (batch, error) 
 		return next, nil
 	}
 
-	q.useAdapter(bRes.transferAdapterName)
+	q.useAdapter(bRes.TransferAdapterName)
 	q.startProgress.Do(q.meter.Start)
 
 	toTransfer := make([]*Transfer, 0, len(bRes.Objects))

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -311,7 +311,7 @@ func (q *TransferQueue) enqueueAndCollectRetriesFor(batch batch) (batch, error) 
 		return next, nil
 	}
 
-	q.useAdapter(bRes.TransferAdapterName)
+	q.useAdapter(bRes.transferAdapterName)
 	q.startProgress.Do(q.meter.Start)
 
 	toTransfer := make([]*Transfer, 0, len(bRes.Objects))
@@ -364,7 +364,7 @@ func (q *TransferQueue) enqueueAndCollectRetriesFor(batch batch) (batch, error) 
 		}
 	}
 
-	retries := q.addToAdapter(bRes.Endpoint, toTransfer)
+	retries := q.addToAdapter(bRes.endpoint, toTransfer)
 	for t := range retries {
 		q.rc.Increment(t.Oid)
 		count := q.rc.CountFor(t.Oid)

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -4,7 +4,6 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/git-lfs/git-lfs/api"
 	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/lfsapi"
 	"github.com/git-lfs/git-lfs/progress"
@@ -72,17 +71,13 @@ func (r *retryCounter) CanRetry(oid string) (int, bool) {
 // all other workers are sitting idle.
 type batch []*objectTuple
 
-func (b batch) ApiObjects() []*api.ObjectResource {
-	transfers := make([]*api.ObjectResource, 0, len(b))
+func (b batch) ApiObjects() []*objectResource {
+	transfers := make([]*objectResource, 0, len(b))
 	for _, t := range b {
-		transfers = append(transfers, tupleToApiObject(t))
+		transfers = append(transfers, &objectResource{Oid: t.Oid, Size: t.Size})
 	}
 
 	return transfers
-}
-
-func tupleToApiObject(t *objectTuple) *api.ObjectResource {
-	return &api.ObjectResource{Oid: t.Oid, Size: t.Size}
 }
 
 func (b batch) Len() int           { return len(b) }


### PR DESCRIPTION
This removes the last `api` dependency in `tq`.