### PR TITLE
Backport #1861 for v1.5.x: Fix for #1860: Closing stdout pipe before function return

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,6 +146,9 @@ release.
   * rpm
   * apt
 * Bump homebrew version and generate the homebrew hash with `curl --location https://github.com/git-lfs/git-lfs/archive/vx.y.z.tar.gz | shasum -a 256` ([example](https://github.com/Homebrew/homebrew-core/pull/413/commits/dc0eb1f62514f48f3f5a8d01ad3bea06f78bd566))
+* Create release branch for bug fixes, such as `release-1.5`.
+* Increment version in `config/version.go` to the next expected version. If
+v1.5 just shipped, set the version in master to `1.6-pre`, for example.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,20 @@
 # Git Large File Storage
 
+<<<<<<< HEAD
 [![Build Status](https://travis-ci.org/github/git-lfs.svg?branch=master)](https://travis-ci.org/github/git-lfs)
 [![Build status](https://ci.appveyor.com/api/projects/status/46a5yoqc3hk59bl5/branch/master?svg=true)](https://ci.appveyor.com/project/git-lfs/git-lfs/branch/master)
+=======
+| Linux | macOS | Windows |
+| :---- | :------ | :---- |
+[ ![Linux build status][1]][2] | [![macOS build status][3]][4] | [![Windows build status][5]][6] |
+
+[1]: https://travis-ci.org/git-lfs/git-lfs.svg?branch=master
+[2]: https://travis-ci.org/git-lfs/git-lfs
+[3]: https://circleci.com/gh/git-lfs/git-lfs.svg?style=shield&circle-token=856152c2b02bfd236f54d21e1f581f3e4ebf47ad
+[4]: https://circleci.com/gh/git-lfs/git-lfs
+[5]: https://ci.appveyor.com/api/projects/status/46a5yoqc3hk59bl5/branch/master?svg=true
+[6]: https://ci.appveyor.com/project/git-lfs/git-lfs/branch/master
+>>>>>>> f8a50160... Merge branch 'master' into no-dwarf-tables
 
 Git LFS is a command line extension and [specification](docs/spec.md) for
 managing large files with Git. The client is written in Go, with pre-compiled

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,13 +7,17 @@ environment:
 clone_folder: $(GOPATH)\src\github.com\git-lfs\git-lfs
 
 install:
+<<<<<<< HEAD
   - echo $(GOPATH)
   - rd C:\Go /s /q
   - appveyor DownloadFile https://storage.googleapis.com/golang/go1.7.4.windows-amd64.zip
   - 7z x go1.7.4.windows-amd64.zip -oC:\ >nul
   - C:\go\bin\go version
+=======
+  - cinst golang --version 1.7.4 -y
+>>>>>>> f8a50160... Merge branch 'master' into no-dwarf-tables
   - cinst InnoSetup -y
-  - set PATH="C:\Program Files (x86)\Inno Setup 5";%PATH%
+  - refreshenv
 
 build_script:
   - bash --login -c 'GOARCH=386 script/bootstrap'

--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -90,15 +90,21 @@ func lockPath(file string) (string, error) {
 
 	abs := filepath.Join(wd, file)
 	path := strings.TrimPrefix(abs, repo)
+<<<<<<< HEAD
 
 	if stat, err := longpathos.Stat(abs); err != nil {
 		return "", err
+=======
+	path = strings.TrimPrefix(path, string(os.PathSeparator))
+	if stat, err := os.Stat(abs); err != nil {
+		return path, err
+>>>>>>> f8a50160... Merge branch 'master' into no-dwarf-tables
 	} else {
 		if stat.IsDir() {
-			return "", fmt.Errorf("lfs: cannot lock directory: %s", file)
+			return path, fmt.Errorf("lfs: cannot lock directory: %s", file)
 		}
 
-		return path[1:], nil
+		return path, nil
 	}
 }
 

--- a/commands/command_locks.go
+++ b/commands/command_locks.go
@@ -27,6 +27,7 @@ func locksCommand(cmd *cobra.Command, args []string) {
 			Exit("Error communicating with LFS API.")
 		}
 
+<<<<<<< HEAD
 		if resp.Err != "" {
 			Error(resp.Err)
 		}
@@ -43,6 +44,11 @@ func locksCommand(cmd *cobra.Command, args []string) {
 		} else {
 			break
 		}
+=======
+	for _, lock := range locks {
+		Print("%s\t%s", lock.Path, lock.Owner)
+		lockCount++
+>>>>>>> f8a50160... Merge branch 'master' into no-dwarf-tables
 	}
 
 	Print("\n%d lock(s) matched query:", len(locks))

--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -9,7 +9,10 @@ import (
 	"github.com/git-lfs/git-lfs/filepathfilter"
 	"github.com/git-lfs/git-lfs/lfs"
 	"github.com/git-lfs/git-lfs/tools"
+<<<<<<< HEAD
 	"github.com/git-lfs/git-lfs/tools/longpathos"
+=======
+>>>>>>> f8a50160... Merge branch 'master' into no-dwarf-tables
 	"github.com/spf13/cobra"
 )
 

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -42,6 +42,7 @@ func trackCommand(cmd *cobra.Command, args []string) {
 	}
 
 	lfs.InstallHooks(false)
+<<<<<<< HEAD
 	knownPatterns := findPatterns()
 
 	if len(args) == 0 {
@@ -64,6 +65,18 @@ func trackCommand(cmd *cobra.Command, args []string) {
 		if _, werr := attributesFile.WriteString("\n"); werr != nil {
 			Print("Error writing to .gitattributes")
 		}
+=======
+
+	if len(args) == 0 {
+		listPatterns()
+		return
+	}
+
+	knownPatterns := git.GetAttributePaths(config.LocalWorkingDir, config.LocalGitDir)
+	lineEnd := getAttributeLineEnding(knownPatterns)
+	if len(lineEnd) == 0 {
+		lineEnd = gitLineEnding(cfg.Git)
+>>>>>>> f8a50160... Merge branch 'master' into no-dwarf-tables
 	}
 
 	wd, _ := os.Getwd()
@@ -82,10 +95,84 @@ ArgsLoop:
 			}
 		}
 
+<<<<<<< HEAD
 		// Make sure any existing git tracked files have their timestamp updated
 		// so they will now show as modifed
 		// note this is relative to current dir which is how we write .gitattributes
 		// deliberately not done in parallel as a chan because we'll be marking modified
+=======
+		// Generate the new / changed attrib line for merging
+		encodedArg := strings.Replace(pattern, " ", "[[:space:]]", -1)
+		lockableArg := ""
+		if trackLockableFlag { // no need to test trackNotLockableFlag, if we got here we're disabling
+			lockableArg = " " + git.LockableAttrib
+		}
+
+		changedAttribLines[pattern] = fmt.Sprintf("%s filter=lfs diff=lfs merge=lfs -text%v%s", encodedArg, lockableArg, lineEnd)
+
+		if trackLockableFlag {
+			readOnlyPatterns = append(readOnlyPatterns, pattern)
+		} else {
+			writeablePatterns = append(writeablePatterns, pattern)
+		}
+
+		Print("Tracking %s", pattern)
+	}
+
+	// Now read the whole local attributes file and iterate over the contents,
+	// replacing any lines where the values have changed, and appending new lines
+	// change this:
+
+	attribContents, err := ioutil.ReadFile(".gitattributes")
+	// it's fine for file to not exist
+	if err != nil && !os.IsNotExist(err) {
+		Print("Error reading .gitattributes file")
+		return
+	}
+	// Re-generate the file with merge of old contents and new (to deal with changes)
+	attributesFile, err := os.OpenFile(".gitattributes", os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0660)
+	if err != nil {
+		Print("Error opening .gitattributes file")
+		return
+	}
+	defer attributesFile.Close()
+
+	if len(attribContents) > 0 {
+		scanner := bufio.NewScanner(bytes.NewReader(attribContents))
+		for scanner.Scan() {
+			line := scanner.Text()
+			fields := strings.Fields(line)
+			if len(fields) < 1 {
+				continue
+			}
+
+			pattern := fields[0]
+			if newline, ok := changedAttribLines[pattern]; ok {
+				// Replace this line (newline already embedded)
+				attributesFile.WriteString(newline)
+				// Remove from map so we know we don't have to add it to the end
+				delete(changedAttribLines, pattern)
+			} else {
+				// Write line unchanged (replace newline)
+				attributesFile.WriteString(line + lineEnd)
+			}
+		}
+
+		// Our method of writing also made sure there's always a newline at end
+	}
+
+	// Any items left in the map, write new lines at the end of the file
+	// Note this is only new patterns, not ones which changed locking flags
+	for pattern, newline := range changedAttribLines {
+		// Newline already embedded
+		attributesFile.WriteString(newline)
+
+		// Also, for any new patterns we've added, make sure any existing git
+		// tracked files have their timestamp updated so they will now show as
+		// modifed note this is relative to current dir which is how we write
+		// .gitattributes deliberately not done in parallel as a chan because
+		// we'll be marking modified
+>>>>>>> f8a50160... Merge branch 'master' into no-dwarf-tables
 		//
 		// NOTE: `git ls-files` does not do well with leading slashes.
 		// Since all `git-lfs track` calls are relative to the root of
@@ -94,6 +181,7 @@ ArgsLoop:
 		if trackVerboseLoggingFlag {
 			Print("Searching for files matching pattern: %s", pattern)
 		}
+
 		gittracked, err := git.GetTrackedFiles(pattern)
 		if err != nil {
 			Exit("Error getting tracked files for %q: %s", pattern, err)
@@ -109,7 +197,6 @@ ArgsLoop:
 				Print("Pattern %s matches forbidden file %s. If you would like to track %s, modify .gitattributes manually.", pattern, f, f)
 				matchedBlocklist = true
 			}
-
 		}
 		if matchedBlocklist {
 			continue
@@ -140,6 +227,7 @@ ArgsLoop:
 			}
 		}
 	}
+<<<<<<< HEAD
 }
 
 type mediaPattern struct {
@@ -201,6 +289,12 @@ func findAttributeFiles() []string {
 
 func needsTrailingLinebreak(filename string) bool {
 	file, err := longpathos.Open(filename)
+=======
+
+	// now flip read-only mode based on lockable / not lockable changes
+	lockClient := newLockClient(cfg.CurrentRemote)
+	err = lockClient.FixFileWriteFlagsInDir(relpath, readOnlyPatterns, writeablePatterns)
+>>>>>>> f8a50160... Merge branch 'master' into no-dwarf-tables
 	if err != nil {
 		return false
 	}
@@ -219,6 +313,31 @@ func needsTrailingLinebreak(filename string) bool {
 	}
 
 	return !strings.HasSuffix(string(buf[0:bytesRead]), "\n")
+}
+
+func listPatterns() {
+	knownPatterns := git.GetAttributePaths(config.LocalWorkingDir, config.LocalGitDir)
+	if len(knownPatterns) < 1 {
+		return
+	}
+
+	Print("Listing tracked patterns")
+	for _, t := range knownPatterns {
+		if t.Lockable {
+			Print("    %s [lockable] (%s)", t.Path, t.Source)
+		} else {
+			Print("    %s (%s)", t.Path, t.Source)
+		}
+	}
+}
+
+func getAttributeLineEnding(attribs []git.AttributePath) string {
+	for _, a := range attribs {
+		if a.Source.Path == ".gitattributes" {
+			return a.Source.LineEnding
+		}
+	}
+	return ""
 }
 
 // blocklistItem returns the name of the blocklist item preventing the given

--- a/commands/command_unlock.go
+++ b/commands/command_unlock.go
@@ -3,7 +3,12 @@ package commands
 import (
 	"errors"
 
+<<<<<<< HEAD
 	"github.com/git-lfs/git-lfs/api"
+=======
+	"github.com/git-lfs/git-lfs/git"
+	"github.com/git-lfs/git-lfs/locking"
+>>>>>>> f8a50160... Merge branch 'master' into no-dwarf-tables
 	"github.com/spf13/cobra"
 )
 
@@ -34,6 +39,7 @@ func unlockCommand(cmd *cobra.Command, args []string) {
 	var id string
 	if len(args) != 0 {
 		path, err := lockPath(args[0])
+<<<<<<< HEAD
 		if err != nil {
 			Error(err.Error())
 		}
@@ -43,6 +49,28 @@ func unlockCommand(cmd *cobra.Command, args []string) {
 		}
 	} else if unlockCmdFlags.Id != "" {
 		id = unlockCmdFlags.Id
+=======
+		if err != nil && !unlockCmdFlags.Force {
+			Exit("Unable to determine path: %v", err.Error())
+		}
+
+		// This call can early-out
+		unlockAbortIfFileModified(path)
+
+		err = lockClient.UnlockFile(path, unlockCmdFlags.Force)
+		if err != nil {
+			Exit("Unable to unlock: %v", err.Error())
+		}
+	} else if unlockCmdFlags.Id != "" {
+
+		// This call can early-out
+		unlockAbortIfFileModifiedById(unlockCmdFlags.Id, lockClient)
+
+		err := lockClient.UnlockFileById(unlockCmdFlags.Id, unlockCmdFlags.Force)
+		if err != nil {
+			Exit("Unable to unlock %v: %v", unlockCmdFlags.Id, err.Error())
+		}
+>>>>>>> f8a50160... Merge branch 'master' into no-dwarf-tables
 	} else {
 		Error("Usage: git lfs unlock (--id my-lock-id | <path>)")
 	}
@@ -90,6 +118,43 @@ func lockIdFromPath(path string) (string, error) {
 	default:
 		return "", errLockAmbiguous
 	}
+}
+
+func unlockAbortIfFileModified(path string) {
+	modified, err := git.IsFileModified(path)
+
+	if err != nil {
+		Exit(err.Error())
+	}
+
+	if modified {
+		if unlockCmdFlags.Force {
+			// Only a warning
+			Error("Warning: unlocking with uncommitted changes because --force")
+		} else {
+			Exit("Cannot unlock file with uncommitted changes")
+		}
+
+	}
+}
+
+func unlockAbortIfFileModifiedById(id string, lockClient *locking.Client) {
+	// Get the path so we can check the status
+	filter := map[string]string{"id": id}
+	// try local cache first
+	locks, _ := lockClient.SearchLocks(filter, 0, true)
+	if len(locks) == 0 {
+		// Fall back on calling server
+		locks, _ = lockClient.SearchLocks(filter, 0, false)
+	}
+
+	if len(locks) == 0 {
+		// Don't block if we can't determine the path, may be cleaning up old data
+		return
+	}
+
+	unlockAbortIfFileModified(locks[0].Path)
+
 }
 
 func init() {

--- a/commands/path.go
+++ b/commands/path.go
@@ -1,0 +1,17 @@
+package commands
+
+import "strings"
+
+func gitLineEnding(git env) string {
+	value, _ := git.Get("core.autocrlf")
+	switch strings.ToLower(value) {
+	case "input", "true", "t", "1":
+		return "\r\n"
+	default:
+		return osLineEnding()
+	}
+}
+
+type env interface {
+	Get(string) (string, bool)
+}

--- a/commands/path_nix.go
+++ b/commands/path_nix.go
@@ -6,3 +6,7 @@ package commands
 func cleanRootPath(pattern string) string {
 	return pattern
 }
+
+func osLineEnding() string {
+	return "\n"
+}

--- a/commands/path_windows.go
+++ b/commands/path_windows.go
@@ -17,6 +17,10 @@ var (
 	winBashRe     *regexp.Regexp
 )
 
+func osLineEnding() string {
+	return "\r\n"
+}
+
 // cleanRootPath replaces the windows root path prefix with a unix path prefix:
 // "/". Git Bash (provided with Git For Windows) expands a path like "/foo" to
 // the actual Windows directory, but with forward slashes. You can see this

--- a/config/version.go
+++ b/config/version.go
@@ -12,6 +12,13 @@ var (
 	VersionDesc string
 )
 
+<<<<<<< HEAD
+=======
+const (
+	Version = "2.0-pre"
+)
+
+>>>>>>> f8a50160... Merge branch 'master' into no-dwarf-tables
 func init() {
 	gitCommit := ""
 	if len(GitCommit) > 0 {

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -6,8 +6,15 @@ goes through looks like this:
 
 1. [Discover the LFS Server to use](./server-discovery.md).
 2. [Apply Authentication](./authentication.md).
-3. [Request the Batch API](./batch.md) to upload or download objects.
-4. The Batch API's response dictates how the client will transfer the objects.
+3. Make the request. See the Batch and File Locking API sections.
+
+## Batch API
+
+The Batch API is used to request the ability to transfer LFS objects with the
+LFS server.
+
+API Specification:
+  * [Batch API](./batch.md)
 
 Current transfer adapters include:
   * [Basic](./basic-transfers.md)
@@ -15,3 +22,11 @@ Current transfer adapters include:
 Experimental transfer adapters include:
   * Tus.io (upload only)
   * [Custom](../custom-transfers.md)
+
+## File Locking API
+
+The File Locking API is used to create, list, and delete locks, as well as
+verify that locks are respected in Git pushes.
+
+API Specification:
+  * [File Locking API](./locking.md)

--- a/docs/api/batch.md
+++ b/docs/api/batch.md
@@ -1,5 +1,7 @@
 # Git LFS Batch API
 
+Added: v0.6
+
 The Batch API is used to request the ability to transfer LFS objects with the
 LFS server. The Batch URL is built by adding `/objects/batch` to the LFS server
 URL.
@@ -172,7 +174,7 @@ errors.
 
 {
   "message": "Not found",
-  "documentation_url": "https://git-lfs-server.com/docs/errors",
+  "documentation_url": "https://lfs-server.com/docs/errors",
   "request_id": "123"
 }
 ```
@@ -189,7 +191,7 @@ a custom header key so it does not trigger password prompts in browsers.
 
 {
   "message": "Credentials needed",
-  "documentation_url": "https://git-lfs-server.com/docs/errors",
+  "documentation_url": "https://lfs-server.com/docs/errors",
   "request_id": "123"
 }
 ```

--- a/docs/api/locking.md
+++ b/docs/api/locking.md
@@ -1,0 +1,436 @@
+# Git LFS File Locking API
+
+Added: v2.0
+
+The File Locking API is used to create, list, and delete locks, as well as
+verify that locks are respected in Git pushes. The locking URLs are built
+by adding a suffix to the LFS Server URL.
+
+Git remote: https://git-server.com/foo/bar  
+LFS server: https://git-server.com/foo/bar.git/info/lfs  
+Locks API: https://git-server.com/foo/bar.git/info/lfs/locks
+
+See the [Server Discovery doc](./server-discovery.md) for more info on how LFS
+builds the LFS server URL.
+
+All File Locking requests require the following HTTP headers:
+
+    Accept: application/vnd.git-lfs+json
+    Content-Type: application/vnd.git-lfs+json
+
+See the [Authentication doc](./authentication.md) for more info on how LFS
+gets authorizes Batch API requests.
+
+Note: This is the first version of the File Locking API, supporting only the
+simplest use case: single branch locking. The API is designed to be extensible
+as we experiment with more advanced locking scenarios, as defined in the
+[original proposal](/docs/proposals/locking.md).
+
+## Create Lock
+
+The client sends the following to create a lock by sending a `POST` to `/locks`
+(appended to the LFS server url, as described above).
+
+* `path` - String path name of the file that is locked. This should be
+relative to the root of the repository working directory.
+
+```js
+// POST https://lfs-server.com/locks
+// Accept: application/vnd.git-lfs+json
+// Content-Type: application/vnd.git-lfs+json
+// Authorization: Basic ...
+{
+  "path": "foo/bar.zip"
+}
+```
+
+### Successful Response
+
+Successful responses return the created lock:
+
+* `id` - String ID of the Lock. Git LFS doesn't enforce what type of ID is used,
+as long as it's returned a string.
+* `path` - String path name of the locked file. This should be relative to the
+root of the repository working directory.
+* `locked_at` - The string ISO 8601 formatted timestamp the lock was created.
+* `owner` - The name of the user that created the Lock. This should be set from
+the user credentials posted when creating the lock.
+
+```js
+// HTTP/1.1 201 Created
+// Content-Type: application/vnd.git-lfs+json
+{
+  "lock": {
+    "id": "some-uuid",
+    "path": "/path/to/file",
+    "locked_at": "2016-05-17T15:49:06+00:00",
+    "owner": {
+      "name": "Jane Doe",
+    }
+  }
+}
+```
+
+### Bad Response: Lock Exists
+
+Lock services should reject lock creations if one already exists for the given
+path on the current repository.
+
+* `lock` - The existing Lock that clashes with the request.
+* `message` - String error message.
+* `request_id` - Optional String unique identifier for the request. Useful for
+debugging.
+* `documentation_url` - Optional String to give the user a place to report
+errors.
+
+```js
+// HTTP/1.1 409 Conflict
+// Content-Type: application/vnd.git-lfs+json
+{
+  "lock": {
+    // details of existing lock
+  },
+  "message": "already created lock",
+  "documentation_url": "https://lfs-server.com/docs/errors",
+  "request_id": "123"
+}
+```
+
+### Unauthorized Response
+
+Lock servers should require that users have push access to the repository before
+they can create locks.
+
+* `message` - String error message.
+* `request_id` - Optional String unique identifier for the request. Useful for
+debugging.
+* `documentation_url` - Optional String to give the user a place to report
+errors.
+
+```js
+// HTTP/1.1 403 Forbidden
+// Content-Type: application/vnd.git-lfs+json
+{
+  "message": "You must have push access to create a lock",
+  "documentation_url": "https://lfs-server.com/docs/errors",
+  "request_id": "123"
+}
+```
+
+### Error Response
+
+* `message` - String error message.
+* `request_id` - Optional String unique identifier for the request. Useful for
+debugging.
+* `documentation_url` - Optional String to give the user a place to report
+errors.
+
+```js
+// HTTP/1.1 500 Internal server error
+// Content-Type: application/vnd.git-lfs+json
+{
+  "message": "already created lock",
+  "documentation_url": "https://lfs-server.com/docs/errors",
+  "request_id": "123"
+}
+```
+
+## List Locks
+
+The client can request the current active locks for a repository by sending a
+`GET` to `/locks` (appended to the LFS server url, as described above). The
+properties are sent as URI query values, instead of through a JSON body:
+
+* `path` - Optional string path to match against locks on the server.
+* `id` - Optional string ID to match against a lock on the server.
+* `cursor` - The optional string value to continue listing locks. This value
+should be the `next_cursor` from a previous request.
+* `limit` - The integer limit of the number of locks to return. The server
+should have its own upper and lower bounds on the supported limits.
+
+```js
+// GET https://lfs-server.com/locks?path=&id=&cursor=&limit=
+// Accept: application/vnd.git-lfs+json
+// Authorization: Basic ... (if needed)
+```
+
+### Successful Response
+
+A successful response will list the matching locks:
+
+* `locks` - Array of matching Lock objects. See the "Create Lock" successful
+response section to see what Lock properties are possible.
+* `next_cursor` - Optional string cursor that the server can return if there
+are more locks matching the given filters. The client will re-do the request,
+setting the `?cursor` query value with this `next_cursor` value.
+
+Note: If the server has no locks, it must return an empty `locks` array.
+
+```js
+// HTTP/1.1 200 Ok
+// Content-Type: application/vnd.git-lfs+json
+{
+  "locks": [
+    {
+      "id": "some-uuid",
+      "path": "/path/to/file",
+      "locked_at": "2016-05-17T15:49:06+00:00",
+      "owner": {
+        "name": "Jane Doe"
+      }
+    }
+  ],
+  "next_cursor": "optional next ID",
+}
+```
+
+### Unauthorized Response
+
+Lock servers should require that users have pull access to the repository before
+they can list locks.
+
+* `message` - String error message.
+* `request_id` - Optional String unique identifier for the request. Useful for
+debugging.
+* `documentation_url` - Optional String to give the user a place to report
+errors.
+
+```js
+// HTTP/1.1 403 Forbidden
+// Content-Type: application/vnd.git-lfs+json
+{
+  "message": "You must have pull access to list locks",
+  "documentation_url": "https://lfs-server.com/docs/errors",
+  "request_id": "123"
+}
+```
+
+### Error Response
+
+* `message` - String error message.
+* `request_id` - Optional String unique identifier for the request. Useful for
+debugging.
+* `documentation_url` - Optional String to give the user a place to report
+errors.
+
+```js
+// HTTP/1.1 500 Internal server error
+// Content-Type: application/vnd.git-lfs+json
+{
+  "message": "unable to list locks",
+  "documentation_url": "https://lfs-server.com/docs/errors",
+  "request_id": "123"
+}
+```
+
+## List Locks for Verification
+
+The client can use the Lock Verification endpoint to check for active locks
+that can affect a Git push. For a caller, this endpoint is very similar to the
+"List Locks" endpoint above, except:
+
+* Verification requires a `POST` request.
+* The `cursor` and `limit` values are sent as properties in the json request
+body.
+* The response includes locks partitioned into `ours` and `theirs` properties.
+
+Clients send the following to list locks for verification by sending a `POST`
+to `/locks/verify` (appended to the LFS server url, as described above):
+
+* `cursor`
+* `limit`
+
+```js
+// POST https://lfs-server.com/locks/verify
+// Accept: application/vnd.git-lfs+json
+// Content-Type: application/vnd.git-lfs+json
+// Authorization: Basic ...
+{
+  "cursor": "optional cursor",
+  "limit": 100 // also optional
+}
+```
+
+Note: As more advanced locking workflows are implemented, more details will
+likely be added to this request body in future iterations.
+
+### Successful Response
+
+A successful response will list the relevant locks:
+
+* `ours` - Array of Lock objects currently owned by the authenticated user.
+modify.
+* `theirs` - Array of Lock objects currently owned by other users.
+* `next_cursor` - Optional string cursor that the server can return if there
+are more locks matching the given filters. The client will re-do the request,
+setting the `cursor` property with this `next_cursor` value.
+
+If a Git push updates any files matching any of "our" locks, Git LFS will list
+them in the push output, in case the user will want to unlock them after the
+push. However, any updated files matching one of "their" locks will halt the
+push. At this point, it is up to the user to resolve the lock conflict with
+their team.
+
+Note: If the server has no locks, it must return an empty array in the `ours` or
+`theirs` properties.
+
+```js
+// HTTP/1.1 200 Ok
+// Content-Type: application/vnd.git-lfs+json
+{
+  "ours": [
+    {
+      "id": "some-uuid",
+      "path": "/path/to/file",
+      "locked_at": "2016-05-17T15:49:06+00:00",
+      "owner": {
+        "name": "Jane Doe"
+      }
+    }
+  ],
+  "theirs": [],
+  "next_cursor": "optional next ID",
+}
+```
+
+### Not Found Response
+
+By default, an LFS server that doesn't implement any locking endpoints should
+return 404. This response will not halt any Git pushes.
+
+Any 404 will do, but Git LFS will show a better error message with a json
+response.
+
+* `message` - String error message.
+* `request_id` - Optional String unique identifier for the request. Useful for
+debugging.
+* `documentation_url` - Optional String to give the user a place to report
+errors.
+
+```js
+// HTTP/1.1 404 Not found
+// Content-Type: application/vnd.git-lfs+json
+{
+  "message": "Not found",
+  "documentation_url": "https://lfs-server.com/docs/errors",
+  "request_id": "123"
+}
+```
+
+### Unauthorized Response
+
+Lock servers should require that users have push access to the repository before
+they can get a list of locks to verify a Git push.
+
+* `message` - String error message.
+* `request_id` - Optional String unique identifier for the request. Useful for
+debugging.
+* `documentation_url` - Optional String to give the user a place to report
+errors.
+
+```js
+// HTTP/1.1 403 Forbidden
+// Content-Type: application/vnd.git-lfs+json
+{
+  "message": "You must have push access to verify locks",
+  "documentation_url": "https://lfs-server.com/docs/errors",
+  "request_id": "123"
+}
+```
+
+### Error Response
+
+* `message` - String error message.
+* `request_id` - Optional String unique identifier for the request. Useful for
+debugging.
+* `documentation_url` - Optional String to give the user a place to report
+errors.
+
+```js
+// HTTP/1.1 500 Internal server error
+// Content-Type: application/vnd.git-lfs+json
+{
+  "message": "unable to list locks",
+  "documentation_url": "https://lfs-server.com/docs/errors",
+  "request_id": "123"
+}
+```
+
+## Delete Lock
+
+The client can delete a lock, given its ID, by sending a `POST` to
+`/locks/:id/unlock` (appended to the LFS server url, as described above):
+
+* `force` - Optional boolean specifying that the user is deleting another user's
+lock.
+
+```js
+// POST https://lfs-server.com/locks/:id/unlock
+// Accept: application/vnd.git-lfs+json
+// Content-Type: application/vnd.git-lfs+json
+// Authorization: Basic ...
+
+{
+  "force": true
+}
+```
+
+### Successful Response
+
+Successful deletions return the deleted lock. See the "Create Lock" successful
+response section to see what Lock properties are possible.
+
+```js
+// HTTP/1.1 200 Ok
+// Content-Type: application/vnd.git-lfs+json
+{
+  "lock": {
+    "id": "some-uuid",
+    "path": "/path/to/file",
+    "locked_at": "2016-05-17T15:49:06+00:00",
+    "owner": {
+      "name": "Jane Doe"
+    }
+  }
+}
+```
+
+### Unauthorized Response
+
+Lock servers should require that users have push access to the repository before
+they can delete locks. Also, if the `force` parameter is omitted, or false,
+the user should only be allowed to delete locks that they created.
+
+* `message` - String error message.
+* `request_id` - Optional String unique identifier for the request. Useful for
+debugging.
+* `documentation_url` - Optional String to give the user a place to report
+errors.
+
+```js
+// HTTP/1.1 403 Forbidden
+// Content-Type: application/vnd.git-lfs+json
+{
+  "message": "You must have push access to verify locks",
+  "documentation_url": "https://lfs-server.com/docs/errors",
+  "request_id": "123"
+}
+```
+
+### Error response
+
+* `message` - String error message.
+* `request_id` - Optional String unique identifier for the request. Useful for
+debugging.
+* `documentation_url` - Optional String to give the user a place to report
+errors.
+
+```js
+// HTTP/1.1 500 Internal server error
+// Content-Type: application/vnd.git-lfs+json
+{
+  "message": "already deleting lock",
+  "documentation_url": "https://lfs-server.com/docs/errors",
+  "request_id": "123"
+}
+```

--- a/docs/api/schemas/http-lock-create-request-schema.json
+++ b/docs/api/schemas/http-lock-create-request-schema.json
@@ -1,0 +1,1 @@
+../../../locking/schemas/http-lock-create-request-schema.json

--- a/docs/api/schemas/http-lock-create-response-schema.json
+++ b/docs/api/schemas/http-lock-create-response-schema.json
@@ -1,0 +1,1 @@
+../../../locking/schemas/http-lock-create-response-schema.json

--- a/docs/api/schemas/http-lock-delete-request-schema.json
+++ b/docs/api/schemas/http-lock-delete-request-schema.json
@@ -1,0 +1,1 @@
+../../../locking/schemas/http-lock-delete-request-schema.json

--- a/docs/api/schemas/http-lock-list-response-schema.json
+++ b/docs/api/schemas/http-lock-list-response-schema.json
@@ -1,0 +1,1 @@
+../../../locking/schemas/http-lock-list-response-schema.json

--- a/docs/api/schemas/http-lock-verify-response-schema.json
+++ b/docs/api/schemas/http-lock-verify-response-schema.json
@@ -1,0 +1,1 @@
+../../../locking/schemas/http-lock-verify-response-schema.json

--- a/git/attribs.go
+++ b/git/attribs.go
@@ -1,0 +1,157 @@
+package git
+
+import (
+	"bufio"
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/git-lfs/git-lfs/tools"
+	"github.com/rubyist/tracerx"
+)
+
+const (
+	LockableAttrib = "lockable"
+)
+
+// AttributePath is a path entry in a gitattributes file which has the LFS filter
+type AttributePath struct {
+	// Path entry in the attribute file
+	Path string
+	// The attribute file which was the source of this entry
+	Source *AttributeSource
+	// Path also has the 'lockable' attribute
+	Lockable bool
+}
+
+type AttributeSource struct {
+	Path       string
+	LineEnding string
+}
+
+func (s *AttributeSource) String() string {
+	return s.Path
+}
+
+// GetAttributePaths returns a list of entries in .gitattributes which are
+// configured with the filter=lfs attribute
+// workingDIr is the root of the working copy
+// gitDir is the root of the git repo
+func GetAttributePaths(workingDir, gitDir string) []AttributePath {
+	paths := make([]AttributePath, 0)
+
+	for _, path := range findAttributeFiles(workingDir, gitDir) {
+		attributes, err := os.Open(path)
+		if err != nil {
+			continue
+		}
+
+		relfile, _ := filepath.Rel(workingDir, path)
+		reldir := filepath.Dir(relfile)
+		source := &AttributeSource{Path: relfile}
+
+		le := &lineEndingSplitter{}
+		scanner := bufio.NewScanner(attributes)
+		scanner.Split(le.ScanLines)
+
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.Contains(line, "filter=lfs") {
+				fields := strings.Fields(line)
+				pattern := fields[0]
+				if len(reldir) > 0 {
+					pattern = filepath.Join(reldir, pattern)
+				}
+				// Find lockable flag in any position after pattern to avoid
+				// edge case of matching "lockable" to a file pattern
+				lockable := false
+				for _, f := range fields[1:] {
+					if f == LockableAttrib {
+						lockable = true
+						break
+					}
+				}
+				paths = append(paths, AttributePath{
+					Path:     pattern,
+					Source:   source,
+					Lockable: lockable,
+				})
+			}
+		}
+
+		source.LineEnding = le.LineEnding()
+	}
+
+	return paths
+}
+
+// copies bufio.ScanLines(), counting LF vs CRLF in a file
+type lineEndingSplitter struct {
+	LFCount   int
+	CRLFCount int
+}
+
+func (s *lineEndingSplitter) LineEnding() string {
+	if s.CRLFCount > s.LFCount {
+		return "\r\n"
+	} else if s.LFCount == 0 {
+		return ""
+	}
+	return "\n"
+}
+
+func (s *lineEndingSplitter) ScanLines(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+	if i := bytes.IndexByte(data, '\n'); i >= 0 {
+		// We have a full newline-terminated line.
+		return i + 1, s.dropCR(data[0:i]), nil
+	}
+	// If we're at EOF, we have a final, non-terminated line. Return it.
+	if atEOF {
+		return len(data), data, nil
+	}
+	// Request more data.
+	return 0, nil, nil
+}
+
+// dropCR drops a terminal \r from the data.
+func (s *lineEndingSplitter) dropCR(data []byte) []byte {
+	if len(data) > 0 && data[len(data)-1] == '\r' {
+		s.CRLFCount++
+		return data[0 : len(data)-1]
+	}
+	s.LFCount++
+	return data
+}
+
+func findAttributeFiles(workingDir, gitDir string) []string {
+	var paths []string
+
+	repoAttributes := filepath.Join(gitDir, "info", "attributes")
+	if info, err := os.Stat(repoAttributes); err == nil && !info.IsDir() {
+		paths = append(paths, repoAttributes)
+	}
+
+	tools.FastWalkGitRepo(workingDir, func(parentDir string, info os.FileInfo, err error) {
+		if err != nil {
+			tracerx.Printf("Error finding .gitattributes: %v", err)
+			return
+		}
+
+		if info.IsDir() || info.Name() != ".gitattributes" {
+			return
+		}
+		paths = append(paths, filepath.Join(parentDir, info.Name()))
+	})
+
+	// reverse the order of the files so more specific entries are found first
+	// when iterating from the front (respects precedence)
+	for i, j := 0, len(paths)-1; i < j; i, j = i+1, j-1 {
+		paths[i], paths[j] = paths[j], paths[i]
+	}
+
+	return paths
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: f2f29e58b092d821d790461bd12a16239d6b8ca15db6c092fd884d82d3ef2010
-updated: 2016-11-22T09:41:32.528134176-07:00
+hash: 53affc5afb75c731ebb7be5683c55d635afefd093f90015ae2c62ea88130a4cc
+updated: 2017-02-13T11:32:39.724259135-07:00
 imports:
 - name: github.com/bgentry/go-netrc
   version: 9fd32a8b3d3d3f9d43c341bfe098430e07609480
@@ -29,7 +29,6 @@ imports:
   version: 6cb3b85ef5a0efef77caef88363ec4d4b5c0976d
   subpackages:
   - assert
-  - mock
   - require
 - name: github.com/ThomsonReutersEikon/go-ntlm
   version: b00ec39bbdd04f845950f4dbb4fd0a2c3155e830
@@ -41,15 +40,13 @@ imports:
 - name: github.com/xeipuuv/gojsonreference
   version: e02fc20de94c78484cd5ffb007f8af96be030a45
 - name: github.com/xeipuuv/gojsonschema
-  version: d5336c75940ef31c9ceeb0ae64cf92944bccb4ee
+  version: 6b67b3fab74d992bd07f72550006ab2c6907c416
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 346938d642f2ec3594ed81d874461961cd0faa76
+  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
 - name: github.com/pmezard/go-difflib
-  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
-- name: github.com/stretchr/objx
-  version: 1a9d0bb9f541897e62256577b352fdbc1fb4fd94

--- a/glide.yaml
+++ b/glide.yaml
@@ -33,6 +33,6 @@ import:
 - package: github.com/xeipuuv/gojsonreference
   version: e02fc20de94c78484cd5ffb007f8af96be030a45
 - package: github.com/xeipuuv/gojsonschema
-  version: d5336c75940ef31c9ceeb0ae64cf92944bccb4ee
+  version: 6b67b3fab74d992bd07f72550006ab2c6907c416
 - package: github.com/pkg/errors
   version: 01fa4104b9c248c8945d14d9f128454d5b28d595

--- a/lfsapi/errors.go
+++ b/lfsapi/errors.go
@@ -1,0 +1,125 @@
+package lfsapi
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/git-lfs/git-lfs/errors"
+)
+
+type httpError interface {
+	Error() string
+	HTTPResponse() *http.Response
+}
+
+func IsHTTP(err error) (*http.Response, bool) {
+	if httpErr, ok := err.(httpError); ok {
+		return httpErr.HTTPResponse(), true
+	}
+	return nil, false
+}
+
+func ClientErrorMessage(msg, docURL, reqID string) string {
+	if len(docURL) > 0 {
+		msg += "\nDocs: " + docURL
+	}
+	if len(reqID) > 0 {
+		msg += "\nRequest ID: " + reqID
+	}
+	return msg
+}
+
+type ClientError struct {
+	Message          string `json:"message"`
+	DocumentationUrl string `json:"documentation_url,omitempty"`
+	RequestId        string `json:"request_id,omitempty"`
+	response         *http.Response
+}
+
+func (e *ClientError) HTTPResponse() *http.Response {
+	return e.response
+}
+
+func (e *ClientError) Error() string {
+	return ClientErrorMessage(e.Message, e.DocumentationUrl, e.RequestId)
+}
+
+func (c *Client) handleResponse(res *http.Response) error {
+	if res.StatusCode < 400 {
+		return nil
+	}
+
+	cliErr := &ClientError{response: res}
+	err := DecodeJSON(res, cliErr)
+	if IsDecodeTypeError(err) {
+		err = nil
+	}
+
+	if err == nil {
+		if len(cliErr.Message) == 0 {
+			err = defaultError(res)
+		} else {
+			err = errors.Wrap(cliErr, "http")
+		}
+	}
+
+	if res.StatusCode == 401 {
+		return errors.NewAuthError(err)
+	}
+
+	if res.StatusCode > 499 && res.StatusCode != 501 && res.StatusCode != 507 && res.StatusCode != 509 {
+		return errors.NewFatalError(err)
+	}
+
+	return err
+}
+
+type statusCodeError struct {
+	response *http.Response
+}
+
+func NewStatusCodeError(res *http.Response) error {
+	return &statusCodeError{response: res}
+}
+
+func (e *statusCodeError) Error() string {
+	req := e.response.Request
+	return fmt.Sprintf("Invalid HTTP status for %s %s: %d",
+		req.Method,
+		strings.SplitN(req.URL.String(), "?", 2)[0],
+		e.response.StatusCode,
+	)
+}
+
+func (e *statusCodeError) HTTPResponse() *http.Response {
+	return e.response
+}
+
+var (
+	defaultErrors = map[int]string{
+		400: "Client error: %s",
+		401: "Authorization error: %s\nCheck that you have proper access to the repository",
+		403: "Authorization error: %s\nCheck that you have proper access to the repository",
+		404: "Repository or object not found: %s\nCheck that it exists and that you have proper access to it",
+		429: "Rate limit exceeded: %s",
+		500: "Server error: %s",
+		501: "Not Implemented: %s",
+		507: "Insufficient server storage: %s",
+		509: "Bandwidth limit exceeded: %s",
+	}
+)
+
+func defaultError(res *http.Response) error {
+	var msgFmt string
+
+	if f, ok := defaultErrors[res.StatusCode]; ok {
+		msgFmt = f
+	} else if res.StatusCode < 500 {
+		msgFmt = defaultErrors[400] + fmt.Sprintf(" from HTTP %d", res.StatusCode)
+	} else {
+		msgFmt = defaultErrors[500] + fmt.Sprintf(" from HTTP %d", res.StatusCode)
+	}
+
+	return errors.Errorf(msgFmt, res.Request.URL)
+}

--- a/locking/api.go
+++ b/locking/api.go
@@ -1,0 +1,260 @@
+package locking
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/git-lfs/git-lfs/lfsapi"
+)
+
+type lockClient struct {
+	*lfsapi.Client
+}
+
+// LockRequest encapsulates the payload sent across the API when a client would
+// like to obtain a lock against a particular path on a given remote.
+type lockRequest struct {
+	// Path is the path that the client would like to obtain a lock against.
+	Path string `json:"path"`
+}
+
+// LockResponse encapsulates the information sent over the API in response to
+// a `LockRequest`.
+type lockResponse struct {
+	// Lock is the Lock that was optionally created in response to the
+	// payload that was sent (see above). If the lock already exists, then
+	// the existing lock is sent in this field instead, and the author of
+	// that lock remains the same, meaning that the client failed to obtain
+	// that lock. An HTTP status of "409 - Conflict" is used here.
+	//
+	// If the lock was unable to be created, this field will hold the
+	// zero-value of Lock and the Err field will provide a more detailed set
+	// of information.
+	//
+	// If an error was experienced in creating this lock, then the
+	// zero-value of Lock should be sent here instead.
+	Lock *Lock `json:"lock"`
+
+	// Message is the optional error that was encountered while trying to create
+	// the above lock.
+	Message          string `json:"message,omitempty"`
+	DocumentationURL string `json:"documentation_url,omitempty"`
+	RequestID        string `json:"request_id,omitempty"`
+}
+
+func (c *lockClient) Lock(remote string, lockReq *lockRequest) (*lockResponse, *http.Response, error) {
+	e := c.Endpoints.Endpoint("upload", remote)
+	req, err := c.NewRequest("POST", e, "locks", lockReq)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	res, err := c.DoWithAuth(remote, req)
+	if err != nil {
+		return nil, res, err
+	}
+
+	lockRes := &lockResponse{}
+	return lockRes, res, lfsapi.DecodeJSON(res, lockRes)
+}
+
+// UnlockRequest encapsulates the data sent in an API request to remove a lock.
+type unlockRequest struct {
+	// Force determines whether or not the lock should be "forcibly"
+	// unlocked; that is to say whether or not a given individual should be
+	// able to break a different individual's lock.
+	Force bool `json:"force"`
+}
+
+// UnlockResponse is the result sent back from the API when asked to remove a
+// lock.
+type unlockResponse struct {
+	// Lock is the lock corresponding to the asked-about lock in the
+	// `UnlockPayload` (see above). If no matching lock was found, this
+	// field will take the zero-value of Lock, and Err will be non-nil.
+	Lock *Lock `json:"lock"`
+
+	// Message is an optional field which holds any error that was experienced
+	// while removing the lock.
+	Message          string `json:"message,omitempty"`
+	DocumentationURL string `json:"documentation_url,omitempty"`
+	RequestID        string `json:"request_id,omitempty"`
+}
+
+func (c *lockClient) Unlock(remote, id string, force bool) (*unlockResponse, *http.Response, error) {
+	e := c.Endpoints.Endpoint("upload", remote)
+	suffix := fmt.Sprintf("locks/%s/unlock", id)
+	req, err := c.NewRequest("POST", e, suffix, &unlockRequest{Force: force})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	res, err := c.DoWithAuth(remote, req)
+	if err != nil {
+		return nil, res, err
+	}
+
+	unlockRes := &unlockResponse{}
+	err = lfsapi.DecodeJSON(res, unlockRes)
+	return unlockRes, res, err
+}
+
+// Filter represents a single qualifier to apply against a set of locks.
+type lockFilter struct {
+	// Property is the property to search against.
+	// Value is the value that the property must take.
+	Property, Value string
+}
+
+// LockSearchRequest encapsulates the request sent to the server when the client
+// would like a list of locks that match the given criteria.
+type lockSearchRequest struct {
+	// Filters is the set of filters to query against. If the client wishes
+	// to obtain a list of all locks, an empty array should be passed here.
+	Filters []lockFilter
+	// Cursor is an optional field used to tell the server which lock was
+	// seen last, if scanning through multiple pages of results.
+	//
+	// Servers must return a list of locks sorted in reverse chronological
+	// order, so the Cursor provides a consistent method of viewing all
+	// locks, even if more were created between two requests.
+	Cursor string
+	// Limit is the maximum number of locks to return in a single page.
+	Limit int
+}
+
+func (r *lockSearchRequest) QueryValues() map[string]string {
+	q := make(map[string]string)
+	for _, filter := range r.Filters {
+		q[filter.Property] = filter.Value
+	}
+
+	if len(r.Cursor) > 0 {
+		q["cursor"] = r.Cursor
+	}
+
+	if r.Limit > 0 {
+		q["limit"] = strconv.Itoa(r.Limit)
+	}
+
+	return q
+}
+
+// LockList encapsulates a set of Locks.
+type lockList struct {
+	// Locks is the set of locks returned back, typically matching the query
+	// parameters sent in the LockListRequest call. If no locks were matched
+	// from a given query, then `Locks` will be represented as an empty
+	// array.
+	Locks []Lock `json:"locks"`
+	// NextCursor returns the Id of the Lock the client should update its
+	// cursor to, if there are multiple pages of results for a particular
+	// `LockListRequest`.
+	NextCursor string `json:"next_cursor,omitempty"`
+	// Message populates any error that was encountered during the search. If no
+	// error was encountered and the operation was succesful, then a value
+	// of nil will be passed here.
+	Message          string `json:"message,omitempty"`
+	DocumentationURL string `json:"documentation_url,omitempty"`
+	RequestID        string `json:"request_id,omitempty"`
+}
+
+func (c *lockClient) Search(remote string, searchReq *lockSearchRequest) (*lockList, *http.Response, error) {
+	e := c.Endpoints.Endpoint("upload", remote)
+	req, err := c.NewRequest("GET", e, "locks", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	q := req.URL.Query()
+	for key, value := range searchReq.QueryValues() {
+		q.Add(key, value)
+	}
+	req.URL.RawQuery = q.Encode()
+
+	res, err := c.DoWithAuth(remote, req)
+	if err != nil {
+		return nil, res, err
+	}
+
+	locks := &lockList{}
+	if res.StatusCode == http.StatusOK {
+		err = lfsapi.DecodeJSON(res, locks)
+	}
+
+	return locks, res, err
+}
+
+// lockVerifiableRequest encapsulates the request sent to the server when the
+// client would like a list of locks to verify a Git push.
+type lockVerifiableRequest struct {
+	// Cursor is an optional field used to tell the server which lock was
+	// seen last, if scanning through multiple pages of results.
+	//
+	// Servers must return a list of locks sorted in reverse chronological
+	// order, so the Cursor provides a consistent method of viewing all
+	// locks, even if more were created between two requests.
+	Cursor string `json:"cursor,omitempty"`
+	// Limit is the maximum number of locks to return in a single page.
+	Limit int `json:"limit,omitempty"`
+}
+
+// lockVerifiableList encapsulates a set of Locks to verify a Git push.
+type lockVerifiableList struct {
+	// Ours is the set of locks returned back matching filenames that the user
+	// is allowed to edit.
+	Ours []Lock `json:"ours"`
+
+	// Their is the set of locks returned back matching filenames that the user
+	// is NOT allowed to edit. Any edits matching these files should reject
+	// the Git push.
+	Theirs []Lock `json:"theirs"`
+
+	// NextCursor returns the Id of the Lock the client should update its
+	// cursor to, if there are multiple pages of results for a particular
+	// `LockListRequest`.
+	NextCursor string `json:"next_cursor,omitempty"`
+	// Message populates any error that was encountered during the search. If no
+	// error was encountered and the operation was succesful, then a value
+	// of nil will be passed here.
+	Message          string `json:"message,omitempty"`
+	DocumentationURL string `json:"documentation_url,omitempty"`
+	RequestID        string `json:"request_id,omitempty"`
+}
+
+func (c *lockClient) SearchVerifiable(remote string, vreq *lockVerifiableRequest) (*lockVerifiableList, *http.Response, error) {
+	e := c.Endpoints.Endpoint("upload", remote)
+	req, err := c.NewRequest("POST", e, "locks/verify", vreq)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	res, err := c.DoWithAuth(remote, req)
+	if err != nil {
+		return nil, res, err
+	}
+
+	locks := &lockVerifiableList{}
+	if res.StatusCode == http.StatusOK {
+		err = lfsapi.DecodeJSON(res, locks)
+	}
+
+	return locks, res, err
+}
+
+// User represents the owner of a lock.
+type User struct {
+	// Name is the name of the individual who would like to obtain the
+	// lock, for instance: "Rick Sanchez".
+	Name string `json:"name"`
+}
+
+func NewUser(name string) *User {
+	return &User{Name: name}
+}
+
+// String implements the fmt.Stringer interface.
+func (u *User) String() string {
+	return u.Name
+}

--- a/locking/api_test.go
+++ b/locking/api_test.go
@@ -1,0 +1,271 @@
+package locking
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/git-lfs/git-lfs/lfsapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/xeipuuv/gojsonschema"
+)
+
+func TestAPILock(t *testing.T) {
+	require.NotNil(t, createReqSchema)
+	require.NotNil(t, createResSchema)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/locks" {
+			w.WriteHeader(404)
+			return
+		}
+
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, lfsapi.MediaType, r.Header.Get("Accept"))
+		assert.Equal(t, lfsapi.MediaType, r.Header.Get("Content-Type"))
+		assert.Equal(t, "18", r.Header.Get("Content-Length"))
+
+		reqLoader, body := gojsonschema.NewReaderLoader(r.Body)
+		lockReq := &lockRequest{}
+		err := json.NewDecoder(body).Decode(lockReq)
+		r.Body.Close()
+		assert.Nil(t, err)
+		assert.Equal(t, "request", lockReq.Path)
+		assertSchema(t, createReqSchema, reqLoader)
+
+		w.Header().Set("Content-Type", "application/json")
+		resLoader, resWriter := gojsonschema.NewWriterLoader(w)
+		err = json.NewEncoder(resWriter).Encode(&lockResponse{
+			Lock: &Lock{
+				Id:   "1",
+				Path: "response",
+			},
+		})
+		assert.Nil(t, err)
+		assertSchema(t, createResSchema, resLoader)
+	}))
+	defer srv.Close()
+
+	c, err := lfsapi.NewClient(nil, lfsapi.TestEnv(map[string]string{
+		"lfs.url": srv.URL + "/api",
+	}))
+	require.Nil(t, err)
+
+	lc := &lockClient{Client: c}
+	lockRes, res, err := lc.Lock("", &lockRequest{Path: "request"})
+	require.Nil(t, err)
+	assert.Equal(t, 200, res.StatusCode)
+	assert.Equal(t, "1", lockRes.Lock.Id)
+	assert.Equal(t, "response", lockRes.Lock.Path)
+}
+
+func TestAPIUnlock(t *testing.T) {
+	require.NotNil(t, delReqSchema)
+	require.NotNil(t, createResSchema)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/locks/123/unlock" {
+			w.WriteHeader(404)
+			return
+		}
+
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, lfsapi.MediaType, r.Header.Get("Accept"))
+		assert.Equal(t, lfsapi.MediaType, r.Header.Get("Content-Type"))
+
+		reqLoader, body := gojsonschema.NewReaderLoader(r.Body)
+		unlockReq := &unlockRequest{}
+		err := json.NewDecoder(body).Decode(unlockReq)
+		r.Body.Close()
+		assert.Nil(t, err)
+		assert.True(t, unlockReq.Force)
+		assertSchema(t, delReqSchema, reqLoader)
+
+		w.Header().Set("Content-Type", "application/json")
+		resLoader, resWriter := gojsonschema.NewWriterLoader(w)
+		err = json.NewEncoder(resWriter).Encode(&unlockResponse{
+			Lock: &Lock{
+				Id:   "123",
+				Path: "response",
+			},
+		})
+		assert.Nil(t, err)
+		assertSchema(t, createResSchema, resLoader)
+	}))
+	defer srv.Close()
+
+	c, err := lfsapi.NewClient(nil, lfsapi.TestEnv(map[string]string{
+		"lfs.url": srv.URL + "/api",
+	}))
+	require.Nil(t, err)
+
+	lc := &lockClient{Client: c}
+	unlockRes, res, err := lc.Unlock("", "123", true)
+	require.Nil(t, err)
+	assert.Equal(t, 200, res.StatusCode)
+	assert.Equal(t, "123", unlockRes.Lock.Id)
+	assert.Equal(t, "response", unlockRes.Lock.Path)
+}
+
+func TestAPISearch(t *testing.T) {
+	require.NotNil(t, listResSchema)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/locks" {
+			w.WriteHeader(404)
+			return
+		}
+
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, lfsapi.MediaType, r.Header.Get("Accept"))
+		assert.Equal(t, "", r.Header.Get("Content-Type"))
+
+		q := r.URL.Query()
+		assert.Equal(t, "A", q.Get("a"))
+		assert.Equal(t, "cursor", q.Get("cursor"))
+		assert.Equal(t, "5", q.Get("limit"))
+
+		w.Header().Set("Content-Type", "application/json")
+		resLoader, resWriter := gojsonschema.NewWriterLoader(w)
+		err := json.NewEncoder(resWriter).Encode(&lockList{
+			Locks: []Lock{
+				{Id: "1"},
+				{Id: "2"},
+			},
+		})
+		assert.Nil(t, err)
+		assertSchema(t, listResSchema, resLoader)
+	}))
+	defer srv.Close()
+
+	c, err := lfsapi.NewClient(nil, lfsapi.TestEnv(map[string]string{
+		"lfs.url": srv.URL + "/api",
+	}))
+	require.Nil(t, err)
+
+	lc := &lockClient{Client: c}
+	locks, res, err := lc.Search("", &lockSearchRequest{
+		Filters: []lockFilter{
+			{Property: "a", Value: "A"},
+		},
+		Cursor: "cursor",
+		Limit:  5,
+	})
+	require.Nil(t, err)
+	assert.Equal(t, 200, res.StatusCode)
+	assert.Equal(t, 2, len(locks.Locks))
+	assert.Equal(t, "1", locks.Locks[0].Id)
+	assert.Equal(t, "2", locks.Locks[1].Id)
+}
+
+func TestAPIVerifiableLocks(t *testing.T) {
+	require.NotNil(t, verifyResSchema)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/locks/verify" {
+			w.WriteHeader(404)
+			return
+		}
+
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, lfsapi.MediaType, r.Header.Get("Accept"))
+		assert.Equal(t, lfsapi.MediaType, r.Header.Get("Content-Type"))
+
+		body := lockVerifiableRequest{}
+		if assert.Nil(t, json.NewDecoder(r.Body).Decode(&body)) {
+			assert.Equal(t, "cursor", body.Cursor)
+			assert.Equal(t, 5, body.Limit)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		resLoader, resWriter := gojsonschema.NewWriterLoader(w)
+		err := json.NewEncoder(resWriter).Encode(&lockVerifiableList{
+			Ours: []Lock{
+				{Id: "1"},
+				{Id: "2"},
+			},
+			Theirs: []Lock{
+				{Id: "3"},
+			},
+		})
+		assert.Nil(t, err)
+		assertSchema(t, verifyResSchema, resLoader)
+	}))
+	defer srv.Close()
+
+	c, err := lfsapi.NewClient(nil, lfsapi.TestEnv(map[string]string{
+		"lfs.url": srv.URL + "/api",
+	}))
+	require.Nil(t, err)
+
+	lc := &lockClient{Client: c}
+	locks, res, err := lc.SearchVerifiable("", &lockVerifiableRequest{
+		Cursor: "cursor",
+		Limit:  5,
+	})
+	require.Nil(t, err)
+	assert.Equal(t, 200, res.StatusCode)
+	assert.Equal(t, 2, len(locks.Ours))
+	assert.Equal(t, "1", locks.Ours[0].Id)
+	assert.Equal(t, "2", locks.Ours[1].Id)
+	assert.Equal(t, 1, len(locks.Theirs))
+	assert.Equal(t, "3", locks.Theirs[0].Id)
+}
+
+var (
+	createReqSchema *sourcedSchema
+	createResSchema *sourcedSchema
+	delReqSchema    *sourcedSchema
+	listResSchema   *sourcedSchema
+	verifyResSchema *sourcedSchema
+)
+
+func init() {
+	wd, err := os.Getwd()
+	if err != nil {
+		fmt.Println("getwd error:", err)
+		return
+	}
+
+	createReqSchema = getSchema(wd, "schemas/http-lock-create-request-schema.json")
+	createResSchema = getSchema(wd, "schemas/http-lock-create-response-schema.json")
+	delReqSchema = getSchema(wd, "schemas/http-lock-delete-request-schema.json")
+	listResSchema = getSchema(wd, "schemas/http-lock-list-response-schema.json")
+	verifyResSchema = getSchema(wd, "schemas/http-lock-verify-response-schema.json")
+}
+
+type sourcedSchema struct {
+	Source string
+	*gojsonschema.Schema
+}
+
+func getSchema(wd, relpath string) *sourcedSchema {
+	abspath := filepath.ToSlash(filepath.Join(wd, relpath))
+	s, err := gojsonschema.NewSchema(gojsonschema.NewReferenceLoader(fmt.Sprintf("file:///%s", abspath)))
+	if err != nil {
+		fmt.Printf("schema load error for %q: %+v\n", relpath, err)
+	}
+	return &sourcedSchema{Source: relpath, Schema: s}
+}
+
+func assertSchema(t *testing.T, schema *sourcedSchema, dataLoader gojsonschema.JSONLoader) {
+	res, err := schema.Validate(dataLoader)
+	if assert.Nil(t, err) {
+		if res.Valid() {
+			return
+		}
+
+		resErrors := res.Errors()
+		valErrors := make([]string, 0, len(resErrors))
+		for _, resErr := range resErrors {
+			valErrors = append(valErrors, resErr.String())
+		}
+		t.Errorf("Schema: %s\n%s", schema.Source, strings.Join(valErrors, "\n"))
+	}
+}

