### PR TITLE
commands: unhalt locking pre-push checks 

### DIFF
--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -49,11 +49,12 @@ func newUploadContext(remote string, dryRun bool) *uploadContext {
 	lockClient := newLockClient(remote)
 	locks, err := lockClient.SearchLocks(nil, 0, false)
 	if err != nil {
-		ExitWithError(err)
-	}
-
-	for _, l := range locks {
-		ctx.locks[l.Path] = l
+		Error("WARNING: Unable to search for locks contained in this push.")
+		Error("         Temporarily skipping check ...")
+	} else {
+		for _, l := range locks {
+			ctx.locks[l.Path] = l
+		}
 	}
 
 	return ctx

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -150,8 +150,6 @@ func uploadPointers(c *uploadContext, unfiltered ...*lfs.WrappedPointer) {
 }
 
 func (c *uploadContext) Await() {
-	var avoidPush bool
-
 	c.tq.Wait()
 
 	for _, err := range c.tq.Errors() {
@@ -159,8 +157,10 @@ func (c *uploadContext) Await() {
 	}
 
 	if len(c.tq.Errors()) > 0 {
-		avoidPush = true
+		os.Exit(2)
 	}
+
+	var avoidPush bool
 
 	c.trackedLocksMu.Lock()
 	if ul := len(c.unownedLocks); ul > 0 {
@@ -179,6 +179,6 @@ func (c *uploadContext) Await() {
 	c.trackedLocksMu.Unlock()
 
 	if avoidPush {
-		os.Exit(2)
+		Error("WARNING: The above files would have halted this push.")
 	}
 }

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -529,11 +529,6 @@ begin_test "pre-push with unowned lock"
     ok="${PIPESTATUS[0]}"
     set -e
 
-    if [ "0" -eq $ok ]; then
-      echo >&2 "ERR: expected push to fail, didn't..."
-      exit 1
-    fi
-
     grep "Unable to push 1 locked file(s)" push.log
     grep "* locked_unowned.dat - Example Locker <locker@example.com>" push.log
   popd >/dev/null

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -524,10 +524,7 @@ begin_test "pre-push with unowned lock"
     # --no-verify is used to avoid the pre-commit hook which is not under test
     git commit --no-verify -m "add unauthroized changes"
 
-    set +e
     git push origin master 2>&1 | tee push.log
-    ok="${PIPESTATUS[0]}"
-    set -e
 
     grep "Unable to push 1 locked file(s)" push.log
     grep "* locked_unowned.dat - Example Locker <locker@example.com>" push.log


### PR DESCRIPTION
This pull-request temporarily makes failed lock searches and pushes containing modifications to un-owned locks non-fatal.

---

/cc @git-lfs/core 