### PR TITLE
Fix clash between progress meter and credential helper

### DIFF
--- a/progress/meter.go
+++ b/progress/meter.go
@@ -106,13 +106,14 @@ func NewMeter(options ...meterOption) *ProgressMeter {
 
 // Start begins sending status updates to the optional log file, and stdout.
 func (p *ProgressMeter) Start() {
-	if atomic.SwapInt32(&p.started, 1) == 0 {
+	if atomic.CompareAndSwapInt32(&p.started, 0, 1) {
 		go p.writer()
 	}
 }
 
+// Pause stops sending status updates temporarily, until Start() is called again.
 func (p *ProgressMeter) Pause() {
-	if atomic.SwapInt32(&p.started, 0) == 1 {
+	if atomic.CompareAndSwapInt32(&p.started, 1, 0) {
 		p.finished <- true
 	}
 }

--- a/progress/meter.go
+++ b/progress/meter.go
@@ -111,6 +111,12 @@ func (p *ProgressMeter) Start() {
 	}
 }
 
+func (p *ProgressMeter) Pause() {
+	if atomic.SwapInt32(&p.started, 0) == 1 {
+		p.finished <- true
+	}
+}
+
 // Add tells the progress meter that a single file of the given size will
 // possibly be transferred. If a file doesn't need to be transferred for some
 // reason, be sure to call Skip(int64) with the same size.

--- a/progress/noop.go
+++ b/progress/noop.go
@@ -7,6 +7,7 @@ func Noop() Meter {
 type nonMeter struct{}
 
 func (m *nonMeter) Start()                                                               {}
+func (m *nonMeter) Pause()                                                               {}
 func (m *nonMeter) Add(size int64)                                                       {}
 func (m *nonMeter) Skip(size int64)                                                      {}
 func (m *nonMeter) StartTransfer(name string)                                            {}

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -4,6 +4,7 @@ package progress
 
 type Meter interface {
 	Start()
+	Pause()
 	Add(int64)
 	Skip(size int64)
 	StartTransfer(name string)


### PR DESCRIPTION
This is an attempt to fix #847. It pauses the progress meter before making the batch api request, and then starts it when it passing the batch api response to the transfer adapters. This works because:

* `(progress.Meter) Start()`, `Finish()`, and `Pause()` internally use channels and `atomic/sync`. No need for that `sync.Once` in `tq.TransferQueue`.
* The `tq.TransferQueue` only transfers items from a single batch concurrently. The sequence (Batch API -> _n_ transfer adapter workers) runs sequentially, so that the next batch (if needed) can process the retries from the previous batch.

Unfortunately, there isn't really a way to test this, since it requires interactive input.  Here's an example of this PR working (with a tiny hack to change the batch size to 2):

```
$ git lfs fetch --all 2>&1
Scanning for all objects ever referenced...
✔ 9 objects found
Fetching objects...
Username for 'https://github.com': technoweenie
Password for 'https://technoweenie@github.com':
Git LFS: (0 of 9 files) 0 B / 1.03 MB                                                                                                                                                                                                        Username for 'https://github.com': technoweenie
Password for 'https://technoweenie@github.com':
Git LFS: (3 of 9 files) 356.27 KB / 1.03 MB                                                                                                                                                                                                  Username for 'https://github.com': technoweenie
Password for 'https://technoweenie@github.com':
Git LFS: (5 of 9 files) 886.59 KB / 1.03 MB                                                                                                                                                                                                  Username for 'https://github.com': technoweenie
Password for 'https://technoweenie@github.com':
Git LFS: (7 of 9 files) 948.33 KB / 1.03 MB                                                                                                                                                                                                  Username for 'https://github.com': technoweenie
Password for 'https://technoweenie@github.com':
Git LFS: (9 of 9 files) 1000.70 KB / 1.03 MB
```

Here's the same, without pausing:

```
$ git lfs fetch --all 2>&1
Scanning for all objects ever referenced...
✔ 9 objects found
Fetching objects...
Username for 'https://github.com': technoweenie
Password for 'https://technoweenie@github.com':
Git LFS: (1 of 9 files) 0 B / 1.03 MB                                                                                                                                                                                                        UGit LFS: (2 of 9 files) 0 B / 1.03 MB
```