### PR TITLE
config: bump version to '2.0-pre' 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,6 +146,9 @@ release.
   * rpm
   * apt
 * Bump homebrew version and generate the homebrew hash with `curl --location https://github.com/git-lfs/git-lfs/archive/vx.y.z.tar.gz | shasum -a 256` ([example](https://github.com/Homebrew/homebrew-core/pull/413/commits/dc0eb1f62514f48f3f5a8d01ad3bea06f78bd566))
+* Create release branch for bug fixes, such as `release-1.5`.
+* Increment version in `config/version.go` to the next expected version. If
+v1.5 just shipped, set the version in master to `1.6-pre`, for example.
 
 ## Resources
 

--- a/config/version.go
+++ b/config/version.go
@@ -14,7 +14,7 @@ var (
 )
 
 const (
-	Version = "1.5.0"
+	Version = "2.0-pre"
 )
 
 func init() {


### PR DESCRIPTION
This makes it super clear that you're not on an official LFS release.

```
$ script/run version
git-lfs/2.0-pre (GitHub; darwin amd64; go 1.7.5; git a699d202)
```