### PR TITLE
AppVeyor: Again use a Chocolatey package for installing Golang

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,9 +8,7 @@ clone_folder: $(GOPATH)\src\github.com\git-lfs\git-lfs
 
 install:
   - rd C:\Go /s /q
-  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.8.windows-amd64.zip
-  - 7z x go1.8.windows-amd64.zip -oC:\ >nul
-  - C:\go\bin\go version
+  - cinst golang --version 1.8.0 -y
   - cinst InnoSetup -y
   - refreshenv
 

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
+go version
+
 if uname -s | grep -q "_NT-"; then
   # Tell Cygwin / MSYS to really create symbolic links.
   export CYGWIN="$CYGWIN winsymlinks:nativestrict"

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 set -e
+
+go version
+
 script/test
 
 # re-run test to ensure GIT_TRACE output doesn't leak into the git package


### PR DESCRIPTION
This time for version 1.8.0, which is available now.