### PR TITLE
Backport #1852 for v1.5.x: lfs: only buffer first 1k when creating a CleanPointerError

### DIFF
--- a/lfs/pointer_clean.go
+++ b/lfs/pointer_clean.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/git-lfs/git-lfs/config"
@@ -79,7 +78,11 @@ func copyToTemp(reader io.Reader, fileSize int64, cb progress.CopyCallback) (oid
 	}
 
 	ptr, buf, err := DecodeFrom(reader)
-	by, rerr := ioutil.ReadAll(buf)
+
+	by := make([]byte, blobSizeCutoff)
+	n, rerr := buf.Read(by)
+	by = by[:n]
+
 	if rerr != nil || (err == nil && len(by) < 512) {
 		err = errors.NewCleanPointerError(ptr, by)
 		return


### PR DESCRIPTION
This backports #1852.