### PR TITLE
Fix lfsapi inconsistencies

### DIFF
--- a/lfsapi/body.go
+++ b/lfsapi/body.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strconv"
 )
 
 type ReadSeekCloser interface {
@@ -18,7 +19,9 @@ func MarshalToRequest(req *http.Request, obj interface{}) error {
 		return err
 	}
 
-	req.ContentLength = int64(len(by))
+	clen := len(by)
+	req.Header.Set("Content-Length", strconv.Itoa(clen))
+	req.ContentLength = int64(clen)
 	req.Body = NewByteBody(by)
 	return nil
 }

--- a/lfsapi/client_test.go
+++ b/lfsapi/client_test.go
@@ -181,3 +181,38 @@ func TestNewRequest(t *testing.T) {
 		assert.Equal(t, test[2], req.URL.String(), fmt.Sprintf("endpoint: %s, suffix: %s, expected: %s", test[0], test[1], test[2]))
 	}
 }
+
+func TestNewRequestWithBody(t *testing.T) {
+	c, err := NewClient(nil, TestEnv(map[string]string{
+		"lfs.url": "https://example.com",
+	}))
+	require.Nil(t, err)
+
+	body := struct {
+		Test string
+	}{Test: "test"}
+	req, err := c.NewRequest("POST", c.Endpoints.Endpoint("", ""), "body", body)
+	require.Nil(t, err)
+
+	assert.NotNil(t, req.Body)
+	assert.Equal(t, "15", req.Header.Get("Content-Length"))
+	assert.EqualValues(t, 15, req.ContentLength)
+}
+
+func TestMarshalToRequest(t *testing.T) {
+	req, err := http.NewRequest("POST", "https://foo/bar", nil)
+	require.Nil(t, err)
+
+	assert.Nil(t, req.Body)
+	assert.Equal(t, "", req.Header.Get("Content-Length"))
+	assert.EqualValues(t, 0, req.ContentLength)
+
+	body := struct {
+		Test string
+	}{Test: "test"}
+	require.Nil(t, MarshalToRequest(req, body))
+
+	assert.NotNil(t, req.Body)
+	assert.Equal(t, "15", req.Header.Get("Content-Length"))
+	assert.EqualValues(t, 15, req.ContentLength)
+}

--- a/lfsapi/endpoint.go
+++ b/lfsapi/endpoint.go
@@ -15,6 +15,20 @@ type Endpoint struct {
 	SshUserAndHost string
 	SshPath        string
 	SshPort        string
+	Operation      string
+}
+
+func endpointOperation(e Endpoint, method string) string {
+	if len(e.Operation) > 0 {
+		return e.Operation
+	}
+
+	switch method {
+	case "GET", "HEAD":
+		return "download"
+	default:
+		return "upload"
+	}
 }
 
 // endpointFromBareSshUrl constructs a new endpoint from a bare SSH URL:

--- a/lfsapi/endpoint_finder.go
+++ b/lfsapi/endpoint_finder.go
@@ -65,6 +65,12 @@ func NewEndpointFinder(git Env) EndpointFinder {
 }
 
 func (e *endpointGitFinder) Endpoint(operation, remote string) Endpoint {
+	ep := e.getEndpoint(operation, remote)
+	ep.Operation = operation
+	return ep
+}
+
+func (e *endpointGitFinder) getEndpoint(operation, remote string) Endpoint {
 	if e.git == nil {
 		return Endpoint{}
 	}

--- a/lfsapi/ssh_test.go
+++ b/lfsapi/ssh_test.go
@@ -30,19 +30,20 @@ func TestSSHGetLFSExeAndArgs(t *testing.T) {
 		"git-lfs-authenticate user/repo download",
 	}, args)
 
