### PR TITLE
Check that files are not uncommitted before unlock

### DIFF
--- a/commands/command_unlock.go
+++ b/commands/command_unlock.go
@@ -92,11 +92,13 @@ func unlockAbortIfFileModifiedById(id string, lockClient *locking.Client) {
 		locks, _ = lockClient.SearchLocks(filter, 0, false)
 	}
 
-	if len(locks) > 0 {
-		unlockAbortIfFileModified(locks[0].Path)
+	if len(locks) == 0 {
+		// Don't block if we can't determine the path, may be cleaning up old data
+		return
 	}
 
-	// Don't block if we can't determine the path, may be cleaning up old data
+	unlockAbortIfFileModified(locks[0].Path)
+
 }
 
 func init() {

--- a/git/git.go
+++ b/git/git.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	lfserrors "github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/subprocess"
 	"github.com/rubyist/tracerx"
 )
@@ -1108,10 +1109,10 @@ func IsFileModified(filepath string) (bool, error) {
 	cmd := subprocess.ExecCommand("git", args...)
 	outp, err := cmd.StdoutPipe()
 	if err != nil {
-		return false, fmt.Errorf("Failed to call git status: %v", err)
+		return false, lfserrors.Wrap(err, "Failed to call git status")
 	}
 	if err := cmd.Start(); err != nil {
-		return false, fmt.Errorf("Failed to start git status: %v", err)
+		return false, lfserrors.Wrap(err, "Failed to start git status")
 	}
 	scanner := bufio.NewScanner(outp)
 	matched := false
@@ -1127,10 +1128,9 @@ func IsFileModified(filepath string) (bool, error) {
 				// will typically fall straight through anyway due to 1 line output
 			}
 		}
-
 	}
 	if err := cmd.Wait(); err != nil {
-		return false, fmt.Errorf("Git status failed: %v", err)
+		return false, lfserrors.Wrap(err, "Git status failed")
 	}
 
 	return matched, nil

