### PR TITLE
pre-push: make lock verification optional for servers that don't support it

### DIFF
--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -96,7 +96,9 @@ func verifyLocks(remote string) (ours, theirs []locking.Lock) {
 			Print("Remote %q does not support the LFS locking API. Consider disabling it with:", remote)
 			Print("  $ git config 'lfs.%s.locksverify' false", endpoint.Url)
 
-			ExitWithError(err)
+			if state == verifyStateEnabled {
+				ExitWithError(err)
+			}
 		}
 	} else if state == verifyStateUnknown {
 		Print("Locking support detected on remote %q. Consider enabling it with:", remote)

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -2,14 +2,19 @@ package commands
 
 import (
 	"os"
+	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/git-lfs/git-lfs/errors"
+	"github.com/git-lfs/git-lfs/git"
 	"github.com/git-lfs/git-lfs/lfs"
+	"github.com/git-lfs/git-lfs/lfsapi"
 	"github.com/git-lfs/git-lfs/locking"
 	"github.com/git-lfs/git-lfs/progress"
 	"github.com/git-lfs/git-lfs/tools"
 	"github.com/git-lfs/git-lfs/tq"
+	"github.com/rubyist/tracerx"
 )
 
 type uploadContext struct {
@@ -37,6 +42,14 @@ type uploadContext struct {
 	unownedLocks []*locking.Lock
 }
 
+type verifyState byte
+
+const (
+	verifyStateUnknown verifyState = iota
+	verifyStateEnabled
+	verifyStateDisabled
+)
+
 func newUploadContext(remote string, dryRun bool) *uploadContext {
 	cfg.CurrentRemote = remote
 
@@ -54,21 +67,43 @@ func newUploadContext(remote string, dryRun bool) *uploadContext {
 	ctx.tq = newUploadQueue(ctx.Manifest, ctx.Remote, tq.WithProgress(ctx.meter), tq.DryRun(ctx.DryRun))
 	ctx.committerName, ctx.committerEmail = cfg.CurrentCommitter()
 
-	lockClient := newLockClient(remote)
-	ourLocks, theirLocks, err := lockClient.VerifiableLocks(0)
-	if err != nil {
-		Error("WARNING: Unable to search for locks contained in this push.")
-		Error("         Temporarily skipping check ...")
-	} else {
-		for _, l := range theirLocks {
-			ctx.theirLocks[l.Path] = &l
-		}
-		for _, l := range ourLocks {
-			ctx.ourLocks[l.Path] = &l
-		}
+	ourLocks, theirLocks := verifyLocks(remote)
+	for _, l := range theirLocks {
+		ctx.theirLocks[l.Path] = &l
+	}
+	for _, l := range ourLocks {
+		ctx.ourLocks[l.Path] = &l
 	}
 
 	return ctx
+}
+
+func verifyLocks(remote string) (ours, theirs []locking.Lock) {
+	endpoint := getAPIClient().Endpoints.Endpoint("upload", remote)
+
+	state := getVerifyStateFor(endpoint)
+	if state == verifyStateDisabled {
+		return
+	}
+
+	lockClient := newLockClient(remote)
+
+	ours, theirs, err := lockClient.VerifiableLocks(0)
+	if err != nil {
+		if errors.IsNotImplementedError(err) {
+			disableFor(endpoint)
+		} else {
+			Print("Remote %q does not support the LFS locking API. Consider disabling it with:", remote)
+			Print("    git config lfs.%s.locksverify false", endpoint.Url)
+
+			ExitWithError(err)
+		}
+	} else if state == verifyStateUnknown {
+		Print("Locking support detected on remote %q. Consider enabling it with:", remote)
+		Print("    git config lfs.%s.locksverify true", endpoint.Url)
+	}
+
+	return ours, theirs
 }
 
 // AddUpload adds the given oid to the set of oids that have been uploaded in
@@ -191,4 +226,32 @@ func (c *uploadContext) Await() {
 	if avoidPush {
 		Error("WARNING: The above files would have halted this push.")
 	}
+}
+
+// getVerifyStateFor returns whether or not lock verification is enabled for the
+// given "endpoint". If no state has been explicitly set, an "unknown" state
+// will be returned instead.
+func getVerifyStateFor(endpoint lfsapi.Endpoint) verifyState {
+	key := strings.Join([]string{"lfs", endpoint.Url, "locksverify"}, ".")
+
+	v, ok := cfg.Git.Get(key)
+	if !ok {
+		return verifyStateUnknown
+	}
+
+	if enabled, _ := strconv.ParseBool(v); enabled {
+		return verifyStateEnabled
+	}
+	return verifyStateDisabled
+}
+
+// disableFor disables lock verification for the given lfsapi.Endpoint,
+// "endpoint".
+func disableFor(endpoint lfsapi.Endpoint) error {
+	tracerx.Printf("commands: disabling lock verification for %q", endpoint.Url)
+
+	key := strings.Join([]string{"lfs", endpoint.Url, "locksverify"}, ".")
+
+	_, err := git.Config.SetLocal("", key, "false")
+	return err
 }

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -94,13 +94,13 @@ func verifyLocks(remote string) (ours, theirs []locking.Lock) {
 			disableFor(endpoint)
 		} else {
 			Print("Remote %q does not support the LFS locking API. Consider disabling it with:", remote)
-			Print("    git config lfs.%s.locksverify false", endpoint.Url)
+			Print("  $ git config 'lfs.%s.locksverify' false", endpoint.Url)
 
 			ExitWithError(err)
 		}
 	} else if state == verifyStateUnknown {
 		Print("Locking support detected on remote %q. Consider enabling it with:", remote)
-		Print("    git config lfs.%s.locksverify true", endpoint.Url)
+		Print("  $ git config 'lfs.%s.locksverify' true", endpoint.Url)
 	}
 
 	return ours, theirs

--- a/locking/locks.go
+++ b/locking/locks.go
@@ -2,6 +2,7 @@ package locking
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sync"
@@ -194,7 +195,11 @@ func (c *Client) VerifiableLocks(limit int) (ourLocks, theirLocks []Lock, err er
 	}
 
 	for {
-		list, _, err := c.client.SearchVerifiable(c.Remote, body)
+		list, res, err := c.client.SearchVerifiable(c.Remote, body)
+		if res != nil && res.StatusCode == http.StatusNotImplemented {
+			return ourLocks, theirLocks, errors.NewNotImplementedError(err)
+		}
+
 		if err != nil {
 			return ourLocks, theirLocks, err
 		}

--- a/test/cmd/lfstest-gitserver.go
+++ b/test/cmd/lfstest-gitserver.go
@@ -968,6 +968,15 @@ func locksHandler(w http.ResponseWriter, r *http.Request, repo string) {
 		}
 
 		if strings.HasSuffix(r.URL.Path, "/locks/verify") {
+			if strings.HasSuffix(repo, "verify-5xx") {
+				w.WriteHeader(500)
+				return
+			}
+			if strings.HasSuffix(repo, "verify-501") {
+				w.WriteHeader(501)
+				return
+			}
+
 			switch repo {
 			case "pre_push_locks_verify_404":
 				w.WriteHeader(http.StatusNotFound)

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -530,3 +530,163 @@ begin_test "pre-push with their lock"
   popd >/dev/null
 )
 end_test
+
+begin_test "pre-push locks verify 5xx with verification enabled"
+(
+  set -e
+
+  reponame="lock-enabled-verify-5xx"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  endpoint="$(repo_endpoint $GITSERVER $reponame)"
+
+  printf "example" > a.dat
+  git lfs track "*.dat"
+  git add .gitattributes a.dat
+  git commit --message "initial commit"
+
+  git config "lfs.$endpoint.locksverify" true
+
+  git push origin master 2>&1 | tee push.log
+  grep "\"origin\" does not support the LFS locking API" push.log
+  grep "git config lfs.$endpoint.locksverify false" push.log
+)
+end_test
+
+
+begin_test "pre-push locks verify 5xx with verification disabled"
+(
+  set -e
+
+  reponame="lock-disabled-verify-5xx"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  endpoint="$(repo_endpoint $GITSERVER $reponame)"
+
+  printf "example" > a.dat
+  git lfs track "*.dat"
+  git add .gitattributes a.dat
+  git commit --message "initial commit"
+
+  git config "lfs.$endpoint.locksverify" false
+
+  git push origin master 2>&1 | tee push.log
+  [ "0" -eq "$(grep -c "\"origin\" does not support the LFS locking API" push.log)" ]
+)
+end_test
+
+begin_test "pre-push locks verify 5xx with verification unset"
+(
+  set -e
+
+  reponame="lock-unset-verify-5xx"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  endpoint="$(repo_endpoint $GITSERVER $reponame)"
+
+  printf "example" > a.dat
+  git lfs track "*.dat"
+  git add .gitattributes a.dat
+  git commit --message "initial commit"
+
+  [ -z "$(git config "lfs.$endpoint.locksverify")" ]
+
+  git push origin master 2>&1 | tee push.log
+  grep "\"origin\" does not support the LFS locking API" push.log
+)
+end_test
+
+begin_test "pre-push locks verify 501 with verification enabled"
+(
+  set -e
+
+  reponame="lock-enabled-verify-501"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  endpoint="$(repo_endpoint $GITSERVER $reponame)"
+
+  printf "example" > a.dat
+  git lfs track "*.dat"
+  git add .gitattributes a.dat
+  git commit --message "initial commit"
+
+  git config "lfs.$endpoint.locksverify" true
+
+  git push origin master 2>&1 | tee push.log
+
+  [ "false" = "$(git config "lfs.$endpoint.locksverify")" ]
+)
+end_test
+
+
+begin_test "pre-push locks verify 501 with verification disabled"
+(
+  set -e
+
+  reponame="lock-disabled-verify-501"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  endpoint="$(repo_endpoint $GITSERVER $reponame)"
+
+  printf "example" > a.dat
+  git lfs track "*.dat"
+  git add .gitattributes a.dat
+  git commit --message "initial commit"
+
+  git config "lfs.$endpoint.locksverify" false
+
+  git push origin master 2>&1 | tee push.log
+
+  [ "false" = "$(git config "lfs.$endpoint.locksverify")" ]
+)
+end_test
+
+begin_test "pre-push locks verify 501 with verification unset"
+(
+  set -e
+
+  reponame="lock-unset-verify-501"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  endpoint="$(repo_endpoint $GITSERVER $reponame)"
+
+  printf "example" > a.dat
+  git lfs track "*.dat"
+  git add .gitattributes a.dat
+  git commit --message "initial commit"
+
+  [ -z "$(git config "lfs.$endpoint.locksverify")" ]
+
+  git push origin master 2>&1 | tee push.log
+
+  [ "false" = "$(git config "lfs.$endpoint.locksverify")" ]
+)
+end_test
+
+begin_test "pre-push locks verify 200"
+(
+  set -e
+
+  reponame="lock-verify-200"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  endpoint="$(repo_endpoint $GITSERVER $reponame)"
+  [ -z "$(git config "lfs.$endpoint.locksverify")" ]
+
+  printf "example" > a.dat
+  git lfs track "*.dat"
+  git add .gitattributes a.dat
+  git commit --message "initial commit"
+
+  git push origin master 2>&1 | tee push.log
+
+  grep "Locking support detected on remote \"origin\"." push.log
+  grep "git config lfs.$endpoint.locksverify true" push.log
+)

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -541,7 +541,9 @@ begin_test "pre-push locks verify 5xx with verification enabled"
 
   endpoint="$(repo_endpoint $GITSERVER $reponame)"
 
-  printf "example" > a.dat
+  contents="example"
+  contents_oid="$(calc_oid "$contents")"
+  printf "$contents" > a.dat
   git lfs track "*.dat"
   git add .gitattributes a.dat
   git commit --message "initial commit"
@@ -551,6 +553,8 @@ begin_test "pre-push locks verify 5xx with verification enabled"
   git push origin master 2>&1 | tee push.log
   grep "\"origin\" does not support the LFS locking API" push.log
   grep "git config 'lfs.$endpoint.locksverify' false" push.log
+
+  refute_server_object "$reponame" "$contents_oid"
 )
 end_test
 
@@ -574,6 +578,8 @@ begin_test "pre-push locks verify 5xx with verification disabled"
 
   git push origin master 2>&1 | tee push.log
   [ "0" -eq "$(grep -c "\"origin\" does not support the LFS locking API" push.log)" ]
+
+  refute_server_object "$reponame" "$contents_oid"
 )
 end_test
 
@@ -596,6 +602,8 @@ begin_test "pre-push locks verify 5xx with verification unset"
 
   git push origin master 2>&1 | tee push.log
   grep "\"origin\" does not support the LFS locking API" push.log
+
+  refute_server_object "$reponame" "$contents_oid"
 )
 end_test
 
@@ -609,7 +617,9 @@ begin_test "pre-push locks verify 501 with verification enabled"
 
   endpoint="$(repo_endpoint $GITSERVER $reponame)"
 
-  printf "example" > a.dat
+  contents="example"
+  contents_oid="$(calc_oid "$contents")"
+  printf "$contents" > a.dat
   git lfs track "*.dat"
   git add .gitattributes a.dat
   git commit --message "initial commit"
@@ -618,6 +628,7 @@ begin_test "pre-push locks verify 501 with verification enabled"
 
   git push origin master 2>&1 | tee push.log
 
+  assert_server_object "$reponame" "$contents_oid"
   [ "false" = "$(git config "lfs.$endpoint.locksverify")" ]
 )
 end_test
@@ -633,7 +644,9 @@ begin_test "pre-push locks verify 501 with verification disabled"
 
   endpoint="$(repo_endpoint $GITSERVER $reponame)"
 
-  printf "example" > a.dat
+  contents="example"
+  contents_oid="$(calc_oid "$contents")"
+  printf "$contents" > a.dat
   git lfs track "*.dat"
   git add .gitattributes a.dat
   git commit --message "initial commit"
@@ -642,6 +655,7 @@ begin_test "pre-push locks verify 501 with verification disabled"
 
   git push origin master 2>&1 | tee push.log
 
+  assert_server_object "$reponame" "$contents_oid"
   [ "false" = "$(git config "lfs.$endpoint.locksverify")" ]
 )
 end_test
