### PR TITLE
tq: bump 'defaultMaxRetries' to 8

### DIFF
--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -99,8 +99,8 @@ lfs option can be scoped inside the configuration for a remote.
 
   Specifies how many retries LFS will attempt per OID before marking the
   transfer as failed. Must be an integer which is at least one. If the value is
-  not an integer, is less than one, or is not given, a value of one will be used
-  instead.
+  not an integer, is less than one, or is not given, a value of eight will be
+  used instead.
 
 ### Fetch settings
 

--- a/tq/manifest.go
+++ b/tq/manifest.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	defaultMaxRetries          = 1
+	defaultMaxRetries          = 8
 	defaultConcurrentTransfers = 3
 )
 

--- a/tq/manifest_test.go
+++ b/tq/manifest_test.go
@@ -27,7 +27,7 @@ func TestManifestChecksNTLM(t *testing.T) {
 	require.Nil(t, err)
 
 	m := NewManifestWithClient(cli)
-	assert.Equal(t, 1, m.MaxRetries())
+	assert.Equal(t, 8, m.MaxRetries())
 }
 
 func TestManifestClampsValidValues(t *testing.T) {
@@ -37,7 +37,7 @@ func TestManifestClampsValidValues(t *testing.T) {
 	require.Nil(t, err)
 
 	m := NewManifestWithClient(cli)
-	assert.Equal(t, 1, m.MaxRetries())
+	assert.Equal(t, 8, m.MaxRetries())
 }
 
 func TestManifestIgnoresNonInts(t *testing.T) {
@@ -47,5 +47,5 @@ func TestManifestIgnoresNonInts(t *testing.T) {
 	require.Nil(t, err)
 
 	m := NewManifestWithClient(cli)
-	assert.Equal(t, 1, m.MaxRetries())
+	assert.Equal(t, 8, m.MaxRetries())
 }

--- a/tq/transfer_queue_test.go
+++ b/tq/transfer_queue_test.go
@@ -7,12 +7,12 @@ import (
 )
 
 func TestManifestDefaultsToFixedRetries(t *testing.T) {
-	assert.Equal(t, 1, NewManifest().MaxRetries())
+	assert.Equal(t, 8, NewManifest().MaxRetries())
 }
 
 func TestRetryCounterDefaultsToFixedRetries(t *testing.T) {
 	rc := newRetryCounter()
-	assert.Equal(t, 1, rc.MaxRetries)
+	assert.Equal(t, 8, rc.MaxRetries)
 }
 
 func TestRetryCounterIncrementsObjects(t *testing.T) {
@@ -23,6 +23,7 @@ func TestRetryCounterIncrementsObjects(t *testing.T) {
 
 func TestRetryCounterCanNotRetryAfterExceedingRetryCount(t *testing.T) {
 	rc := newRetryCounter()
+	rc.MaxRetries = 1
 	rc.Increment("oid")
 
 	count, canRetry := rc.CanRetry("oid")


### PR DESCRIPTION
This pull request bumps the default maximum retries LFS will make before failing an object transfer to eight, in conjunction with #1781.

---

/cc @git-lfs/core 