### PR TITLE
config: environments are immutable

### DIFF
--- a/config/environment.go
+++ b/config/environment.go
@@ -40,10 +40,6 @@ type Environment interface {
 
 	// All returns a copy of all the key/value pairs for the current environment.
 	All() map[string]string
-
-	// deprecated, don't use
-	set(key, value string)
-	del(key string)
 }
 
 type environment struct {
@@ -93,12 +89,4 @@ func (e *environment) Int(key string, def int) (val int) {
 
 func (e *environment) All() map[string]string {
 	return e.Fetcher.All()
-}
-
-func (e *environment) set(key, value string) {
-	e.Fetcher.set(key, value)
-}
-
-func (e *environment) del(key string) {
-	e.Fetcher.del(key)
 }

--- a/config/fetcher.go
+++ b/config/fetcher.go
@@ -10,8 +10,4 @@ type Fetcher interface {
 
 	// All returns a copy of all the key/value pairs for the current environment.
 	All() map[string]string
-
-	// deprecated, don't use
-	set(key, value string)
-	del(key string)
 }

--- a/config/git_environment.go
+++ b/config/git_environment.go
@@ -44,18 +44,6 @@ func (g *gitEnvironment) All() map[string]string {
 	return g.git.All()
 }
 
-func (g *gitEnvironment) set(key, value string) {
-	g.loadGitConfig()
-
-	g.git.set(key, value)
-}
-
-func (g *gitEnvironment) del(key string) {
-	g.loadGitConfig()
-
-	g.git.del(key)
-}
-
 // loadGitConfig reads and parses the .gitconfig by calling ReadGitConfig. It
 // also sets values on the configuration instance `g.config`.
 //

--- a/config/git_fetcher.go
+++ b/config/git_fetcher.go
@@ -139,18 +139,6 @@ func (g *GitFetcher) All() map[string]string {
 	return newmap
 }
 
-func (g *GitFetcher) set(key, value string) {
-	g.vmu.Lock()
-	defer g.vmu.Unlock()
-	g.vals[strings.ToLower(key)] = value
-}
-
-func (g *GitFetcher) del(key string) {
-	g.vmu.Lock()
-	defer g.vmu.Unlock()
-	delete(g.vals, strings.ToLower(key))
-}
-
 func getGitConfigs() (sources []*GitConfig) {
 	if lfsconfig := getFileGitConfig(".lfsconfig"); lfsconfig != nil {
 		sources = append(sources, lfsconfig)

--- a/config/map_fetcher.go
+++ b/config/map_fetcher.go
@@ -21,11 +21,3 @@ func (m mapFetcher) All() map[string]string {
 	}
 	return newmap
 }
-
-func (m mapFetcher) set(key, value string) {
-	m[key] = value
-}
-
-func (m mapFetcher) del(key string) {
-	delete(m, key)
-}

--- a/config/os_fetcher.go
+++ b/config/os_fetcher.go
@@ -57,11 +57,3 @@ func (o *OsFetcher) Get(key string) (val string, ok bool) {
 func (o *OsFetcher) All() map[string]string {
 	return nil
 }
-
-func (o *OsFetcher) set(key, value string) {
-	panic("cannot modify OS ENV keys")
-}
-
-func (o *OsFetcher) del(key string) {
-	panic("cannot modify OS ENV keys")
-}


### PR DESCRIPTION
This removes some deprecated functions in the `config.Environment` interface. This was used for the code that sets the `lfs.{url}.access` key, when an LFS endpoint requires authentication. Git LFS now handles this in the [`lfsapi.EndpointFinder`](https://github.com/git-lfs/git-lfs/blob/2e213cf9c4423c75f72cb9fbdf5acb16e11ea799/lfsapi/endpoint_finder.go#L180-L216) by caching the url in-memory when it's set. This is fine, since `git-lfs` is typically a short-lived command.