@@ -656,7 +670,9 @@ begin_test "pre-push locks verify 501 with verification unset"
 
   endpoint="$(repo_endpoint $GITSERVER $reponame)"
 
-  printf "example" > a.dat
+  contents="example"
+  contents_oid="$(calc_oid "$contents")"
+  printf "$contents" > a.dat
   git lfs track "*.dat"
   git add .gitattributes a.dat
   git commit --message "initial commit"
@@ -665,6 +681,7 @@ begin_test "pre-push locks verify 501 with verification unset"
 
   git push origin master 2>&1 | tee push.log
 
+  assert_server_object "$reponame" "$contents_oid"
   [ "false" = "$(git config "lfs.$endpoint.locksverify")" ]
 )
 end_test
@@ -680,7 +697,9 @@ begin_test "pre-push locks verify 200"
   endpoint="$(repo_endpoint $GITSERVER $reponame)"
   [ -z "$(git config "lfs.$endpoint.locksverify")" ]
 
-  printf "example" > a.dat
+  contents="example"
+  contents_oid="$(calc_oid "$contents")"
+  printf "$contents" > a.dat
   git lfs track "*.dat"
   git add .gitattributes a.dat
   git commit --message "initial commit"
@@ -689,4 +708,5 @@ begin_test "pre-push locks verify 200"
 
   grep "Locking support detected on remote \"origin\"." push.log
   grep "git config 'lfs.$endpoint.locksverify' true" push.log
