### PR TITLE
malformed pointer bugs

### DIFF
--- a/test/test-malformed-pointers.sh
+++ b/test/test-malformed-pointers.sh
@@ -14,6 +14,7 @@ begin_test "malformed pointers"
   git add .gitattributes
   git commit -m "initial commit"
 
+                                     > malformed_empty.dat
   base64 /dev/urandom | head -c 1023 > malformed_small.dat
   base64 /dev/urandom | head -c 1024 > malformed_exact.dat
   base64 /dev/urandom | head -c 1025 > malformed_large.dat
@@ -33,6 +34,7 @@ begin_test "malformed pointers"
   pushd .. >/dev/null
     clone_repo "$reponame" "$reponame-assert"
 
+    grep "malformed_empty.dat" clone.log && false
     grep "malformed_small.dat" clone.log
     grep "malformed_exact.dat" clone.log
     grep "malformed_large.dat" clone.log

--- a/test/test-malformed-pointers.sh
+++ b/test/test-malformed-pointers.sh
@@ -18,6 +18,9 @@ begin_test "malformed pointers"
   base64 /dev/urandom | head -c 1024 > malformed_exact.dat
   base64 /dev/urandom | head -c 1025 > malformed_large.dat
 
+  base64 /dev/urandom | head -c 200160 > malformed_xxl_works.dat
+  base64 /dev/urandom | head -c 200161 > malformed_xxl_fails.dat
+
   git \
     -c "filter.lfs.process=" \
     -c "filter.lfs.clean=cat" \


### PR DESCRIPTION
Hi folks,

I discovered two bugs and added a test case to demonstrate them.

Cheers,
Lars

--

**BUG 1**
Malformed pointers >200160 bytes make Git LFS hang.
Reproducible with latest master and v1.5.5 on macOS and Windows using the filter-protocol.

@ttaylorr any idea? Pretty weird number 🤔 

**BUG 2**
Empty pointers are listed as malformed pointers.