### PR TITLE
AppVeyor: Override PATH with our Chocolatey Go version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,13 @@
 skip_branch_with_pr: true
 
 environment:
+  PATH: c:\tools\go\bin;$(PATH)
   GOPATH: $(HOMEDRIVE)$(HOMEPATH)\go
   MSYSTEM: MINGW64
 
 clone_folder: $(GOPATH)\src\github.com\git-lfs\git-lfs
 
 install:
-  - rd C:\Go /s /q
   - cinst golang --version 1.8.0 -y
   - cinst InnoSetup -y
   - refreshenv


### PR DESCRIPTION
This is nicer than removing the system Go directory.