### PR TITLE
Add `--skip-repo` option to `git lfs install` & use in tests

### DIFF
--- a/commands/command_install.go
+++ b/commands/command_install.go
@@ -13,6 +13,7 @@ var (
 	localInstall      = false
 	systemInstall     = false
 	skipSmudgeInstall = false
+	skipRepoInstall   = false
 )
 
 func installCommand(cmd *cobra.Command, args []string) {
@@ -41,7 +42,7 @@ func installCommand(cmd *cobra.Command, args []string) {
 		Exit("Run `git lfs install --force` to reset git config.")
 	}
 
-	if localInstall || lfs.InRepo() {
+	if !skipRepoInstall && (localInstall || lfs.InRepo()) {
 		localstorage.InitStorageOrFail()
 		installHooksCommand(cmd, args)
 	}
@@ -60,6 +61,7 @@ func init() {
 		cmd.Flags().BoolVarP(&localInstall, "local", "l", false, "Set the Git LFS config for the local Git repository only.")
 		cmd.Flags().BoolVarP(&systemInstall, "system", "", false, "Set the Git LFS config in system-wide scope.")
 		cmd.Flags().BoolVarP(&skipSmudgeInstall, "skip-smudge", "s", false, "Skip automatic downloading of objects on clone or pull.")
+		cmd.Flags().BoolVarP(&skipRepoInstall, "skip-repo", "", false, "Skip repo setup, just install global filters.")
 		cmd.AddCommand(NewCommand("hooks", installHooksCommand))
 		cmd.PreRun = setupLocalStorage
 	})

--- a/docs/man/git-lfs-install.1.ronn
+++ b/docs/man/git-lfs-install.1.ronn
@@ -33,6 +33,9 @@ filters if they are not already set.
     Skips automatic downloading of objects on clone or pull. This requires a
     manual "git lfs pull" every time a new commit is checked out on your
     repository.
+* `--skip-repo`:
+    Skips setup of the local repo; use if you want to install the global lfs
+    filters but not make changes to the current repo.
 
 ## SEE ALSO
 

--- a/test/test-install.sh
+++ b/test/test-install.sh
@@ -237,3 +237,25 @@ begin_test "install in directory without access to .git/lfs"
   [ "git-lfs clean -- %f" = "$(git config filter.lfs.clean)" ]
 )
 end_test
+
+
+begin_test "install in repo without changing hooks"
+(
+  set -e
+  git init non-lfs-repo
+  cd non-lfs-repo
+
+  git lfs install --skip-repo
+
+  # should not install hooks
+  [ ! -f .git/hooks/pre-push ]
+  [ ! -f .git/hooks/post-checkout ]
+  [ ! -f .git/hooks/post-merge ]
+  [ ! -f .git/hooks/post-commit ]
+
+  # filters should still be installed
+  [ "git-lfs clean -- %f" = "$(git config filter.lfs.clean)" ]
+  [ "git-lfs smudge -- %f" = "$(git config filter.lfs.smudge)" ]
+  [ "git-lfs filter-process" = "$(git config filter.lfs.process)" ]
+)
+end_test

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -335,7 +335,7 @@ setup() {
   # Set up the initial git config and osx keychain if applicable
   HOME="$TESTHOME"
   mkdir "$HOME"
-  git lfs install
+  git lfs install --skip-repo
   git config --global credential.usehttppath true
   git config --global credential.helper lfstest
   git config --global user.name "Git LFS Tests"


### PR DESCRIPTION
It's bugged me for a while that the integration tests keep creating the `pre-push` hook in my local `git-lfs` working copy repo whenever I run them; it gets much worse when you factor in the new hooks we're starting to add. This happens even if you use `GIT_LFS_TEST_DIR`, if you run the tests from within the working copy.

Seems useful to have a `--skip-repo` option in `git lfs install` which skips the local repo changes, for when you just want to install filters. This is how our tests need to use it. 

I could have just made the tests `cd` to a non-repo folder instead but being explicit seems better.