--- a/git/git.go
+++ b/git/git.go
@@ -1114,9 +1114,8 @@ func IsFileModified(filepath string) (bool, error) {
 	if err := cmd.Start(); err != nil {
 		return false, lfserrors.Wrap(err, "Failed to start git status")
 	}
-	scanner := bufio.NewScanner(outp)
 	matched := false
-	for scanner.Scan() {
+	for scanner := bufio.NewScanner(outp); scanner.Scan(); {
 		line := scanner.Text()
 		// Porcelain format is "<I><W> <filename>"
 		// Where <I> = index status, <W> = working copy status

--- a/git/git.go
+++ b/git/git.go
@@ -1114,6 +1114,7 @@ func IsFileModified(filepath string) (bool, error) {
 		return false, fmt.Errorf("Failed to start git status: %v", err)
 	}
 	scanner := bufio.NewScanner(outp)
+	matched := false
 	for scanner.Scan() {
 		line := scanner.Text()
 		// Porcelain format is "<I><W> <filename>"
@@ -1121,7 +1122,9 @@ func IsFileModified(filepath string) (bool, error) {
 		if len(line) > 3 {
 			// Double-check even though should be only match
 			if strings.TrimSpace(line[3:]) == filepath {
-				return true, nil
+				matched = true
+				// keep consuming output to exit cleanly
+				// will typically fall straight through anyway due to 1 line output
 			}
 		}
 
@@ -1130,5 +1133,5 @@ func IsFileModified(filepath string) (bool, error) {
 		return false, fmt.Errorf("Git status failed: %v", err)
 	}
 
-	return false, nil
+	return matched, nil
 }

--- a/test/test-unlock.sh
+++ b/test/test-unlock.sh
@@ -121,3 +121,34 @@ begin_test "unlocking a lock while uncommitted with --force"
   refute_server_lock "$reponame" "$id"
 )
 end_test
+
+begin_test "unlocking a lock while untracked"
+(
+  set -e
+
+  reponame="unlock_untracked"
+  setup_remote_repo_with_file "$reponame" "notrelevant.dat"
+
+  git lfs track "*.dat"
+  # Create file but don't add it to git
+  # Shouldn't be able to unlock it
+  echo "something" > untracked.dat
+  GITLFSLOCKSENABLED=1 git lfs lock "untracked.dat" | tee lock.log
+
+  id=$(grep -oh "\((.*)\)" lock.log | tr -d "()")
+  assert_server_lock "$reponame" "$id"
+
+  GITLFSLOCKSENABLED=1 git lfs unlock "untracked.dat" 2>&1 | tee unlock.log
+  [ ${PIPESTATUS[0]} -ne "0" ]
+
+  grep "Cannot unlock file with uncommitted changes" unlock.log
+
+  assert_server_lock "$reponame" "$id"
+
+  # should allow after add/commit
+  git add untracked.dat
+  git commit -m "Added untracked"
+  GITLFSLOCKSENABLED=1 git lfs unlock "untracked.dat" 2>&1 | tee unlock.log
+  refute_server_lock "$reponame" "$id"
+)
+end_test

--- a/test/test-unlock.sh
+++ b/test/test-unlock.sh
@@ -78,16 +78,16 @@ begin_test "unlocking a lock while uncommitted"
   set -e
 
   reponame="unlock_modified"
-  setup_remote_repo_with_file "$reponame" "f.dat"
+  setup_remote_repo_with_file "$reponame" "mod.dat"
 
-  GITLFSLOCKSENABLED=1 git lfs lock "f.dat" | tee lock.log
+  GITLFSLOCKSENABLED=1 git lfs lock "mod.dat" | tee lock.log
 
   id=$(grep -oh "\((.*)\)" lock.log | tr -d "()")
   assert_server_lock "$reponame" "$id"
 
-  echo "\nSomething" >> f.dat
+  echo "\nSomething" >> mod.dat
 
-  GITLFSLOCKSENABLED=1 git lfs unlock "f.dat" 2>&1 | tee unlock.log
+  GITLFSLOCKSENABLED=1 git lfs unlock "mod.dat" 2>&1 | tee unlock.log
   [ ${PIPESTATUS[0]} -ne "0" ]
 
   grep "Cannot unlock file with uncommitted changes" unlock.log
@@ -95,8 +95,8 @@ begin_test "unlocking a lock while uncommitted"
   assert_server_lock "$reponame" "$id"
 
   # should allow after discard
-  git checkout f.dat
-  GITLFSLOCKSENABLED=1 git lfs unlock "f.dat" 2>&1 | tee unlock.log
+  git checkout mod.dat
+  GITLFSLOCKSENABLED=1 git lfs unlock "mod.dat" 2>&1 | tee unlock.log
   refute_server_lock "$reponame" "$id"
 )
 end_test
@@ -106,17 +106,17 @@ begin_test "unlocking a lock while uncommitted with --force"
   set -e
 
   reponame="unlock_modified_force"
-  setup_remote_repo_with_file "$reponame" "g.dat"
+  setup_remote_repo_with_file "$reponame" "modforce.dat"
 
-  GITLFSLOCKSENABLED=1 git lfs lock "g.dat" | tee lock.log
+  GITLFSLOCKSENABLED=1 git lfs lock "modforce.dat" | tee lock.log
 
   id=$(grep -oh "\((.*)\)" lock.log | tr -d "()")
   assert_server_lock "$reponame" "$id"
 
-  echo "\nSomething" >> g.dat
+  echo "\nSomething" >> modforce.dat
 
   # should allow with --force
-  GITLFSLOCKSENABLED=1 git lfs unlock --force "g.dat" 2>&1 | tee unlock.log
+  GITLFSLOCKSENABLED=1 git lfs unlock --force "modforce.dat" 2>&1 | tee unlock.log
   grep "Warning: unlocking with uncommitted changes" unlock.log
   refute_server_lock "$reponame" "$id"
 )


### PR DESCRIPTION
A user should not have any uncommitted changes in their working copy when unlocking a file, since to relinquish the lock means that they've either finished making changes, or they don't want to keep their changes. It must be assumed that when relinquishing the lock other users are free to lock & begin making changes immediately which would clash with these outstanding changes.

`--force` overrides this check but with a warning.

This is only part of the overall solution; in future we'll also want to ensure they don't have any unpushed changes before allowing the unlock since those will have the same effect. However this will form part of #1844 which is a more complex proposal. This is an easy win in comparison and easy to understand.