### PR TITLE
lfsapi/schema: implement `schema` pkg

### DIFF
--- a/lfsapi/schema/fixture/invalid.json
+++ b/lfsapi/schema/fixture/invalid.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "type": "not-a-type"
+}

--- a/lfsapi/schema/fixture/valid.json
+++ b/lfsapi/schema/fixture/valid.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "type": "number",
+    "minimum": 0,
+    "exclusiveMinimum": false
+}

--- a/lfsapi/schema/reader.go
+++ b/lfsapi/schema/reader.go
@@ -11,9 +11,9 @@ import (
 )
 
 var (
-	// ErrValidationIncomplete is an error returned when `ValidationErr()`
+	// errValidationIncomplete is an error returned when `ValidationErr()`
 	// is called while the reader is still processing data.
-	ErrValidationIncomplete = errors.New("lfsapi/schema: validation incomplete")
+	errValidationIncomplete = errors.New("lfsapi/schema: validation incomplete")
 )
 
 // state represents the set of valid states a `*Reader` (see below) can be in
@@ -86,7 +86,7 @@ func (r *Reader) ValidationErr() error {
 	} else {
 		switch state(atomic.LoadUint32(&r.state)) {
 		case stateNotStarted, stateProcessing:
-			return ErrValidationIncomplete
+			return errValidationIncomplete
 		}
 	}
 

--- a/lfsapi/schema/reader.go
+++ b/lfsapi/schema/reader.go
@@ -1,0 +1,108 @@
+package schema
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"sync/atomic"
+
+	"github.com/git-lfs/git-lfs/errors"
+	"github.com/xeipuuv/gojsonschema"
+)
+
+var (
+	// ErrNoValidationDone is an error returned when `ValidationErr()` is
+	// called before having processed any data.
+	ErrNoValidationDone = errors.New("lfsapi/schema: no validation done")
+	// ErrValidationIncomplete is an error returned when `ValidationErr()`
+	// is called while the reader is still processing data.
+	ErrValidationIncomplete = errors.New("lfsapi/schema: validation incomplete")
+)
+
+// state represents the set of valid states a `*Reader` (see below) can be in
+type state uint32
+
+const (
+	// stateNotStarted means the `*Reader` has no processed any data
+	stateNotStarted state = iota
+	// stateProcessing means the `*Reader` has received a `Read()` call at
+	// least once, but has not received an `io.EOF` yet.
+	stateProcessing
+	// stateProcessed means the `*Reader` has received a `Read()` call at
+	// least once and has gotten an `io.EOF`, meaning there is no more data
+	// to process.
+	stateProcessed
+)
+
+type Reader struct {
+	// r is the underlying io.Reader this one is wrapping.
+	r io.Reader
+	// buf is the buffer of data read from the underlying reader
+	buf *bytes.Buffer
+	// schema is the *gojsonschema.Schema to valid the buffer against
+	schema *gojsonschema.Schema
+
+	// state is the current state that this `*Reader` is in, and is updated
+	// atomically through `atomic.SetUint32`, and etc.
+	state uint32
+
+	// result stores the result of the schema validation
+	result *gojsonschema.Result
+	// resultErr stores the (optional) error returned from the schema
+	// validation
+	resultErr error
+}
+
+var _ io.Reader = (*Reader)(nil)
+
+// Read implements io.Reader.Read, and returns exactly the data received from
+// the underlying reader.
+//
+// Read also sometimes advances state, as according to the valid instances of
+// the `state` from above. If transitioning into the `stateProcessed` state, the
+// schema will be validated.
+func (r *Reader) Read(p []byte) (n int, err error) {
+	atomic.CompareAndSwapUint32(&r.state, uint32(stateNotStarted), uint32(stateProcessing))
+
+	n, err = r.r.Read(p)
+	if err == io.EOF {
+		got := gojsonschema.NewStringLoader(r.buf.String())
+		r.result, r.resultErr = r.schema.Validate(got)
+
+		atomic.CompareAndSwapUint32(&r.state, uint32(stateProcessing), uint32(stateProcessed))
+	}
+
+	return
+}
+
+// ValidationErr returns an error assosciated with validating the data. If
+// there was an error performing the validation itself, that error will be
+// returned with priority. If the validation has not started, or is incomplete,
+// an appropriate error will be returned.
+//
+// Otherwise, if any validation errors were present, an error will be returned
+// containing all of the validation errors. If the data passed validation, a
+// value of 'nil' will be returned instead.
+func (r *Reader) ValidationErr() error {
+	if r.resultErr != nil {
+		return r.resultErr
+	} else {
+		switch state(atomic.LoadUint32(&r.state)) {
+		case stateNotStarted:
+			return ErrNoValidationDone
+		case stateProcessing:
+			return ErrValidationIncomplete
+		}
+	}
+
+	if r.result.Valid() {
+		return nil
+	}
+
+	msg := "Validation errors:\n"
+	for _, e := range r.result.Errors() {
+		msg = strings.Join([]string{msg, e.Description()}, "\n")
+	}
+
+	return errors.New(msg)
+}