-	exe, args = sshGetLFSExeAndArgs(cli.OSEnv(), endpoint, "POST")
-	assert.Equal(t, "ssh", exe)
-	assert.Equal(t, []string{
-		"user@foo.com",
-		"git-lfs-authenticate user/repo upload",
-	}, args)
-
-	endpoint.Operation = "download"
+	// this is going by endpoint.Operation, implicitly set by Endpoint() on L15.
 	exe, args = sshGetLFSExeAndArgs(cli.OSEnv(), endpoint, "POST")
 	assert.Equal(t, "ssh", exe)
 	assert.Equal(t, []string{
 		"user@foo.com",
 		"git-lfs-authenticate user/repo download",
+	}, args)
+
+	endpoint.Operation = "upload"
+	exe, args = sshGetLFSExeAndArgs(cli.OSEnv(), endpoint, "POST")
+	assert.Equal(t, "ssh", exe)
+	assert.Equal(t, []string{
+		"user@foo.com",
+		"git-lfs-authenticate user/repo upload",
 	}, args)
 }
 

--- a/lfsapi/ssh_test.go
+++ b/lfsapi/ssh_test.go
@@ -8,6 +8,44 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestSSHGetLFSExeAndArgs(t *testing.T) {
+	cli, err := NewClient(TestEnv(map[string]string{}), nil)
+	require.Nil(t, err)
+
+	endpoint := cli.Endpoints.Endpoint("download", "")
+	endpoint.SshUserAndHost = "user@foo.com"
+	endpoint.SshPath = "user/repo"
+
+	exe, args := sshGetLFSExeAndArgs(cli.OSEnv(), endpoint, "GET")
+	assert.Equal(t, "ssh", exe)
+	assert.Equal(t, []string{
+		"user@foo.com",
+		"git-lfs-authenticate user/repo download",
+	}, args)
+
+	exe, args = sshGetLFSExeAndArgs(cli.OSEnv(), endpoint, "HEAD")
+	assert.Equal(t, "ssh", exe)
+	assert.Equal(t, []string{
+		"user@foo.com",
+		"git-lfs-authenticate user/repo download",
+	}, args)
+
+	exe, args = sshGetLFSExeAndArgs(cli.OSEnv(), endpoint, "POST")
+	assert.Equal(t, "ssh", exe)
+	assert.Equal(t, []string{
+		"user@foo.com",
+		"git-lfs-authenticate user/repo upload",
+	}, args)
+
+	endpoint.Operation = "download"
+	exe, args = sshGetLFSExeAndArgs(cli.OSEnv(), endpoint, "POST")
+	assert.Equal(t, "ssh", exe)
+	assert.Equal(t, []string{
+		"user@foo.com",
+		"git-lfs-authenticate user/repo download",
+	}, args)
+}
+
 func TestSSHGetExeAndArgsSsh(t *testing.T) {
 	cli, err := NewClient(TestEnv(map[string]string{
 		"GIT_SSH_COMMAND": "",

--- a/locking/api_test.go
+++ b/locking/api_test.go
@@ -21,6 +21,7 @@ func TestAPILock(t *testing.T) {
 		assert.Equal(t, "POST", r.Method)
 		assert.Equal(t, lfsapi.MediaType, r.Header.Get("Accept"))
 		assert.Equal(t, lfsapi.MediaType, r.Header.Get("Content-Type"))
+		assert.Equal(t, "61", r.Header.Get("Content-Length"))
 
 		lockReq := &lockRequest{}
 		err := json.NewDecoder(r.Body).Decode(lockReq)

--- a/tq/api_test.go
+++ b/tq/api_test.go
@@ -19,6 +19,7 @@ func TestAPIBatch(t *testing.T) {
 		}
 
 		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "80", r.Header.Get("Content-Length"))
 
 		bReq := &batchRequest{}
 		err := json.NewDecoder(r.Body).Decode(bReq)


### PR DESCRIPTION
I noticed a few inconsistencies with the completely rewritten API code:

1. Requests from Git LFS aren't sending a `Content-Length` request header.
2. ALL ssh auth requests send the `upload` operation, which interferes with the SSH command `ssh  user@githost.com git-lfs-authenticate user/repo {operation}`.

This PR fixes both.