+  assert_server_object "$reponame" "$contents_oid"
 )

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -550,7 +550,7 @@ begin_test "pre-push locks verify 5xx with verification enabled"
 
   git push origin master 2>&1 | tee push.log
   grep "\"origin\" does not support the LFS locking API" push.log
-  grep "git config lfs.$endpoint.locksverify false" push.log
+  grep "git config 'lfs.$endpoint.locksverify' false" push.log
 )
 end_test
 
@@ -688,5 +688,5 @@ begin_test "pre-push locks verify 200"
   git push origin master 2>&1 | tee push.log
 
   grep "Locking support detected on remote \"origin\"." push.log
-  grep "git config lfs.$endpoint.locksverify true" push.log
+  grep "git config 'lfs.$endpoint.locksverify' true" push.log
 )

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -569,7 +569,9 @@ begin_test "pre-push locks verify 5xx with verification disabled"
 
   endpoint="$(repo_endpoint $GITSERVER $reponame)"
 
-  printf "example" > a.dat
+  contents="example"
+  contents_oid="$(calc_oid "$contents")"
+  printf "$contents" > a.dat
   git lfs track "*.dat"
   git add .gitattributes a.dat
   git commit --message "initial commit"
@@ -579,7 +581,7 @@ begin_test "pre-push locks verify 5xx with verification disabled"
   git push origin master 2>&1 | tee push.log
   [ "0" -eq "$(grep -c "\"origin\" does not support the LFS locking API" push.log)" ]
 
