### PR TITLE
commands/smudge: treat empty pointers as empty files

### DIFF
--- a/test/test-malformed-pointers.sh
+++ b/test/test-malformed-pointers.sh
@@ -53,3 +53,35 @@ begin_test "malformed pointers"
   popd >/dev/null
 )
 end_test
+
+begin_test "empty pointers"
+(
+  set -e
+
+  reponame="empty-pointers"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  touch empty.dat
+
+  git \
+    -c "filter.lfs.process=" \
+    -c "filter.lfs.clean=cat" \
+    -c "filter.lfs.required=false" \
+    add empty.dat
+  git commit -m "add empty pointer"
+
+  git push origin master
+
+  pushd .. >/dev/null
+    clone_repo "$reponame" "$reponame-assert"
+
+    [ "0" -eq "$(grep -c "empty.dat" clone.log)" ]
+    [ "0" -eq "$(wc -c < empty.dat)" ]
+  popd >/dev/null
+)
+end_test


### PR DESCRIPTION
This pull request treats empty pointers as empty objects, and writes them out as such.

Previously, an empty pointer would be treated as malformed. An empty file _would_ get written out, but the file would also be marked as belonging to a malformed pointer.

With this change, LFS counts the number of bytes spooled out to Git. If there was no error in spooling, and the number of bytes written is zero (meaning that we successfully wrote zero bytes with the intent to do so), return a nil error, instead of marking it as a malformed pointer.

--- 

/cc @git-lfs/core 
/x-ref https://github.com/git-lfs/git-lfs/pull/1922