### PR TITLE
locking: reintroduce `Committer` field

### DIFF
--- a/commands/command_locks.go
+++ b/commands/command_locks.go
@@ -32,7 +32,7 @@ func locksCommand(cmd *cobra.Command, args []string) {
 	}
 
 	for _, lock := range locks {
-		Print("%s\t%s <%s>", lock.Path, lock.Committer.Name, lock.Committer.Email)
+		Print("%s\t%s", lock.Path, lock.Committer)
 		lockCount++
 	}
 

--- a/commands/command_locks.go
+++ b/commands/command_locks.go
@@ -32,7 +32,7 @@ func locksCommand(cmd *cobra.Command, args []string) {
 	}
 
 	for _, lock := range locks {
-		Print("%s\t%s <%s>", lock.Path, lock.Name, lock.Email)
+		Print("%s\t%s <%s>", lock.Path, lock.Committer.Name, lock.Committer.Email)
 		lockCount++
 	}
 

--- a/locking/api.go
+++ b/locking/api.go
@@ -22,7 +22,7 @@ type lockRequest struct {
 	// `.git/refs/origin/<name>`.
 	LatestRemoteCommit string `json:"latest_remote_commit"`
 	// Committer is the individual that wishes to obtain the lock.
-	Committer committer `json:"committer"`
+	Committer Committer `json:"committer"`
 }
 
 // LockResponse encapsulates the information sent over the API in response to
@@ -188,7 +188,7 @@ func (c *lockClient) Search(remote string, searchReq *lockSearchRequest) (*lockL
 }
 
 // Committer represents a "First Last <email@domain.com>" pair.
-type committer struct {
+type Committer struct {
 	// Name is the name of the individual who would like to obtain the
 	// lock, for instance: "Rick Olson".
 	Name string `json:"name"`
@@ -197,6 +197,7 @@ type committer struct {
 	Email string `json:"email"`
 }
 
-func newCommitter(name, email string) committer {
-	return committer{Name: name, Email: email}
+func NewCommitter(name, email string) Committer {
+	return Committer{Name: name, Email: email}
+}
 }

--- a/locking/api.go
+++ b/locking/api.go
@@ -200,4 +200,9 @@ type Committer struct {
 func NewCommitter(name, email string) Committer {
 	return Committer{Name: name, Email: email}
 }
+
+// String implements the fmt.Stringer interface by returning a string
+// representation of the Committer in the format "First Last <email>".
+func (c *Committer) String() string {
+	return fmt.Sprintf("%s <%s>", c.Name, c.Email)
 }

--- a/locking/locks.go
+++ b/locking/locks.go
@@ -86,7 +86,7 @@ func (c *Client) LockFile(path string) (Lock, error) {
 	lockReq := &lockRequest{
 		Path:               path,
 		LatestRemoteCommit: latest.Sha,
-		Committer:          newCommitter(c.client.CurrentUser()),
+		Committer:          NewCommitter(c.client.CurrentUser()),
 	}
 
 	lockRes, _, err := c.client.Lock(c.Remote, lockReq)
@@ -146,10 +146,9 @@ type Lock struct {
 	// Path is an absolute path to the file that is locked as a part of this
 	// lock.
 	Path string `json:"path"`
-	// Name is the name of the person holding this lock
-	Name string `json:"name"`
-	// Email address of the person holding this lock
-	Email string `json:"email"`
+	// Committer is the identity of the person who holds the ownership of
+	// this lock.
+	Committer Committer `json:"committer"`
 	// LockedAt is the time at which this lock was acquired.
 	LockedAt time.Time `json:"locked_at"`
 }
@@ -267,7 +266,7 @@ func (c *Client) refreshLockCache() error {
 
 	_, email := c.client.CurrentUser()
 	for _, l := range locks {
-		if l.Email == email {
+		if l.Committer.Email == email {
 			c.cache.Add(l)
 		}
 	}

--- a/locking/locks_test.go
+++ b/locking/locks_test.go
@@ -32,11 +32,11 @@ func TestRefreshCache(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		err = json.NewEncoder(w).Encode(lockList{
 			Locks: []Lock{
-				Lock{Id: "99", Path: "folder/test3.dat", Name: "Alice", Email: "alice@wonderland.com"},
-				Lock{Id: "101", Path: "folder/test1.dat", Name: "Fred", Email: "fred@bloggs.com"},
-				Lock{Id: "102", Path: "folder/test2.dat", Name: "Fred", Email: "fred@bloggs.com"},
-				Lock{Id: "103", Path: "root.dat", Name: "Fred", Email: "fred@bloggs.com"},
-				Lock{Id: "199", Path: "other/test1.dat", Name: "Charles", Email: "charles@incharge.com"},
+				Lock{Id: "99", Path: "folder/test3.dat", Committer: Committer{Name: "Alice", Email: "alice@wonderland.com"}},
+				Lock{Id: "101", Path: "folder/test1.dat", Committer: Committer{Name: "Fred", Email: "fred@bloggs.com"}},
+				Lock{Id: "102", Path: "folder/test2.dat", Committer: Committer{Name: "Fred", Email: "fred@bloggs.com"}},
+				Lock{Id: "103", Path: "root.dat", Committer: Committer{Name: "Fred", Email: "fred@bloggs.com"}},
+				Lock{Id: "199", Path: "other/test1.dat", Committer: Committer{Name: "Charles", Email: "charles@incharge.com"}},
 			},
 		})
 		assert.Nil(t, err)
@@ -74,9 +74,9 @@ func TestRefreshCache(t *testing.T) {
 	// Sort locks for stable comparison
 	sort.Sort(LocksById(locks))
 	assert.Equal(t, []Lock{
-		Lock{Path: "folder/test1.dat", Id: "101", Name: "Fred", Email: "fred@bloggs.com", LockedAt: zeroTime},
-		Lock{Path: "folder/test2.dat", Id: "102", Name: "Fred", Email: "fred@bloggs.com", LockedAt: zeroTime},
-		Lock{Path: "root.dat", Id: "103", Name: "Fred", Email: "fred@bloggs.com", LockedAt: zeroTime},
+		Lock{Path: "folder/test1.dat", Id: "101", Committer: Committer{Name: "Fred", Email: "fred@bloggs.com"}, LockedAt: zeroTime},
+		Lock{Path: "folder/test2.dat", Id: "102", Committer: Committer{Name: "Fred", Email: "fred@bloggs.com"}, LockedAt: zeroTime},
+		Lock{Path: "root.dat", Id: "103", Committer: Committer{Name: "Fred", Email: "fred@bloggs.com"}, LockedAt: zeroTime},
 	}, locks)
 
 }


### PR DESCRIPTION
This pull-request reintroduces the `Committer` field on the `*locking.Lock` type.

This was the [original interface][1] of that type, but was removed in #1732 in favor of `Name` and `Email` top-level fields on the `Lock` type. Instead, let's bring back the original API which:

- has parity with how the data is sent over the network, and...
- is more direct in it's meaning. A lock has a committer, not a name and email. 

This pull-request also comes with some additional benefits:

1. Fix a bug where the `gitserver` was unable to find the fields to de-serialize the committer's name and email, thus making all locks have `""` empty-string owners.
2. Implement `fmt.Stringer` on the `Committer` type, which yields the expected format: `First Last <email@example.com>`.

---

/cc @git-lfs/core 

[1]: https://github.com/git-lfs/git-lfs/blob/7f578a97cef74a2e7fef6723bfc6ce30e512e44b/api/lock_api.go#L113-L114