### PR TITLE
progress: fix never reading bytes with sufficiently small files

### DIFF
--- a/progress/copycallback.go
+++ b/progress/copycallback.go
@@ -31,12 +31,11 @@ func (r *bodyWithCallback) Read(p []byte) (int, error) {
 
 	if n > 0 {
 		r.readSize += int64(n)
-	}
 
-	if err == nil && r.c != nil {
-		err = r.c(r.totalSize, r.readSize, n)
+		if (err == nil || err == io.EOF) && r.c != nil {
+			err = r.c(r.totalSize, r.readSize, n)
+		}
 	}
-
 	return n, err
 }
 
@@ -52,12 +51,11 @@ func (w *CallbackReader) Read(p []byte) (int, error) {
 
 	if n > 0 {
 		w.ReadSize += int64(n)
-	}
 
-	if err == nil && w.C != nil {
-		err = w.C(w.TotalSize, w.ReadSize, n)
+		if (err == nil || err == io.EOF) && w.C != nil {
+			err = w.C(w.TotalSize, w.ReadSize, n)
+		}
 	}
-
 	return n, err
 }
 

--- a/progress/copycallback_test.go
+++ b/progress/copycallback_test.go
@@ -1,0 +1,47 @@
+package progress
+
+import (
+	"bytes"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCopyCallbackReaderCallsCallbackUnderfilledBuffer(t *testing.T) {
+	var (
+		calls               uint32
+		actualTotalSize     int64
+		actualReadSoFar     int64
+		actualReadSinceLast int
+	)
+
+	cb := func(totalSize int64, readSoFar int64, readSinceLast int) error {
+		atomic.AddUint32(&calls, 1)
+
+		actualTotalSize = totalSize
+		actualReadSoFar = readSoFar
+		actualReadSinceLast = readSinceLast
+
+		return nil
+	}
+
+	buf := []byte{0x1}
+	r := &CallbackReader{
+		C:         cb,
+		TotalSize: 3,
+		ReadSize:  2,
+		Reader:    bytes.NewReader(buf),
+	}
+
+	p := make([]byte, len(buf)+1)
+	n, err := r.Read(p)
+
+	assert.Equal(t, 1, n)
+	assert.Nil(t, err)
+
+	assert.EqualValues(t, 1, calls)
+	assert.EqualValues(t, 3, actualTotalSize)
+	assert.EqualValues(t, 2+1, actualReadSoFar)
+	assert.EqualValues(t, 1, actualReadSinceLast)
+}

--- a/test/test-progress-meter.sh
+++ b/test/test-progress-meter.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+. "test/testlib.sh"
+
+begin_test "progress meter displays positive progress"
+(
+  set -e
+
+  reponame="progress-meter"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  for i in `seq 1 128`; do
+    printf "$i" > "$i.dat"
+  done
+
+  git add *.dat
+  git commit -m "add many objects"
+
+  git push origin master 2>&1 | tee push.log
+  [ "0" -eq "${PIPESTATUS[0]}" ]
+
+  grep "Git LFS: (128 of 128 files) 276 B / 276 B" push.log
+)
+end_test


### PR DESCRIPTION
This pull-requests fixes #1926, a bug which would cause push/pull operations with small objects to look like this:

```
~/Desktop $ git lfs clone git@github.com:larsxschneider/lfstest-manyfiles.git
Cloning into 'lfstest-manyfiles'...
remote: Counting objects: 15012, done.
remote: Total 15012 (delta 0), reused 0 (delta 0), pack-reused 15012
Receiving objects: 100% (15012/15012), 2.02 MiB | 2.25 MiB/s, done.
Checking out files: 100% (15001/15001), done.
Git LFS: (87 of 201 files) 0 B / 1.15 KB
                           ^
```

The issue lies in the fact that `io.Reader`s, when at the end of a stream, can either return 
- `([]byte, nil)` then `(nil, io.EOF)`, or
- `([]byte, io.EOF)`

From the Go documentation<sup>[[1](https://golang.org/pkg/io/#Reader)]</sup>:

> An instance of this general case is that a Reader returning a non-zero number of bytes at the end of the input stream may return either err == EOF or err == nil. The next Read should return 0, EOF.

Particularly, the problem lied [here][1]:

```go
if err == nil && w.C != nil {
	err = w.C(w.TotalSize, w.ReadSize, n)
}
```

`err` could be `io.EOF` even when there was a positive number of bytes `n` to progress upon. This happens when the buffer "p" being read into is larger than the available data on the stream. In other words, small files make this incredibly common.

However, changing `err == nil` to `err == nil || err == io.EOF` isn't quite the right fix, since `(nil, io.EOF)` is a valid return value from io.Readers. Instead, let's check for positive values of `n`, and increment based on that. This is semantically equivalent to `err == nil || (err == io.EOF && n > 0)`, since the interface documentation specifies that non-nil errors should indicate zero bytes read.

I added an integration test to verify that we counted the bytes correctly for small files, and a unit test to prevent further regressions.

```
~/Desktop $ git lfs clone git@github.com:larsxschneider/lfstest-manyfiles.git
Cloning into 'lfstest-manyfiles'...
remote: Counting objects: 15012, done.
remote: Total 15012 (delta 0), reused 0 (delta 0), pack-reused 15012
Receiving objects: 100% (15012/15012), 2.02 MiB | 2.40 MiB/s, done.
Git LFS: (61 of 201 files) 366 B / 1.15 KB
```

---

/cc @git-lfs/core 

[1]: https://github.com/git-lfs/git-lfs/blob/c22c48bb6471499f57ffbbe5dbfbaa6c1a1e9e35/progress/copycallback.go#L57