### PR TITLE
all: build using Go 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # http://docs.travis-ci.com/user/languages/go/
 language: go
 
-go: 1.7.4
+go: 1.8
 
 os:
   - linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,10 @@ environment:
 clone_folder: $(GOPATH)\src\github.com\git-lfs\git-lfs
 
 install:
-  - cinst golang --version 1.7.4 -y
+  - rd C:\Go /s /q
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.8.windows-amd64.zip
+  - 7z x go1.8.windows-amd64.zip -oC:\ >nul
+  - C:\go\bin\go version
   - cinst InnoSetup -y
   - refreshenv
 


### PR DESCRIPTION
This pull request upgrades our testing infrastructure to use Go 1.8.

- Travis: bumped in the `.travis.yml` to use 1.8.
- AppVeyor: Go 1.8 isn't in on `cinst` yet, so let's install it ourselves.
- CircleCI: upgrade through https://github.com/Homebrew/homebrew-core/pull/10048

---

/cc @git-lfs/core 