### PR TITLE
Custom transfer terminate

### DIFF
--- a/docs/custom-transfers.md
+++ b/docs/custom-transfers.md
@@ -129,8 +129,10 @@ Or if there was an error:
 
 #### Stage 2: 0..N Transfers
 
-After the initiation exchange, git-lfs will send any number of transfer 
-requests to the stdin of the transfer process. 
+After the initiation exchange, git-lfs will send any number of transfer
+requests to the stdin of the transfer process, in a serial sequence. Once a
+transfer request is sent to the process, it awaits a completion response before
+sending the next request.
 
 ##### Uploads
 

--- a/test/test-custom-transfers.sh
+++ b/test/test-custom-transfers.sh
@@ -103,6 +103,8 @@ begin_test "custom-transfer-upload-download"
   grep "xfer\[lfstest-customadapter\]:" fetchcustom.log
   grep "11 of 11 files" fetchcustom.log
 
+  grep "Terminating test custom adapter gracefully" fetchcustom.log
+
   objectlist=`find .git/lfs/objects -type f`
   [ "$(echo "$objectlist" | wc -l)" -eq 11 ]
 )

--- a/tq/custom.go
+++ b/tq/custom.go
@@ -86,7 +86,7 @@ func NewCustomAdapterDownloadRequest(oid string, size int64, action *Action) *cu
 }
 
 type customAdapterTerminateRequest struct {
-	MessageType string `json:"type"`
+	Event string `json:"event"`
 }
 
 func NewCustomAdapterTerminateRequest() *customAdapterTerminateRequest {


### PR DESCRIPTION
The message sent to terminate the custom adapter should have been named `event`, not `type`; this was left over from a terminology change and went unnoticed until it was pointed out in #1845 that it didn't conform to the docs.

This adds a test to check for that and fixes the problem. I've tested with our own Bitbucket custom adapter here and it's fine; like the test custom adapter it didn't notice this mistake because it was terminating when the I/O stream was closed anyway and there was no additional clean up.

Also includes a small tweak to the docs indicating the sequencing within a single adapter as ambiguity was pointed out in #1845.