### PR TITLE
Backport #1932 for v1.5.x: Spool malformed pointers to avoid deadlock

### DIFF
--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -8,7 +8,11 @@ import (
 	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/filepathfilter"
 	"github.com/git-lfs/git-lfs/lfs"
+<<<<<<< HEAD
 	"github.com/git-lfs/git-lfs/tools/longpathos"
+=======
+	"github.com/git-lfs/git-lfs/tools"
+>>>>>>> 038626b1... Merge pull request #1932 from git-lfs/malformed-spool
 	"github.com/spf13/cobra"
 )
 
@@ -27,6 +31,10 @@ var (
 // smudge smudges the given `*lfs.Pointer`, "ptr", and writes its objects
 // contents to the `io.Writer`, "to".
 //
+// If the encoded LFS pointer is not parse-able as a pointer, the contents of
+// that file will instead be spooled to a temporary location on disk and then
+// copied out back to Git.
+//
 // If the smudged object did not "pass" the include and exclude filterset, it
 // will not be downloaded, and the object will remain a pointer on disk, as if
 // the smudge filter had not been applied at all.
@@ -37,7 +45,7 @@ var (
 func smudge(to io.Writer, from io.Reader, filename string, skip bool, filter *filepathfilter.Filter) error {
 	ptr, pbuf, perr := lfs.DecodeFrom(from)
 	if perr != nil {
-		if _, err := io.Copy(to, pbuf); err != nil {
+		if _, err := tools.Spool(to, pbuf); err != nil {
 			return errors.Wrap(err, perr.Error())
 		}
 

--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -8,11 +8,8 @@ import (
 	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/filepathfilter"
 	"github.com/git-lfs/git-lfs/lfs"
-<<<<<<< HEAD
-	"github.com/git-lfs/git-lfs/tools/longpathos"
-=======
 	"github.com/git-lfs/git-lfs/tools"
->>>>>>> 038626b1... Merge pull request #1932 from git-lfs/malformed-spool
+	"github.com/git-lfs/git-lfs/tools/longpathos"
 	"github.com/spf13/cobra"
 )
 

--- a/test/test-malformed-pointers.sh
+++ b/test/test-malformed-pointers.sh
@@ -17,6 +17,7 @@ begin_test "malformed pointers"
   base64 /dev/urandom | head -c 1023 > malformed_small.dat
   base64 /dev/urandom | head -c 1024 > malformed_exact.dat
   base64 /dev/urandom | head -c 1025 > malformed_large.dat
+  base64 /dev/urandom | head -c 1048576 > malformed_xxl.dat
 
   git \
     -c "filter.lfs.process=" \
@@ -33,18 +34,22 @@ begin_test "malformed pointers"
     grep "malformed_small.dat" clone.log
     grep "malformed_exact.dat" clone.log
     grep "malformed_large.dat" clone.log
+    grep "malformed_xxl.dat" clone.log
 
     expected_small="$(cat ../$reponame/malformed_small.dat)"
     expected_exact="$(cat ../$reponame/malformed_exact.dat)"
     expected_large="$(cat ../$reponame/malformed_large.dat)"
+    expected_xxl="$(cat ../$reponame/malformed_xxl.dat)"
 
     actual_small="$(cat malformed_small.dat)"
     actual_exact="$(cat malformed_exact.dat)"
     actual_large="$(cat malformed_large.dat)"
+    actual_xxl="$(cat malformed_xxl.dat)"
 
     [ "$expected_small" = "$actual_small" ]
     [ "$expected_exact" = "$actual_exact" ]
     [ "$expected_large" = "$actual_large" ]
+    [ "$expected_xxl" = "$actual_xxl" ]
   popd >/dev/null
 )
 end_test

--- a/tools/iotools.go
+++ b/tools/iotools.go
@@ -1,15 +1,19 @@
 package tools
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"hash"
 	"io"
+	"io/ioutil"
+	"os"
 
 	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/progress"
 )
 
+<<<<<<< HEAD
 type readSeekCloserWrapper struct {
 	readSeeker io.ReadSeeker
 }
@@ -31,6 +35,14 @@ func (r *readSeekCloserWrapper) Close() error {
 func NewReadSeekCloserWrapper(r io.ReadSeeker) io.ReadCloser {
 	return &readSeekCloserWrapper{r}
 }
+=======
+const (
+	// memoryBufferLimit is the number of bytes to buffer in memory before
+	// spooling the contents of an `io.Reader` in `Spool()` to a temporary
+	// file on disk.
+	memoryBufferLimit = 1024
+)
+>>>>>>> 038626b1... Merge pull request #1932 from git-lfs/malformed-spool
 
 // CopyWithCallback copies reader to writer while performing a progress callback
 func CopyWithCallback(writer io.Writer, reader io.Reader, totalSize int64, cb progress.CopyCallback) (int64, error) {
@@ -110,4 +122,49 @@ func (r *RetriableReader) Read(b []byte) (int, error) {
 	}
 
 	return n, errors.NewRetriableError(err)
+}
+
+// Spool spools the contents from 'from' to 'to' by buffering the entire
+// contents of 'from' into a temprorary buffer. That buffer is held in memory
+// until the file grows to larger than 'memoryBufferLimit`, then the remaining
+// contents are spooled to disk.
+//
+// The temporary file is cleaned up after the copy is complete.
+//
+// The number of bytes written to "to", as well as any error encountered are
+// returned.
+func Spool(to io.Writer, from io.Reader) (n int64, err error) {
+	// First, buffer up to `memoryBufferLimit` in memory.
+	buf := make([]byte, memoryBufferLimit)
+	if bn, err := from.Read(buf); err != nil && err != io.EOF {
+		return int64(bn), err
+	} else {
+		buf = buf[:bn]
+	}
+
+	var spool io.Reader = bytes.NewReader(buf)
+	if err != io.EOF {
+		// If we weren't at the end of the stream, create a temporary
+		// file, and spool the remaining contents there.
+		tmp, err := ioutil.TempFile("", "")
+		if err != nil {
+			return 0, errors.Wrap(err, "spool tmp")
+		}
+		defer os.Remove(tmp.Name())
+
+		if n, err = io.Copy(tmp, from); err != nil {
+			return n, errors.Wrap(err, "unable to spool")
+		}
+
+		if _, err = tmp.Seek(0, io.SeekStart); err != nil {
+			return 0, errors.Wrap(err, "unable to seek")
+		}
+
+		// The spooled contents will now be the concatenation of the
+		// contents we stored in memory, then the remainder of the
+		// contents on disk.
+		spool = io.MultiReader(spool, tmp)
+	}
+
+	return io.Copy(to, spool)
 }

--- a/tools/iotools.go
+++ b/tools/iotools.go
@@ -13,7 +13,6 @@ import (
 	"github.com/git-lfs/git-lfs/progress"
 )
 
-<<<<<<< HEAD
 type readSeekCloserWrapper struct {
 	readSeeker io.ReadSeeker
 }
@@ -35,14 +34,13 @@ func (r *readSeekCloserWrapper) Close() error {
 func NewReadSeekCloserWrapper(r io.ReadSeeker) io.ReadCloser {
 	return &readSeekCloserWrapper{r}
 }
-=======
+
 const (
 	// memoryBufferLimit is the number of bytes to buffer in memory before
 	// spooling the contents of an `io.Reader` in `Spool()` to a temporary
 	// file on disk.
 	memoryBufferLimit = 1024
 )
->>>>>>> 038626b1... Merge pull request #1932 from git-lfs/malformed-spool
 
 // CopyWithCallback copies reader to writer while performing a progress callback
 func CopyWithCallback(writer io.Writer, reader io.Reader, totalSize int64, cb progress.CopyCallback) (int64, error) {


### PR DESCRIPTION
This backports #1932.

Conflicting files:
- commands/command_smudge.go
- tools/iotools.go