### PR TITLE
Backport #1921 for v1.5.x: commands: teach track how to handle empty lines in .gitattributes

### DIFF
--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -82,10 +82,85 @@ ArgsLoop:
 			}
 		}
 
+<<<<<<< HEAD
 		// Make sure any existing git tracked files have their timestamp updated
 		// so they will now show as modifed
 		// note this is relative to current dir which is how we write .gitattributes
 		// deliberately not done in parallel as a chan because we'll be marking modified
+=======
+		// Generate the new / changed attrib line for merging
+		encodedArg := strings.Replace(pattern, " ", "[[:space:]]", -1)
+		lockableArg := ""
+		if trackLockableFlag { // no need to test trackNotLockableFlag, if we got here we're disabling
+			lockableArg = " " + git.LockableAttrib
+		}
+
+		changedAttribLines[pattern] = fmt.Sprintf("%s filter=lfs diff=lfs merge=lfs -text%v\n", encodedArg, lockableArg)
+
+		if trackLockableFlag {
+			readOnlyPatterns = append(readOnlyPatterns, pattern)
+		} else {
+			writeablePatterns = append(writeablePatterns, pattern)
+		}
+
+		Print("Tracking %s", pattern)
+
+	}
+
+	// Now read the whole local attributes file and iterate over the contents,
+	// replacing any lines where the values have changed, and appending new lines
+	// change this:
+
+	attribContents, err := ioutil.ReadFile(".gitattributes")
+	// it's fine for file to not exist
+	if err != nil && !os.IsNotExist(err) {
+		Print("Error reading .gitattributes file")
+		return
+	}
+	// Re-generate the file with merge of old contents and new (to deal with changes)
+	attributesFile, err := os.OpenFile(".gitattributes", os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0660)
+	if err != nil {
+		Print("Error opening .gitattributes file")
+		return
+	}
+	defer attributesFile.Close()
+
+	if len(attribContents) > 0 {
+		scanner := bufio.NewScanner(bytes.NewReader(attribContents))
+		for scanner.Scan() {
+			line := scanner.Text()
+			fields := strings.Fields(line)
+			if len(fields) < 1 {
+				continue
+			}
+
+			pattern := fields[0]
+			if newline, ok := changedAttribLines[pattern]; ok {
+				// Replace this line (newline already embedded)
+				attributesFile.WriteString(newline)
+				// Remove from map so we know we don't have to add it to the end
+				delete(changedAttribLines, pattern)
+			} else {
+				// Write line unchanged (replace newline)
+				attributesFile.WriteString(line + "\n")
+			}
+		}
+
+		// Our method of writing also made sure there's always a newline at end
+	}
+
+	// Any items left in the map, write new lines at the end of the file
+	// Note this is only new patterns, not ones which changed locking flags
+	for pattern, newline := range changedAttribLines {
+		// Newline already embedded
+		attributesFile.WriteString(newline)
+
+		// Also, for any new patterns we've added, make sure any existing git
+		// tracked files have their timestamp updated so they will now show as
+		// modifed note this is relative to current dir which is how we write
+		// .gitattributes deliberately not done in parallel as a chan because
+		// we'll be marking modified
+>>>>>>> 0685231f... Merge pull request #1921 from git-lfs/track-with-empty-lines
 		//
 		// NOTE: `git ls-files` does not do well with leading slashes.
 		// Since all `git-lfs track` calls are relative to the root of

--- a/test/test-track.sh
+++ b/test/test-track.sh
@@ -12,6 +12,13 @@ begin_test "track"
   cd track
   git init
 
+  echo "###############################################################################
+# Set default behavior to automatically normalize line endings.
+###############################################################################
+* text=auto
+
+#*.cs     diff=csharp" > .gitattributes
+
   # track *.jpg once
   git lfs track "*.jpg" | grep "Tracking \*.jpg"
   numjpg=$(grep "\*.jpg" .gitattributes | wc -l)
@@ -36,12 +43,18 @@ begin_test "track"
   echo "*.gif filter=lfs -text" > a/.gitattributes
   echo "*.png filter=lfs -text" > a/b/.gitattributes
 
-  out=$(git lfs track)
-  echo "$out" | grep "Listing tracked patterns"
-  echo "$out" | grep "*.mov ($(native_path_escaped ".git/info/attributes"))"
-  echo "$out" | grep "*.jpg (.gitattributes)"
-  echo "$out" | grep "*.gif ($(native_path_escaped "a/.gitattributes"))"
-  echo "$out" | grep "*.png ($(native_path_escaped "a/b/.gitattributes"))"
+  git lfs track | tee track.log
+  grep "Listing tracked patterns" track.log
+  grep "*.mov ($(native_path_escaped ".git/info/attributes"))" track.log
+  grep "*.jpg (.gitattributes)" track.log
+  grep "*.gif ($(native_path_escaped "a/.gitattributes"))" track.log
+  grep "*.png ($(native_path_escaped "a/b/.gitattributes"))" track.log
+
+  grep "Set default behavior" .gitattributes
+  grep "############" .gitattributes
+  grep "* text=auto" .gitattributes
+  grep "diff=csharp" .gitattributes
+  grep "*.jpg" .gitattributes
 )
 end_test
 
