### PR TITLE
lfs: only buffer first 1k when creating a CleanPointerError

### DIFF
--- a/lfs/pointer_clean.go
+++ b/lfs/pointer_clean.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/git-lfs/git-lfs/config"
@@ -78,7 +77,11 @@ func copyToTemp(reader io.Reader, fileSize int64, cb progress.CopyCallback) (oid
 	}
 
 	ptr, buf, err := DecodeFrom(reader)
-	by, rerr := ioutil.ReadAll(buf)
+
+	by := make([]byte, blobSizeCutoff)
+	n, rerr := buf.Read(by)
+	by = by[:n]
+
 	if rerr != nil || (err == nil && len(by) < 512) {
 		err = errors.NewCleanPointerError(ptr, by)
 		return


### PR DESCRIPTION
This pull-request fixes a bug where the entire contents of a malformed pointers would be buffered in memory, as reported in #1851.

Some backstory: in v1.5.4 I merged #1796 (via #1805) which re-added support to stream the entire contents of a malformed pointer though the filter-protocol added in Git v2.11. This involved a change to the signature of DecodeFrom where instead returning a `[]byte`, containing the data it buffered, it instead returned an `io.Reader` which contained the entire contents of the pointer and could be read from by the caller.

To bring the calling code up to speed, I introduced the following line to grab a `[]byte` of the data buffered from reading the pointer:

```go
by, rerr := ioutil.ReadAll(buf)
```

This is fine for small pointers, but will exhaust system memory when the malformed pointer is large. The original behavior was to only buffer _at most_ the first 1024 (see: `lfs.blobSizeCutoff`) bytes to return with the `NewCleanPointerError`, and this pull-request brings that back.

We only need to buffer the first 1k here, since when writing the data back via `NewCleanPointerError`, we're dealing with the case that the file is _already_ a pointer, and should be written back wholesale. More information about this code-path is in https://github.com/git-lfs/git-lfs/issues/1851#issuecomment-272028412.

The entire reader is still available if an error was not returned (i.e., if the `len(by) >= 512`), so that it can be copied to the writer, `writer`, on [L94](https://github.com/git-lfs/git-lfs/compare/buffer-blob-size-only?expand=1#diff-994fa3aaef34aea73bc14575fa685a83L94).

After some 👀 get a chance to take a look at this, I think we should release this patch as v1.5.5 (and hopefully the last patch in the 1.5.x series).

---

/cc @git-lfs/core #1851 