### PR TITLE
Cygwin tools

### DIFF
--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -28,7 +28,7 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 	}
 
 	// now execute pull (need to be inside dir)
-	cwd, err := os.Getwd()
+	cwd, err := tools.Getwd()
 	if err != nil {
 		Exit("Unable to derive current working dir: %v", err)
 	}

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -13,6 +13,7 @@ import (
 	"github.com/git-lfs/git-lfs/config"
 	"github.com/git-lfs/git-lfs/git"
 	"github.com/git-lfs/git-lfs/lfs"
+	"github.com/git-lfs/git-lfs/tools"
 	"github.com/spf13/cobra"
 )
 
@@ -53,7 +54,7 @@ func trackCommand(cmd *cobra.Command, args []string) {
 		lineEnd = gitLineEnding(cfg.Git)
 	}
 
-	wd, _ := os.Getwd()
+	wd, _ := tools.Getwd()
 	relpath, err := filepath.Rel(config.LocalWorkingDir, wd)
 	if err != nil {
 		Exit("Current directory %q outside of git working directory %q.", wd, config.LocalWorkingDir)

--- a/git/git.go
+++ b/git/git.go
@@ -595,7 +595,7 @@ func GitAndRootDirs() (string, string, error) {
 	pathLen := len(paths)
 
 	for i := 0; i < pathLen; i++ {
-		paths[i], err = tools.TranslateIfCygwin(paths[i])
+		paths[i], err = tools.TranslateCygwinPath(paths[i])
 	}
 
 	if pathLen == 0 {
@@ -623,7 +623,7 @@ func RootDir() (string, error) {
 	}
 
 	path := strings.TrimSpace(string(out))
-	path, err = tools.TranslateIfCygwin(path)
+	path, err = tools.TranslateCygwinPath(path)
 	if len(path) > 0 {
 		return filepath.Abs(path)
 	}

--- a/git/git.go
+++ b/git/git.go
@@ -19,6 +19,7 @@ import (
 
 	lfserrors "github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/subprocess"
+	"github.com/git-lfs/git-lfs/tools"
 	"github.com/rubyist/tracerx"
 )
 
@@ -579,27 +580,6 @@ func GetCommitSummary(commit string) (*CommitSummary, error) {
 	}
 }
 
-func isCygwin() bool {
-	cmd := subprocess.ExecCommand("uname")
-	out, err := cmd.Output()
-	if err != nil {
-		return false
-	}
-	return bytes.Contains(out, []byte("CYGWIN"))
-}
-
-func translateCygwinPath(path string) (string, error) {
-	cmd := subprocess.ExecCommand("cygpath", "-w", path)
-	buf := &bytes.Buffer{}
-	cmd.Stderr = buf
-	out, err := cmd.Output()
-	output := strings.TrimSpace(string(out))
-	if err != nil {
-		return path, fmt.Errorf("Failed to translate path from cygwin to windows: %s", buf.String())
-	}
-	return output, nil
-}
-
 func GitAndRootDirs() (string, string, error) {
 	cmd := subprocess.ExecCommand("git", "rev-parse", "--git-dir", "--show-toplevel")
 	buf := &bytes.Buffer{}
@@ -614,10 +594,8 @@ func GitAndRootDirs() (string, string, error) {
 	paths := strings.Split(output, "\n")
 	pathLen := len(paths)
 
-	if isCygwin() {
-		for i := 0; i < pathLen; i++ {
-			paths[i], err = translateCygwinPath(paths[i])
-		}
+	for i := 0; i < pathLen; i++ {
+		paths[i], err = tools.TranslateIfCygwin(paths[i])
 	}
 
 	if pathLen == 0 {
@@ -645,9 +623,7 @@ func RootDir() (string, error) {
 	}
 
 	path := strings.TrimSpace(string(out))
-	if isCygwin() {
-		path, err = translateCygwinPath(path)
-	}
+	path, err = tools.TranslateIfCygwin(path)
 	if len(path) > 0 {
 		return filepath.Abs(path)
 	}

--- a/tools/cygwin.go
+++ b/tools/cygwin.go
@@ -1,0 +1,7 @@
+// +build !windows
+
+package tools
+
+func isCygwin() bool {
+	return false
+}

--- a/tools/cygwin_windows.go
+++ b/tools/cygwin_windows.go
@@ -1,0 +1,18 @@
+// +build windows
+
+package tools
+
+import (
+	"bytes"
+
+	"github.com/git-lfs/git-lfs/subprocess"
+)
+
+func isCygwin() bool {
+	cmd := subprocess.ExecCommand("uname")
+	out, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	return bytes.Contains(out, []byte("CYGWIN"))
+}

--- a/tools/cygwin_windows.go
+++ b/tools/cygwin_windows.go
@@ -33,7 +33,7 @@ var (
 )
 
 func isCygwin() bool {
-	if cygwinState != cygwinUnknown {
+	if cygwinState != cygwinStateUnknown {
 		return cygwinState.Enabled()
 	}
 

--- a/tools/cygwin_windows.go
+++ b/tools/cygwin_windows.go
@@ -4,15 +4,50 @@ package tools
 
 import (
 	"bytes"
+	"fmt"
 
 	"github.com/git-lfs/git-lfs/subprocess"
 )
 
+type cygwinSupport byte
+
+const (
+	cygwinStateUnknown cygwinSupport = iota
+	cygwinStateEnabled
+	cygwinStateDisabled
+)
+
+func (c cygwinSupport) Enabled() bool {
+	switch c {
+	case cygwinStateEnabled:
+		return true
+	case cygwinStateDisabled:
+		return false
+	default:
+		panic(fmt.Sprintf("unknown enabled state for %v", c))
+	}
+}
+
+var (
+	cygwinState cygwinSupport
+)
+
 func isCygwin() bool {
+	if cygwinState != cygwinUnknown {
+		return cygwinState.Enabled()
+	}
+
 	cmd := subprocess.ExecCommand("uname")
 	out, err := cmd.Output()
 	if err != nil {
 		return false
 	}
-	return bytes.Contains(out, []byte("CYGWIN"))
+
+	if bytes.Contains(out, []byte("CYGWIN")) {
+		cygwinState = cygwinStateEnabled
+	} else {
+		cygwinState = cygwinStateDisabled
+	}
+
+	return cygwinState.Enabled()
 }

--- a/tools/os_tools.go
+++ b/tools/os_tools.go
@@ -38,7 +38,7 @@ func translateCygwinPath(path string) (string, error) {
 	return output, nil
 }
 
-func TranslateIfCygwin(path string) (string, error) {
+func TranslateCygwinPath(path string) (string, error) {
 	if isCygwin() {
 		var err error
 

--- a/tools/os_tools.go
+++ b/tools/os_tools.go
@@ -1,0 +1,51 @@
+package tools
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/git-lfs/git-lfs/subprocess"
+	"github.com/pkg/errors"
+)
+
+func Getwd() (dir string, err error) {
+	dir, err = os.Getwd()
+	if err != nil {
+		return
+	}
+
+	if isCygwin() {
+		dir, err = translateCygwinPath(dir)
+		if err != nil {
+			return "", errors.Wrap(err, "convert wd to cygwin")
+		}
+	}
+
+	return
+}
+
+func translateCygwinPath(path string) (string, error) {
+	cmd := subprocess.ExecCommand("cygpath", "-w", path)
+	buf := &bytes.Buffer{}
+	cmd.Stderr = buf
+	out, err := cmd.Output()
+	output := strings.TrimSpace(string(out))
+	if err != nil {
+		return path, fmt.Errorf("Failed to translate path from cygwin to windows: %s", buf.String())
+	}
+	return output, nil
+}
+
+func TranslateIfCygwin(path string) (string, error) {
+	if isCygwin() {
+		var err error
+
+		path, err = translateCygwinPath(path)
+		if err != nil {
+			return "", err
+		}
+	}
+	return path, nil
+}


### PR DESCRIPTION
This pull-request expands on #1820 by spiking out some functions in the `tools` package to convert Windows paths to Cygwin paths. 

This was prompted by https://github.com/git-lfs/git-lfs/issues/865#issuecomment-281044331, which was comparing the Windows path from `os.Getwd()` with the Git working dir in Cygwin format from `config.LocalWorkingDir`.

Since we don't have integration tests on Cygwin (though we should look into that) I'm leaving this as a [WIP] until we can verify that it works as expected.