--- a/locking/locks.go
+++ b/locking/locks.go
@@ -1,0 +1,377 @@
+package locking
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/git-lfs/git-lfs/errors"
+	"github.com/git-lfs/git-lfs/filepathfilter"
+	"github.com/git-lfs/git-lfs/lfsapi"
+	"github.com/git-lfs/git-lfs/tools"
+	"github.com/git-lfs/git-lfs/tools/kv"
+	"github.com/rubyist/tracerx"
+)
+
+var (
+	// ErrNoMatchingLocks is an error returned when no matching locks were
+	// able to be resolved
+	ErrNoMatchingLocks = errors.New("lfs: no matching locks found")
+	// ErrLockAmbiguous is an error returned when multiple matching locks
+	// were found
+	ErrLockAmbiguous = errors.New("lfs: multiple locks found; ambiguous")
+)
+
+type LockCacher interface {
+	Add(l Lock) error
+	RemoveByPath(filePath string) error
+	RemoveById(id string) error
+	Locks() []Lock
+	Clear()
+	Save() error
+}
+
+// Client is the main interface object for the locking package
+type Client struct {
+	Remote string
+	client *lockClient
+	cache  LockCacher
+
+	lockablePatterns []string
+	lockableFilter   *filepathfilter.Filter
+	lockableMutex    sync.Mutex
+
+	LocalWorkingDir          string
+	LocalGitDir              string
+	SetLockableFilesReadOnly bool
+}
+
+// NewClient creates a new locking client with the given configuration
+// You must call the returned object's `Close` method when you are finished with
+// it
+func NewClient(remote string, lfsClient *lfsapi.Client) (*Client, error) {
+	return &Client{
+		Remote: remote,
+		client: &lockClient{Client: lfsClient},
+		cache:  &nilLockCacher{},
+	}, nil
+}
+
+func (c *Client) SetupFileCache(path string) error {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return errors.Wrap(err, "init lock cache")
+	}
+
+	lockFile := path
+	if stat.IsDir() {
+		lockFile = filepath.Join(path, "lockcache.db")
+	}
+
+	cache, err := NewLockCache(lockFile)
+	if err != nil {
+		return errors.Wrap(err, "init lock cache")
+	}
+
+	c.cache = cache
+	return nil
+}
+
+// Close this client instance; must be called to dispose of resources
+func (c *Client) Close() error {
+	return c.cache.Save()
+}
+
+// LockFile attempts to lock a file on the current remote
+// path must be relative to the root of the repository
+// Returns the lock id if successful, or an error
+func (c *Client) LockFile(path string) (Lock, error) {
+	lockRes, _, err := c.client.Lock(c.Remote, &lockRequest{Path: path})
+	if err != nil {
+		return Lock{}, errors.Wrap(err, "api")
+	}
+
+	if len(lockRes.Message) > 0 {
+		return Lock{}, fmt.Errorf("Server unable to create lock: %s",
+			lfsapi.ClientErrorMessage(
+				lockRes.Message,
+				lockRes.DocumentationURL,
+				lockRes.RequestID,
+			))
+	}
+
+	lock := *lockRes.Lock
+	if err := c.cache.Add(lock); err != nil {
+		return Lock{}, errors.Wrap(err, "lock cache")
+	}
+
+	// Ensure writeable on return
+	if err := tools.SetFileWriteFlag(path, true); err != nil {
+		return Lock{}, err
+	}
+
+	return lock, nil
+}
+
+// UnlockFile attempts to unlock a file on the current remote
+// path must be relative to the root of the repository
+// Force causes the file to be unlocked from other users as well
+func (c *Client) UnlockFile(path string, force bool) error {
+	id, err := c.lockIdFromPath(path)
+	if err != nil {
+		return fmt.Errorf("Unable to get lock id: %v", err)
+	}
+
+	err = c.UnlockFileById(id, force)
+	if err != nil {
+		return err
+	}
+
+	// Make non-writeable if required
+	if c.SetLockableFilesReadOnly && c.IsFileLockable(path) {
+		return tools.SetFileWriteFlag(path, false)
+	}
+	return nil
+
+}
+
+// UnlockFileById attempts to unlock a lock with a given id on the current remote
+// Force causes the file to be unlocked from other users as well
+func (c *Client) UnlockFileById(id string, force bool) error {
+	unlockRes, _, err := c.client.Unlock(c.Remote, id, force)
+	if err != nil {
+		return errors.Wrap(err, "api")
+	}
+
+	if len(unlockRes.Message) > 0 {
+		return fmt.Errorf("Server unable to unlock: %s",
+			lfsapi.ClientErrorMessage(
+				unlockRes.Message,
+				unlockRes.DocumentationURL,
+				unlockRes.RequestID,
+			))
+	}
+
+	if err := c.cache.RemoveById(id); err != nil {
+		return fmt.Errorf("Error caching unlock information: %v", err)
+	}
+
+	return nil
+}
+
+// Lock is a record of a locked file
+type Lock struct {
+	// Id is the unique identifier corresponding to this particular Lock. It
+	// must be consistent with the local copy, and the server's copy.
+	Id string `json:"id"`
+	// Path is an absolute path to the file that is locked as a part of this
+	// lock.
+	Path string `json:"path"`
+	// Owner is the identity of the user that created this lock.
+	Owner *User `json:"owner,omitempty"`
+	// LockedAt is the time at which this lock was acquired.
+	LockedAt time.Time `json:"locked_at"`
+}
+
+// SearchLocks returns a channel of locks which match the given name/value filter
+// If limit > 0 then search stops at that number of locks
+// If localOnly = true, don't query the server & report only own local locks
+func (c *Client) SearchLocks(filter map[string]string, limit int, localOnly bool) ([]Lock, error) {
+	if localOnly {
+		return c.searchCachedLocks(filter, limit)
+	} else {
+		return c.searchRemoteLocks(filter, limit)
+	}
+}
+
+func (c *Client) VerifiableLocks(limit int) (ourLocks, theirLocks []Lock, err error) {
+	ourLocks = make([]Lock, 0, limit)
+	theirLocks = make([]Lock, 0, limit)
+	body := &lockVerifiableRequest{
+		Limit: limit,
+	}
+
+	for {
+		list, _, err := c.client.SearchVerifiable(c.Remote, body)
+		if err != nil {
+			return ourLocks, theirLocks, err
+		}
+
+		if list.Message != "" {
+			return ourLocks, theirLocks, fmt.Errorf("Server error searching locks: %s",
+				lfsapi.ClientErrorMessage(
+					list.Message,
+					list.DocumentationURL,
+					list.RequestID,
+				))
+		}
+
+		for _, l := range list.Ours {
+			ourLocks = append(ourLocks, l)
+			if limit > 0 && (len(ourLocks)+len(theirLocks)) >= limit {
+				return ourLocks, theirLocks, nil
+			}
+		}
+
+		for _, l := range list.Theirs {
+			theirLocks = append(theirLocks, l)
+			if limit > 0 && (len(ourLocks)+len(theirLocks)) >= limit {
+				return ourLocks, theirLocks, nil
+			}
+		}
+
+		if list.NextCursor != "" {
+			body.Cursor = list.NextCursor
+		} else {
+			break
+		}
+	}
+
+	return ourLocks, theirLocks, nil
+}
+
+func (c *Client) searchCachedLocks(filter map[string]string, limit int) ([]Lock, error) {
+	cachedlocks := c.cache.Locks()
+	path, filterByPath := filter["path"]
+	id, filterById := filter["id"]
+	lockCount := 0
+	locks := make([]Lock, 0, len(cachedlocks))
+	for _, l := range cachedlocks {
+		// Manually filter by Path/Id
+		if (filterByPath && path != l.Path) ||
+			(filterById && id != l.Id) {
+			continue
+		}
+		locks = append(locks, l)
+		lockCount++
+		if limit > 0 && lockCount >= limit {
+			break
+		}
+	}
+	return locks, nil
+}
+
+func (c *Client) searchRemoteLocks(filter map[string]string, limit int) ([]Lock, error) {
+	locks := make([]Lock, 0, limit)
+
+	apifilters := make([]lockFilter, 0, len(filter))
+	for k, v := range filter {
+		apifilters = append(apifilters, lockFilter{Property: k, Value: v})
+	}
+	query := &lockSearchRequest{Filters: apifilters}
+	for {
+		list, _, err := c.client.Search(c.Remote, query)
+		if err != nil {
+			return locks, errors.Wrap(err, "locking")
+		}
+
+		if list.Message != "" {
+			return locks, fmt.Errorf("Server error searching for locks: %s",
+				lfsapi.ClientErrorMessage(
+					list.Message,
+					list.DocumentationURL,
+					list.RequestID,
+				))
+		}
+
+		for _, l := range list.Locks {
+			locks = append(locks, l)
+			if limit > 0 && len(locks) >= limit {
+				// Exit outer loop too
+				return locks, nil
+			}
+		}
+
+		if list.NextCursor != "" {
+			query.Cursor = list.NextCursor
+		} else {
+			break
+		}
+	}
+
+	return locks, nil
+}
+
+// lockIdFromPath makes a call to the LFS API and resolves the ID for the locked
+// locked at the given path.
+//
+// If the API call failed, an error will be returned. If multiple locks matched
+// the given path (should not happen during real-world usage), an error will be
+// returnd. If no locks matched the given path, an error will be returned.
+//
+// If the API call is successful, and only one lock matches the given filepath,
+// then its ID will be returned, along with a value of "nil" for the error.
+func (c *Client) lockIdFromPath(path string) (string, error) {
+	list, _, err := c.client.Search(c.Remote, &lockSearchRequest{
+		Filters: []lockFilter{
+			{Property: "path", Value: path},
+		},
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	switch len(list.Locks) {
+	case 0:
+		return "", ErrNoMatchingLocks
+	case 1:
+		return list.Locks[0].Id, nil
+	default:
+		return "", ErrLockAmbiguous
+	}
+}
+
+// Fetch locked files for the current user and cache them locally
+// This can be used to sync up locked files when moving machines
+func (c *Client) refreshLockCache() error {
+	ourLocks, _, err := c.VerifiableLocks(0)
+	if err != nil {
+		return err
+	}
+
+	// We're going to overwrite the entire local cache
+	c.cache.Clear()
+	for _, l := range ourLocks {
+		c.cache.Add(l)
+	}
+
+	return nil
+}
+
+// IsFileLockedByCurrentCommitter returns whether a file is locked by the
+// current user, as cached locally
+func (c *Client) IsFileLockedByCurrentCommitter(path string) bool {
+	filter := map[string]string{"path": path}
+	locks, err := c.searchCachedLocks(filter, 1)
+	if err != nil {
+		tracerx.Printf("Error searching cached locks: %s\nForcing remote search", err)
+		locks, _ = c.searchRemoteLocks(filter, 1)
+	}
+	return len(locks) > 0
+}
+
+func init() {
+	kv.RegisterTypeForStorage(&Lock{})
+}
+
+type nilLockCacher struct{}
+
+func (c *nilLockCacher) Add(l Lock) error {
+	return nil
+}
+func (c *nilLockCacher) RemoveByPath(filePath string) error {
+	return nil
+}
+func (c *nilLockCacher) RemoveById(id string) error {
+	return nil
+}
+func (c *nilLockCacher) Locks() []Lock {
+	return nil
+}
+func (c *nilLockCacher) Clear() {}
+func (c *nilLockCacher) Save() error {
+	return nil
+}

--- a/locking/locks_test.go
+++ b/locking/locks_test.go
@@ -1,0 +1,152 @@
+package locking
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/git-lfs/git-lfs/lfsapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type LocksById []Lock
+
+func (a LocksById) Len() int           { return len(a) }
+func (a LocksById) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a LocksById) Less(i, j int) bool { return a[i].Id < a[j].Id }
+
+func TestRefreshCache(t *testing.T) {
+	var err error
+	tempDir, err := ioutil.TempDir("", "testCacheLock")
+	assert.Nil(t, err)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/locks/verify", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		err = json.NewEncoder(w).Encode(lockVerifiableList{
+			Theirs: []Lock{
+				Lock{Id: "99", Path: "folder/test3.dat", Owner: &User{Name: "Alice"}},
+				Lock{Id: "199", Path: "other/test1.dat", Owner: &User{Name: "Charles"}},
+			},
+			Ours: []Lock{
+				Lock{Id: "101", Path: "folder/test1.dat", Owner: &User{Name: "Fred"}},
+				Lock{Id: "102", Path: "folder/test2.dat", Owner: &User{Name: "Fred"}},
+				Lock{Id: "103", Path: "root.dat", Owner: &User{Name: "Fred"}},
+			},
+		})
+		assert.Nil(t, err)
+	}))
+
+	defer func() {
+		srv.Close()
+	}()
+
+	lfsclient, err := lfsapi.NewClient(nil, lfsapi.TestEnv(map[string]string{
+		"lfs.url":    srv.URL + "/api",
+		"user.name":  "Fred",
+		"user.email": "fred@bloggs.com",
+	}))
+	require.Nil(t, err)
+
+	client, err := NewClient("", lfsclient)
+	assert.Nil(t, err)
+	assert.Nil(t, client.SetupFileCache(tempDir))
+
+	// Should start with no cached items
+	locks, err := client.SearchLocks(nil, 0, true)
+	assert.Nil(t, err)
+	assert.Empty(t, locks)
+
+	// Should load from test data, just Fred's
+	err = client.refreshLockCache()
+	assert.Nil(t, err)
+
+	locks, err = client.SearchLocks(nil, 0, true)
+	assert.Nil(t, err)
+	// Need to include zero time in structure for equal to work
+	zeroTime := time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Sort locks for stable comparison
+	sort.Sort(LocksById(locks))
+	assert.Equal(t, []Lock{
+		Lock{Path: "folder/test1.dat", Id: "101", Owner: &User{Name: "Fred"}, LockedAt: zeroTime},
+		Lock{Path: "folder/test2.dat", Id: "102", Owner: &User{Name: "Fred"}, LockedAt: zeroTime},
+		Lock{Path: "root.dat", Id: "103", Owner: &User{Name: "Fred"}, LockedAt: zeroTime},
+	}, locks)
+}
+
+func TestGetVerifiableLocks(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/locks/verify", r.URL.Path)
+
+		body := lockVerifiableRequest{}
+		if assert.Nil(t, json.NewDecoder(r.Body).Decode(&body)) {
+			w.Header().Set("Content-Type", "application/json")
+			list := lockVerifiableList{}
+			if body.Cursor == "1" {
+				list.Ours = []Lock{
+					Lock{Path: "folder/1/test1.dat", Id: "111"},
+				}
+				list.Theirs = []Lock{
+					Lock{Path: "folder/1/test2.dat", Id: "112"},
+					Lock{Path: "folder/1/test3.dat", Id: "113"},
+				}
+			} else {
+				list.Ours = []Lock{
+					Lock{Path: "folder/0/test1.dat", Id: "101"},
+					Lock{Path: "folder/0/test2.dat", Id: "102"},
+				}
+				list.Theirs = []Lock{
+					Lock{Path: "folder/0/test3.dat", Id: "103"},
+				}
+				list.NextCursor = "1"
+			}
+
+			err := json.NewEncoder(w).Encode(&list)
+			assert.Nil(t, err)
+		} else {
+			w.WriteHeader(500)
+		}
+	}))
+
+	defer srv.Close()
+
+	lfsclient, err := lfsapi.NewClient(nil, lfsapi.TestEnv(map[string]string{
+		"lfs.url":    srv.URL + "/api",
+		"user.name":  "Fred",
+		"user.email": "fred@bloggs.com",
+	}))
+	require.Nil(t, err)
+
+	client, err := NewClient("", lfsclient)
+	assert.Nil(t, err)
+
+	ourLocks, theirLocks, err := client.VerifiableLocks(0)
+	assert.Nil(t, err)
+
+	// Need to include zero time in structure for equal to work
+	zeroTime := time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Sort locks for stable comparison
+	sort.Sort(LocksById(ourLocks))
+	assert.Equal(t, []Lock{
+		Lock{Path: "folder/0/test1.dat", Id: "101", LockedAt: zeroTime},
+		Lock{Path: "folder/0/test2.dat", Id: "102", LockedAt: zeroTime},
+		Lock{Path: "folder/1/test1.dat", Id: "111", LockedAt: zeroTime},
+	}, ourLocks)
+
+	sort.Sort(LocksById(theirLocks))
+	assert.Equal(t, []Lock{
+		Lock{Path: "folder/0/test3.dat", Id: "103", LockedAt: zeroTime},
+		Lock{Path: "folder/1/test2.dat", Id: "112", LockedAt: zeroTime},
+		Lock{Path: "folder/1/test3.dat", Id: "113", LockedAt: zeroTime},
+	}, theirLocks)
+}

