### PR TITLE
locking: ensure verifiable locks call is made with the correct operation

### DIFF
--- a/locking/api.go
+++ b/locking/api.go
@@ -226,7 +226,7 @@ type lockVerifiableList struct {
 }
 
 func (c *lockClient) SearchVerifiable(remote string, vreq *lockVerifiableRequest) (*lockVerifiableList, *http.Response, error) {
-	e := c.Endpoints.Endpoint("download", remote)
+	e := c.Endpoints.Endpoint("upload", remote)
 	req, err := c.NewRequest("POST", e, "locks/verify", vreq)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
Really minor tweak that ensures that Git LFS will attempt to convert `lfs.pushurl` or `remote.{name}.pushurl` to build the LFS server url.