--- a/lfsapi/schema/reader.go
+++ b/lfsapi/schema/reader.go
@@ -11,9 +11,6 @@ import (
 )
 
 var (
-	// ErrNoValidationDone is an error returned when `ValidationErr()` is
-	// called before having processed any data.
-	ErrNoValidationDone = errors.New("lfsapi/schema: no validation done")
 	// ErrValidationIncomplete is an error returned when `ValidationErr()`
 	// is called while the reader is still processing data.
 	ErrValidationIncomplete = errors.New("lfsapi/schema: validation incomplete")
@@ -88,9 +85,7 @@ func (r *Reader) ValidationErr() error {
 		return r.resultErr
 	} else {
 		switch state(atomic.LoadUint32(&r.state)) {
-		case stateNotStarted:
-			return ErrNoValidationDone
-		case stateProcessing:
+		case stateNotStarted, stateProcessing:
 			return ErrValidationIncomplete
 		}
 	}

--- a/lfsapi/schema/reader_test.go
+++ b/lfsapi/schema/reader_test.go
@@ -36,7 +36,7 @@ func TestSchemaReaderBeforeValidation(t *testing.T) {
 
 	r := schema.Reader(strings.NewReader("1"))
 
-	assert.Equal(t, ErrNoValidationDone, r.ValidationErr())
+	assert.Equal(t, ErrValidationIncomplete, r.ValidationErr())
 }
 
 func TestSchemaReaderDuringValidation(t *testing.T) {

--- a/lfsapi/schema/reader_test.go
+++ b/lfsapi/schema/reader_test.go
@@ -36,7 +36,7 @@ func TestSchemaReaderBeforeValidation(t *testing.T) {
 
 	r := schema.Reader(strings.NewReader("1"))
 
-	assert.Equal(t, ErrValidationIncomplete, r.ValidationErr())
+	assert.Equal(t, errValidationIncomplete, r.ValidationErr())
 }
 
 func TestSchemaReaderDuringValidation(t *testing.T) {
@@ -51,5 +51,5 @@ func TestSchemaReaderDuringValidation(t *testing.T) {
 	assert.Equal(t, 1, n)
 	assert.Nil(t, err)
 
-	assert.Equal(t, ErrValidationIncomplete, r.ValidationErr())
+	assert.Equal(t, errValidationIncomplete, r.ValidationErr())
 }

--- a/lfsapi/schema/reader_test.go
+++ b/lfsapi/schema/reader_test.go
@@ -1,0 +1,55 @@
+package schema
+
+import (
+	"io"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSchemaReaderWithValidPayload(t *testing.T) {
+	schema, err := FromJSON(ValidSchemaPath)
+	require.Nil(t, err)
+
+	r := schema.Reader(strings.NewReader("1"))
+	io.Copy(ioutil.Discard, r)
+
+	assert.Nil(t, r.ValidationErr())
+}
+
+func TestSchemaReaderWithInvalidPayload(t *testing.T) {
+	schema, err := FromJSON(ValidSchemaPath)
+	require.Nil(t, err)
+
+	r := schema.Reader(strings.NewReader("-1"))
+	io.Copy(ioutil.Discard, r)
+
+	assert.NotNil(t, r.ValidationErr())
+}
+
+func TestSchemaReaderBeforeValidation(t *testing.T) {
+	schema, err := FromJSON(ValidSchemaPath)
+	require.Nil(t, err)
+
+	r := schema.Reader(strings.NewReader("1"))
+
+	assert.Equal(t, ErrNoValidationDone, r.ValidationErr())
+}
+
+func TestSchemaReaderDuringValidation(t *testing.T) {
+	schema, err := FromJSON(ValidSchemaPath)
+	require.Nil(t, err)
+
+	r := schema.Reader(strings.NewReader("12"))
+
+	var b [1]byte
+	n, err := r.Read(b[:])
+
+	assert.Equal(t, 1, n)
+	assert.Nil(t, err)
+
+	assert.Equal(t, ErrValidationIncomplete, r.ValidationErr())
+}

--- a/lfsapi/schema/schema.go
+++ b/lfsapi/schema/schema.go
@@ -1,0 +1,68 @@
+package schema
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/xeipuuv/gojsonschema"
+)
+
+// Schema holds a JSON schema to be used for validation against various
+// payloads.
+type Schema struct {
+	// s is the internal handle on the implementation of the JSON schema
+	// specification.
+	s *gojsonschema.Schema
+}
+
+// FromJSON constructs a new `*Schema` instance from the JSON schema at
+// `schemaPath` relative to the package this code was called from.
+//
+// If the file could not be accessed, or was unable to be parsed as a valid JSON
+// schema, an appropriate error will be returned. Otherwise, the `*Schema` will
+// be returned with a nil error.
+func FromJSON(schemaPath string) (*Schema, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+
+	// Platform compatibility: use "/" separators always for file://
+	dir = filepath.ToSlash(dir)
+	schemaPath = filepath.Join(dir, schemaPath)
+
+	if _, err := os.Stat(schemaPath); err != nil {
+		return nil, err
+	}
+
+	schema, err := gojsonschema.NewSchema(gojsonschema.NewReferenceLoader(
+		fmt.Sprintf("file:///%s", schemaPath),
+	))
+	if err != nil {
+		return nil, err
+	}
+
+	return &Schema{schema}, nil
+}
+
+// Reader wraps the given `io.Reader`, "r" as a `*schema.Reader`, allowing the
+// contents passed through the reader to be inspected as conforming to the JSON
+// schema or not.
+//
+// If the reader "r" already _is_ a `*schema.Reader`, it will be returned as-is.
+func (s *Schema) Reader(r io.Reader) *Reader {
+	if sr, ok := r.(*Reader); ok {
+		return sr
+	}
+
+	rdr := &Reader{
+		buf:    new(bytes.Buffer),
+		schema: s.s,
+	}
+	rdr.r = io.TeeReader(r, rdr.buf)
+
+	return rdr
+}

--- a/lfsapi/schema/schema.go
+++ b/lfsapi/schema/schema.go
@@ -30,7 +30,6 @@ func FromJSON(schemaPath string) (*Schema, error) {
 		return nil, err
 	}
 
-	// Platform compatibility: use "/" separators always for file://
 	dir = filepath.ToSlash(dir)
 	schemaPath = filepath.Join(dir, schemaPath)
 
@@ -39,7 +38,8 @@ func FromJSON(schemaPath string) (*Schema, error) {
 	}
 
 	schema, err := gojsonschema.NewSchema(gojsonschema.NewReferenceLoader(
-		fmt.Sprintf("file:///%s", schemaPath),
+		// Platform compatibility: use "/" separators always for file://
+		fmt.Sprintf("file:///%s", filepath.ToSlash(schemaPath)),
 	))
 	if err != nil {
 		return nil, err

--- a/lfsapi/schema/schema_test.go
+++ b/lfsapi/schema/schema_test.go
@@ -1,0 +1,46 @@
+package schema
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	ValidSchemaPath   = "fixture/valid.json"
+	InvalidSchemaPath = "fixture/invalid.json"
+	MissingSchemaPath = "fixture/missing.json"
+)
+
+func TestCreatingAValidSchema(t *testing.T) {
+	_, err := FromJSON(ValidSchemaPath)
+
+	assert.Nil(t, err)
+}
+
+func TestCreatingAMissingSchema(t *testing.T) {
+	_, err := FromJSON(MissingSchemaPath)
+
+	assert.NotNil(t, err)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestCreatingAnInvalidSchema(t *testing.T) {
+	_, err := FromJSON(InvalidSchemaPath)
+
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "not-a-type is not a valid type")
+}
+
+func TestWrappingASchemaReader(t *testing.T) {
+	s, err := FromJSON(ValidSchemaPath)
+	require.Nil(t, err)
+
+	sr := s.Reader(new(bytes.Buffer))
+	wrapped := s.Reader(sr)
+
+	assert.Equal(t, sr, wrapped)
+}


### PR DESCRIPTION
This pull-request implements @technoweenie's idea in https://github.com/git-lfs/git-lfs/pull/1846#issuecomment-271621665 to introduce an `io.Reader` implementation: `schema.Reader`, capable of validating the data it's read against a JSON schema.

This will change our testing methodology a little bit, since instead of creating valid/invalid instances of request and response types, _then_ marshaling them to JSON, we have to valid data as it is sent and received. In other words, we'd be doing validation in `*net/http/httptest.Server`s against `req.Body`, which I think is a more appropriate level to test at, anyway.

---

/cc @git-lfs/core 