--- a/locking/schemas/http-lock-create-request-schema.json
+++ b/locking/schemas/http-lock-create-request-schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "Git LFS HTTPS Lock Creation API Request",
+  "type": "object",
+  "properties": {
+    "path": {
+      "type": "string"
+    }
+  },
+  "required": ["path"]
+}

--- a/locking/schemas/http-lock-create-response-schema.json
+++ b/locking/schemas/http-lock-create-response-schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "Git LFS HTTPS Lock Creation API Response",
+  "type": "object",
+  "properties": {
+    "lock": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "locked_at": {
+          "type": "string"
+        },
+        "owner": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "required": ["id", "path"]
+    },
+    "message": {
+      "type": "string"
+    },
+    "request_id": {
+      "type": "string"
+    },
+    "documentation_url": {
+      "type": "string"
+    }
+  },
+  "required": ["lock"]
+}

--- a/locking/schemas/http-lock-delete-request-schema.json
+++ b/locking/schemas/http-lock-delete-request-schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "Git LFS HTTPS Lock Deletion API Request",
+  "type": "object",
+  "properties": {
+    "force": {
+      "type": "boolean"
+    }
+  }
+}

--- a/locking/schemas/http-lock-list-response-schema.json
+++ b/locking/schemas/http-lock-list-response-schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "Git LFS HTTPS Lock List API Response",
+  "type": "object",
+  "properties": {
+    "locks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "locked_at": {
+            "type": "string"
+          },
+          "owner": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "next_cursor": {
+      "type": "string"
+    }
+  },
+  "required": ["locks"]
+}

--- a/locking/schemas/http-lock-verify-response-schema.json
+++ b/locking/schemas/http-lock-verify-response-schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "Git LFS HTTPS Lock Verify API Response",
+  "type": "object",
+
+  "definitions": {
+    "lock": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "locked_at": {
+          "type": "string"
+        },
+        "owner": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "required": ["id", "path"]
+    }
+  },
+
+  "properties": {
+    "ours": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/lock"
+      }
+    },
+    "theirs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/lock"
+      }
+    },
+    "next_cursor": {
+      "type": "string"
+    }
+  },
+  "required": ["ours", "theirs"]
+}

--- a/test/cmd/lfstest-gitserver.go
+++ b/test/cmd/lfstest-gitserver.go
@@ -808,48 +808,56 @@ func redirect307Handler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(307)
 }
 
