### PR TITLE
commands: teach track how to handle empty lines in .gitattributes

### DIFF
--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -119,6 +119,10 @@ ArgsLoop:
 		for scanner.Scan() {
 			line := scanner.Text()
 			fields := strings.Fields(line)
+			if len(fields) < 1 {
+				continue
+			}
+
 			pattern := fields[0]
 			if newline, ok := changedAttribLines[pattern]; ok {
 				// Replace this line (newline already embedded)

--- a/test/test-track.sh
+++ b/test/test-track.sh
@@ -33,12 +33,18 @@ begin_test "track"
   echo "*.gif filter=lfs -text" > a/.gitattributes
   echo "*.png filter=lfs -text" > a/b/.gitattributes
 
-  out=$(git lfs track)
-  echo "$out" | grep "Listing tracked patterns"
-  echo "$out" | grep "*.mov ($(native_path_escaped ".git/info/attributes"))"
-  echo "$out" | grep "*.jpg (.gitattributes)"
-  echo "$out" | grep "*.gif ($(native_path_escaped "a/.gitattributes"))"
-  echo "$out" | grep "*.png ($(native_path_escaped "a/b/.gitattributes"))"
+  git lfs track | tee track.log
+  grep "Listing tracked patterns" track.log
+  grep "*.mov ($(native_path_escaped ".git/info/attributes"))" track.log
+  grep "*.jpg (.gitattributes)" track.log
+  grep "*.gif ($(native_path_escaped "a/.gitattributes"))" track.log
+  grep "*.png ($(native_path_escaped "a/b/.gitattributes"))" track.log
+
+  grep "Set default behavior" .gitattributes
+  grep "############" .gitattributes
+  grep "* text=auto" .gitattributes
+  grep "diff=csharp" .gitattributes
+  grep "*.jpg" .gitattributes
 )
 end_test
 

--- a/test/test-track.sh
+++ b/test/test-track.sh
@@ -12,6 +12,13 @@ begin_test "track"
   cd track
   git init
 
+  echo "###############################################################################
+# Set default behavior to automatically normalize line endings.
+###############################################################################
+* text=auto
+
+#*.cs     diff=csharp" > .gitattributes
+
   # track *.jpg once
   git lfs track "*.jpg" | grep "Tracking \*.jpg"
   assert_attributes_count "jpg" "filter=lfs" 1
@@ -374,4 +381,3 @@ begin_test "track lockable read-only/read-write"
 
 )
 end_test
-


### PR DESCRIPTION
Just got a report from a Visual Studio user that `git lfs track` blows up when parsing the default `.gitattributes` that VS sets up. This fixes a bug with handling blank lines.