@@ -292,3 +305,98 @@ begin_test "track blocklisted files with glob"
   grep "Pattern .git\* matches forbidden file" track.log
 )
 end_test
+<<<<<<< HEAD
+=======
+
+begin_test "track lockable"
+(
+  set -e
+
+  repo="track_lockable"
+  mkdir "$repo"
+  cd "$repo"
+  git init
+
+  # track *.jpg once, lockable
+  git lfs track --lockable "*.jpg" | grep "Tracking \*.jpg"
+  assert_attributes_count "jpg" "lockable" 1
+  # track *.jpg again, don't change anything. Should retain lockable
+  git lfs track "*.jpg" | grep "*.jpg already supported"
+  assert_attributes_count "jpg" "lockable" 1
+
+
+  # track *.png once, not lockable yet
+  git lfs track "*.png" | grep "Tracking \*.png"
+  assert_attributes_count "png" "filter=lfs" 1
+  assert_attributes_count "png" "lockable" 0
+
+  # track png again, enable lockable, should replace
+  git lfs track --lockable "*.png" | grep "Tracking \*.png"
+  assert_attributes_count "png" "filter=lfs" 1
+  assert_attributes_count "png" "lockable" 1
+
+  # track png again, disable lockable, should replace
+  git lfs track --not-lockable "*.png" | grep "Tracking \*.png"
+  assert_attributes_count "png" "filter=lfs" 1
+  assert_attributes_count "png" "lockable" 0
+
+  # check output reflects lockable
+  out=$(git lfs track)
+  echo "$out" | grep "Listing tracked patterns"
+  echo "$out" | grep "*.jpg \[lockable\] (.gitattributes)"
+  echo "$out" | grep "*.png (.gitattributes)"
+)
+end_test
+
+begin_test "track lockable read-only/read-write"
+(
+  set -e
+
+  repo="track_lockable_ro_rw"
+  mkdir "$repo"
+  cd "$repo"
+  git init
+
+  echo "blah blah" > test.bin
+  echo "foo bar" > test.dat
+  mkdir subfolder
+  echo "sub blah blah" > subfolder/test.bin
+  echo "sub foo bar" > subfolder/test.dat
+  # should start writeable
+  [ -w test.bin ]
+  [ -w test.dat ]
+  [ -w subfolder/test.bin ]
+  [ -w subfolder/test.dat ]
+
+  # track *.bin, not lockable yet
+  git lfs track "*.bin" | grep "Tracking \*.bin"
+  # track *.dat, lockable immediately
+  git lfs track --lockable "*.dat" | grep "Tracking \*.dat"
+
+  # bin should remain writeable, dat should have been made read-only
+  [ -w test.bin ]
+  [ ! -w test.dat ]
+  [ -w subfolder/test.bin ]
+  [ ! -w subfolder/test.dat ]
+
+  git add .gitattributes test.bin test.dat
+  git commit -m "First commit"
+
+  # bin should still be writeable
+  [ -w test.bin ]
+  [ -w subfolder/test.bin ]
+  # now make bin lockable
+  git lfs track --lockable "*.bin" | grep "Tracking \*.bin"
+  # bin should now be read-only
+  [ ! -w test.bin ]
+  [ ! -w subfolder/test.bin ]
+
+  # remove lockable again
+  git lfs track --not-lockable "*.bin" | grep "Tracking \*.bin"
+  # bin should now be writeable again
+  [ -w test.bin ]
+  [ -w subfolder/test.bin ]
+
+)
+end_test
+>>>>>>> 0685231f... Merge pull request #1921 from git-lfs/track-with-empty-lines


### PR DESCRIPTION
This backports #1921.

Conflicting files:
- commands/command_track.go
- test/test-track.sh