### PR TITLE
locking: use `*Committer` to implement `fmt.Stringer`

### DIFF
--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -167,7 +167,7 @@ func (c *uploadContext) Await() {
 
 		Print("Unable to push %d locked file(s):", ul)
 		for _, unowned := range c.unownedLocks {
-			Print("* %s - %s", unowned.Path, &unowned.Committer)
+			Print("* %s - %s", unowned.Path, unowned.Committer)
 		}
 	} else if len(c.ownedLocks) > 0 {
 		Print("Consider unlocking your own locked file(s): (`git lfs unlock <path>`)")

--- a/locking/api.go
+++ b/locking/api.go
@@ -22,7 +22,7 @@ type lockRequest struct {
 	// `.git/refs/origin/<name>`.
 	LatestRemoteCommit string `json:"latest_remote_commit"`
 	// Committer is the individual that wishes to obtain the lock.
-	Committer Committer `json:"committer"`
+	Committer *Committer `json:"committer"`
 }
 
 // LockResponse encapsulates the information sent over the API in response to
@@ -200,8 +200,8 @@ type Committer struct {
 	Email string `json:"email"`
 }
 
-func NewCommitter(name, email string) Committer {
-	return Committer{Name: name, Email: email}
+func NewCommitter(name, email string) *Committer {
+	return &Committer{Name: name, Email: email}
 }
 
 // String implements the fmt.Stringer interface by returning a string

--- a/locking/locks.go
+++ b/locking/locks.go
@@ -174,7 +174,7 @@ type Lock struct {
 	Path string `json:"path"`
 	// Committer is the identity of the person who holds the ownership of
 	// this lock.
-	Committer Committer `json:"committer"`
+	Committer *Committer `json:"committer"`
 	// LockedAt is the time at which this lock was acquired.
 	LockedAt time.Time `json:"locked_at"`
 }

--- a/locking/locks_test.go
+++ b/locking/locks_test.go
@@ -32,11 +32,11 @@ func TestRefreshCache(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		err = json.NewEncoder(w).Encode(lockList{
 			Locks: []Lock{
-				Lock{Id: "99", Path: "folder/test3.dat", Committer: Committer{Name: "Alice", Email: "alice@wonderland.com"}},
-				Lock{Id: "101", Path: "folder/test1.dat", Committer: Committer{Name: "Fred", Email: "fred@bloggs.com"}},
-				Lock{Id: "102", Path: "folder/test2.dat", Committer: Committer{Name: "Fred", Email: "fred@bloggs.com"}},
-				Lock{Id: "103", Path: "root.dat", Committer: Committer{Name: "Fred", Email: "fred@bloggs.com"}},
-				Lock{Id: "199", Path: "other/test1.dat", Committer: Committer{Name: "Charles", Email: "charles@incharge.com"}},
+				Lock{Id: "99", Path: "folder/test3.dat", Committer: &Committer{Name: "Alice", Email: "alice@wonderland.com"}},
+				Lock{Id: "101", Path: "folder/test1.dat", Committer: &Committer{Name: "Fred", Email: "fred@bloggs.com"}},
+				Lock{Id: "102", Path: "folder/test2.dat", Committer: &Committer{Name: "Fred", Email: "fred@bloggs.com"}},
+				Lock{Id: "103", Path: "root.dat", Committer: &Committer{Name: "Fred", Email: "fred@bloggs.com"}},
+				Lock{Id: "199", Path: "other/test1.dat", Committer: &Committer{Name: "Charles", Email: "charles@incharge.com"}},
 			},
 		})
 		assert.Nil(t, err)
@@ -74,9 +74,9 @@ func TestRefreshCache(t *testing.T) {
 	// Sort locks for stable comparison
 	sort.Sort(LocksById(locks))
 	assert.Equal(t, []Lock{
-		Lock{Path: "folder/test1.dat", Id: "101", Committer: Committer{Name: "Fred", Email: "fred@bloggs.com"}, LockedAt: zeroTime},
-		Lock{Path: "folder/test2.dat", Id: "102", Committer: Committer{Name: "Fred", Email: "fred@bloggs.com"}, LockedAt: zeroTime},
-		Lock{Path: "root.dat", Id: "103", Committer: Committer{Name: "Fred", Email: "fred@bloggs.com"}, LockedAt: zeroTime},
+		Lock{Path: "folder/test1.dat", Id: "101", Committer: &Committer{Name: "Fred", Email: "fred@bloggs.com"}, LockedAt: zeroTime},
+		Lock{Path: "folder/test2.dat", Id: "102", Committer: &Committer{Name: "Fred", Email: "fred@bloggs.com"}, LockedAt: zeroTime},
+		Lock{Path: "root.dat", Id: "103", Committer: &Committer{Name: "Fred", Email: "fred@bloggs.com"}, LockedAt: zeroTime},
 	}, locks)
 
 }

--- a/test/test-locks.sh
+++ b/test/test-locks.sh
@@ -17,6 +17,7 @@ begin_test "list a single lock"
   GITLFSLOCKSENABLED=1 git lfs locks --path "f.dat" | tee locks.log
   grep "1 lock(s) matched query" locks.log
   grep "f.dat" locks.log
+  grep "Git LFS Tests <git-lfs@example.com>" locks.log
 )
 end_test
 
@@ -34,6 +35,7 @@ begin_test "list a single lock (--json)"
 
   GITLFSLOCKSENABLED=1 git lfs locks --json --path "f_json.dat" | tee locks.log
   grep "\"path\":\"f_json.dat\"" locks.log
+  grep "\"committer\":{\"name\":\"Git LFS Tests\",\"email\":\"git-lfs@example.com\"}" locks.log
 )
 end_test
 


### PR DESCRIPTION
This pull-request changes all references to the `Committer` type within the `locking` package to use `*Committer`, which implements `fmt.Stringer`.

It also adds integration tests to ensure that the committer is formatted correctly when asking for a list of locks.

---

/cc @git-lfs/core 