### PR TITLE
tools: fix truncating string fields between balanced quotes

### DIFF
--- a/lfsapi/ssh.go
+++ b/lfsapi/ssh.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/git-lfs/git-lfs/tools"
 	"github.com/rubyist/tracerx"
 )
 
@@ -66,7 +67,7 @@ func sshGetExeAndArgs(osEnv Env, e Endpoint) (exe string, baseargs []string) {
 
 	ssh, _ := osEnv.Get("GIT_SSH")
 	sshCmd, _ := osEnv.Get("GIT_SSH_COMMAND")
-	cmdArgs := strings.Fields(sshCmd)
+	cmdArgs := tools.QuotedFields(sshCmd)
 	if len(cmdArgs) > 0 {
 		ssh = cmdArgs[0]
 		cmdArgs = cmdArgs[1:]

--- a/lfsapi/ssh_test.go
+++ b/lfsapi/ssh_test.go
@@ -177,6 +177,20 @@ func TestSSHGetExeAndArgsSshCommandArgs(t *testing.T) {
 	assert.Equal(t, []string{"--args", "1", "user@foo.com"}, args)
 }
 
+func TestSSHGetExeAndArgsSshCommandArgsWithMixedQuotes(t *testing.T) {
+	cli, err := NewClient(TestEnv(map[string]string{
+		"GIT_SSH_COMMAND": "sshcmd foo 'bar \"baz\"'",
+	}), nil)
+	require.Nil(t, err)
+
+	endpoint := cli.Endpoints.Endpoint("download", "")
+	endpoint.SshUserAndHost = "user@foo.com"
+
+	exe, args := sshGetExeAndArgs(cli.OSEnv(), endpoint)
+	assert.Equal(t, "sshcmd", exe)
+	assert.Equal(t, []string{"foo", "'bar \"baz\"'", "user@foo.com"}, args)
+}
+
 func TestSSHGetExeAndArgsSshCommandCustomPort(t *testing.T) {
 	cli, err := NewClient(TestEnv(map[string]string{
 		"GIT_SSH_COMMAND": "sshcmd",

--- a/lfsapi/ssh_test.go
+++ b/lfsapi/ssh_test.go
@@ -188,7 +188,7 @@ func TestSSHGetExeAndArgsSshCommandArgsWithMixedQuotes(t *testing.T) {
 
 	exe, args := sshGetExeAndArgs(cli.OSEnv(), endpoint)
 	assert.Equal(t, "sshcmd", exe)
-	assert.Equal(t, []string{"foo", "'bar \"baz\"'", "user@foo.com"}, args)
+	assert.Equal(t, []string{"foo", `bar "baz"`, "user@foo.com"}, args)
 }
 
 func TestSSHGetExeAndArgsSshCommandCustomPort(t *testing.T) {

--- a/tools/str_tools.go
+++ b/tools/str_tools.go
@@ -1,0 +1,22 @@
+package tools
+
+import "regexp"
+
+var (
+	// quoteFieldRe greedily matches between matching pairs of '', "", or
+	// non-word characters.
+	quoteFieldRe = regexp.MustCompile("'.+'|\".+\"|\\S+")
+)
+
+// QuotedFields is an alternative to strings.Fields (see:
+// https://golang.org/pkg/strings#Fields) that respects spaces between matching
+// pairs of quotation delimeters.
+//
+// For instance, the quoted fields of the string "foo bar 'baz etc'" would be:
+//   []string{"foo", "bar", "'baz etc'"}
+//
+// Whereas the same argument given to strings.Fields, would return:
+//   []string{"foo", "bar", "'baz", "etc'"}
+func QuotedFields(s string) []string {
+	return quoteFieldRe.FindAllString(s, -1)
+}

--- a/tools/str_tools.go
+++ b/tools/str_tools.go
@@ -5,7 +5,7 @@ import "regexp"
 var (
 	// quoteFieldRe greedily matches between matching pairs of '', "", or
 	// non-word characters.
-	quoteFieldRe = regexp.MustCompile("'(.+)'|\"(.+)\"|(\\S+)")
+	quoteFieldRe = regexp.MustCompile("'(.*)'|\"(.*)\"|(\\S*)")
 )
 
 // QuotedFields is an alternative to strings.Fields (see:
@@ -22,6 +22,13 @@ func QuotedFields(s string) []string {
 	out := make([]string, 0, len(submatches))
 
 	for _, matches := range submatches {
+		// if a leading or trailing space is found, ignore that
+		if matches[0] == "" {
+			continue
+		}
+
+		// otherwise, find the first non-empty match (inside balanced
+		// quotes, or a space-delimited string)
 		var str string
 		for _, m := range matches[1:] {
 			if len(m) > 0 {

--- a/tools/str_tools.go
+++ b/tools/str_tools.go
@@ -5,7 +5,7 @@ import "regexp"
 var (
 	// quoteFieldRe greedily matches between matching pairs of '', "", or
 	// non-word characters.
-	quoteFieldRe = regexp.MustCompile("'.+'|\".+\"|\\S+")
+	quoteFieldRe = regexp.MustCompile("'(.+)'|\"(.+)\"|(\\S+)")
 )
 
 // QuotedFields is an alternative to strings.Fields (see:
@@ -13,10 +13,25 @@ var (
 // pairs of quotation delimeters.
 //
 // For instance, the quoted fields of the string "foo bar 'baz etc'" would be:
-//   []string{"foo", "bar", "'baz etc'"}
+//   []string{"foo", "bar", "baz etc"}
 //
 // Whereas the same argument given to strings.Fields, would return:
 //   []string{"foo", "bar", "'baz", "etc'"}
 func QuotedFields(s string) []string {
-	return quoteFieldRe.FindAllString(s, -1)
+	submatches := quoteFieldRe.FindAllStringSubmatch(s, -1)
+	out := make([]string, 0, len(submatches))
+
+	for _, matches := range submatches {
+		var str string
+		for _, m := range matches[1:] {
+			if len(m) > 0 {
+				str = m
+				break
+			}
+		}
+
+		out = append(out, str)
+	}
+
+	return out
 }

--- a/tools/str_tools_test.go
+++ b/tools/str_tools_test.go
@@ -46,6 +46,7 @@ func TestQuotedFields(t *testing.T) {
 		"mixed quotes trailing": {"foo 'bar \"baz\"' ", []string{"foo", "'bar \"baz\"'"}},
 		"mixed quotes leading":  {" foo 'bar \"baz\"'", []string{"foo", "'bar \"baz\"'"}},
 	} {
-		t.Run(desc, c.Assert)
+		t.Log(desc)
+		c.Assert(t)
 	}
 }

--- a/tools/str_tools_test.go
+++ b/tools/str_tools_test.go
@@ -1,0 +1,52 @@
+package tools
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type QuotedFieldsTestCase struct {
+	Desc     string
+	Given    string
+	Expected []string
+}
+
+func (c *QuotedFieldsTestCase) Assert(t *testing.T) {
+	actual := QuotedFields(c.Given)
+
+	assert.Equal(t, c.Expected, actual,
+		"tools: expected QuotedFields(%q) to equal %#v (was %#v)",
+		c.Given, c.Expected, actual,
+	)
+}
+
+func TestQuotedFields(t *testing.T) {
+	for _, c := range []QuotedFieldsTestCase{
+		{"simple", "foo bar", []string{"foo", "bar"}},
+		{"simple trailing", "foo bar ", []string{"foo", "bar"}},
+		{"simple leading", " foo bar", []string{"foo", "bar"}},
+
+		{"single quotes", "foo 'bar baz'", []string{"foo", "'bar baz'"}},
+		{"single quotes trailing", "foo 'bar baz' ", []string{"foo", "'bar baz'"}},
+		{"single quotes leading", " foo 'bar baz'", []string{"foo", "'bar baz'"}},
+
+		{"double quotes", "foo \"bar baz\"", []string{"foo", "\"bar baz\""}},
+		{"double quotes trailing", "foo \"bar baz\" ", []string{"foo", "\"bar baz\""}},
+		{"double quotes leading", " foo \"bar baz\"", []string{"foo", "\"bar baz\""}},
+
+		{"nested single quotes", "foo 'bar 'baz''", []string{"foo", "'bar 'baz''"}},
+		{"nested single quotes trailing", "foo 'bar 'baz'' ", []string{"foo", "'bar 'baz''"}},
+		{"nested single quotes leading", " foo 'bar 'baz''", []string{"foo", "'bar 'baz''"}},
+
+		{"nested double quotes", "foo \"bar \"baz\"\"", []string{"foo", "\"bar \"baz\"\""}},
+		{"nested double quotes trailing", "foo \"bar \"baz\"\" ", []string{"foo", "\"bar \"baz\"\""}},
+		{"nested double quotes leading", " foo \"bar \"baz\"\"", []string{"foo", "\"bar \"baz\"\""}},
+
+		{"mixed quotes", "foo 'bar \"baz\"'", []string{"foo", "'bar \"baz\"'"}},
+		{"mixed quotes trailing", "foo 'bar \"baz\"' ", []string{"foo", "'bar \"baz\"'"}},
+		{"mixed quotes leading", " foo 'bar \"baz\"'", []string{"foo", "'bar \"baz\"'"}},
+	} {
+		t.Run(c.Desc, c.Assert)
+	}
+}

--- a/tools/str_tools_test.go
+++ b/tools/str_tools_test.go
@@ -30,21 +30,41 @@ func TestQuotedFields(t *testing.T) {
 		"single quotes trailing": {"foo 'bar baz' ", []string{"foo", "bar baz"}},
 		"single quotes leading":  {" foo 'bar baz'", []string{"foo", "bar baz"}},
 
+		"single quotes empty":          {"foo ''", []string{"foo", ""}},
+		"single quotes trailing empty": {"foo '' ", []string{"foo", ""}},
+		"single quotes leading empty":  {" foo ''", []string{"foo", ""}},
+
 		"double quotes":          {"foo \"bar baz\"", []string{"foo", "bar baz"}},
 		"double quotes trailing": {"foo \"bar baz\" ", []string{"foo", "bar baz"}},
 		"double quotes leading":  {" foo \"bar baz\"", []string{"foo", "bar baz"}},
+
+		"double quotes empty":          {"foo \"\"", []string{"foo", ""}},
+		"double quotes trailing empty": {"foo \"\" ", []string{"foo", ""}},
+		"double quotes leading empty":  {" foo \"\"", []string{"foo", ""}},
 
 		"nested single quotes":          {"foo 'bar 'baz''", []string{"foo", "bar 'baz'"}},
 		"nested single quotes trailing": {"foo 'bar 'baz'' ", []string{"foo", "bar 'baz'"}},
 		"nested single quotes leading":  {" foo 'bar 'baz''", []string{"foo", "bar 'baz'"}},
 
+		"nested single quotes empty":          {"foo 'bar '''", []string{"foo", "bar ''"}},
+		"nested single quotes trailing empty": {"foo 'bar ''' ", []string{"foo", "bar ''"}},
+		"nested single quotes leading empty":  {" foo 'bar '''", []string{"foo", "bar ''"}},
+
 		"nested double quotes":          {"foo \"bar \"baz\"\"", []string{"foo", "bar \"baz\""}},
 		"nested double quotes trailing": {"foo \"bar \"baz\"\" ", []string{"foo", "bar \"baz\""}},
 		"nested double quotes leading":  {" foo \"bar \"baz\"\"", []string{"foo", "bar \"baz\""}},
 
+		"nested double quotes empty":          {"foo \"bar \"\"\"", []string{"foo", "bar \"\""}},
+		"nested double quotes trailing empty": {"foo \"bar \"\"\" ", []string{"foo", "bar \"\""}},
+		"nested double quotes leading empty":  {" foo \"bar \"\"\"", []string{"foo", "bar \"\""}},
+
 		"mixed quotes":          {"foo 'bar \"baz\"'", []string{"foo", "bar \"baz\""}},
 		"mixed quotes trailing": {"foo 'bar \"baz\"' ", []string{"foo", "bar \"baz\""}},
 		"mixed quotes leading":  {" foo 'bar \"baz\"'", []string{"foo", "bar \"baz\""}},
+
+		"mixed quotes empty":          {"foo 'bar \"\"'", []string{"foo", "bar \"\""}},
+		"mixed quotes trailing empty": {"foo 'bar \"\"' ", []string{"foo", "bar \"\""}},
+		"mixed quotes leading empty":  {" foo 'bar \"\"'", []string{"foo", "bar \"\""}},
 	} {
 		t.Log(desc)
 		c.Assert(t)

--- a/tools/str_tools_test.go
+++ b/tools/str_tools_test.go
@@ -22,49 +22,49 @@ func (c *QuotedFieldsTestCase) Assert(t *testing.T) {
 
 func TestQuotedFields(t *testing.T) {
 	for desc, c := range map[string]QuotedFieldsTestCase{
-		"simple":          {"foo bar", []string{"foo", "bar"}},
-		"simple trailing": {"foo bar ", []string{"foo", "bar"}},
-		"simple leading":  {" foo bar", []string{"foo", "bar"}},
+		"simple":          {`foo bar`, []string{"foo", "bar"}},
+		"simple trailing": {`foo bar `, []string{"foo", "bar"}},
+		"simple leading":  {` foo bar`, []string{"foo", "bar"}},
 
-		"single quotes":          {"foo 'bar baz'", []string{"foo", "bar baz"}},
-		"single quotes trailing": {"foo 'bar baz' ", []string{"foo", "bar baz"}},
-		"single quotes leading":  {" foo 'bar baz'", []string{"foo", "bar baz"}},
+		"single quotes":          {`foo 'bar baz'`, []string{"foo", "bar baz"}},
+		"single quotes trailing": {`foo 'bar baz' `, []string{"foo", "bar baz"}},
+		"single quotes leading":  {` foo 'bar baz'`, []string{"foo", "bar baz"}},
 
-		"single quotes empty":          {"foo ''", []string{"foo", ""}},
-		"single quotes trailing empty": {"foo '' ", []string{"foo", ""}},
-		"single quotes leading empty":  {" foo ''", []string{"foo", ""}},
+		"single quotes empty":          {`foo ''`, []string{"foo", ""}},
+		"single quotes trailing empty": {`foo '' `, []string{"foo", ""}},
+		"single quotes leading empty":  {` foo ''`, []string{"foo", ""}},
 
-		"double quotes":          {"foo \"bar baz\"", []string{"foo", "bar baz"}},
-		"double quotes trailing": {"foo \"bar baz\" ", []string{"foo", "bar baz"}},
-		"double quotes leading":  {" foo \"bar baz\"", []string{"foo", "bar baz"}},
+		"double quotes":          {`foo "bar baz"`, []string{"foo", "bar baz"}},
+		"double quotes trailing": {`foo "bar baz" `, []string{"foo", "bar baz"}},
+		"double quotes leading":  {` foo "bar baz"`, []string{"foo", "bar baz"}},
 
-		"double quotes empty":          {"foo \"\"", []string{"foo", ""}},
-		"double quotes trailing empty": {"foo \"\" ", []string{"foo", ""}},
-		"double quotes leading empty":  {" foo \"\"", []string{"foo", ""}},
+		"double quotes empty":          {`foo ""`, []string{"foo", ""}},
+		"double quotes trailing empty": {`foo "" `, []string{"foo", ""}},
+		"double quotes leading empty":  {` foo ""`, []string{"foo", ""}},
 
-		"nested single quotes":          {"foo 'bar 'baz''", []string{"foo", "bar 'baz'"}},
-		"nested single quotes trailing": {"foo 'bar 'baz'' ", []string{"foo", "bar 'baz'"}},
-		"nested single quotes leading":  {" foo 'bar 'baz''", []string{"foo", "bar 'baz'"}},
+		"nested single quotes":          {`foo 'bar 'baz''`, []string{"foo", "bar 'baz'"}},
+		"nested single quotes trailing": {`foo 'bar 'baz'' `, []string{"foo", "bar 'baz'"}},
+		"nested single quotes leading":  {` foo 'bar 'baz''`, []string{"foo", "bar 'baz'"}},
 
-		"nested single quotes empty":          {"foo 'bar '''", []string{"foo", "bar ''"}},
-		"nested single quotes trailing empty": {"foo 'bar ''' ", []string{"foo", "bar ''"}},
-		"nested single quotes leading empty":  {" foo 'bar '''", []string{"foo", "bar ''"}},
+		"nested single quotes empty":          {`foo 'bar '''`, []string{"foo", "bar ''"}},
+		"nested single quotes trailing empty": {`foo 'bar ''' `, []string{"foo", "bar ''"}},
+		"nested single quotes leading empty":  {` foo 'bar '''`, []string{"foo", "bar ''"}},
 
-		"nested double quotes":          {"foo \"bar \"baz\"\"", []string{"foo", "bar \"baz\""}},
-		"nested double quotes trailing": {"foo \"bar \"baz\"\" ", []string{"foo", "bar \"baz\""}},
-		"nested double quotes leading":  {" foo \"bar \"baz\"\"", []string{"foo", "bar \"baz\""}},
+		"nested double quotes":          {`foo "bar "baz""`, []string{"foo", `bar "baz"`}},
+		"nested double quotes trailing": {`foo "bar "baz"" `, []string{"foo", `bar "baz"`}},
+		"nested double quotes leading":  {` foo "bar "baz""`, []string{"foo", `bar "baz"`}},
 
-		"nested double quotes empty":          {"foo \"bar \"\"\"", []string{"foo", "bar \"\""}},
-		"nested double quotes trailing empty": {"foo \"bar \"\"\" ", []string{"foo", "bar \"\""}},
-		"nested double quotes leading empty":  {" foo \"bar \"\"\"", []string{"foo", "bar \"\""}},
+		"nested double quotes empty":          {`foo "bar """`, []string{"foo", `bar ""`}},
+		"nested double quotes trailing empty": {`foo "bar """ `, []string{"foo", `bar ""`}},
+		"nested double quotes leading empty":  {` foo "bar """`, []string{"foo", `bar ""`}},
 
-		"mixed quotes":          {"foo 'bar \"baz\"'", []string{"foo", "bar \"baz\""}},
-		"mixed quotes trailing": {"foo 'bar \"baz\"' ", []string{"foo", "bar \"baz\""}},
-		"mixed quotes leading":  {" foo 'bar \"baz\"'", []string{"foo", "bar \"baz\""}},
+		"mixed quotes":          {`foo 'bar "baz"'`, []string{"foo", `bar "baz"`}},
+		"mixed quotes trailing": {`foo 'bar "baz"' `, []string{"foo", `bar "baz"`}},
+		"mixed quotes leading":  {` foo 'bar "baz"'`, []string{"foo", `bar "baz"`}},
 
-		"mixed quotes empty":          {"foo 'bar \"\"'", []string{"foo", "bar \"\""}},
-		"mixed quotes trailing empty": {"foo 'bar \"\"' ", []string{"foo", "bar \"\""}},
-		"mixed quotes leading empty":  {" foo 'bar \"\"'", []string{"foo", "bar \"\""}},
+		"mixed quotes empty":          {`foo 'bar ""'`, []string{"foo", `bar ""`}},
+		"mixed quotes trailing empty": {`foo 'bar ""' `, []string{"foo", `bar ""`}},
+		"mixed quotes leading empty":  {` foo 'bar ""'`, []string{"foo", `bar ""`}},
 	} {
 		t.Log(desc)
 		c.Assert(t)

--- a/tools/str_tools_test.go
+++ b/tools/str_tools_test.go
@@ -26,25 +26,25 @@ func TestQuotedFields(t *testing.T) {
 		"simple trailing": {"foo bar ", []string{"foo", "bar"}},
 		"simple leading":  {" foo bar", []string{"foo", "bar"}},
 
-		"single quotes":          {"foo 'bar baz'", []string{"foo", "'bar baz'"}},
-		"single quotes trailing": {"foo 'bar baz' ", []string{"foo", "'bar baz'"}},
-		"single quotes leading":  {" foo 'bar baz'", []string{"foo", "'bar baz'"}},
+		"single quotes":          {"foo 'bar baz'", []string{"foo", "bar baz"}},
+		"single quotes trailing": {"foo 'bar baz' ", []string{"foo", "bar baz"}},
+		"single quotes leading":  {" foo 'bar baz'", []string{"foo", "bar baz"}},
 
-		"double quotes":          {"foo \"bar baz\"", []string{"foo", "\"bar baz\""}},
-		"double quotes trailing": {"foo \"bar baz\" ", []string{"foo", "\"bar baz\""}},
-		"double quotes leading":  {" foo \"bar baz\"", []string{"foo", "\"bar baz\""}},
+		"double quotes":          {"foo \"bar baz\"", []string{"foo", "bar baz"}},
+		"double quotes trailing": {"foo \"bar baz\" ", []string{"foo", "bar baz"}},
+		"double quotes leading":  {" foo \"bar baz\"", []string{"foo", "bar baz"}},
 
-		"nested single quotes":          {"foo 'bar 'baz''", []string{"foo", "'bar 'baz''"}},
-		"nested single quotes trailing": {"foo 'bar 'baz'' ", []string{"foo", "'bar 'baz''"}},
-		"nested single quotes leading":  {" foo 'bar 'baz''", []string{"foo", "'bar 'baz''"}},
+		"nested single quotes":          {"foo 'bar 'baz''", []string{"foo", "bar 'baz'"}},
+		"nested single quotes trailing": {"foo 'bar 'baz'' ", []string{"foo", "bar 'baz'"}},
+		"nested single quotes leading":  {" foo 'bar 'baz''", []string{"foo", "bar 'baz'"}},
 
-		"nested double quotes":          {"foo \"bar \"baz\"\"", []string{"foo", "\"bar \"baz\"\""}},
-		"nested double quotes trailing": {"foo \"bar \"baz\"\" ", []string{"foo", "\"bar \"baz\"\""}},
-		"nested double quotes leading":  {" foo \"bar \"baz\"\"", []string{"foo", "\"bar \"baz\"\""}},
+		"nested double quotes":          {"foo \"bar \"baz\"\"", []string{"foo", "bar \"baz\""}},
+		"nested double quotes trailing": {"foo \"bar \"baz\"\" ", []string{"foo", "bar \"baz\""}},
+		"nested double quotes leading":  {" foo \"bar \"baz\"\"", []string{"foo", "bar \"baz\""}},
 
-		"mixed quotes":          {"foo 'bar \"baz\"'", []string{"foo", "'bar \"baz\"'"}},
-		"mixed quotes trailing": {"foo 'bar \"baz\"' ", []string{"foo", "'bar \"baz\"'"}},
-		"mixed quotes leading":  {" foo 'bar \"baz\"'", []string{"foo", "'bar \"baz\"'"}},
+		"mixed quotes":          {"foo 'bar \"baz\"'", []string{"foo", "bar \"baz\""}},
+		"mixed quotes trailing": {"foo 'bar \"baz\"' ", []string{"foo", "bar \"baz\""}},
+		"mixed quotes leading":  {" foo 'bar \"baz\"'", []string{"foo", "bar \"baz\""}},
 	} {
 		t.Log(desc)
 		c.Assert(t)

--- a/tools/str_tools_test.go
+++ b/tools/str_tools_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 type QuotedFieldsTestCase struct {
-	Desc     string
 	Given    string
 	Expected []string
 }
@@ -22,31 +21,31 @@ func (c *QuotedFieldsTestCase) Assert(t *testing.T) {
 }
 
 func TestQuotedFields(t *testing.T) {
-	for _, c := range []QuotedFieldsTestCase{
-		{"simple", "foo bar", []string{"foo", "bar"}},
-		{"simple trailing", "foo bar ", []string{"foo", "bar"}},
-		{"simple leading", " foo bar", []string{"foo", "bar"}},
+	for desc, c := range map[string]QuotedFieldsTestCase{
+		"simple":          {"foo bar", []string{"foo", "bar"}},
+		"simple trailing": {"foo bar ", []string{"foo", "bar"}},
+		"simple leading":  {" foo bar", []string{"foo", "bar"}},
 
-		{"single quotes", "foo 'bar baz'", []string{"foo", "'bar baz'"}},
-		{"single quotes trailing", "foo 'bar baz' ", []string{"foo", "'bar baz'"}},
-		{"single quotes leading", " foo 'bar baz'", []string{"foo", "'bar baz'"}},
+		"single quotes":          {"foo 'bar baz'", []string{"foo", "'bar baz'"}},
+		"single quotes trailing": {"foo 'bar baz' ", []string{"foo", "'bar baz'"}},
+		"single quotes leading":  {" foo 'bar baz'", []string{"foo", "'bar baz'"}},
 
-		{"double quotes", "foo \"bar baz\"", []string{"foo", "\"bar baz\""}},
-		{"double quotes trailing", "foo \"bar baz\" ", []string{"foo", "\"bar baz\""}},
-		{"double quotes leading", " foo \"bar baz\"", []string{"foo", "\"bar baz\""}},
+		"double quotes":          {"foo \"bar baz\"", []string{"foo", "\"bar baz\""}},
+		"double quotes trailing": {"foo \"bar baz\" ", []string{"foo", "\"bar baz\""}},
+		"double quotes leading":  {" foo \"bar baz\"", []string{"foo", "\"bar baz\""}},
 
-		{"nested single quotes", "foo 'bar 'baz''", []string{"foo", "'bar 'baz''"}},
-		{"nested single quotes trailing", "foo 'bar 'baz'' ", []string{"foo", "'bar 'baz''"}},
-		{"nested single quotes leading", " foo 'bar 'baz''", []string{"foo", "'bar 'baz''"}},
+		"nested single quotes":          {"foo 'bar 'baz''", []string{"foo", "'bar 'baz''"}},
+		"nested single quotes trailing": {"foo 'bar 'baz'' ", []string{"foo", "'bar 'baz''"}},
+		"nested single quotes leading":  {" foo 'bar 'baz''", []string{"foo", "'bar 'baz''"}},
 
-		{"nested double quotes", "foo \"bar \"baz\"\"", []string{"foo", "\"bar \"baz\"\""}},
-		{"nested double quotes trailing", "foo \"bar \"baz\"\" ", []string{"foo", "\"bar \"baz\"\""}},
-		{"nested double quotes leading", " foo \"bar \"baz\"\"", []string{"foo", "\"bar \"baz\"\""}},
+		"nested double quotes":          {"foo \"bar \"baz\"\"", []string{"foo", "\"bar \"baz\"\""}},
+		"nested double quotes trailing": {"foo \"bar \"baz\"\" ", []string{"foo", "\"bar \"baz\"\""}},
+		"nested double quotes leading":  {" foo \"bar \"baz\"\"", []string{"foo", "\"bar \"baz\"\""}},
 
-		{"mixed quotes", "foo 'bar \"baz\"'", []string{"foo", "'bar \"baz\"'"}},
-		{"mixed quotes trailing", "foo 'bar \"baz\"' ", []string{"foo", "'bar \"baz\"'"}},
-		{"mixed quotes leading", " foo 'bar \"baz\"'", []string{"foo", "'bar \"baz\"'"}},
+		"mixed quotes":          {"foo 'bar \"baz\"'", []string{"foo", "'bar \"baz\"'"}},
+		"mixed quotes trailing": {"foo 'bar \"baz\"' ", []string{"foo", "'bar \"baz\"'"}},
+		"mixed quotes leading":  {" foo 'bar \"baz\"'", []string{"foo", "'bar \"baz\"'"}},
 	} {
-		t.Run(c.Desc, c.Assert)
+		t.Run(desc, c.Assert)
 	}
 }


### PR DESCRIPTION
This pull-request fixes #1895 by implementing `tools.QuotedFields`, an alternative to `strings.Fields` that respects balanced pairs of quotes.

The problem in #1895 is that a `GIT_SSH_COMMAND` with spaces inside a balanced pair of quotes would be truncated across multiple "fields", causing the arguments to be passed incorrectly.

For instance, the following string:

```
foo bar 'baz "etc"'
```

given to `strings.Fields` would return:

```go
[]string{"foo", "bar", "'baz", "\"etc\"'"}
```

whereas given to `tools.QuotedFields`, it instead returns:

```go
[]string{"foo", "bar", "'baz \"etc\"'"}
```

When trying to figure out the best way to implement this, I considered a few options:

- Instantiate the `exec.Cmd` in such a way that we wouldn't need to de-quote the input string.
- Write a `func(c rune) bool` that could be given to `strings.FieldsFunc`
- Use a regexp.

My findings were that the first and second options were both not possible. In particular, the second option seemed more attractive to me, since it would be a more easily approachable implementation. However, according to the docs of `strings.FieldsFunc`<sup>[[1]](https://golang.org/pkg/strings/#FieldsFunc)</sup>:

> FieldsFunc makes no guarantees about the order in which it calls f(c). If f does not return consistent results for a given c, FieldsFunc may crash.

In my testing, I was not able to make `FieldsFunc` crash, but since we can't rely on that behavior in the future, I chose to implement this with a regular expression instead. It turns out the regular expression isn't that complicated, so I'm fine going forward with this approach.

I also tried my hand at implementing this in a loop that scans each rune in the string and composes the string slice itself. I found this to be much more complicated than the regex, for not a significant performance gain:

```
~/g/git-lfs (fix-fields-with-quotes!) $ go test -bench='BenchmarkQuote' ./tools
BenchmarkQuoteWithRegex-4         500000              3482 ns/op
BenchmarkQuoteWithLoop-4         1000000              1025 ns/op
PASS
ok      github.com/git-lfs/git-lfs/tools        2.977s
```

As a side note, I used this PR as an opportunity to try out the new `testing.T.Run` method in Go 1.8.

---

/cc @git-lfs/core 