-type Committer struct {
-	Name  string `json:"name"`
-	Email string `json:"email"`
+type User struct {
+	Name string `json:"name"`
 }
 
 type Lock struct {
-	Id         string    `json:"id"`
-	Path       string    `json:"path"`
-	Committer  Committer `json:"committer"`
-	CommitSHA  string    `json:"commit_sha"`
-	LockedAt   time.Time `json:"locked_at"`
-	UnlockedAt time.Time `json:"unlocked_at,omitempty"`
+	Id       string    `json:"id"`
+	Path     string    `json:"path"`
+	Owner    User      `json:"owner"`
+	LockedAt time.Time `json:"locked_at"`
 }
 
 type LockRequest struct {
-	Path               string    `json:"path"`
-	LatestRemoteCommit string    `json:"latest_remote_commit"`
-	Committer          Committer `json:"committer"`
+	Path string `json:"path"`
 }
 
 type LockResponse struct {
-	Lock         *Lock  `json:"lock"`
-	CommitNeeded string `json:"commit_needed,omitempty"`
-	Err          string `json:"error,omitempty"`
+	Lock    *Lock  `json:"lock"`
+	Message string `json:"message,omitempty"`
 }
 
 type UnlockRequest struct {
-	Id    string `json:"id"`
-	Force bool   `json:"force"`
+	Force bool `json:"force"`
 }
 
 type UnlockResponse struct {
-	Lock *Lock  `json:"lock"`
-	Err  string `json:"error,omitempty"`
+	Lock    *Lock  `json:"lock"`
+	Message string `json:"message,omitempty"`
 }
 
 type LockList struct {
 	Locks      []Lock `json:"locks"`
 	NextCursor string `json:"next_cursor,omitempty"`
-	Err        string `json:"error,omitempty"`
+	Message    string `json:"message,omitempty"`
 }
 
+<<<<<<< HEAD
+=======
+type VerifiableLockRequest struct {
+	Cursor string `json:"cursor,omitempty"`
+	Limit  int    `json:"limit,omitempty"`
+}
+
+type VerifiableLockList struct {
+	Ours       []Lock `json:"ours"`
+	Theirs     []Lock `json:"theirs"`
+	NextCursor string `json:"next_cursor,omitempty"`
+	Message    string `json:"message,omitempty"`
+}
+
+>>>>>>> f8a50160... Merge branch 'master' into no-dwarf-tables
 var (
 	lmu   sync.RWMutex
 	locks = []Lock{}
@@ -877,7 +885,10 @@ func (c LocksByCreatedAt) Len() int           { return len(c) }
 func (c LocksByCreatedAt) Less(i, j int) bool { return c[i].LockedAt.Before(c[j].LockedAt) }
 func (c LocksByCreatedAt) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
 
-var lockRe = regexp.MustCompile(`/locks/?$`)
+var (
+	lockRe   = regexp.MustCompile(`/locks/?$`)
+	unlockRe = regexp.MustCompile(`locks/([^/]+)/unlock\z`)
+)
 
 func locksHandler(w http.ResponseWriter, r *http.Request) {
 	dec := json.NewDecoder(r.Body)
@@ -945,6 +956,12 @@ func locksHandler(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 
+<<<<<<< HEAD
+=======
+		if err != nil {
+			ll.Message = err.Error()
+		} else {
+>>>>>>> f8a50160... Merge branch 'master' into no-dwarf-tables
 			ll.Locks = locks
 
 			enc.Encode(ll)
@@ -952,7 +969,18 @@ func locksHandler(w http.ResponseWriter, r *http.Request) {
 	case "POST":
 		if strings.HasSuffix(r.URL.Path, "unlock") {
 			var unlockRequest UnlockRequest
+
+			var lockId string
+			if matches := unlockRe.FindStringSubmatch(r.URL.Path); len(matches) > 1 {
+				lockId = matches[1]
+			}
+
+			if len(lockId) == 0 {
+				enc.Encode(&UnlockResponse{Message: "Invalid lock"})
+			}
+
 			if err := dec.Decode(&unlockRequest); err != nil {
+<<<<<<< HEAD
 				enc.Encode(&UnlockResponse{
 					Err: err.Error(),
 				})
@@ -972,24 +1000,76 @@ func locksHandler(w http.ResponseWriter, r *http.Request) {
 				})
 
 				locks = append(locks[:lockIndex], locks[lockIndex+1:]...)
-			} else {
-				enc.Encode(&UnlockResponse{
-					Err: "unable to find lock",
-				})
+=======
+				enc.Encode(&UnlockResponse{Message: err.Error()})
+				return
 			}
+
+			if l := delLock(repo, lockId); l != nil {
+				enc.Encode(&UnlockResponse{Lock: l})
+>>>>>>> f8a50160... Merge branch 'master' into no-dwarf-tables
+			} else {
+				enc.Encode(&UnlockResponse{Message: "unable to find lock"})
+			}
+<<<<<<< HEAD
 		} else {
+=======
+			return
+		}
+
+		if strings.HasSuffix(r.URL.Path, "/locks/verify") {
+			switch repo {
+			case "pre_push_locks_verify_404":
+				w.WriteHeader(http.StatusNotFound)
+				w.Write([]byte(`{"message":"pre_push_locks_verify_404"}`))
+				return
+			case "pre_push_locks_verify_410":
+				w.WriteHeader(http.StatusGone)
+				w.Write([]byte(`{"message":"pre_push_locks_verify_410"}`))
+				return
+			}
+
+			reqBody := &VerifiableLockRequest{}
+			if err := dec.Decode(reqBody); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				enc.Encode(struct {
+					Message string `json:"message"`
+				}{"json decode error: " + err.Error()})
+				return
+			}
+
+			ll := &VerifiableLockList{}
+			locks, nextCursor, err := getFilteredLocks(repo, "",
+				reqBody.Cursor,
+				strconv.Itoa(reqBody.Limit))
+			if err != nil {
+				ll.Message = err.Error()
+			} else {
+				ll.NextCursor = nextCursor
+
+				for _, l := range locks {
+					if strings.Contains(l.Path, "theirs") {
+						ll.Theirs = append(ll.Theirs, l)
+					} else {
+						ll.Ours = append(ll.Ours, l)
+					}
+				}
+			}
+
+			enc.Encode(ll)
+			return
+		}
+
+		if strings.HasSuffix(r.URL.Path, "/locks") {
+>>>>>>> f8a50160... Merge branch 'master' into no-dwarf-tables
 			var lockRequest LockRequest
 			if err := dec.Decode(&lockRequest); err != nil {
-				enc.Encode(&LockResponse{
-					Err: err.Error(),
-				})
+				enc.Encode(&LockResponse{Message: err.Error()})
 			}
 
 			for _, l := range getLocks() {
 				if l.Path == lockRequest.Path {
-					enc.Encode(&LockResponse{
-						Err: "lock already created",
-					})
+					enc.Encode(&LockResponse{Message: "lock already created"})
 					return
 				}
 			}
@@ -998,11 +1078,10 @@ func locksHandler(w http.ResponseWriter, r *http.Request) {
 			rand.Read(id[:])
 
 			lock := &Lock{
-				Id:        fmt.Sprintf("%x", id[:]),
-				Path:      lockRequest.Path,
-				Committer: lockRequest.Committer,
-				CommitSHA: lockRequest.LatestRemoteCommit,
-				LockedAt:  time.Now(),
+				Id:       fmt.Sprintf("%x", id[:]),
+				Path:     lockRequest.Path,
+				Owner:    User{Name: "Git LFS Tests"},
+				LockedAt: time.Now(),
 			}
 
 			addLocks(*lock)

--- a/test/test-locks.sh
+++ b/test/test-locks.sh
@@ -16,6 +16,28 @@ begin_test "list a single lock"
   GITLFSLOCKSENABLED=1 git lfs locks --path "f.dat" | tee locks.log
   grep "1 lock(s) matched query" locks.log
   grep "f.dat" locks.log
+<<<<<<< HEAD
+=======
+  grep "Git LFS Tests" locks.log
+)
+end_test
+
+begin_test "list a single lock (--json)"
+(
+  set -e
+
+  reponame="locks_list_single_json"
+  setup_remote_repo_with_file "$reponame" "f_json.dat"
+
+  GITLFSLOCKSENABLED=1 git lfs lock "f_json.dat" | tee lock.log
+
+  id=$(grep -oh "\((.*)\)" lock.log | tr -d "()")
+  assert_server_lock "$reponame" "$id"
+
+  GITLFSLOCKSENABLED=1 git lfs locks --json --path "f_json.dat" | tee locks.log
+  grep "\"path\":\"f_json.dat\"" locks.log
+  grep "\"owner\":{\"name\":\"Git LFS Tests\"}" locks.log
+>>>>>>> f8a50160... Merge branch 'master' into no-dwarf-tables
 )
 end_test
 

--- a/test/test-track.sh
+++ b/test/test-track.sh
@@ -12,6 +12,13 @@ begin_test "track"
   cd track
   git init
 
+  echo "###############################################################################
+# Set default behavior to automatically normalize line endings.
+###############################################################################
+* text=auto
+
+#*.cs     diff=csharp" > .gitattributes
+
   # track *.jpg once
   git lfs track "*.jpg" | grep "Tracking \*.jpg"
   numjpg=$(grep "\*.jpg" .gitattributes | wc -l)
@@ -36,12 +43,18 @@ begin_test "track"
   echo "*.gif filter=lfs -text" > a/.gitattributes
   echo "*.png filter=lfs -text" > a/b/.gitattributes
 
-  out=$(git lfs track)
-  echo "$out" | grep "Listing tracked patterns"
-  echo "$out" | grep "*.mov ($(native_path_escaped ".git/info/attributes"))"
-  echo "$out" | grep "*.jpg (.gitattributes)"
-  echo "$out" | grep "*.gif ($(native_path_escaped "a/.gitattributes"))"
-  echo "$out" | grep "*.png ($(native_path_escaped "a/b/.gitattributes"))"
+  git lfs track | tee track.log
+  grep "Listing tracked patterns" track.log
+  grep "*.mov ($(native_path_escaped ".git/info/attributes"))" track.log
+  grep "*.jpg (.gitattributes)" track.log
+  grep "*.gif ($(native_path_escaped "a/.gitattributes"))" track.log
+  grep "*.png ($(native_path_escaped "a/b/.gitattributes"))" track.log
+
+  grep "Set default behavior" .gitattributes
+  grep "############" .gitattributes
+  grep "* text=auto" .gitattributes
+  grep "diff=csharp" .gitattributes
+  grep "*.jpg" .gitattributes
 )
 end_test
 
@@ -109,16 +122,76 @@ begin_test "track without trailing linebreak"
   mkdir no-linebreak
   cd no-linebreak
   git init
+
   printf "*.mov filter=lfs -text" > .gitattributes
+  [ "*.mov filter=lfs -text" = "$(cat .gitattributes)" ]
 
   git lfs track "*.gif"
+  expected="*.mov filter=lfs -text$(cat_end)
+*.gif filter=lfs diff=lfs merge=lfs -text$(cat_end)"
+  [ "$expected" = "$(cat -e .gitattributes)" ]
+)
+end_test
 
-  expected="*.mov filter=lfs -text
-*.gif filter=lfs diff=lfs merge=lfs -text"
+begin_test "track with existing crlf"
+(
+  set -e
 
-  if [ "$expected" != "$(cat .gitattributes)" ]; then
-    exit 1
-  fi
+  mkdir existing-crlf
+  cd existing-crlf
+  git init
+
+  git config core.autocrlf true
+  git lfs track "*.mov"
+  git lfs track "*.gif"
+  expected="*.mov filter=lfs diff=lfs merge=lfs -text^M$
+*.gif filter=lfs diff=lfs merge=lfs -text^M$"
+  [ "$expected" = "$(cat -e .gitattributes)" ]
+
+  git config core.autocrlf false
+  git lfs track "*.jpg"
+  expected="*.mov filter=lfs diff=lfs merge=lfs -text^M$
+*.gif filter=lfs diff=lfs merge=lfs -text^M$
+*.jpg filter=lfs diff=lfs merge=lfs -text^M$"
+  [ "$expected" = "$(cat -e .gitattributes)" ]
+)
+end_test
+
+begin_test "track with autocrlf=true"
+(
+  set -e
+
+  mkdir autocrlf-true
+  cd autocrlf-true
+  git init
+  git config core.autocrlf true
+
+  printf "*.mov filter=lfs -text" > .gitattributes
+  [ "*.mov filter=lfs -text" = "$(cat .gitattributes)" ]
+
+  git lfs track "*.gif"
+  expected="*.mov filter=lfs -text^M$
+*.gif filter=lfs diff=lfs merge=lfs -text^M$"
+  [ "$expected" = "$(cat -e .gitattributes)" ]
+)
+end_test
+
+begin_test "track with autocrlf=input"
+(
+  set -e
+
+  mkdir autocrlf-input
+  cd autocrlf-input
+  git init
+  git config core.autocrlf input
+
+  printf "*.mov filter=lfs -text" > .gitattributes
+  [ "*.mov filter=lfs -text" = "$(cat .gitattributes)" ]
+
+  git lfs track "*.gif"
+  expected="*.mov filter=lfs -text^M$
+*.gif filter=lfs diff=lfs merge=lfs -text^M$"
+  [ "$expected" = "$(cat -e .gitattributes)" ]
 )
 end_test
 
@@ -292,3 +365,98 @@ begin_test "track blocklisted files with glob"
   grep "Pattern .git\* matches forbidden file" track.log
 )
 end_test
+<<<<<<< HEAD
+=======
+
+begin_test "track lockable"
+(
+  set -e
+
+  repo="track_lockable"
+  mkdir "$repo"
+  cd "$repo"
+  git init
+
+  # track *.jpg once, lockable
+  git lfs track --lockable "*.jpg" | grep "Tracking \*.jpg"
+  assert_attributes_count "jpg" "lockable" 1
+  # track *.jpg again, don't change anything. Should retain lockable
+  git lfs track "*.jpg" | grep "*.jpg already supported"
+  assert_attributes_count "jpg" "lockable" 1
+
+
+  # track *.png once, not lockable yet
+  git lfs track "*.png" | grep "Tracking \*.png"
+  assert_attributes_count "png" "filter=lfs" 1
+  assert_attributes_count "png" "lockable" 0
+
+  # track png again, enable lockable, should replace
+  git lfs track --lockable "*.png" | grep "Tracking \*.png"
+  assert_attributes_count "png" "filter=lfs" 1
+  assert_attributes_count "png" "lockable" 1
+
+  # track png again, disable lockable, should replace
+  git lfs track --not-lockable "*.png" | grep "Tracking \*.png"
+  assert_attributes_count "png" "filter=lfs" 1
+  assert_attributes_count "png" "lockable" 0
+
+  # check output reflects lockable
+  out=$(git lfs track)
+  echo "$out" | grep "Listing tracked patterns"
+  echo "$out" | grep "*.jpg \[lockable\] (.gitattributes)"
+  echo "$out" | grep "*.png (.gitattributes)"
+)
+end_test
+
+begin_test "track lockable read-only/read-write"
+(
+  set -e
+
+  repo="track_lockable_ro_rw"
+  mkdir "$repo"
+  cd "$repo"
+  git init
+
+  echo "blah blah" > test.bin
+  echo "foo bar" > test.dat
+  mkdir subfolder
+  echo "sub blah blah" > subfolder/test.bin
+  echo "sub foo bar" > subfolder/test.dat
+  # should start writeable
+  [ -w test.bin ]
+  [ -w test.dat ]
+  [ -w subfolder/test.bin ]
+  [ -w subfolder/test.dat ]
+
+  # track *.bin, not lockable yet
+  git lfs track "*.bin" | grep "Tracking \*.bin"
+  # track *.dat, lockable immediately
+  git lfs track --lockable "*.dat" | grep "Tracking \*.dat"
+
+  # bin should remain writeable, dat should have been made read-only
+  [ -w test.bin ]
+  [ ! -w test.dat ]
+  [ -w subfolder/test.bin ]
+  [ ! -w subfolder/test.dat ]
+
+  git add .gitattributes test.bin test.dat
+  git commit -m "First commit"
+
+  # bin should still be writeable
+  [ -w test.bin ]
+  [ -w subfolder/test.bin ]
+  # now make bin lockable
+  git lfs track --lockable "*.bin" | grep "Tracking \*.bin"
+  # bin should now be read-only
+  [ ! -w test.bin ]
+  [ ! -w subfolder/test.bin ]
+
+  # remove lockable again
+  git lfs track --not-lockable "*.bin" | grep "Tracking \*.bin"
+  # bin should now be writeable again
+  [ -w test.bin ]
+  [ -w subfolder/test.bin ]
+
+)
+end_test
+>>>>>>> f8a50160... Merge branch 'master' into no-dwarf-tables

--- a/test/test-unlock.sh
+++ b/test/test-unlock.sh
@@ -14,7 +14,56 @@ begin_test "unlocking a lock by path"
   assert_server_lock $id
 
   GITLFSLOCKSENABLED=1 git lfs unlock "c.dat" 2>&1 | tee unlock.log
+<<<<<<< HEAD
   refute_server_lock $id
+=======
+  refute_server_lock "$reponame" "$id"
+)
+end_test
+
+begin_test "force unlocking lock with missing file"
+(
+  set -e
+
+  reponame="force-unlock-missing-file"
+  setup_remote_repo_with_file "$reponame" "a.dat"
+
+  GITLFSLOCKSENABLED=1 git lfs lock "a.dat" | tee lock.log
+  id=$(grep -oh "\((.*)\)" lock.log | tr -d "()")
+  assert_server_lock "$reponame" "$id"
+
+  git rm a.dat
+  git commit -m "a.dat"
+  rm *.log *.json # ensure clean git status
+  git status
+
+  GITLFSLOCKSENABLED=1 git lfs unlock "a.dat" 2>&1 | tee unlock.log
+  grep "Unable to determine path" unlock.log
+  assert_server_lock "$reponame" "$id"
+
+  rm unlock.log
+  GITLFSLOCKSENABLED=1 git lfs unlock --force "a.dat" 2>&1 | tee unlock.log
+  refute_server_lock "$reponame" "$id"
+)
+end_test
+
+begin_test "unlocking a lock (--json)"
+(
+  set -e
+
+  reponame="unlock_by_path_json"
+  setup_remote_repo_with_file "$reponame" "c_json.dat"
+
+  GITLFSLOCKSENABLED=1 git lfs lock "c_json.dat" | tee lock.log
+
+  id=$(grep -oh "\((.*)\)" lock.log | tr -d "()")
+  assert_server_lock "$reponame" "$id"
+
+  GITLFSLOCKSENABLED=1 git lfs unlock --json "c_json.dat" 2>&1 | tee unlock.log
+  grep "\"unlocked\":true" unlock.log
+
+  refute_server_lock "$reponame" "$id"
+>>>>>>> f8a50160... Merge branch 'master' into no-dwarf-tables
 )
 end_test
 
@@ -48,5 +97,85 @@ begin_test "unlocking a lock without sufficient info"
   GITLFSLOCKSENABLED=1 git lfs unlock 2>&1 | tee unlock.log
   grep "Usage: git lfs unlock" unlock.log
   assert_server_lock $id
+)
+end_test
+
+begin_test "unlocking a lock while uncommitted"
+(
+  set -e
+
+  reponame="unlock_modified"
+  setup_remote_repo_with_file "$reponame" "mod.dat"
+
+  GITLFSLOCKSENABLED=1 git lfs lock "mod.dat" | tee lock.log
+
+  id=$(grep -oh "\((.*)\)" lock.log | tr -d "()")
+  assert_server_lock "$reponame" "$id"
+
+  echo "\nSomething" >> mod.dat
+
+  GITLFSLOCKSENABLED=1 git lfs unlock "mod.dat" 2>&1 | tee unlock.log
+  [ ${PIPESTATUS[0]} -ne "0" ]
+
+  grep "Cannot unlock file with uncommitted changes" unlock.log
+
+  assert_server_lock "$reponame" "$id"
+
+  # should allow after discard
+  git checkout mod.dat
+  GITLFSLOCKSENABLED=1 git lfs unlock "mod.dat" 2>&1 | tee unlock.log
+  refute_server_lock "$reponame" "$id"
+)
+end_test
+
+begin_test "unlocking a lock while uncommitted with --force"
+(
+  set -e
+
+  reponame="unlock_modified_force"
+  setup_remote_repo_with_file "$reponame" "modforce.dat"
+
+  GITLFSLOCKSENABLED=1 git lfs lock "modforce.dat" | tee lock.log
+
+  id=$(grep -oh "\((.*)\)" lock.log | tr -d "()")
+  assert_server_lock "$reponame" "$id"
+
+  echo "\nSomething" >> modforce.dat
+
+  # should allow with --force
+  GITLFSLOCKSENABLED=1 git lfs unlock --force "modforce.dat" 2>&1 | tee unlock.log
+  grep "Warning: unlocking with uncommitted changes" unlock.log
+  refute_server_lock "$reponame" "$id"
+)
+end_test
+
+begin_test "unlocking a lock while untracked"
+(
+  set -e
+
+  reponame="unlock_untracked"
+  setup_remote_repo_with_file "$reponame" "notrelevant.dat"
+
+  git lfs track "*.dat"
+  # Create file but don't add it to git
+  # Shouldn't be able to unlock it
+  echo "something" > untracked.dat
+  GITLFSLOCKSENABLED=1 git lfs lock "untracked.dat" | tee lock.log
+
+  id=$(grep -oh "\((.*)\)" lock.log | tr -d "()")
+  assert_server_lock "$reponame" "$id"
+
+  GITLFSLOCKSENABLED=1 git lfs unlock "untracked.dat" 2>&1 | tee unlock.log
+  [ ${PIPESTATUS[0]} -ne "0" ]
+
+  grep "Cannot unlock file with uncommitted changes" unlock.log
+
+  assert_server_lock "$reponame" "$id"
+
+  # should allow after add/commit
+  git add untracked.dat
+  git commit -m "Added untracked"
+  GITLFSLOCKSENABLED=1 git lfs unlock "untracked.dat" 2>&1 | tee unlock.log
+  refute_server_lock "$reponame" "$id"
 )
 end_test

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -507,6 +507,14 @@ native_path_escaped() {
   escape_path "$unescaped"
 }
 
+cat_end() {
+  if [ $IS_WINDOWS -eq 1 ]; then
+    printf '^M$'
+  else
+    printf '$'
+  fi
+}
+
 # Compare 2 lists which are newline-delimited in a string, ignoring ordering and blank lines
 contains_same_elements() {
   # Remove blank lines then sort

--- a/tools/iotools.go
+++ b/tools/iotools.go
@@ -13,6 +13,7 @@ import (
 	"github.com/git-lfs/git-lfs/progress"
 )
 
+<<<<<<< HEAD
 type readSeekCloserWrapper struct {
 	readSeeker io.ReadSeeker
 }
@@ -35,6 +36,8 @@ func NewReadSeekCloserWrapper(r io.ReadSeeker) io.ReadCloser {
 	return &readSeekCloserWrapper{r}
 }
 
+=======
+>>>>>>> f8a50160... Merge branch 'master' into no-dwarf-tables
 const (
 	// memoryBufferLimit is the number of bytes to buffer in memory before
 	// spooling the contents of an `io.Reader` in `Spool()` to a temporary

--- a/tq/api_test.go
+++ b/tq/api_test.go
@@ -1,0 +1,188 @@
+package tq
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/git-lfs/git-lfs/lfsapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/xeipuuv/gojsonschema"
+)
+
+func TestAPIBatch(t *testing.T) {
+	require.NotNil(t, batchReqSchema, batchReqSchema.Source)
+	require.NotNil(t, batchResSchema, batchResSchema.Source)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/objects/batch" {
+			w.WriteHeader(404)
+			return
+		}
+
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "80", r.Header.Get("Content-Length"))
+
+		bodyLoader, body := gojsonschema.NewReaderLoader(r.Body)
+		bReq := &batchRequest{}
+		err := json.NewDecoder(body).Decode(bReq)
+		r.Body.Close()
+		assert.Nil(t, err)
+		assertSchema(t, batchReqSchema, bodyLoader)
+
+		assert.EqualValues(t, []string{"basic", "whatev"}, bReq.TransferAdapterNames)
+		if assert.Equal(t, 1, len(bReq.Objects)) {
+			assert.Equal(t, "a", bReq.Objects[0].Oid)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+
+		writeLoader, resWriter := gojsonschema.NewWriterLoader(w)
+		err = json.NewEncoder(resWriter).Encode(&BatchResponse{
+			TransferAdapterName: "basic",
+			Objects:             bReq.Objects,
+		})
+
+		assert.Nil(t, err)
+		assertSchema(t, batchResSchema, writeLoader)
+	}))
+	defer srv.Close()
+
+	c, err := lfsapi.NewClient(nil, lfsapi.TestEnv(map[string]string{
+		"lfs.url": srv.URL + "/api",
+	}))
+	require.Nil(t, err)
+
+	tqc := &tqClient{Client: c}
+	bReq := &batchRequest{
+		TransferAdapterNames: []string{"basic", "whatev"},
+		Objects: []*Transfer{
+			&Transfer{Oid: "a", Size: 1},
+		},
+	}
+	bRes, err := tqc.Batch("remote", bReq)
+	require.Nil(t, err)
+	assert.Equal(t, "basic", bRes.TransferAdapterName)
+	if assert.Equal(t, 1, len(bRes.Objects)) {
+		assert.Equal(t, "a", bRes.Objects[0].Oid)
+	}
+}
+
+func TestAPIBatchOnlyBasic(t *testing.T) {
+	require.NotNil(t, batchReqSchema, batchReqSchema.Source)
+	require.NotNil(t, batchResSchema, batchResSchema.Source)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/objects/batch" {
+			w.WriteHeader(404)
+			return
+		}
+
+		assert.Equal(t, "POST", r.Method)
+
+		bodyLoader, body := gojsonschema.NewReaderLoader(r.Body)
+		bReq := &batchRequest{}
+		err := json.NewDecoder(body).Decode(bReq)
+		r.Body.Close()
+		assert.Nil(t, err)
+		assertSchema(t, batchReqSchema, bodyLoader)
+
+		assert.Equal(t, 0, len(bReq.TransferAdapterNames))
+		if assert.Equal(t, 1, len(bReq.Objects)) {
+			assert.Equal(t, "a", bReq.Objects[0].Oid)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		writeLoader, resWriter := gojsonschema.NewWriterLoader(w)
+		err = json.NewEncoder(resWriter).Encode(&BatchResponse{
+			TransferAdapterName: "basic",
+			Objects:             make([]*Transfer, 0),
+		})
+
+		assert.Nil(t, err)
+		assertSchema(t, batchResSchema, writeLoader)
+	}))
+	defer srv.Close()
+
+	c, err := lfsapi.NewClient(nil, lfsapi.TestEnv(map[string]string{
+		"lfs.url": srv.URL + "/api",
+	}))
+	require.Nil(t, err)
+
+	tqc := &tqClient{Client: c}
+	bReq := &batchRequest{
+		TransferAdapterNames: []string{"basic"},
+		Objects: []*Transfer{
+			&Transfer{Oid: "a", Size: 1},
+		},
+	}
+	bRes, err := tqc.Batch("remote", bReq)
+	require.Nil(t, err)
+	assert.Equal(t, "basic", bRes.TransferAdapterName)
+}
+
+func TestAPIBatchEmptyObjects(t *testing.T) {
+	c, err := lfsapi.NewClient(nil, nil)
+	require.Nil(t, err)
+
+	tqc := &tqClient{Client: c}
+	bReq := &batchRequest{
+		TransferAdapterNames: []string{"basic", "whatev"},
+	}
+	bRes, err := tqc.Batch("remote", bReq)
+	require.Nil(t, err)
+	assert.Equal(t, "", bRes.TransferAdapterName)
+	assert.Equal(t, 0, len(bRes.Objects))
+}
+
+var (
+	batchReqSchema *sourcedSchema
+	batchResSchema *sourcedSchema
+)
+
+func init() {
+	wd, err := os.Getwd()
+	if err != nil {
+		fmt.Println("getwd error:", err)
+		return
+	}
+
+	batchReqSchema = getSchema(wd, "schemas/http-batch-request-schema.json")
+	batchResSchema = getSchema(wd, "schemas/http-batch-response-schema.json")
+}
+
+type sourcedSchema struct {
+	Source string
+	*gojsonschema.Schema
+}
+
+func getSchema(wd, relpath string) *sourcedSchema {
+	abspath := filepath.ToSlash(filepath.Join(wd, relpath))
+	s, err := gojsonschema.NewSchema(gojsonschema.NewReferenceLoader(fmt.Sprintf("file:///%s", abspath)))
+	if err != nil {
+		fmt.Printf("schema load error for %q: %+v\n", relpath, err)
+	}
+	return &sourcedSchema{Source: relpath, Schema: s}
+}
+
+func assertSchema(t *testing.T, schema *sourcedSchema, dataLoader gojsonschema.JSONLoader) {
+	res, err := schema.Validate(dataLoader)
+	if assert.Nil(t, err) {
+		if res.Valid() {
+			return
+		}
+
+		resErrors := res.Errors()
+		valErrors := make([]string, 0, len(resErrors))
+		for _, resErr := range resErrors {
+			valErrors = append(valErrors, resErr.String())
+		}
+		t.Errorf("Schema: %s\n%s", schema.Source, strings.Join(valErrors, "\n"))
+	}
+}

--- a/tq/schemas/http-batch-request-schema.json
+++ b/tq/schemas/http-batch-request-schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "Git LFS HTTPS Batch API Request",
+  "type": "object",
+  "properties": {
+    "transfers": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "operation": {
+      "type": "string"
+    },
+    "objects": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "oid": {
+            "type": "string"
+          },
+          "size": {
+            "type": "number",
+            "minimum": 0
+          },
+          "authenticated": {
+            "type": "boolean"
+          }
+        },
+        "required": ["oid", "size"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["objects", "operation"]
+}

--- a/tq/schemas/http-batch-response-schema.json
+++ b/tq/schemas/http-batch-response-schema.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "Git LFS HTTPS Batch API Response",
+  "type": "object",
+
+  "definitions": {
+    "action": {
+      "type": "object",
+      "properties": {
+        "href": {
+          "type": "string"
+        },
+        "header": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "expires_at": {
+          "type": "string"
+        }
+      },
+      "required": ["href"],
+      "additionalProperties": false
+    }
+  },
+
+  "properties": {
+    "transfer": {
+      "type": "string"
+    },
+    "objects": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "oid": {
+            "type": "string"
+          },
+          "size": {
+            "type": "number",
+            "minimum": 0
+          },
+          "authenticated": {
+            "type": "boolean"
+          },
+          "actions": {
+            "type": "object",
+            "properties": {
+              "download": { "$ref": "#/definitions/action" },
+              "upload": { "$ref": "#/definitions/action" },
+              "verify": { "$ref": "#/definitions/action" }
+            },
+            "additionalProperties": false
+          },
+          "error": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "number"
+              },
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": ["code", "message"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["oid", "size"],
+        "additionalProperties": false
+      }
+    },
+    "message": {
+      "type": "string"
+    },
+    "request_id": {
+      "type": "string"
+    },
+    "documentation_url": {
+      "type": "string"
+    }
+  },
+  "required": ["objects"]
+}

--- a/vendor/github.com/xeipuuv/gojsonschema/README.md
+++ b/vendor/github.com/xeipuuv/gojsonschema/README.md
@@ -197,9 +197,9 @@ Note: An error of RequiredType has an err.Type() return value of "required"
 
 **err.Details()**: *gojsonschema.ErrorDetails* Returns a map[string]interface{} of additional error details specific to the error. For example, GTE errors will have a "min" value, LTE will have a "max" value. See errors.go for a full description of all the error details. Every error always contains a "field" key that holds the value of *err.Field()*
 
-Note in most cases, the err.Details() will be used to generate replacement strings in your locales. and not used directly i.e.
+Note in most cases, the err.Details() will be used to generate replacement strings in your locales, and not used directly. These strings follow the text/template format i.e.
 ```
-%field% must be greater than or equal to %min%
+{{.field}} must be greater than or equal to {{.min}}
 ```
 
 ## Formats

--- a/vendor/github.com/xeipuuv/gojsonschema/errors.go
+++ b/vendor/github.com/xeipuuv/gojsonschema/errors.go
@@ -1,9 +1,19 @@
 package gojsonschema
 
 import (
-	"fmt"
-	"strings"
+	"bytes"
+	"sync"
+	"text/template"
 )