-  refute_server_object "$reponame" "$contents_oid"
+  assert_server_object "$reponame" "$contents_oid"
 )
 end_test
 
@@ -593,7 +595,9 @@ begin_test "pre-push locks verify 5xx with verification unset"
 
   endpoint="$(repo_endpoint $GITSERVER $reponame)"
 
-  printf "example" > a.dat
+  contents="example"
+  contents_oid="$(calc_oid "$contents")"
+  printf "$contents" > a.dat
   git lfs track "*.dat"
   git add .gitattributes a.dat
   git commit --message "initial commit"
@@ -603,7 +607,7 @@ begin_test "pre-push locks verify 5xx with verification unset"
   git push origin master 2>&1 | tee push.log
   grep "\"origin\" does not support the LFS locking API" push.log
 
-  refute_server_object "$reponame" "$contents_oid"
+  assert_server_object "$reponame" "$contents_oid"
 )
 end_test
 

--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -10,6 +10,8 @@ begin_test "push"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" repo
 
+  git config "lfs.$(repo_endpoint "$GITSERVER" "$reponame").locksverify" true
+
   git lfs track "*.dat"
   echo "push a" > a.dat
   git add .gitattributes a.dat
@@ -67,6 +69,7 @@ push_all_setup() {
   [ -d "push-all" ] && exit 0
 
   clone_repo "$reponame" "push-all"
+  git config "lfs.$(repo_endpoint "$GITSERVER" "$reponame").locksverify" true
   git lfs track "*.dat"
 
   echo "[
@@ -114,6 +117,7 @@ push_all_setup() {
   git rev-parse HEAD > .git/refs/remotes/origin/HEAD
 
   setup_alternate_remote "$reponame-$suffix"
+  git config "lfs.$(repo_endpoint "$GITSERVER" "$reponame-$suffix").locksverify" true
 }
 
 begin_test "push --all (no ref args)"
@@ -142,6 +146,8 @@ begin_test "push --all (no ref args)"
 
   echo "push while missing old objects locally"
   setup_alternate_remote "$reponame-$suffix-2"
+  git config "lfs.$(repo_endpoint "$GITSERVER" "$reponame-$suffix-2").locksverify" true
+
   git lfs push --object-id origin $oid1
   assert_server_object "$reponame-$suffix-2" "$oid1"
   refute_server_object "$reponame-$suffix-2" "$oid2"
@@ -196,6 +202,7 @@ begin_test "push --all (1 ref arg)"
 
   echo "push while missing old objects locally"
   setup_alternate_remote "$reponame-$suffix-2"
+  git config "lfs.$(repo_endpoint "$GITSERVER" "$reponame-$suffix-2").locksverify" true
   git lfs push --object-id origin $oid1
   assert_server_object "$reponame-$suffix-2" "$oid1"
   refute_server_object "$reponame-$suffix-2" "$oid2"
@@ -246,6 +253,7 @@ begin_test "push --all (multiple ref args)"
 
   echo "push while missing old objects locally"
   setup_alternate_remote "$reponame-$suffix-2"
+  git config "lfs.$(repo_endpoint "$GITSERVER" "$reponame-$suffix-2").locksverify" true
   git lfs push --object-id origin $oid1
   assert_server_object "$reponame-$suffix-2" "$oid1"
   refute_server_object "$reponame-$suffix-2" "$oid2"
@@ -298,6 +306,7 @@ begin_test "push --all (ref with deleted files)"
 
   echo "push while missing old objects locally"
   setup_alternate_remote "$reponame-$suffix-2"
+  git config "lfs.$(repo_endpoint "$GITSERVER" "$reponame-$suffix-2").locksverify" true
   git lfs push --object-id origin $oid1
   assert_server_object "$reponame-$suffix-2" "$oid1"
   refute_server_object "$reponame-$suffix-2" "$oid2"
@@ -333,6 +342,8 @@ begin_test "push object id(s)"
   reponame="$(basename "$0" ".sh")"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" repo2
+
+  git config "lfs.$(repo_endpoint "$GITSERVER" "$reponame").locksverify" true
 
   git lfs track "*.dat"
   echo "push a" > a.dat

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -348,6 +348,16 @@ substring_position() {
     | wc -c
 }
 
+# repo_endpoint returns the LFS endpoint for a given server and repository.
+#
+#     [ "$GITSERVER/example/repo.git/info/lfs" = "$(repo_endpoint $GITSERVER example-repo)" ]
+repo_endpoint() {
+  local server="$1"
+  local repo="$2"
+
+  echo "$server/$repo.git/info/lfs"
+}
+
 # setup initializes the clean, isolated environment for integration tests.
 setup() {
   cd "$ROOTDIR"


### PR DESCRIPTION
This pull-request allows the LFS client to be configured in such a way that makes lock verification a no-op for servers that don't yet support the new locking API.

At face value, this also makes it very easy for users to disable lock verification to push locked files to servers that don't block pushes not owned by the lock owner. However, there's really no change before/after this PR, since all of this logic is wrapped up in a Git hook anyway, you can still just delete the hook.

Here are the rules:

- If the `.locksverify` rule is unset, make the verify API call...
  - If it was successful, notify the user they should "enable" lock verification for that remote
  - If it failed...
    - AND the failure was a 501, disable the lock verification and move on
    - OR print a warning, but still push
- If the `.locksverify` config is true, make the verify API call...
  - If it was successful, move on
  - If it failed...
    - AND the failure was a 501, disable the lock verification and move on
    - OR print a warning and halt the push  
- If the `.locksverify` config was false, skip the verify API call.

Pushing to a sever that doesn't support locking:

```
~/g/git-lfs (optional-pre-push) $ git push origin master
[master (root-commit) edbdd87] initial commit
 2 files changed, 4 insertions(+)
 create mode 100644 .gitattributes
 create mode 100644 a.dat
Remote "origin" does not support the LFS locking API. Consider disabling it with:
  $ git config lfs.http://127.0.0.1:61354/lock-unset-verify-5xx.git/info/lfs.locksverify false
http: Fatal error: Unable to parse HTTP response for POST http://127.0.0.1:61354/lock-unset-verify-5xx.git/info/lfs/locks/verify: EOF
```

Pushing to a server that does support locking:
```
~/g/git-lfs (optional-pre-push) $ git push origin master
[master (root-commit) a4f4c34] initial commit
 2 files changed, 4 insertions(+)
 create mode 100644 .gitattributes
 create mode 100644 a.dat
Locking support detected on remote "origin". Consider enabling it with:
  $ git config lfs.http://127.0.0.1:61383/lock-unset-verify.git/info/lfs.locksverify true
Git LFS: (1 of 1 files) 7 B / 7 B
To http://127.0.0.1:61383/lock-unset-verify
 * [new branch]      master -> master
```

---

/cc @git-lfs/core 