+
+var errorTemplates errorTemplate = errorTemplate{template.New("errors-new"),sync.RWMutex{}}
+
+// template.Template is not thread-safe for writing, so some locking is done
+// sync.RWMutex is used for efficiently locking when new templates are created
+type errorTemplate struct {
+	*template.Template
+	sync.RWMutex
+}
 
 type (
 	// RequiredError. ErrorDetails: property string
@@ -230,13 +240,35 @@ func newError(err ResultError, context *jsonContext, value interface{}, locale l
 	err.SetDescription(formatErrorDescription(d, details))
 }
 
-// formatErrorDescription takes a string in this format: %field% is required
-// and converts it to a string with replacements. The fields come from
-// the ErrorDetails struct and vary for each type of error.
+// formatErrorDescription takes a string in the default text/template
+// format and converts it to a string with replacements. The fields come
+// from the ErrorDetails struct and vary for each type of error.
 func formatErrorDescription(s string, details ErrorDetails) string {
-	for name, val := range details {
-		s = strings.Replace(s, "%"+strings.ToLower(name)+"%", fmt.Sprintf("%v", val), -1)
+
+	var tpl *template.Template
+	var descrAsBuffer bytes.Buffer
+	var err error
+
+	errorTemplates.RLock()
+	tpl = errorTemplates.Lookup(s)
+	errorTemplates.RUnlock()
+
+	if tpl == nil {
+		errorTemplates.Lock()
+		tpl = errorTemplates.New(s)
+
+		tpl, err = tpl.Parse(s)
+		errorTemplates.Unlock()
+
+		if err != nil {
+			return err.Error()
+		}
 	}
 
-	return s
+	err = tpl.Execute(&descrAsBuffer, details)
+	if err != nil {
+		return err.Error()
+	}
+
+	return descrAsBuffer.String()
 }

--- a/vendor/github.com/xeipuuv/gojsonschema/format_checkers.go
+++ b/vendor/github.com/xeipuuv/gojsonschema/format_checkers.go
@@ -60,6 +60,9 @@ type (
 
 	// UUIDFormatChecker validates a UUID is in the correct format
 	UUIDFormatChecker struct{}
+
+	// RegexFormatChecker validates a regex is in the correct format
+	RegexFormatChecker struct{}
 )
 
 var (
@@ -74,6 +77,7 @@ var (
 			"ipv6":      IPV6FormatChecker{},
 			"uri":       URIFormatChecker{},
 			"uuid":      UUIDFormatChecker{},
+			"regex":     RegexFormatChecker{},
 		},
 	}
 
@@ -175,4 +179,16 @@ func (f HostnameFormatChecker) IsFormat(input string) bool {
 
 func (f UUIDFormatChecker) IsFormat(input string) bool {
 	return rxUUID.MatchString(input)
+}
+
+// IsFormat implements FormatChecker interface.
+func (f RegexFormatChecker) IsFormat(input string) bool {
+	if input == "" {
+		return true
+	}
+	_, err := regexp.Compile(input)
+	if err != nil {
+		return false
+	}
+	return true
 }

--- a/vendor/github.com/xeipuuv/gojsonschema/jsonLoader.go
+++ b/vendor/github.com/xeipuuv/gojsonschema/jsonLoader.go
@@ -46,9 +46,35 @@ var osFS = osFileSystem(os.Open)
 // JSON loader interface
 
 type JSONLoader interface {
-	jsonSource() interface{}
-	loadJSON() (interface{}, error)
-	loadSchema() (*Schema, error)
+	JsonSource() interface{}
+	LoadJSON() (interface{}, error)
+	JsonReference() (gojsonreference.JsonReference, error)
+	LoaderFactory() JSONLoaderFactory
+}
+
+type JSONLoaderFactory interface {
+	New(source string) JSONLoader
+}
+
+type DefaultJSONLoaderFactory struct {
+}
+
+type FileSystemJSONLoaderFactory struct {
+	fs http.FileSystem
+}
+
+func (d DefaultJSONLoaderFactory) New(source string) JSONLoader {
+	return &jsonReferenceLoader{
+		fs:     osFS,
+		source: source,
+	}
+}
+
+func (f FileSystemJSONLoaderFactory) New(source string) JSONLoader {
+	return &jsonReferenceLoader{
+		fs:     f.fs,
+		source: source,
+	}
 }
 
 // osFileSystem is a functional wrapper for os.Open that implements http.FileSystem.
@@ -66,8 +92,18 @@ type jsonReferenceLoader struct {
 	source string
 }
 
-func (l *jsonReferenceLoader) jsonSource() interface{} {
+func (l *jsonReferenceLoader) JsonSource() interface{} {
 	return l.source
+}
+
+func (l *jsonReferenceLoader) JsonReference() (gojsonreference.JsonReference, error) {
+	return gojsonreference.NewJsonReference(l.JsonSource().(string))
+}
+
+func (l *jsonReferenceLoader) LoaderFactory() JSONLoaderFactory {
+	return &FileSystemJSONLoaderFactory{
+		fs: l.fs,
+	}
 }
 
 // NewReferenceLoader returns a JSON reference loader using the given source and the local OS file system.
@@ -86,11 +122,11 @@ func NewReferenceLoaderFileSystem(source string, fs http.FileSystem) *jsonRefere
 	}
 }
 
-func (l *jsonReferenceLoader) loadJSON() (interface{}, error) {
+func (l *jsonReferenceLoader) LoadJSON() (interface{}, error) {
 
 	var err error
 
-	reference, err := gojsonreference.NewJsonReference(l.jsonSource().(string))
+	reference, err := gojsonreference.NewJsonReference(l.JsonSource().(string))
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +138,7 @@ func (l *jsonReferenceLoader) loadJSON() (interface{}, error) {
 
 	if reference.HasFileScheme {
 
-		filename := strings.Replace(refToUrl.String(), "file://", "", -1)
+		filename := strings.Replace(refToUrl.GetUrl().Path, "file://", "", -1)
 		if runtime.GOOS == "windows" {
 			// on Windows, a file URL may have an extra leading slash, use slashes
 			// instead of backslashes, and have spaces escaped
@@ -110,7 +146,6 @@ func (l *jsonReferenceLoader) loadJSON() (interface{}, error) {
 				filename = filename[1:]
 			}
 			filename = filepath.FromSlash(filename)
-			filename = strings.Replace(filename, "%20", " ", -1)
 		}
 
 		document, err = l.loadFromFile(filename)
@@ -128,33 +163,6 @@ func (l *jsonReferenceLoader) loadJSON() (interface{}, error) {
 	}
 
 	return document, nil
-
-}
-
-func (l *jsonReferenceLoader) loadSchema() (*Schema, error) {
-
-	var err error
-
-	d := Schema{}
-	d.pool = newSchemaPool(l.fs)
-	d.referencePool = newSchemaReferencePool()
-
-	d.documentReference, err = gojsonreference.NewJsonReference(l.jsonSource().(string))
-	if err != nil {
-		return nil, err
-	}
-
-	spd, err := d.pool.GetDocument(d.documentReference)
-	if err != nil {
-		return nil, err
-	}
-
-	err = d.parse(spd.Document)
-	if err != nil {
-		return nil, err
-	}
-
-	return &d, nil
 
 }
 
@@ -201,45 +209,52 @@ type jsonStringLoader struct {
 	source string
 }
 
-func (l *jsonStringLoader) jsonSource() interface{} {
+func (l *jsonStringLoader) JsonSource() interface{} {
 	return l.source
+}
+
+func (l *jsonStringLoader) JsonReference() (gojsonreference.JsonReference, error) {
+	return gojsonreference.NewJsonReference("#")
+}
+
+func (l *jsonStringLoader) LoaderFactory() JSONLoaderFactory {
+	return &DefaultJSONLoaderFactory{}
 }
 
 func NewStringLoader(source string) *jsonStringLoader {
 	return &jsonStringLoader{source: source}
 }
 
-func (l *jsonStringLoader) loadJSON() (interface{}, error) {
+func (l *jsonStringLoader) LoadJSON() (interface{}, error) {
 
-	return decodeJsonUsingNumber(strings.NewReader(l.jsonSource().(string)))
+	return decodeJsonUsingNumber(strings.NewReader(l.JsonSource().(string)))
 
 }
 
-func (l *jsonStringLoader) loadSchema() (*Schema, error) {
+// JSON bytes loader
 
-	var err error
+type jsonBytesLoader struct {
+	source []byte
+}
 
-	document, err := l.loadJSON()
-	if err != nil {
-		return nil, err
-	}
+func (l *jsonBytesLoader) JsonSource() interface{} {
+	return l.source
+}
 
-	d := Schema{}
-	d.pool = newSchemaPool(osFS)
-	d.referencePool = newSchemaReferencePool()
-	d.documentReference, err = gojsonreference.NewJsonReference("#")
-	d.pool.SetStandaloneDocument(document)
-	if err != nil {
-		return nil, err
-	}
+func (l *jsonBytesLoader) JsonReference() (gojsonreference.JsonReference, error) {
+	return gojsonreference.NewJsonReference("#")
+}
 
-	err = d.parse(document)
-	if err != nil {
-		return nil, err
-	}
+func (l *jsonBytesLoader) LoaderFactory() JSONLoaderFactory {
+	return &DefaultJSONLoaderFactory{}
+}
 
-	return &d, nil
+func NewBytesLoader(source []byte) *jsonBytesLoader {
+	return &jsonBytesLoader{source: source}
+}
 
+func (l *jsonBytesLoader) LoadJSON() (interface{}, error) {
+	return decodeJsonUsingNumber(bytes.NewReader(l.JsonSource().([]byte)))
 }
 
 // JSON Go (types) loader
@@ -249,19 +264,27 @@ type jsonGoLoader struct {
 	source interface{}
 }
 
-func (l *jsonGoLoader) jsonSource() interface{} {
+func (l *jsonGoLoader) JsonSource() interface{} {
 	return l.source
+}
+
+func (l *jsonGoLoader) JsonReference() (gojsonreference.JsonReference, error) {
+	return gojsonreference.NewJsonReference("#")
+}
+
+func (l *jsonGoLoader) LoaderFactory() JSONLoaderFactory {
+	return &DefaultJSONLoaderFactory{}
 }
 
 func NewGoLoader(source interface{}) *jsonGoLoader {
 	return &jsonGoLoader{source: source}
 }
 
-func (l *jsonGoLoader) loadJSON() (interface{}, error) {
+func (l *jsonGoLoader) LoadJSON() (interface{}, error) {
 
 	// convert it to a compliant JSON first to avoid types "mismatches"
 
-	jsonBytes, err := json.Marshal(l.jsonSource())
+	jsonBytes, err := json.Marshal(l.JsonSource())
 	if err != nil {
 		return nil, err
 	}
@@ -270,31 +293,34 @@ func (l *jsonGoLoader) loadJSON() (interface{}, error) {
 
 }
 
-func (l *jsonGoLoader) loadSchema() (*Schema, error) {
+type jsonIOLoader struct {
+	buf *bytes.Buffer
+}
 
-	var err error
+func NewReaderLoader(source io.Reader) (*jsonIOLoader, io.Reader) {
+	buf := &bytes.Buffer{}
+	return &jsonIOLoader{buf: buf}, io.TeeReader(source, buf)
+}
 
-	document, err := l.loadJSON()
-	if err != nil {
-		return nil, err
-	}
+func NewWriterLoader(source io.Writer) (*jsonIOLoader, io.Writer) {
+	buf := &bytes.Buffer{}
+	return &jsonIOLoader{buf: buf}, io.MultiWriter(source, buf)
+}
 
-	d := Schema{}
-	d.pool = newSchemaPool(osFS)
-	d.referencePool = newSchemaReferencePool()
-	d.documentReference, err = gojsonreference.NewJsonReference("#")
-	d.pool.SetStandaloneDocument(document)
-	if err != nil {
-		return nil, err
-	}
+func (l *jsonIOLoader) JsonSource() interface{} {
+	return l.buf.String()
+}
 
-	err = d.parse(document)
-	if err != nil {
-		return nil, err
-	}
+func (l *jsonIOLoader) LoadJSON() (interface{}, error) {
+	return decodeJsonUsingNumber(l.buf)
+}
 
-	return &d, nil
+func (l *jsonIOLoader) JsonReference() (gojsonreference.JsonReference, error) {
+	return gojsonreference.NewJsonReference("#")
+}
 
+func (l *jsonIOLoader) LoaderFactory() JSONLoaderFactory {
+	return &DefaultJSONLoaderFactory{}
 }
 
 func decodeJsonUsingNumber(r io.Reader) (interface{}, error) {

--- a/vendor/github.com/xeipuuv/gojsonschema/locales.go
+++ b/vendor/github.com/xeipuuv/gojsonschema/locales.go
@@ -37,6 +37,7 @@ type (
 		MissingDependency() string
 		Internal() string
 		Enum() string
+		ArrayNotEnoughItems() string
 		ArrayNoAdditionalItems() string
 		ArrayMinItems() string
 		ArrayMaxItems() string
@@ -83,11 +84,11 @@ type (
 )
 
 func (l DefaultLocale) Required() string {
-	return `%property% is required`
+	return `{{.property}} is required`
 }
 
 func (l DefaultLocale) InvalidType() string {
-	return `Invalid type. Expected: %expected%, given: %given%`
+	return `Invalid type. Expected: {{.expected}}, given: {{.given}}`
 }
 
 func (l DefaultLocale) NumberAnyOf() string {
@@ -107,157 +108,161 @@ func (l DefaultLocale) NumberNot() string {
 }
 
 func (l DefaultLocale) MissingDependency() string {
-	return `Has a dependency on %dependency%`
+	return `Has a dependency on {{.dependency}}`
 }
 
 func (l DefaultLocale) Internal() string {
-	return `Internal Error %error%`
+	return `Internal Error {{.error}}`
 }
 
 func (l DefaultLocale) Enum() string {
-	return `%field% must be one of the following: %allowed%`
+	return `{{.field}} must be one of the following: {{.allowed}}`
 }
 
 func (l DefaultLocale) ArrayNoAdditionalItems() string {
 	return `No additional items allowed on array`
 }
 
+func (l DefaultLocale) ArrayNotEnoughItems() string {
+	return `Not enough items on array to match positional list of schema`
+}
+
 func (l DefaultLocale) ArrayMinItems() string {
-	return `Array must have at least %min% items`
+	return `Array must have at least {{.min}} items`
 }
 
 func (l DefaultLocale) ArrayMaxItems() string {
-	return `Array must have at most %max% items`
+	return `Array must have at most {{.max}} items`
 }
 
 func (l DefaultLocale) Unique() string {
-	return `%type% items must be unique`
+	return `{{.type}} items must be unique`
 }
 
 func (l DefaultLocale) ArrayMinProperties() string {
-	return `Must have at least %min% properties`
+	return `Must have at least {{.min}} properties`
 }
 
 func (l DefaultLocale) ArrayMaxProperties() string {
-	return `Must have at most %max% properties`
+	return `Must have at most {{.max}} properties`
 }
 
 func (l DefaultLocale) AdditionalPropertyNotAllowed() string {
-	return `Additional property %property% is not allowed`
+	return `Additional property {{.property}} is not allowed`
 }
 
 func (l DefaultLocale) InvalidPropertyPattern() string {
-	return `Property "%property%" does not match pattern %pattern%`
+	return `Property "{{.property}}" does not match pattern {{.pattern}}`
 }
 
 func (l DefaultLocale) StringGTE() string {
-	return `String length must be greater than or equal to %min%`
+	return `String length must be greater than or equal to {{.min}}`
 }
 
 func (l DefaultLocale) StringLTE() string {
-	return `String length must be less than or equal to %max%`
+	return `String length must be less than or equal to {{.max}}`
 }
 
 func (l DefaultLocale) DoesNotMatchPattern() string {
-	return `Does not match pattern '%pattern%'`
+	return `Does not match pattern '{{.pattern}}'`
 }
 
 func (l DefaultLocale) DoesNotMatchFormat() string {
-	return `Does not match format '%format%'`
+	return `Does not match format '{{.format}}'`
 }
 
 func (l DefaultLocale) MultipleOf() string {
-	return `Must be a multiple of %multiple%`
+	return `Must be a multiple of {{.multiple}}`
 }
 
 func (l DefaultLocale) NumberGTE() string {
-	return `Must be greater than or equal to %min%`
+	return `Must be greater than or equal to {{.min}}`
 }
 
 func (l DefaultLocale) NumberGT() string {
-	return `Must be greater than %min%`
+	return `Must be greater than {{.min}}`
 }
 
 func (l DefaultLocale) NumberLTE() string {
-	return `Must be less than or equal to %max%`
+	return `Must be less than or equal to {{.max}}`
 }
 
 func (l DefaultLocale) NumberLT() string {
-	return `Must be less than %max%`
+	return `Must be less than {{.max}}`
 }
 
 // Schema validators
 func (l DefaultLocale) RegexPattern() string {
-	return `Invalid regex pattern '%pattern%'`
+	return `Invalid regex pattern '{{.pattern}}'`
 }
 
 func (l DefaultLocale) GreaterThanZero() string {
-	return `%number% must be strictly greater than 0`
+	return `{{.number}} must be strictly greater than 0`
 }
 
 func (l DefaultLocale) MustBeOfA() string {
-	return `%x% must be of a %y%`
+	return `{{.x}} must be of a {{.y}}`
 }
 
 func (l DefaultLocale) MustBeOfAn() string {
-	return `%x% must be of an %y%`
+	return `{{.x}} must be of an {{.y}}`
 }
 
 func (l DefaultLocale) CannotBeUsedWithout() string {
-	return `%x% cannot be used without %y%`
+	return `{{.x}} cannot be used without {{.y}}`
 }
 
 func (l DefaultLocale) CannotBeGT() string {
-	return `%x% cannot be greater than %y%`
+	return `{{.x}} cannot be greater than {{.y}}`
 }
 
 func (l DefaultLocale) MustBeOfType() string {
-	return `%key% must be of type %type%`
+	return `{{.key}} must be of type {{.type}}`
 }
 
 func (l DefaultLocale) MustBeValidRegex() string {
-	return `%key% must be a valid regex`
+	return `{{.key}} must be a valid regex`
 }
 
 func (l DefaultLocale) MustBeValidFormat() string {
-	return `%key% must be a valid format %given%`
+	return `{{.key}} must be a valid format {{.given}}`
 }
 
 func (l DefaultLocale) MustBeGTEZero() string {
-	return `%key% must be greater than or equal to 0`
+	return `{{.key}} must be greater than or equal to 0`
 }
 
 func (l DefaultLocale) KeyCannotBeGreaterThan() string {
-	return `%key% cannot be greater than %y%`
+	return `{{.key}} cannot be greater than {{.y}}`
 }
 
 func (l DefaultLocale) KeyItemsMustBeOfType() string {
-	return `%key% items must be %type%`
+	return `{{.key}} items must be {{.type}}`
 }
 
 func (l DefaultLocale) KeyItemsMustBeUnique() string {
-	return `%key% items must be unique`
+	return `{{.key}} items must be unique`
 }
 
 func (l DefaultLocale) ReferenceMustBeCanonical() string {
-	return `Reference %reference% must be canonical`
+	return `Reference {{.reference}} must be canonical`
 }
 
 func (l DefaultLocale) NotAValidType() string {
-	return `%type% is not a valid type -- `
+	return `{{.type}} is not a valid type -- `
 }
 
 func (l DefaultLocale) Duplicated() string {
-	return `%type% type is duplicated`
+	return `{{.type}} type is duplicated`
 }
 
 func (l DefaultLocale) httpBadStatus() string {
-	return `Could not read schema from HTTP, response status is %status%`
+	return `Could not read schema from HTTP, response status is {{.status}}`
 }
 
 // Replacement options: field, description, context, value
 func (l DefaultLocale) ErrorFormat() string {
-	return `%field%: %description%`
+	return `{{.field}}: {{.description}}`
 }
 
 const (

--- a/vendor/github.com/xeipuuv/gojsonschema/result.go
+++ b/vendor/github.com/xeipuuv/gojsonschema/result.go
@@ -48,6 +48,7 @@ type (
 		Value() interface{}
 		SetDetails(ErrorDetails)
 		Details() ErrorDetails
+		String() string
 	}
 
 	// ResultErrorFields holds the fields for each ResultError implementation.

--- a/vendor/github.com/xeipuuv/gojsonschema/schemaPool.go
+++ b/vendor/github.com/xeipuuv/gojsonschema/schemaPool.go
@@ -28,7 +28,6 @@ package gojsonschema
 
 import (
 	"errors"
-	"net/http"
 
 	"github.com/xeipuuv/gojsonreference"
 )
@@ -40,15 +39,15 @@ type schemaPoolDocument struct {
 type schemaPool struct {
 	schemaPoolDocuments map[string]*schemaPoolDocument
 	standaloneDocument  interface{}
-	fs                  http.FileSystem
+	jsonLoaderFactory   JSONLoaderFactory
 }
 
-func newSchemaPool(fs http.FileSystem) *schemaPool {
+func newSchemaPool(f JSONLoaderFactory) *schemaPool {
 
 	p := &schemaPool{}
 	p.schemaPoolDocuments = make(map[string]*schemaPoolDocument)
 	p.standaloneDocument = nil
-	p.fs = fs
+	p.jsonLoaderFactory = f
 
 	return p
 }
@@ -96,8 +95,8 @@ func (p *schemaPool) GetDocument(reference gojsonreference.JsonReference) (*sche
 		return spd, nil
 	}
 
-	jsonReferenceLoader := NewReferenceLoaderFileSystem(reference.String(), p.fs)
-	document, err := jsonReferenceLoader.loadJSON()
+	jsonReferenceLoader := p.jsonLoaderFactory.New(reference.String())
+	document, err := jsonReferenceLoader.LoadJSON()
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/xeipuuv/gojsonschema/schema_test.go
+++ b/vendor/github.com/xeipuuv/gojsonschema/schema_test.go
@@ -26,7 +26,10 @@
 package gojsonschema
 
 import (
+	"bytes"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"reflect"
@@ -35,6 +38,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const displayErrorMessages = false
@@ -58,284 +63,284 @@ func TestJsonSchemaTestSuite(t *testing.T) {
 
 	JsonSchemaTestSuiteMap := []map[string]string{
 
-		map[string]string{"phase": "integer type matches integers", "test": "an integer is an integer", "schema": "type/schema_0.json", "data": "type/data_00.json", "valid": "true"},
-		map[string]string{"phase": "integer type matches integers", "test": "a float is not an integer", "schema": "type/schema_0.json", "data": "type/data_01.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "integer type matches integers", "test": "a string is not an integer", "schema": "type/schema_0.json", "data": "type/data_02.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "integer type matches integers", "test": "an object is not an integer", "schema": "type/schema_0.json", "data": "type/data_03.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "integer type matches integers", "test": "an array is not an integer", "schema": "type/schema_0.json", "data": "type/data_04.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "integer type matches integers", "test": "a boolean is not an integer", "schema": "type/schema_0.json", "data": "type/data_05.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "integer type matches integers", "test": "null is not an integer", "schema": "type/schema_0.json", "data": "type/data_06.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "number type matches numbers", "test": "an integer is a number", "schema": "type/schema_1.json", "data": "type/data_10.json", "valid": "true"},
-		map[string]string{"phase": "number type matches numbers", "test": "a float is a number", "schema": "type/schema_1.json", "data": "type/data_11.json", "valid": "true"},
-		map[string]string{"phase": "number type matches numbers", "test": "a string is not a number", "schema": "type/schema_1.json", "data": "type/data_12.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "number type matches numbers", "test": "an object is not a number", "schema": "type/schema_1.json", "data": "type/data_13.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "number type matches numbers", "test": "an array is not a number", "schema": "type/schema_1.json", "data": "type/data_14.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "number type matches numbers", "test": "a boolean is not a number", "schema": "type/schema_1.json", "data": "type/data_15.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "number type matches numbers", "test": "null is not a number", "schema": "type/schema_1.json", "data": "type/data_16.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "string type matches strings", "test": "1 is not a string", "schema": "type/schema_2.json", "data": "type/data_20.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "string type matches strings", "test": "a float is not a string", "schema": "type/schema_2.json", "data": "type/data_21.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "string type matches strings", "test": "a string is a string", "schema": "type/schema_2.json", "data": "type/data_22.json", "valid": "true"},
-		map[string]string{"phase": "string type matches strings", "test": "an object is not a string", "schema": "type/schema_2.json", "data": "type/data_23.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "string type matches strings", "test": "an array is not a string", "schema": "type/schema_2.json", "data": "type/data_24.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "string type matches strings", "test": "a boolean is not a string", "schema": "type/schema_2.json", "data": "type/data_25.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "string type matches strings", "test": "null is not a string", "schema": "type/schema_2.json", "data": "type/data_26.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "object type matches objects", "test": "an integer is not an object", "schema": "type/schema_3.json", "data": "type/data_30.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "object type matches objects", "test": "a float is not an object", "schema": "type/schema_3.json", "data": "type/data_31.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "object type matches objects", "test": "a string is not an object", "schema": "type/schema_3.json", "data": "type/data_32.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "object type matches objects", "test": "an object is an object", "schema": "type/schema_3.json", "data": "type/data_33.json", "valid": "true"},
-		map[string]string{"phase": "object type matches objects", "test": "an array is not an object", "schema": "type/schema_3.json", "data": "type/data_34.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "object type matches objects", "test": "a boolean is not an object", "schema": "type/schema_3.json", "data": "type/data_35.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "object type matches objects", "test": "null is not an object", "schema": "type/schema_3.json", "data": "type/data_36.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "array type matches arrays", "test": "an integer is not an array", "schema": "type/schema_4.json", "data": "type/data_40.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "array type matches arrays", "test": "a float is not an array", "schema": "type/schema_4.json", "data": "type/data_41.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "array type matches arrays", "test": "a string is not an array", "schema": "type/schema_4.json", "data": "type/data_42.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "array type matches arrays", "test": "an object is not an array", "schema": "type/schema_4.json", "data": "type/data_43.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "array type matches arrays", "test": "an array is not an array", "schema": "type/schema_4.json", "data": "type/data_44.json", "valid": "true"},
-		map[string]string{"phase": "array type matches arrays", "test": "a boolean is not an array", "schema": "type/schema_4.json", "data": "type/data_45.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "array type matches arrays", "test": "null is not an array", "schema": "type/schema_4.json", "data": "type/data_46.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "boolean type matches booleans", "test": "an integer is not a boolean", "schema": "type/schema_5.json", "data": "type/data_50.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "boolean type matches booleans", "test": "a float is not a boolean", "schema": "type/schema_5.json", "data": "type/data_51.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "boolean type matches booleans", "test": "a string is not a boolean", "schema": "type/schema_5.json", "data": "type/data_52.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "boolean type matches booleans", "test": "an object is not a boolean", "schema": "type/schema_5.json", "data": "type/data_53.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "boolean type matches booleans", "test": "an array is not a boolean", "schema": "type/schema_5.json", "data": "type/data_54.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "boolean type matches booleans", "test": "a boolean is not a boolean", "schema": "type/schema_5.json", "data": "type/data_55.json", "valid": "true", "errors": "invalid_type"},
-		map[string]string{"phase": "boolean type matches booleans", "test": "null is not a boolean", "schema": "type/schema_5.json", "data": "type/data_56.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "null type matches only the null object", "test": "an integer is not null", "schema": "type/schema_6.json", "data": "type/data_60.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "null type matches only the null object", "test": "a float is not null", "schema": "type/schema_6.json", "data": "type/data_61.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "null type matches only the null object", "test": "a string is not null", "schema": "type/schema_6.json", "data": "type/data_62.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "null type matches only the null object", "test": "an object is not null", "schema": "type/schema_6.json", "data": "type/data_63.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "null type matches only the null object", "test": "an array is not null", "schema": "type/schema_6.json", "data": "type/data_64.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "null type matches only the null object", "test": "a boolean is not null", "schema": "type/schema_6.json", "data": "type/data_65.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "null type matches only the null object", "test": "null is null", "schema": "type/schema_6.json", "data": "type/data_66.json", "valid": "true"},
-		map[string]string{"phase": "multiple types can be specified in an array", "test": "an integer is valid", "schema": "type/schema_7.json", "data": "type/data_70.json", "valid": "true"},
-		map[string]string{"phase": "multiple types can be specified in an array", "test": "a string is valid", "schema": "type/schema_7.json", "data": "type/data_71.json", "valid": "true"},
-		map[string]string{"phase": "multiple types can be specified in an array", "test": "a float is invalid", "schema": "type/schema_7.json", "data": "type/data_72.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "multiple types can be specified in an array", "test": "an object is invalid", "schema": "type/schema_7.json", "data": "type/data_73.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "multiple types can be specified in an array", "test": "an array is invalid", "schema": "type/schema_7.json", "data": "type/data_74.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "multiple types can be specified in an array", "test": "a boolean is invalid", "schema": "type/schema_7.json", "data": "type/data_75.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "multiple types can be specified in an array", "test": "null is invalid", "schema": "type/schema_7.json", "data": "type/data_76.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "required validation", "test": "present required property is valid", "schema": "required/schema_0.json", "data": "required/data_00.json", "valid": "true"},
-		map[string]string{"phase": "required validation", "test": "non-present required property is invalid", "schema": "required/schema_0.json", "data": "required/data_01.json", "valid": "false", "errors": "required"},
-		map[string]string{"phase": "required default validation", "test": "not required by default", "schema": "required/schema_1.json", "data": "required/data_10.json", "valid": "true"},
-		map[string]string{"phase": "uniqueItems validation", "test": "unique array of integers is valid", "schema": "uniqueItems/schema_0.json", "data": "uniqueItems/data_00.json", "valid": "true"},
-		map[string]string{"phase": "uniqueItems validation", "test": "non-unique array of integers is invalid", "schema": "uniqueItems/schema_0.json", "data": "uniqueItems/data_01.json", "valid": "false", "errors": "unique"},
-		map[string]string{"phase": "uniqueItems validation", "test": "numbers are unique if mathematically unequal", "schema": "uniqueItems/schema_0.json", "data": "uniqueItems/data_02.json", "valid": "false", "errors": "unique, unique"},
-		map[string]string{"phase": "uniqueItems validation", "test": "unique array of objects is valid", "schema": "uniqueItems/schema_0.json", "data": "uniqueItems/data_03.json", "valid": "true"},
-		map[string]string{"phase": "uniqueItems validation", "test": "non-unique array of objects is invalid", "schema": "uniqueItems/schema_0.json", "data": "uniqueItems/data_04.json", "valid": "false", "errors": "unique"},
-		map[string]string{"phase": "uniqueItems validation", "test": "unique array of nested objects is valid", "schema": "uniqueItems/schema_0.json", "data": "uniqueItems/data_05.json", "valid": "true"},
-		map[string]string{"phase": "uniqueItems validation", "test": "non-unique array of nested objects is invalid", "schema": "uniqueItems/schema_0.json", "data": "uniqueItems/data_06.json", "valid": "false", "errors": "unique"},
-		map[string]string{"phase": "uniqueItems validation", "test": "unique array of arrays is valid", "schema": "uniqueItems/schema_0.json", "data": "uniqueItems/data_07.json", "valid": "true"},
-		map[string]string{"phase": "uniqueItems validation", "test": "non-unique array of arrays is invalid", "schema": "uniqueItems/schema_0.json", "data": "uniqueItems/data_08.json", "valid": "false", "errors": "unique"},
-		map[string]string{"phase": "uniqueItems validation", "test": "1 and true are unique", "schema": "uniqueItems/schema_0.json", "data": "uniqueItems/data_09.json", "valid": "true"},
-		map[string]string{"phase": "uniqueItems validation", "test": "0 and false are unique", "schema": "uniqueItems/schema_0.json", "data": "uniqueItems/data_010.json", "valid": "true"},
-		map[string]string{"phase": "uniqueItems validation", "test": "unique heterogeneous types are valid", "schema": "uniqueItems/schema_0.json", "data": "uniqueItems/data_011.json", "valid": "true"},
-		map[string]string{"phase": "uniqueItems validation", "test": "non-unique heterogeneous types are invalid", "schema": "uniqueItems/schema_0.json", "data": "uniqueItems/data_012.json", "valid": "false", "errors": "unique"},
-		map[string]string{"phase": "pattern validation", "test": "a matching pattern is valid", "schema": "pattern/schema_0.json", "data": "pattern/data_00.json", "valid": "true"},
-		map[string]string{"phase": "pattern validation", "test": "a non-matching pattern is invalid", "schema": "pattern/schema_0.json", "data": "pattern/data_01.json", "valid": "false", "errors": "pattern"},
-		map[string]string{"phase": "pattern validation", "test": "ignores non-strings", "schema": "pattern/schema_0.json", "data": "pattern/data_02.json", "valid": "true"},
-		map[string]string{"phase": "simple enum validation", "test": "one of the enum is valid", "schema": "enum/schema_0.json", "data": "enum/data_00.json", "valid": "true"},
-		map[string]string{"phase": "simple enum validation", "test": "something else is invalid", "schema": "enum/schema_0.json", "data": "enum/data_01.json", "valid": "false", "errors": "enum"},
-		map[string]string{"phase": "heterogeneous enum validation", "test": "one of the enum is valid", "schema": "enum/schema_1.json", "data": "enum/data_10.json", "valid": "true"},
-		map[string]string{"phase": "heterogeneous enum validation", "test": "something else is invalid", "schema": "enum/schema_1.json", "data": "enum/data_11.json", "valid": "false", "errors": "enum"},
-		map[string]string{"phase": "heterogeneous enum validation", "test": "objects are deep compared", "schema": "enum/schema_1.json", "data": "enum/data_12.json", "valid": "false", "errors": "enum"},
-		map[string]string{"phase": "minLength validation", "test": "longer is valid", "schema": "minLength/schema_0.json", "data": "minLength/data_00.json", "valid": "true"},
-		map[string]string{"phase": "minLength validation", "test": "exact length is valid", "schema": "minLength/schema_0.json", "data": "minLength/data_01.json", "valid": "true"},
-		map[string]string{"phase": "minLength validation", "test": "too short is invalid", "schema": "minLength/schema_0.json", "data": "minLength/data_02.json", "valid": "false", "errors": "string_gte"},
-		map[string]string{"phase": "minLength validation", "test": "ignores non-strings", "schema": "minLength/schema_0.json", "data": "minLength/data_03.json", "valid": "true"},
-		map[string]string{"phase": "minLength validation", "test": "counts utf8 length correctly", "schema": "minLength/schema_0.json", "data": "minLength/data_04.json", "valid": "false", "errors": "string_gte"},
-		map[string]string{"phase": "maxLength validation", "test": "shorter is valid", "schema": "maxLength/schema_0.json", "data": "maxLength/data_00.json", "valid": "true"},
-		map[string]string{"phase": "maxLength validation", "test": "exact length is valid", "schema": "maxLength/schema_0.json", "data": "maxLength/data_01.json", "valid": "true"},
-		map[string]string{"phase": "maxLength validation", "test": "too long is invalid", "schema": "maxLength/schema_0.json", "data": "maxLength/data_02.json", "valid": "false", "errors": "string_lte"},
-		map[string]string{"phase": "maxLength validation", "test": "ignores non-strings", "schema": "maxLength/schema_0.json", "data": "maxLength/data_03.json", "valid": "true"},
-		map[string]string{"phase": "maxLength validation", "test": "counts utf8 length correctly", "schema": "maxLength/schema_0.json", "data": "maxLength/data_04.json", "valid": "true"},
-		map[string]string{"phase": "minimum validation", "test": "above the minimum is valid", "schema": "minimum/schema_0.json", "data": "minimum/data_00.json", "valid": "true"},
-		map[string]string{"phase": "minimum validation", "test": "below the minimum is invalid", "schema": "minimum/schema_0.json", "data": "minimum/data_01.json", "valid": "false", "errors": "number_gte"},
-		map[string]string{"phase": "minimum validation", "test": "ignores non-numbers", "schema": "minimum/schema_0.json", "data": "minimum/data_02.json", "valid": "true"},
-		map[string]string{"phase": "exclusiveMinimum validation", "test": "above the minimum is still valid", "schema": "minimum/schema_1.json", "data": "minimum/data_10.json", "valid": "true"},
-		map[string]string{"phase": "exclusiveMinimum validation", "test": "boundary point is invalid", "schema": "minimum/schema_1.json", "data": "minimum/data_11.json", "valid": "false", "errors": "number_gt"},
-		map[string]string{"phase": "maximum validation", "test": "below the maximum is valid", "schema": "maximum/schema_0.json", "data": "maximum/data_00.json", "valid": "true"},
-		map[string]string{"phase": "maximum validation", "test": "above the maximum is invalid", "schema": "maximum/schema_0.json", "data": "maximum/data_01.json", "valid": "false", "errors": "number_lte"},
-		map[string]string{"phase": "maximum validation", "test": "ignores non-numbers", "schema": "maximum/schema_0.json", "data": "maximum/data_02.json", "valid": "true"},
-		map[string]string{"phase": "exclusiveMaximum validation", "test": "below the maximum is still valid", "schema": "maximum/schema_1.json", "data": "maximum/data_10.json", "valid": "true"},
-		map[string]string{"phase": "exclusiveMaximum validation", "test": "boundary point is invalid", "schema": "maximum/schema_1.json", "data": "maximum/data_11.json", "valid": "false", "errors": "number_lt"},
-		map[string]string{"phase": "allOf", "test": "allOf", "schema": "allOf/schema_0.json", "data": "allOf/data_00.json", "valid": "true"},
-		map[string]string{"phase": "allOf", "test": "mismatch second", "schema": "allOf/schema_0.json", "data": "allOf/data_01.json", "valid": "false", "errors": "number_all_of, required"},
-		map[string]string{"phase": "allOf", "test": "mismatch first", "schema": "allOf/schema_0.json", "data": "allOf/data_02.json", "valid": "false", "errors": "number_all_of, required"},
-		map[string]string{"phase": "allOf", "test": "wrong type", "schema": "allOf/schema_0.json", "data": "allOf/data_03.json", "valid": "false", "errors": "number_all_of, invalid_type"},
-		map[string]string{"phase": "allOf with base schema", "test": "valid", "schema": "allOf/schema_1.json", "data": "allOf/data_10.json", "valid": "true"},
-		map[string]string{"phase": "allOf with base schema", "test": "mismatch base schema", "schema": "allOf/schema_1.json", "data": "allOf/data_11.json", "valid": "false", "errors": "required"},
-		map[string]string{"phase": "allOf with base schema", "test": "mismatch first allOf", "schema": "allOf/schema_1.json", "data": "allOf/data_12.json", "valid": "false", "errors": "number_all_of, required"},
-		map[string]string{"phase": "allOf with base schema", "test": "mismatch second allOf", "schema": "allOf/schema_1.json", "data": "allOf/data_13.json", "valid": "false", "errors": "number_all_of, required"},
-		map[string]string{"phase": "allOf with base schema", "test": "mismatch both", "schema": "allOf/schema_1.json", "data": "allOf/data_14.json", "valid": "false", "errors": "number_all_of, required, required"},
-		map[string]string{"phase": "allOf simple types", "test": "valid", "schema": "allOf/schema_2.json", "data": "allOf/data_20.json", "valid": "true"},
-		map[string]string{"phase": "allOf simple types", "test": "mismatch one", "schema": "allOf/schema_2.json", "data": "allOf/data_21.json", "valid": "false", "errors": "number_all_of, number_lte"},
-		map[string]string{"phase": "oneOf", "test": "first oneOf valid", "schema": "oneOf/schema_0.json", "data": "oneOf/data_00.json", "valid": "true"},
-		map[string]string{"phase": "oneOf", "test": "second oneOf valid", "schema": "oneOf/schema_0.json", "data": "oneOf/data_01.json", "valid": "true"},
-		map[string]string{"phase": "oneOf", "test": "both oneOf valid", "schema": "oneOf/schema_0.json", "data": "oneOf/data_02.json", "valid": "false", "errors": "number_one_of"},
-		map[string]string{"phase": "oneOf", "test": "neither oneOf valid", "schema": "oneOf/schema_0.json", "data": "oneOf/data_03.json", "valid": "false"},
-		map[string]string{"phase": "oneOf with base schema", "test": "mismatch base schema", "schema": "oneOf/schema_1.json", "data": "oneOf/data_10.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "oneOf with base schema", "test": "one oneOf valid", "schema": "oneOf/schema_1.json", "data": "oneOf/data_11.json", "valid": "true"},
-		map[string]string{"phase": "oneOf with base schema", "test": "both oneOf valid", "schema": "oneOf/schema_1.json", "data": "oneOf/data_12.json", "valid": "false", "errors": "number_one_of"},
-		map[string]string{"phase": "anyOf", "test": "first anyOf valid", "schema": "anyOf/schema_0.json", "data": "anyOf/data_00.json", "valid": "true"},
-		map[string]string{"phase": "anyOf", "test": "second anyOf valid", "schema": "anyOf/schema_0.json", "data": "anyOf/data_01.json", "valid": "true"},
-		map[string]string{"phase": "anyOf", "test": "both anyOf valid", "schema": "anyOf/schema_0.json", "data": "anyOf/data_02.json", "valid": "true"},
-		map[string]string{"phase": "anyOf", "test": "neither anyOf valid", "schema": "anyOf/schema_0.json", "data": "anyOf/data_03.json", "valid": "false", "errors": "number_any_of, number_gte"},
-		map[string]string{"phase": "anyOf with base schema", "test": "mismatch base schema", "schema": "anyOf/schema_1.json", "data": "anyOf/data_10.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "anyOf with base schema", "test": "one anyOf valid", "schema": "anyOf/schema_1.json", "data": "anyOf/data_11.json", "valid": "true"},
-		map[string]string{"phase": "anyOf with base schema", "test": "both anyOf invalid", "schema": "anyOf/schema_1.json", "data": "anyOf/data_12.json", "valid": "false", "errors": "number_any_of, string_lte"},
-		map[string]string{"phase": "not", "test": "allowed", "schema": "not/schema_0.json", "data": "not/data_00.json", "valid": "true"},
-		map[string]string{"phase": "not", "test": "disallowed", "schema": "not/schema_0.json", "data": "not/data_01.json", "valid": "false", "errors": "number_not"},
-		map[string]string{"phase": "not multiple types", "test": "valid", "schema": "not/schema_1.json", "data": "not/data_10.json", "valid": "true"},
-		map[string]string{"phase": "not multiple types", "test": "mismatch", "schema": "not/schema_1.json", "data": "not/data_11.json", "valid": "false", "errors": "number_not"},
-		map[string]string{"phase": "not multiple types", "test": "other mismatch", "schema": "not/schema_1.json", "data": "not/data_12.json", "valid": "false", "errors": "number_not"},
-		map[string]string{"phase": "not more complex schema", "test": "match", "schema": "not/schema_2.json", "data": "not/data_20.json", "valid": "true"},
-		map[string]string{"phase": "not more complex schema", "test": "other match", "schema": "not/schema_2.json", "data": "not/data_21.json", "valid": "true"},
-		map[string]string{"phase": "not more complex schema", "test": "mismatch", "schema": "not/schema_2.json", "data": "not/data_22.json", "valid": "false", "errors": "number_not"},
-		map[string]string{"phase": "minProperties validation", "test": "longer is valid", "schema": "minProperties/schema_0.json", "data": "minProperties/data_00.json", "valid": "true"},
-		map[string]string{"phase": "minProperties validation", "test": "exact length is valid", "schema": "minProperties/schema_0.json", "data": "minProperties/data_01.json", "valid": "true"},
-		map[string]string{"phase": "minProperties validation", "test": "too short is invalid", "schema": "minProperties/schema_0.json", "data": "minProperties/data_02.json", "valid": "false", "errors": "array_min_properties"},
-		map[string]string{"phase": "minProperties validation", "test": "ignores non-objects", "schema": "minProperties/schema_0.json", "data": "minProperties/data_03.json", "valid": "true"},
-		map[string]string{"phase": "maxProperties validation", "test": "shorter is valid", "schema": "maxProperties/schema_0.json", "data": "maxProperties/data_00.json", "valid": "true"},
-		map[string]string{"phase": "maxProperties validation", "test": "exact length is valid", "schema": "maxProperties/schema_0.json", "data": "maxProperties/data_01.json", "valid": "true"},
-		map[string]string{"phase": "maxProperties validation", "test": "too long is invalid", "schema": "maxProperties/schema_0.json", "data": "maxProperties/data_02.json", "valid": "false", "errors": "array_max_properties"},
-		map[string]string{"phase": "maxProperties validation", "test": "ignores non-objects", "schema": "maxProperties/schema_0.json", "data": "maxProperties/data_03.json", "valid": "true"},
-		map[string]string{"phase": "by int", "test": "int by int", "schema": "multipleOf/schema_0.json", "data": "multipleOf/data_00.json", "valid": "true"},
-		map[string]string{"phase": "by int", "test": "int by int fail", "schema": "multipleOf/schema_0.json", "data": "multipleOf/data_01.json", "valid": "false", "errors": "multiple_of"},
-		map[string]string{"phase": "by int", "test": "ignores non-numbers", "schema": "multipleOf/schema_0.json", "data": "multipleOf/data_02.json", "valid": "true"},
-		map[string]string{"phase": "by number", "test": "zero is multiple of anything", "schema": "multipleOf/schema_1.json", "data": "multipleOf/data_10.json", "valid": "true"},
-		map[string]string{"phase": "by number", "test": "4.5 is multiple of 1.5", "schema": "multipleOf/schema_1.json", "data": "multipleOf/data_11.json", "valid": "true"},
-		map[string]string{"phase": "by number", "test": "35 is not multiple of 1.5", "schema": "multipleOf/schema_1.json", "data": "multipleOf/data_12.json", "valid": "false", "errors": "multiple_of"},
-		map[string]string{"phase": "by small number", "test": "0.0075 is multiple of 0.0001", "schema": "multipleOf/schema_2.json", "data": "multipleOf/data_20.json", "valid": "true"},
-		map[string]string{"phase": "by small number", "test": "0.00751 is not multiple of 0.0001", "schema": "multipleOf/schema_2.json", "data": "multipleOf/data_21.json", "valid": "false", "errors": "multiple_of"},
-		map[string]string{"phase": "minItems validation", "test": "longer is valid", "schema": "minItems/schema_0.json", "data": "minItems/data_00.json", "valid": "true"},
-		map[string]string{"phase": "minItems validation", "test": "exact length is valid", "schema": "minItems/schema_0.json", "data": "minItems/data_01.json", "valid": "true"},
-		map[string]string{"phase": "minItems validation", "test": "too short is invalid", "schema": "minItems/schema_0.json", "data": "minItems/data_02.json", "valid": "false", "errors": "array_min_items"},
-		map[string]string{"phase": "minItems validation", "test": "ignores non-arrays", "schema": "minItems/schema_0.json", "data": "minItems/data_03.json", "valid": "true"},
-		map[string]string{"phase": "maxItems validation", "test": "shorter is valid", "schema": "maxItems/schema_0.json", "data": "maxItems/data_00.json", "valid": "true"},
-		map[string]string{"phase": "maxItems validation", "test": "exact length is valid", "schema": "maxItems/schema_0.json", "data": "maxItems/data_01.json", "valid": "true"},
-		map[string]string{"phase": "maxItems validation", "test": "too long is invalid", "schema": "maxItems/schema_0.json", "data": "maxItems/data_02.json", "valid": "false", "errors": "array_max_items"},
-		map[string]string{"phase": "maxItems validation", "test": "ignores non-arrays", "schema": "maxItems/schema_0.json", "data": "maxItems/data_03.json", "valid": "true"},
-		map[string]string{"phase": "object properties validation", "test": "both properties present and valid is valid", "schema": "properties/schema_0.json", "data": "properties/data_00.json", "valid": "true"},
-		map[string]string{"phase": "object properties validation", "test": "one property invalid is invalid", "schema": "properties/schema_0.json", "data": "properties/data_01.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "object properties validation", "test": "both properties invalid is invalid", "schema": "properties/schema_0.json", "data": "properties/data_02.json", "valid": "false", "errors": "invalid_type, invalid_type"},
-		map[string]string{"phase": "object properties validation", "test": "doesn't invalidate other properties", "schema": "properties/schema_0.json", "data": "properties/data_03.json", "valid": "true"},
-		map[string]string{"phase": "object properties validation", "test": "ignores non-objects", "schema": "properties/schema_0.json", "data": "properties/data_04.json", "valid": "true"},
-		map[string]string{"phase": "properties, patternProperties, additionalProperties interaction", "test": "property validates property", "schema": "properties/schema_1.json", "data": "properties/data_10.json", "valid": "true"},
-		map[string]string{"phase": "properties, patternProperties, additionalProperties interaction", "test": "property invalidates property", "schema": "properties/schema_1.json", "data": "properties/data_11.json", "valid": "false", "errors": "array_max_items"},
-		map[string]string{"phase": "properties, patternProperties, additionalProperties interaction", "test": "patternProperty invalidates property", "schema": "properties/schema_1.json", "data": "properties/data_12.json", "valid": "false", "errors": "array_min_items, invalid_type"},
-		map[string]string{"phase": "properties, patternProperties, additionalProperties interaction", "test": "patternProperty validates nonproperty", "schema": "properties/schema_1.json", "data": "properties/data_13.json", "valid": "true"},
-		map[string]string{"phase": "properties, patternProperties, additionalProperties interaction", "test": "patternProperty invalidates nonproperty", "schema": "properties/schema_1.json", "data": "properties/data_14.json", "valid": "false", "errors": "array_min_items, invalid_type"},
-		map[string]string{"phase": "properties, patternProperties, additionalProperties interaction", "test": "additionalProperty ignores property", "schema": "properties/schema_1.json", "data": "properties/data_15.json", "valid": "true"},
-		map[string]string{"phase": "properties, patternProperties, additionalProperties interaction", "test": "additionalProperty validates others", "schema": "properties/schema_1.json", "data": "properties/data_16.json", "valid": "true"},
-		map[string]string{"phase": "properties, patternProperties, additionalProperties interaction", "test": "additionalProperty invalidates others", "schema": "properties/schema_1.json", "data": "properties/data_17.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "root pointer ref", "test": "match", "schema": "ref/schema_0.json", "data": "ref/data_00.json", "valid": "true"},
-		map[string]string{"phase": "root pointer ref", "test": "recursive match", "schema": "ref/schema_0.json", "data": "ref/data_01.json", "valid": "true"},
-		map[string]string{"phase": "root pointer ref", "test": "mismatch", "schema": "ref/schema_0.json", "data": "ref/data_02.json", "valid": "false", "errors": "additional_property_not_allowed"},
-		map[string]string{"phase": "root pointer ref", "test": "recursive mismatch", "schema": "ref/schema_0.json", "data": "ref/data_03.json", "valid": "false", "errors": "additional_property_not_allowed"},
-		map[string]string{"phase": "relative pointer ref to object", "test": "match", "schema": "ref/schema_1.json", "data": "ref/data_10.json", "valid": "true"},
-		map[string]string{"phase": "relative pointer ref to object", "test": "mismatch", "schema": "ref/schema_1.json", "data": "ref/data_11.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "relative pointer ref to array", "test": "match array", "schema": "ref/schema_2.json", "data": "ref/data_20.json", "valid": "true"},
-		map[string]string{"phase": "relative pointer ref to array", "test": "mismatch array", "schema": "ref/schema_2.json", "data": "ref/data_21.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "escaped pointer ref", "test": "slash", "schema": "ref/schema_3.json", "data": "ref/data_30.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "escaped pointer ref", "test": "tilda", "schema": "ref/schema_3.json", "data": "ref/data_31.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "escaped pointer ref", "test": "percent", "schema": "ref/schema_3.json", "data": "ref/data_32.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "nested refs", "test": "nested ref valid", "schema": "ref/schema_4.json", "data": "ref/data_40.json", "valid": "true"},
-		map[string]string{"phase": "nested refs", "test": "nested ref invalid", "schema": "ref/schema_4.json", "data": "ref/data_41.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "remote ref, containing refs itself", "test": "remote ref valid", "schema": "ref/schema_5.json", "data": "ref/data_50.json", "valid": "true"},
-		map[string]string{"phase": "remote ref, containing refs itself", "test": "remote ref invalid", "schema": "ref/schema_5.json", "data": "ref/data_51.json", "valid": "false", "errors": "number_all_of, number_gte"},
-		map[string]string{"phase": "a schema given for items", "test": "valid items", "schema": "items/schema_0.json", "data": "items/data_00.json", "valid": "true"},
-		map[string]string{"phase": "a schema given for items", "test": "wrong type of items", "schema": "items/schema_0.json", "data": "items/data_01.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "a schema given for items", "test": "ignores non-arrays", "schema": "items/schema_0.json", "data": "items/data_02.json", "valid": "true"},
-		map[string]string{"phase": "an array of schemas for items", "test": "correct types", "schema": "items/schema_1.json", "data": "items/data_10.json", "valid": "true"},
-		map[string]string{"phase": "an array of schemas for items", "test": "wrong types", "schema": "items/schema_1.json", "data": "items/data_11.json", "valid": "false", "errors": "invalid_type, invalid_type"},
-		map[string]string{"phase": "valid definition", "test": "valid definition schema", "schema": "definitions/schema_0.json", "data": "definitions/data_00.json", "valid": "true"},
-		map[string]string{"phase": "invalid definition", "test": "invalid definition schema", "schema": "definitions/schema_1.json", "data": "definitions/data_10.json", "valid": "false", "errors": "number_any_of, enum"},
-		map[string]string{"phase": "additionalItems as schema", "test": "additional items match schema", "schema": "additionalItems/schema_0.json", "data": "additionalItems/data_00.json", "valid": "true"},
-		map[string]string{"phase": "additionalItems as schema", "test": "additional items do not match schema", "schema": "additionalItems/schema_0.json", "data": "additionalItems/data_01.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "items is schema, no additionalItems", "test": "all items match schema", "schema": "additionalItems/schema_1.json", "data": "additionalItems/data_10.json", "valid": "true"},
-		map[string]string{"phase": "array of items with no additionalItems", "test": "no additional items present", "schema": "additionalItems/schema_2.json", "data": "additionalItems/data_20.json", "valid": "true"},
-		map[string]string{"phase": "array of items with no additionalItems", "test": "additional items are not permitted", "schema": "additionalItems/schema_2.json", "data": "additionalItems/data_21.json", "valid": "false", "errors": "array_no_additional_items"},
-		map[string]string{"phase": "additionalItems as false without items", "test": "items defaults to empty schema so everything is valid", "schema": "additionalItems/schema_3.json", "data": "additionalItems/data_30.json", "valid": "true"},
-		map[string]string{"phase": "additionalItems as false without items", "test": "ignores non-arrays", "schema": "additionalItems/schema_3.json", "data": "additionalItems/data_31.json", "valid": "true"},
-		map[string]string{"phase": "additionalItems are allowed by default", "test": "only the first item is validated", "schema": "additionalItems/schema_4.json", "data": "additionalItems/data_40.json", "valid": "true"},
-		map[string]string{"phase": "additionalProperties being false does not allow other properties", "test": "no additional properties is valid", "schema": "additionalProperties/schema_0.json", "data": "additionalProperties/data_00.json", "valid": "true"},
-		map[string]string{"phase": "additionalProperties being false does not allow other properties", "test": "an additional property is invalid", "schema": "additionalProperties/schema_0.json", "data": "additionalProperties/data_01.json", "valid": "false", "errors": "additional_property_not_allowed"},
-		map[string]string{"phase": "additionalProperties being false does not allow other properties", "test": "ignores non-objects", "schema": "additionalProperties/schema_0.json", "data": "additionalProperties/data_02.json", "valid": "true"},
-		map[string]string{"phase": "additionalProperties being false does not allow other properties", "test": "patternProperties are not additional properties", "schema": "additionalProperties/schema_0.json", "data": "additionalProperties/data_03.json", "valid": "true"},
-		map[string]string{"phase": "additionalProperties allows a schema which should validate", "test": "no additional properties is valid", "schema": "additionalProperties/schema_1.json", "data": "additionalProperties/data_10.json", "valid": "true"},
-		map[string]string{"phase": "additionalProperties allows a schema which should validate", "test": "an additional valid property is valid", "schema": "additionalProperties/schema_1.json", "data": "additionalProperties/data_11.json", "valid": "true"},
-		map[string]string{"phase": "additionalProperties allows a schema which should validate", "test": "an additional invalid property is invalid", "schema": "additionalProperties/schema_1.json", "data": "additionalProperties/data_12.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "additionalProperties are allowed by default", "test": "additional properties are allowed", "schema": "additionalProperties/schema_2.json", "data": "additionalProperties/data_20.json", "valid": "true"},
-		map[string]string{"phase": "dependencies", "test": "neither", "schema": "dependencies/schema_0.json", "data": "dependencies/data_00.json", "valid": "true"},
-		map[string]string{"phase": "dependencies", "test": "nondependant", "schema": "dependencies/schema_0.json", "data": "dependencies/data_01.json", "valid": "true"},
-		map[string]string{"phase": "dependencies", "test": "with dependency", "schema": "dependencies/schema_0.json", "data": "dependencies/data_02.json", "valid": "true"},
-		map[string]string{"phase": "dependencies", "test": "missing dependency", "schema": "dependencies/schema_0.json", "data": "dependencies/data_03.json", "valid": "false", "errors": "missing_dependency"},
-		map[string]string{"phase": "dependencies", "test": "ignores non-objects", "schema": "dependencies/schema_0.json", "data": "dependencies/data_04.json", "valid": "true"},
-		map[string]string{"phase": "multiple dependencies", "test": "neither", "schema": "dependencies/schema_1.json", "data": "dependencies/data_10.json", "valid": "true"},
-		map[string]string{"phase": "multiple dependencies", "test": "nondependants", "schema": "dependencies/schema_1.json", "data": "dependencies/data_11.json", "valid": "true"},
-		map[string]string{"phase": "multiple dependencies", "test": "with dependencies", "schema": "dependencies/schema_1.json", "data": "dependencies/data_12.json", "valid": "true"},
-		map[string]string{"phase": "multiple dependencies", "test": "missing dependency", "schema": "dependencies/schema_1.json", "data": "dependencies/data_13.json", "valid": "false", "errors": "missing_dependency"},
-		map[string]string{"phase": "multiple dependencies", "test": "missing other dependency", "schema": "dependencies/schema_1.json", "data": "dependencies/data_14.json", "valid": "false", "errors": "missing_dependency"},
-		map[string]string{"phase": "multiple dependencies", "test": "missing both dependencies", "schema": "dependencies/schema_1.json", "data": "dependencies/data_15.json", "valid": "false", "errors": "missing_dependency, missing_dependency"},
-		map[string]string{"phase": "multiple dependencies subschema", "test": "valid", "schema": "dependencies/schema_2.json", "data": "dependencies/data_20.json", "valid": "true"},
-		map[string]string{"phase": "multiple dependencies subschema", "test": "no dependency", "schema": "dependencies/schema_2.json", "data": "dependencies/data_21.json", "valid": "true"},
-		map[string]string{"phase": "multiple dependencies subschema", "test": "wrong type", "schema": "dependencies/schema_2.json", "data": "dependencies/data_22.json", "valid": "false"},
-		map[string]string{"phase": "multiple dependencies subschema", "test": "wrong type other", "schema": "dependencies/schema_2.json", "data": "dependencies/data_23.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "multiple dependencies subschema", "test": "wrong type both", "schema": "dependencies/schema_2.json", "data": "dependencies/data_24.json", "valid": "false", "errors": "invalid_type, invalid_type"},
-		map[string]string{"phase": "patternProperties validates properties matching a regex", "test": "a single valid match is valid", "schema": "patternProperties/schema_0.json", "data": "patternProperties/data_00.json", "valid": "true"},
-		map[string]string{"phase": "patternProperties validates properties matching a regex", "test": "multiple valid matches is valid", "schema": "patternProperties/schema_0.json", "data": "patternProperties/data_01.json", "valid": "true"},
-		map[string]string{"phase": "patternProperties validates properties matching a regex", "test": "a single invalid match is invalid", "schema": "patternProperties/schema_0.json", "data": "patternProperties/data_02.json", "valid": "false", "errors": "invalid_property_pattern, invalid_type"},
-		map[string]string{"phase": "patternProperties validates properties matching a regex", "test": "multiple invalid matches is invalid", "schema": "patternProperties/schema_0.json", "data": "patternProperties/data_03.json", "valid": "false", "errors": "invalid_property_pattern, invalid_property_pattern, invalid_type, invalid_type"},
-		map[string]string{"phase": "patternProperties validates properties matching a regex", "test": "ignores non-objects", "schema": "patternProperties/schema_0.json", "data": "patternProperties/data_04.json", "valid": "true"},
-		map[string]string{"phase": "patternProperties validates properties matching a regex", "test": "with additionalProperties combination", "schema": "patternProperties/schema_3.json", "data": "patternProperties/data_24.json", "valid": "false", "errors": "additional_property_not_allowed"},
-		map[string]string{"phase": "patternProperties validates properties matching a regex", "test": "with additionalProperties combination", "schema": "patternProperties/schema_3.json", "data": "patternProperties/data_25.json", "valid": "false", "errors": "additional_property_not_allowed"},
-		map[string]string{"phase": "patternProperties validates properties matching a regex", "test": "with additionalProperties combination", "schema": "patternProperties/schema_4.json", "data": "patternProperties/data_26.json", "valid": "false", "errors": "additional_property_not_allowed"},
-		map[string]string{"phase": "multiple simultaneous patternProperties are validated", "test": "a single valid match is valid", "schema": "patternProperties/schema_1.json", "data": "patternProperties/data_10.json", "valid": "true"},
-		map[string]string{"phase": "multiple simultaneous patternProperties are validated", "test": "a simultaneous match is valid", "schema": "patternProperties/schema_1.json", "data": "patternProperties/data_11.json", "valid": "true"},
-		map[string]string{"phase": "multiple simultaneous patternProperties are validated", "test": "multiple matches is valid", "schema": "patternProperties/schema_1.json", "data": "patternProperties/data_12.json", "valid": "true"},
-		map[string]string{"phase": "multiple simultaneous patternProperties are validated", "test": "an invalid due to one is invalid", "schema": "patternProperties/schema_1.json", "data": "patternProperties/data_13.json", "valid": "false", "errors": "invalid_property_pattern, invalid_type"},
-		map[string]string{"phase": "multiple simultaneous patternProperties are validated", "test": "an invalid due to the other is invalid", "schema": "patternProperties/schema_1.json", "data": "patternProperties/data_14.json", "valid": "false", "errors": "number_lte"},
-		map[string]string{"phase": "multiple simultaneous patternProperties are validated", "test": "an invalid due to both is invalid", "schema": "patternProperties/schema_1.json", "data": "patternProperties/data_15.json", "valid": "false", "errors": "invalid_type, number_lte"},
-		map[string]string{"phase": "regexes are not anchored by default and are case sensitive", "test": "non recognized members are ignored", "schema": "patternProperties/schema_2.json", "data": "patternProperties/data_20.json", "valid": "true"},
-		map[string]string{"phase": "regexes are not anchored by default and are case sensitive", "test": "recognized members are accounted for", "schema": "patternProperties/schema_2.json", "data": "patternProperties/data_21.json", "valid": "false", "errors": "invalid_property_pattern, invalid_type"},
-		map[string]string{"phase": "regexes are not anchored by default and are case sensitive", "test": "regexes are case sensitive", "schema": "patternProperties/schema_2.json", "data": "patternProperties/data_22.json", "valid": "true"},
-		map[string]string{"phase": "regexes are not anchored by default and are case sensitive", "test": "regexes are case sensitive, 2", "schema": "patternProperties/schema_2.json", "data": "patternProperties/data_23.json", "valid": "false", "errors": "invalid_property_pattern, invalid_type"},
-		map[string]string{"phase": "remote ref", "test": "remote ref valid", "schema": "refRemote/schema_0.json", "data": "refRemote/data_00.json", "valid": "true"},
-		map[string]string{"phase": "remote ref", "test": "remote ref invalid", "schema": "refRemote/schema_0.json", "data": "refRemote/data_01.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "fragment within remote ref", "test": "remote fragment valid", "schema": "refRemote/schema_1.json", "data": "refRemote/data_10.json", "valid": "true"},
-		map[string]string{"phase": "fragment within remote ref", "test": "remote fragment invalid", "schema": "refRemote/schema_1.json", "data": "refRemote/data_11.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "ref within remote ref", "test": "ref within ref valid", "schema": "refRemote/schema_2.json", "data": "refRemote/data_20.json", "valid": "true"},
-		map[string]string{"phase": "ref within remote ref", "test": "ref within ref invalid", "schema": "refRemote/schema_2.json", "data": "refRemote/data_21.json", "valid": "false", "errors": "invalid_type"},
-		map[string]string{"phase": "format validation", "test": "email format is invalid", "schema": "format/schema_0.json", "data": "format/data_00.json", "valid": "false", "errors": "format"},
-		map[string]string{"phase": "format validation", "test": "email format is invalid", "schema": "format/schema_0.json", "data": "format/data_01.json", "valid": "false", "errors": "format"},
-		map[string]string{"phase": "format validation", "test": "email format valid", "schema": "format/schema_0.json", "data": "format/data_02.json", "valid": "true"},
-		map[string]string{"phase": "format validation", "test": "invoice format valid", "schema": "format/schema_1.json", "data": "format/data_03.json", "valid": "true"},
-		map[string]string{"phase": "format validation", "test": "invoice format is invalid", "schema": "format/schema_1.json", "data": "format/data_04.json", "valid": "false", "errors": "format"},
-		map[string]string{"phase": "format validation", "test": "date-time format is valid", "schema": "format/schema_2.json", "data": "format/data_05.json", "valid": "true"},
-		map[string]string{"phase": "format validation", "test": "date-time format is valid", "schema": "format/schema_2.json", "data": "format/data_06.json", "valid": "true"},
-		map[string]string{"phase": "format validation", "test": "date-time format is invalid", "schema": "format/schema_2.json", "data": "format/data_07.json", "valid": "false", "errors": "format"},
-		map[string]string{"phase": "format validation", "test": "date-time format is valid", "schema": "format/schema_2.json", "data": "format/data_08.json", "valid": "false", "errors": "format"},
-		map[string]string{"phase": "format validation", "test": "date-time format is valid", "schema": "format/schema_2.json", "data": "format/data_09.json", "valid": "true"},
-		map[string]string{"phase": "format validation", "test": "date-time format is valid", "schema": "format/schema_2.json", "data": "format/data_10.json", "valid": "true"},
-		map[string]string{"phase": "format validation", "test": "date-time format is valid", "schema": "format/schema_2.json", "data": "format/data_11.json", "valid": "true"},
-		map[string]string{"phase": "format validation", "test": "date-time format is valid", "schema": "format/schema_2.json", "data": "format/data_12.json", "valid": "true"},
-		map[string]string{"phase": "format validation", "test": "hostname format is valid", "schema": "format/schema_3.json", "data": "format/data_13.json", "valid": "true"},
-		map[string]string{"phase": "format validation", "test": "hostname format is valid", "schema": "format/schema_3.json", "data": "format/data_14.json", "valid": "true"},
-		map[string]string{"phase": "format validation", "test": "hostname format is valid", "schema": "format/schema_3.json", "data": "format/data_15.json", "valid": "true"},
-		map[string]string{"phase": "format validation", "test": "hostname format is invalid", "schema": "format/schema_3.json", "data": "format/data_16.json", "valid": "false", "errors": "format"},
-		map[string]string{"phase": "format validation", "test": "hostname format is invalid", "schema": "format/schema_3.json", "data": "format/data_17.json", "valid": "false", "errors": "format"},
-		map[string]string{"phase": "format validation", "test": "ipv4 format is valid", "schema": "format/schema_4.json", "data": "format/data_18.json", "valid": "true"},
-		map[string]string{"phase": "format validation", "test": "ipv4 format is invalid", "schema": "format/schema_4.json", "data": "format/data_19.json", "valid": "false", "errors": "format"},
-		map[string]string{"phase": "format validation", "test": "ipv6 format is valid", "schema": "format/schema_5.json", "data": "format/data_20.json", "valid": "true"},
-		map[string]string{"phase": "format validation", "test": "ipv6 format is valid", "schema": "format/schema_5.json", "data": "format/data_21.json", "valid": "true"},
-		map[string]string{"phase": "format validation", "test": "ipv6 format is invalid", "schema": "format/schema_5.json", "data": "format/data_22.json", "valid": "false", "errors": "format"},
-		map[string]string{"phase": "format validation", "test": "ipv6 format is invalid", "schema": "format/schema_5.json", "data": "format/data_23.json", "valid": "false", "errors": "format"},
-		map[string]string{"phase": "format validation", "test": "uri format is valid", "schema": "format/schema_6.json", "data": "format/data_24.json", "valid": "true"},
-		map[string]string{"phase": "format validation", "test": "uri format is valid", "schema": "format/schema_6.json", "data": "format/data_25.json", "valid": "true"},
-		map[string]string{"phase": "format validation", "test": "uri format is valid", "schema": "format/schema_6.json", "data": "format/data_26.json", "valid": "true"},
-		map[string]string{"phase": "format validation", "test": "uri format is valid", "schema": "format/schema_6.json", "data": "format/data_27.json", "valid": "true"},
-		map[string]string{"phase": "format validation", "test": "uri format is invalid", "schema": "format/schema_6.json", "data": "format/data_28.json", "valid": "false", "errors": "format"},
-		map[string]string{"phase": "format validation", "test": "uri format is invalid", "schema": "format/schema_6.json", "data": "format/data_13.json", "valid": "false", "errors": "format"},
+		{"phase": "integer type matches integers", "test": "an integer is an integer", "schema": "type/schema_0.json", "data": "type/data_00.json", "valid": "true"},
+		{"phase": "integer type matches integers", "test": "a float is not an integer", "schema": "type/schema_0.json", "data": "type/data_01.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "integer type matches integers", "test": "a string is not an integer", "schema": "type/schema_0.json", "data": "type/data_02.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "integer type matches integers", "test": "an object is not an integer", "schema": "type/schema_0.json", "data": "type/data_03.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "integer type matches integers", "test": "an array is not an integer", "schema": "type/schema_0.json", "data": "type/data_04.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "integer type matches integers", "test": "a boolean is not an integer", "schema": "type/schema_0.json", "data": "type/data_05.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "integer type matches integers", "test": "null is not an integer", "schema": "type/schema_0.json", "data": "type/data_06.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "number type matches numbers", "test": "an integer is a number", "schema": "type/schema_1.json", "data": "type/data_10.json", "valid": "true"},
+		{"phase": "number type matches numbers", "test": "a float is a number", "schema": "type/schema_1.json", "data": "type/data_11.json", "valid": "true"},
+		{"phase": "number type matches numbers", "test": "a string is not a number", "schema": "type/schema_1.json", "data": "type/data_12.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "number type matches numbers", "test": "an object is not a number", "schema": "type/schema_1.json", "data": "type/data_13.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "number type matches numbers", "test": "an array is not a number", "schema": "type/schema_1.json", "data": "type/data_14.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "number type matches numbers", "test": "a boolean is not a number", "schema": "type/schema_1.json", "data": "type/data_15.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "number type matches numbers", "test": "null is not a number", "schema": "type/schema_1.json", "data": "type/data_16.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "string type matches strings", "test": "1 is not a string", "schema": "type/schema_2.json", "data": "type/data_20.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "string type matches strings", "test": "a float is not a string", "schema": "type/schema_2.json", "data": "type/data_21.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "string type matches strings", "test": "a string is a string", "schema": "type/schema_2.json", "data": "type/data_22.json", "valid": "true"},
+		{"phase": "string type matches strings", "test": "an object is not a string", "schema": "type/schema_2.json", "data": "type/data_23.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "string type matches strings", "test": "an array is not a string", "schema": "type/schema_2.json", "data": "type/data_24.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "string type matches strings", "test": "a boolean is not a string", "schema": "type/schema_2.json", "data": "type/data_25.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "string type matches strings", "test": "null is not a string", "schema": "type/schema_2.json", "data": "type/data_26.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "object type matches objects", "test": "an integer is not an object", "schema": "type/schema_3.json", "data": "type/data_30.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "object type matches objects", "test": "a float is not an object", "schema": "type/schema_3.json", "data": "type/data_31.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "object type matches objects", "test": "a string is not an object", "schema": "type/schema_3.json", "data": "type/data_32.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "object type matches objects", "test": "an object is an object", "schema": "type/schema_3.json", "data": "type/data_33.json", "valid": "true"},
+		{"phase": "object type matches objects", "test": "an array is not an object", "schema": "type/schema_3.json", "data": "type/data_34.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "object type matches objects", "test": "a boolean is not an object", "schema": "type/schema_3.json", "data": "type/data_35.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "object type matches objects", "test": "null is not an object", "schema": "type/schema_3.json", "data": "type/data_36.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "array type matches arrays", "test": "an integer is not an array", "schema": "type/schema_4.json", "data": "type/data_40.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "array type matches arrays", "test": "a float is not an array", "schema": "type/schema_4.json", "data": "type/data_41.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "array type matches arrays", "test": "a string is not an array", "schema": "type/schema_4.json", "data": "type/data_42.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "array type matches arrays", "test": "an object is not an array", "schema": "type/schema_4.json", "data": "type/data_43.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "array type matches arrays", "test": "an array is not an array", "schema": "type/schema_4.json", "data": "type/data_44.json", "valid": "true"},
+		{"phase": "array type matches arrays", "test": "a boolean is not an array", "schema": "type/schema_4.json", "data": "type/data_45.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "array type matches arrays", "test": "null is not an array", "schema": "type/schema_4.json", "data": "type/data_46.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "boolean type matches booleans", "test": "an integer is not a boolean", "schema": "type/schema_5.json", "data": "type/data_50.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "boolean type matches booleans", "test": "a float is not a boolean", "schema": "type/schema_5.json", "data": "type/data_51.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "boolean type matches booleans", "test": "a string is not a boolean", "schema": "type/schema_5.json", "data": "type/data_52.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "boolean type matches booleans", "test": "an object is not a boolean", "schema": "type/schema_5.json", "data": "type/data_53.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "boolean type matches booleans", "test": "an array is not a boolean", "schema": "type/schema_5.json", "data": "type/data_54.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "boolean type matches booleans", "test": "a boolean is not a boolean", "schema": "type/schema_5.json", "data": "type/data_55.json", "valid": "true", "errors": "invalid_type"},
+		{"phase": "boolean type matches booleans", "test": "null is not a boolean", "schema": "type/schema_5.json", "data": "type/data_56.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "null type matches only the null object", "test": "an integer is not null", "schema": "type/schema_6.json", "data": "type/data_60.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "null type matches only the null object", "test": "a float is not null", "schema": "type/schema_6.json", "data": "type/data_61.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "null type matches only the null object", "test": "a string is not null", "schema": "type/schema_6.json", "data": "type/data_62.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "null type matches only the null object", "test": "an object is not null", "schema": "type/schema_6.json", "data": "type/data_63.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "null type matches only the null object", "test": "an array is not null", "schema": "type/schema_6.json", "data": "type/data_64.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "null type matches only the null object", "test": "a boolean is not null", "schema": "type/schema_6.json", "data": "type/data_65.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "null type matches only the null object", "test": "null is null", "schema": "type/schema_6.json", "data": "type/data_66.json", "valid": "true"},
+		{"phase": "multiple types can be specified in an array", "test": "an integer is valid", "schema": "type/schema_7.json", "data": "type/data_70.json", "valid": "true"},
+		{"phase": "multiple types can be specified in an array", "test": "a string is valid", "schema": "type/schema_7.json", "data": "type/data_71.json", "valid": "true"},
+		{"phase": "multiple types can be specified in an array", "test": "a float is invalid", "schema": "type/schema_7.json", "data": "type/data_72.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "multiple types can be specified in an array", "test": "an object is invalid", "schema": "type/schema_7.json", "data": "type/data_73.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "multiple types can be specified in an array", "test": "an array is invalid", "schema": "type/schema_7.json", "data": "type/data_74.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "multiple types can be specified in an array", "test": "a boolean is invalid", "schema": "type/schema_7.json", "data": "type/data_75.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "multiple types can be specified in an array", "test": "null is invalid", "schema": "type/schema_7.json", "data": "type/data_76.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "required validation", "test": "present required property is valid", "schema": "required/schema_0.json", "data": "required/data_00.json", "valid": "true"},
+		{"phase": "required validation", "test": "non-present required property is invalid", "schema": "required/schema_0.json", "data": "required/data_01.json", "valid": "false", "errors": "required"},
+		{"phase": "required default validation", "test": "not required by default", "schema": "required/schema_1.json", "data": "required/data_10.json", "valid": "true"},
+		{"phase": "uniqueItems validation", "test": "unique array of integers is valid", "schema": "uniqueItems/schema_0.json", "data": "uniqueItems/data_00.json", "valid": "true"},
+		{"phase": "uniqueItems validation", "test": "non-unique array of integers is invalid", "schema": "uniqueItems/schema_0.json", "data": "uniqueItems/data_01.json", "valid": "false", "errors": "unique"},
+		{"phase": "uniqueItems validation", "test": "numbers are unique if mathematically unequal", "schema": "uniqueItems/schema_0.json", "data": "uniqueItems/data_02.json", "valid": "false", "errors": "unique, unique"},
+		{"phase": "uniqueItems validation", "test": "unique array of objects is valid", "schema": "uniqueItems/schema_0.json", "data": "uniqueItems/data_03.json", "valid": "true"},
+		{"phase": "uniqueItems validation", "test": "non-unique array of objects is invalid", "schema": "uniqueItems/schema_0.json", "data": "uniqueItems/data_04.json", "valid": "false", "errors": "unique"},
+		{"phase": "uniqueItems validation", "test": "unique array of nested objects is valid", "schema": "uniqueItems/schema_0.json", "data": "uniqueItems/data_05.json", "valid": "true"},
+		{"phase": "uniqueItems validation", "test": "non-unique array of nested objects is invalid", "schema": "uniqueItems/schema_0.json", "data": "uniqueItems/data_06.json", "valid": "false", "errors": "unique"},
+		{"phase": "uniqueItems validation", "test": "unique array of arrays is valid", "schema": "uniqueItems/schema_0.json", "data": "uniqueItems/data_07.json", "valid": "true"},
+		{"phase": "uniqueItems validation", "test": "non-unique array of arrays is invalid", "schema": "uniqueItems/schema_0.json", "data": "uniqueItems/data_08.json", "valid": "false", "errors": "unique"},
+		{"phase": "uniqueItems validation", "test": "1 and true are unique", "schema": "uniqueItems/schema_0.json", "data": "uniqueItems/data_09.json", "valid": "true"},
+		{"phase": "uniqueItems validation", "test": "0 and false are unique", "schema": "uniqueItems/schema_0.json", "data": "uniqueItems/data_010.json", "valid": "true"},
+		{"phase": "uniqueItems validation", "test": "unique heterogeneous types are valid", "schema": "uniqueItems/schema_0.json", "data": "uniqueItems/data_011.json", "valid": "true"},
+		{"phase": "uniqueItems validation", "test": "non-unique heterogeneous types are invalid", "schema": "uniqueItems/schema_0.json", "data": "uniqueItems/data_012.json", "valid": "false", "errors": "unique"},
+		{"phase": "pattern validation", "test": "a matching pattern is valid", "schema": "pattern/schema_0.json", "data": "pattern/data_00.json", "valid": "true"},
+		{"phase": "pattern validation", "test": "a non-matching pattern is invalid", "schema": "pattern/schema_0.json", "data": "pattern/data_01.json", "valid": "false", "errors": "pattern"},
+		{"phase": "pattern validation", "test": "ignores non-strings", "schema": "pattern/schema_0.json", "data": "pattern/data_02.json", "valid": "true"},
+		{"phase": "simple enum validation", "test": "one of the enum is valid", "schema": "enum/schema_0.json", "data": "enum/data_00.json", "valid": "true"},
+		{"phase": "simple enum validation", "test": "something else is invalid", "schema": "enum/schema_0.json", "data": "enum/data_01.json", "valid": "false", "errors": "enum"},
+		{"phase": "heterogeneous enum validation", "test": "one of the enum is valid", "schema": "enum/schema_1.json", "data": "enum/data_10.json", "valid": "true"},
+		{"phase": "heterogeneous enum validation", "test": "something else is invalid", "schema": "enum/schema_1.json", "data": "enum/data_11.json", "valid": "false", "errors": "enum"},
+		{"phase": "heterogeneous enum validation", "test": "objects are deep compared", "schema": "enum/schema_1.json", "data": "enum/data_12.json", "valid": "false", "errors": "enum"},
+		{"phase": "minLength validation", "test": "longer is valid", "schema": "minLength/schema_0.json", "data": "minLength/data_00.json", "valid": "true"},
+		{"phase": "minLength validation", "test": "exact length is valid", "schema": "minLength/schema_0.json", "data": "minLength/data_01.json", "valid": "true"},
+		{"phase": "minLength validation", "test": "too short is invalid", "schema": "minLength/schema_0.json", "data": "minLength/data_02.json", "valid": "false", "errors": "string_gte"},
+		{"phase": "minLength validation", "test": "ignores non-strings", "schema": "minLength/schema_0.json", "data": "minLength/data_03.json", "valid": "true"},
+		{"phase": "minLength validation", "test": "counts utf8 length correctly", "schema": "minLength/schema_0.json", "data": "minLength/data_04.json", "valid": "false", "errors": "string_gte"},
+		{"phase": "maxLength validation", "test": "shorter is valid", "schema": "maxLength/schema_0.json", "data": "maxLength/data_00.json", "valid": "true"},
+		{"phase": "maxLength validation", "test": "exact length is valid", "schema": "maxLength/schema_0.json", "data": "maxLength/data_01.json", "valid": "true"},
+		{"phase": "maxLength validation", "test": "too long is invalid", "schema": "maxLength/schema_0.json", "data": "maxLength/data_02.json", "valid": "false", "errors": "string_lte"},
+		{"phase": "maxLength validation", "test": "ignores non-strings", "schema": "maxLength/schema_0.json", "data": "maxLength/data_03.json", "valid": "true"},
+		{"phase": "maxLength validation", "test": "counts utf8 length correctly", "schema": "maxLength/schema_0.json", "data": "maxLength/data_04.json", "valid": "true"},
+		{"phase": "minimum validation", "test": "above the minimum is valid", "schema": "minimum/schema_0.json", "data": "minimum/data_00.json", "valid": "true"},
+		{"phase": "minimum validation", "test": "below the minimum is invalid", "schema": "minimum/schema_0.json", "data": "minimum/data_01.json", "valid": "false", "errors": "number_gte"},
+		{"phase": "minimum validation", "test": "ignores non-numbers", "schema": "minimum/schema_0.json", "data": "minimum/data_02.json", "valid": "true"},
+		{"phase": "exclusiveMinimum validation", "test": "above the minimum is still valid", "schema": "minimum/schema_1.json", "data": "minimum/data_10.json", "valid": "true"},
+		{"phase": "exclusiveMinimum validation", "test": "boundary point is invalid", "schema": "minimum/schema_1.json", "data": "minimum/data_11.json", "valid": "false", "errors": "number_gt"},
+		{"phase": "maximum validation", "test": "below the maximum is valid", "schema": "maximum/schema_0.json", "data": "maximum/data_00.json", "valid": "true"},
+		{"phase": "maximum validation", "test": "above the maximum is invalid", "schema": "maximum/schema_0.json", "data": "maximum/data_01.json", "valid": "false", "errors": "number_lte"},
+		{"phase": "maximum validation", "test": "ignores non-numbers", "schema": "maximum/schema_0.json", "data": "maximum/data_02.json", "valid": "true"},
+		{"phase": "exclusiveMaximum validation", "test": "below the maximum is still valid", "schema": "maximum/schema_1.json", "data": "maximum/data_10.json", "valid": "true"},
+		{"phase": "exclusiveMaximum validation", "test": "boundary point is invalid", "schema": "maximum/schema_1.json", "data": "maximum/data_11.json", "valid": "false", "errors": "number_lt"},
+		{"phase": "allOf", "test": "allOf", "schema": "allOf/schema_0.json", "data": "allOf/data_00.json", "valid": "true"},
+		{"phase": "allOf", "test": "mismatch second", "schema": "allOf/schema_0.json", "data": "allOf/data_01.json", "valid": "false", "errors": "number_all_of, required"},
+		{"phase": "allOf", "test": "mismatch first", "schema": "allOf/schema_0.json", "data": "allOf/data_02.json", "valid": "false", "errors": "number_all_of, required"},
+		{"phase": "allOf", "test": "wrong type", "schema": "allOf/schema_0.json", "data": "allOf/data_03.json", "valid": "false", "errors": "number_all_of, invalid_type"},
+		{"phase": "allOf with base schema", "test": "valid", "schema": "allOf/schema_1.json", "data": "allOf/data_10.json", "valid": "true"},
+		{"phase": "allOf with base schema", "test": "mismatch base schema", "schema": "allOf/schema_1.json", "data": "allOf/data_11.json", "valid": "false", "errors": "required"},
+		{"phase": "allOf with base schema", "test": "mismatch first allOf", "schema": "allOf/schema_1.json", "data": "allOf/data_12.json", "valid": "false", "errors": "number_all_of, required"},
+		{"phase": "allOf with base schema", "test": "mismatch second allOf", "schema": "allOf/schema_1.json", "data": "allOf/data_13.json", "valid": "false", "errors": "number_all_of, required"},
+		{"phase": "allOf with base schema", "test": "mismatch both", "schema": "allOf/schema_1.json", "data": "allOf/data_14.json", "valid": "false", "errors": "number_all_of, required, required"},
+		{"phase": "allOf simple types", "test": "valid", "schema": "allOf/schema_2.json", "data": "allOf/data_20.json", "valid": "true"},
+		{"phase": "allOf simple types", "test": "mismatch one", "schema": "allOf/schema_2.json", "data": "allOf/data_21.json", "valid": "false", "errors": "number_all_of, number_lte"},
+		{"phase": "oneOf", "test": "first oneOf valid", "schema": "oneOf/schema_0.json", "data": "oneOf/data_00.json", "valid": "true"},
+		{"phase": "oneOf", "test": "second oneOf valid", "schema": "oneOf/schema_0.json", "data": "oneOf/data_01.json", "valid": "true"},
+		{"phase": "oneOf", "test": "both oneOf valid", "schema": "oneOf/schema_0.json", "data": "oneOf/data_02.json", "valid": "false", "errors": "number_one_of"},
+		{"phase": "oneOf", "test": "neither oneOf valid", "schema": "oneOf/schema_0.json", "data": "oneOf/data_03.json", "valid": "false"},
+		{"phase": "oneOf with base schema", "test": "mismatch base schema", "schema": "oneOf/schema_1.json", "data": "oneOf/data_10.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "oneOf with base schema", "test": "one oneOf valid", "schema": "oneOf/schema_1.json", "data": "oneOf/data_11.json", "valid": "true"},
+		{"phase": "oneOf with base schema", "test": "both oneOf valid", "schema": "oneOf/schema_1.json", "data": "oneOf/data_12.json", "valid": "false", "errors": "number_one_of"},
+		{"phase": "anyOf", "test": "first anyOf valid", "schema": "anyOf/schema_0.json", "data": "anyOf/data_00.json", "valid": "true"},
+		{"phase": "anyOf", "test": "second anyOf valid", "schema": "anyOf/schema_0.json", "data": "anyOf/data_01.json", "valid": "true"},
+		{"phase": "anyOf", "test": "both anyOf valid", "schema": "anyOf/schema_0.json", "data": "anyOf/data_02.json", "valid": "true"},
+		{"phase": "anyOf", "test": "neither anyOf valid", "schema": "anyOf/schema_0.json", "data": "anyOf/data_03.json", "valid": "false", "errors": "number_any_of, number_gte"},
+		{"phase": "anyOf with base schema", "test": "mismatch base schema", "schema": "anyOf/schema_1.json", "data": "anyOf/data_10.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "anyOf with base schema", "test": "one anyOf valid", "schema": "anyOf/schema_1.json", "data": "anyOf/data_11.json", "valid": "true"},
+		{"phase": "anyOf with base schema", "test": "both anyOf invalid", "schema": "anyOf/schema_1.json", "data": "anyOf/data_12.json", "valid": "false", "errors": "number_any_of, string_lte"},
+		{"phase": "not", "test": "allowed", "schema": "not/schema_0.json", "data": "not/data_00.json", "valid": "true"},
+		{"phase": "not", "test": "disallowed", "schema": "not/schema_0.json", "data": "not/data_01.json", "valid": "false", "errors": "number_not"},
+		{"phase": "not multiple types", "test": "valid", "schema": "not/schema_1.json", "data": "not/data_10.json", "valid": "true"},
+		{"phase": "not multiple types", "test": "mismatch", "schema": "not/schema_1.json", "data": "not/data_11.json", "valid": "false", "errors": "number_not"},
+		{"phase": "not multiple types", "test": "other mismatch", "schema": "not/schema_1.json", "data": "not/data_12.json", "valid": "false", "errors": "number_not"},
+		{"phase": "not more complex schema", "test": "match", "schema": "not/schema_2.json", "data": "not/data_20.json", "valid": "true"},
+		{"phase": "not more complex schema", "test": "other match", "schema": "not/schema_2.json", "data": "not/data_21.json", "valid": "true"},
+		{"phase": "not more complex schema", "test": "mismatch", "schema": "not/schema_2.json", "data": "not/data_22.json", "valid": "false", "errors": "number_not"},
+		{"phase": "minProperties validation", "test": "longer is valid", "schema": "minProperties/schema_0.json", "data": "minProperties/data_00.json", "valid": "true"},
+		{"phase": "minProperties validation", "test": "exact length is valid", "schema": "minProperties/schema_0.json", "data": "minProperties/data_01.json", "valid": "true"},
+		{"phase": "minProperties validation", "test": "too short is invalid", "schema": "minProperties/schema_0.json", "data": "minProperties/data_02.json", "valid": "false", "errors": "array_min_properties"},
+		{"phase": "minProperties validation", "test": "ignores non-objects", "schema": "minProperties/schema_0.json", "data": "minProperties/data_03.json", "valid": "true"},
+		{"phase": "maxProperties validation", "test": "shorter is valid", "schema": "maxProperties/schema_0.json", "data": "maxProperties/data_00.json", "valid": "true"},
+		{"phase": "maxProperties validation", "test": "exact length is valid", "schema": "maxProperties/schema_0.json", "data": "maxProperties/data_01.json", "valid": "true"},
+		{"phase": "maxProperties validation", "test": "too long is invalid", "schema": "maxProperties/schema_0.json", "data": "maxProperties/data_02.json", "valid": "false", "errors": "array_max_properties"},
+		{"phase": "maxProperties validation", "test": "ignores non-objects", "schema": "maxProperties/schema_0.json", "data": "maxProperties/data_03.json", "valid": "true"},
+		{"phase": "by int", "test": "int by int", "schema": "multipleOf/schema_0.json", "data": "multipleOf/data_00.json", "valid": "true"},
+		{"phase": "by int", "test": "int by int fail", "schema": "multipleOf/schema_0.json", "data": "multipleOf/data_01.json", "valid": "false", "errors": "multiple_of"},
+		{"phase": "by int", "test": "ignores non-numbers", "schema": "multipleOf/schema_0.json", "data": "multipleOf/data_02.json", "valid": "true"},
+		{"phase": "by number", "test": "zero is multiple of anything", "schema": "multipleOf/schema_1.json", "data": "multipleOf/data_10.json", "valid": "true"},
+		{"phase": "by number", "test": "4.5 is multiple of 1.5", "schema": "multipleOf/schema_1.json", "data": "multipleOf/data_11.json", "valid": "true"},
+		{"phase": "by number", "test": "35 is not multiple of 1.5", "schema": "multipleOf/schema_1.json", "data": "multipleOf/data_12.json", "valid": "false", "errors": "multiple_of"},
+		{"phase": "by small number", "test": "0.0075 is multiple of 0.0001", "schema": "multipleOf/schema_2.json", "data": "multipleOf/data_20.json", "valid": "true"},
+		{"phase": "by small number", "test": "0.00751 is not multiple of 0.0001", "schema": "multipleOf/schema_2.json", "data": "multipleOf/data_21.json", "valid": "false", "errors": "multiple_of"},
+		{"phase": "minItems validation", "test": "longer is valid", "schema": "minItems/schema_0.json", "data": "minItems/data_00.json", "valid": "true"},
+		{"phase": "minItems validation", "test": "exact length is valid", "schema": "minItems/schema_0.json", "data": "minItems/data_01.json", "valid": "true"},
+		{"phase": "minItems validation", "test": "too short is invalid", "schema": "minItems/schema_0.json", "data": "minItems/data_02.json", "valid": "false", "errors": "array_min_items"},
+		{"phase": "minItems validation", "test": "ignores non-arrays", "schema": "minItems/schema_0.json", "data": "minItems/data_03.json", "valid": "true"},
+		{"phase": "maxItems validation", "test": "shorter is valid", "schema": "maxItems/schema_0.json", "data": "maxItems/data_00.json", "valid": "true"},
+		{"phase": "maxItems validation", "test": "exact length is valid", "schema": "maxItems/schema_0.json", "data": "maxItems/data_01.json", "valid": "true"},
+		{"phase": "maxItems validation", "test": "too long is invalid", "schema": "maxItems/schema_0.json", "data": "maxItems/data_02.json", "valid": "false", "errors": "array_max_items"},
+		{"phase": "maxItems validation", "test": "ignores non-arrays", "schema": "maxItems/schema_0.json", "data": "maxItems/data_03.json", "valid": "true"},
+		{"phase": "object properties validation", "test": "both properties present and valid is valid", "schema": "properties/schema_0.json", "data": "properties/data_00.json", "valid": "true"},
+		{"phase": "object properties validation", "test": "one property invalid is invalid", "schema": "properties/schema_0.json", "data": "properties/data_01.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "object properties validation", "test": "both properties invalid is invalid", "schema": "properties/schema_0.json", "data": "properties/data_02.json", "valid": "false", "errors": "invalid_type, invalid_type"},
+		{"phase": "object properties validation", "test": "doesn't invalidate other properties", "schema": "properties/schema_0.json", "data": "properties/data_03.json", "valid": "true"},
+		{"phase": "object properties validation", "test": "ignores non-objects", "schema": "properties/schema_0.json", "data": "properties/data_04.json", "valid": "true"},
+		{"phase": "properties, patternProperties, additionalProperties interaction", "test": "property validates property", "schema": "properties/schema_1.json", "data": "properties/data_10.json", "valid": "true"},
+		{"phase": "properties, patternProperties, additionalProperties interaction", "test": "property invalidates property", "schema": "properties/schema_1.json", "data": "properties/data_11.json", "valid": "false", "errors": "array_max_items"},
+		{"phase": "properties, patternProperties, additionalProperties interaction", "test": "patternProperty invalidates property", "schema": "properties/schema_1.json", "data": "properties/data_12.json", "valid": "false", "errors": "array_min_items, invalid_type"},
+		{"phase": "properties, patternProperties, additionalProperties interaction", "test": "patternProperty validates nonproperty", "schema": "properties/schema_1.json", "data": "properties/data_13.json", "valid": "true"},
+		{"phase": "properties, patternProperties, additionalProperties interaction", "test": "patternProperty invalidates nonproperty", "schema": "properties/schema_1.json", "data": "properties/data_14.json", "valid": "false", "errors": "array_min_items, invalid_type"},
+		{"phase": "properties, patternProperties, additionalProperties interaction", "test": "additionalProperty ignores property", "schema": "properties/schema_1.json", "data": "properties/data_15.json", "valid": "true"},
+		{"phase": "properties, patternProperties, additionalProperties interaction", "test": "additionalProperty validates others", "schema": "properties/schema_1.json", "data": "properties/data_16.json", "valid": "true"},
+		{"phase": "properties, patternProperties, additionalProperties interaction", "test": "additionalProperty invalidates others", "schema": "properties/schema_1.json", "data": "properties/data_17.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "root pointer ref", "test": "match", "schema": "ref/schema_0.json", "data": "ref/data_00.json", "valid": "true"},
+		{"phase": "root pointer ref", "test": "recursive match", "schema": "ref/schema_0.json", "data": "ref/data_01.json", "valid": "true"},
+		{"phase": "root pointer ref", "test": "mismatch", "schema": "ref/schema_0.json", "data": "ref/data_02.json", "valid": "false", "errors": "additional_property_not_allowed"},
+		{"phase": "root pointer ref", "test": "recursive mismatch", "schema": "ref/schema_0.json", "data": "ref/data_03.json", "valid": "false", "errors": "additional_property_not_allowed"},
+		{"phase": "relative pointer ref to object", "test": "match", "schema": "ref/schema_1.json", "data": "ref/data_10.json", "valid": "true"},
+		{"phase": "relative pointer ref to object", "test": "mismatch", "schema": "ref/schema_1.json", "data": "ref/data_11.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "relative pointer ref to array", "test": "match array", "schema": "ref/schema_2.json", "data": "ref/data_20.json", "valid": "true"},
+		{"phase": "relative pointer ref to array", "test": "mismatch array", "schema": "ref/schema_2.json", "data": "ref/data_21.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "escaped pointer ref", "test": "slash", "schema": "ref/schema_3.json", "data": "ref/data_30.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "escaped pointer ref", "test": "tilda", "schema": "ref/schema_3.json", "data": "ref/data_31.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "escaped pointer ref", "test": "percent", "schema": "ref/schema_3.json", "data": "ref/data_32.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "nested refs", "test": "nested ref valid", "schema": "ref/schema_4.json", "data": "ref/data_40.json", "valid": "true"},
+		{"phase": "nested refs", "test": "nested ref invalid", "schema": "ref/schema_4.json", "data": "ref/data_41.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "remote ref, containing refs itself", "test": "remote ref valid", "schema": "ref/schema_5.json", "data": "ref/data_50.json", "valid": "true"},
+		{"phase": "remote ref, containing refs itself", "test": "remote ref invalid", "schema": "ref/schema_5.json", "data": "ref/data_51.json", "valid": "false", "errors": "number_all_of, number_gte"},
+		{"phase": "a schema given for items", "test": "valid items", "schema": "items/schema_0.json", "data": "items/data_00.json", "valid": "true"},
+		{"phase": "a schema given for items", "test": "wrong type of items", "schema": "items/schema_0.json", "data": "items/data_01.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "a schema given for items", "test": "ignores non-arrays", "schema": "items/schema_0.json", "data": "items/data_02.json", "valid": "true"},
+		{"phase": "an array of schemas for items", "test": "correct types", "schema": "items/schema_1.json", "data": "items/data_10.json", "valid": "true"},
+		{"phase": "an array of schemas for items", "test": "wrong types", "schema": "items/schema_1.json", "data": "items/data_11.json", "valid": "false", "errors": "invalid_type, invalid_type"},
+		{"phase": "valid definition", "test": "valid definition schema", "schema": "definitions/schema_0.json", "data": "definitions/data_00.json", "valid": "true"},
+		{"phase": "invalid definition", "test": "invalid definition schema", "schema": "definitions/schema_1.json", "data": "definitions/data_10.json", "valid": "false", "errors": "number_any_of, enum"},
+		{"phase": "additionalItems as schema", "test": "additional items match schema", "schema": "additionalItems/schema_0.json", "data": "additionalItems/data_00.json", "valid": "true"},
+		{"phase": "additionalItems as schema", "test": "additional items do not match schema", "schema": "additionalItems/schema_0.json", "data": "additionalItems/data_01.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "items is schema, no additionalItems", "test": "all items match schema", "schema": "additionalItems/schema_1.json", "data": "additionalItems/data_10.json", "valid": "true"},
+		{"phase": "array of items with no additionalItems", "test": "no additional items present", "schema": "additionalItems/schema_2.json", "data": "additionalItems/data_20.json", "valid": "true"},
+		{"phase": "array of items with no additionalItems", "test": "additional items are not permitted", "schema": "additionalItems/schema_2.json", "data": "additionalItems/data_21.json", "valid": "false", "errors": "array_no_additional_items"},
+		{"phase": "additionalItems as false without items", "test": "items defaults to empty schema so everything is valid", "schema": "additionalItems/schema_3.json", "data": "additionalItems/data_30.json", "valid": "true"},
+		{"phase": "additionalItems as false without items", "test": "ignores non-arrays", "schema": "additionalItems/schema_3.json", "data": "additionalItems/data_31.json", "valid": "true"},
+		{"phase": "additionalItems are allowed by default", "test": "only the first item is validated", "schema": "additionalItems/schema_4.json", "data": "additionalItems/data_40.json", "valid": "true"},
+		{"phase": "additionalProperties being false does not allow other properties", "test": "no additional properties is valid", "schema": "additionalProperties/schema_0.json", "data": "additionalProperties/data_00.json", "valid": "true"},
+		{"phase": "additionalProperties being false does not allow other properties", "test": "an additional property is invalid", "schema": "additionalProperties/schema_0.json", "data": "additionalProperties/data_01.json", "valid": "false", "errors": "additional_property_not_allowed"},
+		{"phase": "additionalProperties being false does not allow other properties", "test": "ignores non-objects", "schema": "additionalProperties/schema_0.json", "data": "additionalProperties/data_02.json", "valid": "true"},
+		{"phase": "additionalProperties being false does not allow other properties", "test": "patternProperties are not additional properties", "schema": "additionalProperties/schema_0.json", "data": "additionalProperties/data_03.json", "valid": "true"},
+		{"phase": "additionalProperties allows a schema which should validate", "test": "no additional properties is valid", "schema": "additionalProperties/schema_1.json", "data": "additionalProperties/data_10.json", "valid": "true"},
+		{"phase": "additionalProperties allows a schema which should validate", "test": "an additional valid property is valid", "schema": "additionalProperties/schema_1.json", "data": "additionalProperties/data_11.json", "valid": "true"},
+		{"phase": "additionalProperties allows a schema which should validate", "test": "an additional invalid property is invalid", "schema": "additionalProperties/schema_1.json", "data": "additionalProperties/data_12.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "additionalProperties are allowed by default", "test": "additional properties are allowed", "schema": "additionalProperties/schema_2.json", "data": "additionalProperties/data_20.json", "valid": "true"},
+		{"phase": "dependencies", "test": "neither", "schema": "dependencies/schema_0.json", "data": "dependencies/data_00.json", "valid": "true"},
+		{"phase": "dependencies", "test": "nondependant", "schema": "dependencies/schema_0.json", "data": "dependencies/data_01.json", "valid": "true"},
+		{"phase": "dependencies", "test": "with dependency", "schema": "dependencies/schema_0.json", "data": "dependencies/data_02.json", "valid": "true"},
+		{"phase": "dependencies", "test": "missing dependency", "schema": "dependencies/schema_0.json", "data": "dependencies/data_03.json", "valid": "false", "errors": "missing_dependency"},
+		{"phase": "dependencies", "test": "ignores non-objects", "schema": "dependencies/schema_0.json", "data": "dependencies/data_04.json", "valid": "true"},
+		{"phase": "multiple dependencies", "test": "neither", "schema": "dependencies/schema_1.json", "data": "dependencies/data_10.json", "valid": "true"},
+		{"phase": "multiple dependencies", "test": "nondependants", "schema": "dependencies/schema_1.json", "data": "dependencies/data_11.json", "valid": "true"},
+		{"phase": "multiple dependencies", "test": "with dependencies", "schema": "dependencies/schema_1.json", "data": "dependencies/data_12.json", "valid": "true"},
+		{"phase": "multiple dependencies", "test": "missing dependency", "schema": "dependencies/schema_1.json", "data": "dependencies/data_13.json", "valid": "false", "errors": "missing_dependency"},
+		{"phase": "multiple dependencies", "test": "missing other dependency", "schema": "dependencies/schema_1.json", "data": "dependencies/data_14.json", "valid": "false", "errors": "missing_dependency"},
+		{"phase": "multiple dependencies", "test": "missing both dependencies", "schema": "dependencies/schema_1.json", "data": "dependencies/data_15.json", "valid": "false", "errors": "missing_dependency, missing_dependency"},
+		{"phase": "multiple dependencies subschema", "test": "valid", "schema": "dependencies/schema_2.json", "data": "dependencies/data_20.json", "valid": "true"},
+		{"phase": "multiple dependencies subschema", "test": "no dependency", "schema": "dependencies/schema_2.json", "data": "dependencies/data_21.json", "valid": "true"},
+		{"phase": "multiple dependencies subschema", "test": "wrong type", "schema": "dependencies/schema_2.json", "data": "dependencies/data_22.json", "valid": "false"},
+		{"phase": "multiple dependencies subschema", "test": "wrong type other", "schema": "dependencies/schema_2.json", "data": "dependencies/data_23.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "multiple dependencies subschema", "test": "wrong type both", "schema": "dependencies/schema_2.json", "data": "dependencies/data_24.json", "valid": "false", "errors": "invalid_type, invalid_type"},
+		{"phase": "patternProperties validates properties matching a regex", "test": "a single valid match is valid", "schema": "patternProperties/schema_0.json", "data": "patternProperties/data_00.json", "valid": "true"},
+		{"phase": "patternProperties validates properties matching a regex", "test": "multiple valid matches is valid", "schema": "patternProperties/schema_0.json", "data": "patternProperties/data_01.json", "valid": "true"},
+		{"phase": "patternProperties validates properties matching a regex", "test": "a single invalid match is invalid", "schema": "patternProperties/schema_0.json", "data": "patternProperties/data_02.json", "valid": "false", "errors": "invalid_property_pattern, invalid_type"},
+		{"phase": "patternProperties validates properties matching a regex", "test": "multiple invalid matches is invalid", "schema": "patternProperties/schema_0.json", "data": "patternProperties/data_03.json", "valid": "false", "errors": "invalid_property_pattern, invalid_property_pattern, invalid_type, invalid_type"},
+		{"phase": "patternProperties validates properties matching a regex", "test": "ignores non-objects", "schema": "patternProperties/schema_0.json", "data": "patternProperties/data_04.json", "valid": "true"},
+		{"phase": "patternProperties validates properties matching a regex", "test": "with additionalProperties combination", "schema": "patternProperties/schema_3.json", "data": "patternProperties/data_24.json", "valid": "false", "errors": "additional_property_not_allowed"},
+		{"phase": "patternProperties validates properties matching a regex", "test": "with additionalProperties combination", "schema": "patternProperties/schema_3.json", "data": "patternProperties/data_25.json", "valid": "false", "errors": "additional_property_not_allowed"},
+		{"phase": "patternProperties validates properties matching a regex", "test": "with additionalProperties combination", "schema": "patternProperties/schema_4.json", "data": "patternProperties/data_26.json", "valid": "false", "errors": "additional_property_not_allowed"},
+		{"phase": "multiple simultaneous patternProperties are validated", "test": "a single valid match is valid", "schema": "patternProperties/schema_1.json", "data": "patternProperties/data_10.json", "valid": "true"},
+		{"phase": "multiple simultaneous patternProperties are validated", "test": "a simultaneous match is valid", "schema": "patternProperties/schema_1.json", "data": "patternProperties/data_11.json", "valid": "true"},
+		{"phase": "multiple simultaneous patternProperties are validated", "test": "multiple matches is valid", "schema": "patternProperties/schema_1.json", "data": "patternProperties/data_12.json", "valid": "true"},
+		{"phase": "multiple simultaneous patternProperties are validated", "test": "an invalid due to one is invalid", "schema": "patternProperties/schema_1.json", "data": "patternProperties/data_13.json", "valid": "false", "errors": "invalid_property_pattern, invalid_type"},
+		{"phase": "multiple simultaneous patternProperties are validated", "test": "an invalid due to the other is invalid", "schema": "patternProperties/schema_1.json", "data": "patternProperties/data_14.json", "valid": "false", "errors": "number_lte"},
+		{"phase": "multiple simultaneous patternProperties are validated", "test": "an invalid due to both is invalid", "schema": "patternProperties/schema_1.json", "data": "patternProperties/data_15.json", "valid": "false", "errors": "invalid_type, number_lte"},
+		{"phase": "regexes are not anchored by default and are case sensitive", "test": "non recognized members are ignored", "schema": "patternProperties/schema_2.json", "data": "patternProperties/data_20.json", "valid": "true"},
+		{"phase": "regexes are not anchored by default and are case sensitive", "test": "recognized members are accounted for", "schema": "patternProperties/schema_2.json", "data": "patternProperties/data_21.json", "valid": "false", "errors": "invalid_property_pattern, invalid_type"},
+		{"phase": "regexes are not anchored by default and are case sensitive", "test": "regexes are case sensitive", "schema": "patternProperties/schema_2.json", "data": "patternProperties/data_22.json", "valid": "true"},
+		{"phase": "regexes are not anchored by default and are case sensitive", "test": "regexes are case sensitive, 2", "schema": "patternProperties/schema_2.json", "data": "patternProperties/data_23.json", "valid": "false", "errors": "invalid_property_pattern, invalid_type"},
+		{"phase": "remote ref", "test": "remote ref valid", "schema": "refRemote/schema_0.json", "data": "refRemote/data_00.json", "valid": "true"},
+		{"phase": "remote ref", "test": "remote ref invalid", "schema": "refRemote/schema_0.json", "data": "refRemote/data_01.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "fragment within remote ref", "test": "remote fragment valid", "schema": "refRemote/schema_1.json", "data": "refRemote/data_10.json", "valid": "true"},
+		{"phase": "fragment within remote ref", "test": "remote fragment invalid", "schema": "refRemote/schema_1.json", "data": "refRemote/data_11.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "ref within remote ref", "test": "ref within ref valid", "schema": "refRemote/schema_2.json", "data": "refRemote/data_20.json", "valid": "true"},
+		{"phase": "ref within remote ref", "test": "ref within ref invalid", "schema": "refRemote/schema_2.json", "data": "refRemote/data_21.json", "valid": "false", "errors": "invalid_type"},
+		{"phase": "format validation", "test": "email format is invalid", "schema": "format/schema_0.json", "data": "format/data_00.json", "valid": "false", "errors": "format"},
+		{"phase": "format validation", "test": "email format is invalid", "schema": "format/schema_0.json", "data": "format/data_01.json", "valid": "false", "errors": "format"},
+		{"phase": "format validation", "test": "email format valid", "schema": "format/schema_0.json", "data": "format/data_02.json", "valid": "true"},
+		{"phase": "format validation", "test": "invoice format valid", "schema": "format/schema_1.json", "data": "format/data_03.json", "valid": "true"},
+		{"phase": "format validation", "test": "invoice format is invalid", "schema": "format/schema_1.json", "data": "format/data_04.json", "valid": "false", "errors": "format"},
+		{"phase": "format validation", "test": "date-time format is valid", "schema": "format/schema_2.json", "data": "format/data_05.json", "valid": "true"},
+		{"phase": "format validation", "test": "date-time format is valid", "schema": "format/schema_2.json", "data": "format/data_06.json", "valid": "true"},
+		{"phase": "format validation", "test": "date-time format is invalid", "schema": "format/schema_2.json", "data": "format/data_07.json", "valid": "false", "errors": "format"},
+		{"phase": "format validation", "test": "date-time format is valid", "schema": "format/schema_2.json", "data": "format/data_08.json", "valid": "false", "errors": "format"},
+		{"phase": "format validation", "test": "date-time format is valid", "schema": "format/schema_2.json", "data": "format/data_09.json", "valid": "true"},
+		{"phase": "format validation", "test": "date-time format is valid", "schema": "format/schema_2.json", "data": "format/data_10.json", "valid": "true"},
+		{"phase": "format validation", "test": "date-time format is valid", "schema": "format/schema_2.json", "data": "format/data_11.json", "valid": "true"},
+		{"phase": "format validation", "test": "date-time format is valid", "schema": "format/schema_2.json", "data": "format/data_12.json", "valid": "true"},
+		{"phase": "format validation", "test": "hostname format is valid", "schema": "format/schema_3.json", "data": "format/data_13.json", "valid": "true"},
+		{"phase": "format validation", "test": "hostname format is valid", "schema": "format/schema_3.json", "data": "format/data_14.json", "valid": "true"},
+		{"phase": "format validation", "test": "hostname format is valid", "schema": "format/schema_3.json", "data": "format/data_15.json", "valid": "true"},
+		{"phase": "format validation", "test": "hostname format is invalid", "schema": "format/schema_3.json", "data": "format/data_16.json", "valid": "false", "errors": "format"},
+		{"phase": "format validation", "test": "hostname format is invalid", "schema": "format/schema_3.json", "data": "format/data_17.json", "valid": "false", "errors": "format"},
+		{"phase": "format validation", "test": "ipv4 format is valid", "schema": "format/schema_4.json", "data": "format/data_18.json", "valid": "true"},
+		{"phase": "format validation", "test": "ipv4 format is invalid", "schema": "format/schema_4.json", "data": "format/data_19.json", "valid": "false", "errors": "format"},
+		{"phase": "format validation", "test": "ipv6 format is valid", "schema": "format/schema_5.json", "data": "format/data_20.json", "valid": "true"},
+		{"phase": "format validation", "test": "ipv6 format is valid", "schema": "format/schema_5.json", "data": "format/data_21.json", "valid": "true"},
+		{"phase": "format validation", "test": "ipv6 format is invalid", "schema": "format/schema_5.json", "data": "format/data_22.json", "valid": "false", "errors": "format"},
+		{"phase": "format validation", "test": "ipv6 format is invalid", "schema": "format/schema_5.json", "data": "format/data_23.json", "valid": "false", "errors": "format"},
+		{"phase": "format validation", "test": "uri format is valid", "schema": "format/schema_6.json", "data": "format/data_24.json", "valid": "true"},
+		{"phase": "format validation", "test": "uri format is valid", "schema": "format/schema_6.json", "data": "format/data_25.json", "valid": "true"},
+		{"phase": "format validation", "test": "uri format is valid", "schema": "format/schema_6.json", "data": "format/data_26.json", "valid": "true"},
+		{"phase": "format validation", "test": "uri format is valid", "schema": "format/schema_6.json", "data": "format/data_27.json", "valid": "true"},
+		{"phase": "format validation", "test": "uri format is invalid", "schema": "format/schema_6.json", "data": "format/data_28.json", "valid": "false", "errors": "format"},
+		{"phase": "format validation", "test": "uri format is invalid", "schema": "format/schema_6.json", "data": "format/data_13.json", "valid": "false", "errors": "format"},
 	}
 
 	//TODO Pass failed tests : id(s) as scope for references is not implemented yet
@@ -413,4 +418,150 @@ func TestJsonSchemaTestSuite(t *testing.T) {
 	}
 
 	fmt.Printf("\n%d tests performed / %d total tests to perform ( %.2f %% )\n", len(JsonSchemaTestSuiteMap), 248, float32(len(JsonSchemaTestSuiteMap))/248.0*100.0)
+}
+
+const circularReference = `{
+	"type": "object",
+	"properties": {
+		"games": {
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/game"
+			}
+		}
+	},
+	"definitions": {
+		"game": {
+			"type": "object",
+			"properties": {
+				"winner": {
+					"$ref": "#/definitions/player"
+				},
+				"loser": {
+					"$ref": "#/definitions/player"
+				}
+			}
+		},
+		"player": {
+			"type": "object",
+			"properties": {
+				"user": {
+					"$ref": "#/definitions/user"
+				},
+				"game": {
+					"$ref": "#/definitions/game"
+				}
+			}
+		},
+		"user": {
+			"type": "object",
+			"properties": {
+				"fullName": {
+					"type": "string"
+				}
+			}
+		}
+	}
+}`
+
+func TestCircularReference(t *testing.T) {
+	loader := NewStringLoader(circularReference)
+	// call the target function
+	_, err := NewSchema(loader)
+	if err != nil {
+		t.Errorf("Got error: %s", err.Error())
+	}
+}
+
+// From http://json-schema.org/examples.html
+const simpleSchema = `{
+  "title": "Example Schema",
+  "type": "object",
+  "properties": {
+    "firstName": {
+      "type": "string"
+    },
+    "lastName": {
+      "type": "string"
+    },
+    "age": {
+      "description": "Age in years",
+      "type": "integer",
+      "minimum": 0
+    }
+  },
+  "required": ["firstName", "lastName"]
+}`
+
+func TestLoaders(t *testing.T) {
+	// setup reader loader
+	reader := bytes.NewBufferString(simpleSchema)
+	readerLoader, wrappedReader := NewReaderLoader(reader)
+
+	// drain reader
+	by, err := ioutil.ReadAll(wrappedReader)
+	assert.Nil(t, err)
+	assert.Equal(t, simpleSchema, string(by))
+
+	// setup writer loaders
+	writer := &bytes.Buffer{}
+	writerLoader, wrappedWriter := NewWriterLoader(writer)
+
+	// fill writer
+	n, err := io.WriteString(wrappedWriter, simpleSchema)
+	assert.Nil(t, err)
+	assert.Equal(t, n, len(simpleSchema))
+
+	loaders := []JSONLoader{
+		NewStringLoader(simpleSchema),
+		readerLoader,
+		writerLoader,
+	}
+
+	for _, l := range loaders {
+		_, err := NewSchema(l)
+		assert.Nil(t, err, "loader: %T", l)
+	}
+}
+
+const invalidPattern = `{
+  "title": "Example Pattern",
+  "type": "object",
+  "properties": {
+    "invalid": {
+      "type": "string",
+      "pattern": 99999
+    }
+  }
+}`
+
+func TestLoadersWithInvalidPattern(t *testing.T) {
+	// setup reader loader
+	reader := bytes.NewBufferString(invalidPattern)
+	readerLoader, wrappedReader := NewReaderLoader(reader)
+
+	// drain reader
+	by, err := ioutil.ReadAll(wrappedReader)
+	assert.Nil(t, err)
+	assert.Equal(t, invalidPattern, string(by))
+
+	// setup writer loaders
+	writer := &bytes.Buffer{}
+	writerLoader, wrappedWriter := NewWriterLoader(writer)
+
+	// fill writer
+	n, err := io.WriteString(wrappedWriter, invalidPattern)
+	assert.Nil(t, err)
+	assert.Equal(t, n, len(invalidPattern))
+
+	loaders := []JSONLoader{
+		NewStringLoader(invalidPattern),
+		readerLoader,
+		writerLoader,
+	}
+
+	for _, l := range loaders {
+		_, err := NewSchema(l)
+		assert.NotNil(t, err, "expected error loading invalid pattern: %T", l)
+	}
 }

--- a/vendor/github.com/xeipuuv/gojsonschema/subSchema.go
+++ b/vendor/github.com/xeipuuv/gojsonschema/subSchema.go
@@ -214,7 +214,7 @@ func (s *subSchema) PatternPropertiesString() string {
 	}
 
 	patternPropertiesKeySlice := []string{}
-	for pk, _ := range s.patternProperties {
+	for pk := range s.patternProperties {
 		patternPropertiesKeySlice = append(patternPropertiesKeySlice, `"`+pk+`"`)
 	}
 

--- a/vendor/github.com/xeipuuv/gojsonschema/utils.go
+++ b/vendor/github.com/xeipuuv/gojsonschema/utils.go
@@ -34,7 +34,12 @@ import (
 )
 
 func isKind(what interface{}, kind reflect.Kind) bool {
-	return reflect.ValueOf(what).Kind() == kind
+	target := what
+	if isJsonNumber(what) {
+		// JSON Numbers are strings!
+		target = *mustBeNumber(what)
+	}
+	return reflect.ValueOf(target).Kind() == kind
 }
 
 func existsMapKey(m map[string]interface{}, k string) bool {

--- a/vendor/github.com/xeipuuv/gojsonschema/validation.go
+++ b/vendor/github.com/xeipuuv/gojsonschema/validation.go
@@ -55,7 +55,7 @@ func (v *Schema) Validate(l JSONLoader) (*Result, error) {
 
 	// load document
 
-	root, err := l.loadJSON()
+	root, err := l.LoadJSON()
 	if err != nil {
 		return nil, err
 	}
@@ -412,7 +412,7 @@ func (v *subSchema) validateArray(currentSubSchema *subSchema, value []interface
 		internalLog(" %v", value)
 	}
 
-	nbItems := len(value)
+	nbValues := len(value)
 
 	// TODO explain
 	if currentSubSchema.itemsChildrenIsSingleSchema {
@@ -425,15 +425,18 @@ func (v *subSchema) validateArray(currentSubSchema *subSchema, value []interface
 		if currentSubSchema.itemsChildren != nil && len(currentSubSchema.itemsChildren) > 0 {
 
 			nbItems := len(currentSubSchema.itemsChildren)
-			nbValues := len(value)
 
-			if nbItems == nbValues {
-				for i := 0; i != nbItems; i++ {
-					subContext := newJsonContext(strconv.Itoa(i), context)
-					validationResult := currentSubSchema.itemsChildren[i].subValidateWithContext(value[i], subContext)
-					result.mergeErrors(validationResult)
-				}
-			} else if nbItems < nbValues {
+			// while we have both schemas and values, check them against each other
+			for i := 0; i != nbItems && i != nbValues; i++ {
+				subContext := newJsonContext(strconv.Itoa(i), context)
+				validationResult := currentSubSchema.itemsChildren[i].subValidateWithContext(value[i], subContext)
+				result.mergeErrors(validationResult)
+			}
+
+			if nbItems < nbValues {
+				// we have less schemas than elements in the instance array,
+				// but that might be ok if "additionalItems" is specified.
+
 				switch currentSubSchema.additionalItems.(type) {
 				case bool:
 					if !currentSubSchema.additionalItems.(bool) {
@@ -453,7 +456,7 @@ func (v *subSchema) validateArray(currentSubSchema *subSchema, value []interface
 
 	// minItems & maxItems
 	if currentSubSchema.minItems != nil {
-		if nbItems < int(*currentSubSchema.minItems) {
+		if nbValues < int(*currentSubSchema.minItems) {
 			result.addError(
 				new(ArrayMinItemsError),
 				context,
@@ -463,7 +466,7 @@ func (v *subSchema) validateArray(currentSubSchema *subSchema, value []interface
 		}
 	}
 	if currentSubSchema.maxItems != nil {
-		if nbItems > int(*currentSubSchema.maxItems) {
+		if nbValues > int(*currentSubSchema.maxItems) {
 			result.addError(
 				new(ArrayMaxItemsError),
 				context,


### PR DESCRIPTION
This backports #1861.

Conflicting files:
- README.md
- appveyor.yml
- commands/command_lock.go
- commands/command_locks.go
- commands/command_smudge.go
- commands/command_track.go
- commands/command_unlock.go
- commands/uploader.go
- config/version.go
- docs/api/v1.3/http-v1.3-batch-request-schema.json
- docs/api/v1.3/http-v1.3-batch-response-schema.json
- git/attribs.go
- git/git.go
- lfsapi/errors.go
- locking/api.go
- locking/api_test.go
- locking/locks.go
- locking/locks_test.go
- test/cmd/lfstest-gitserver.go
- test/test-locks.sh
- test/test-pre-push.sh
- test/test-track.sh
- test/test-unlock.sh
- tools/iotools.go
- tq/api_test.go