### PR TITLE
tq: retry verify requests a configurable number of times

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,13 @@
 skip_branch_with_pr: true
 
 environment:
-  PATH: c:\tools\go\bin;$(PATH)
   GOPATH: $(HOMEDRIVE)$(HOMEPATH)\go
   MSYSTEM: MINGW64
 
 clone_folder: $(GOPATH)\src\github.com\git-lfs\git-lfs
 
 install:
+  - rd C:\Go /s /q
   - cinst golang --version 1.8.0 -y
   - cinst InnoSetup -y
   - refreshenv

--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -106,7 +106,7 @@ lfs option can be scoped inside the configuration for a remote.
 
   Specifies how many verification requests LFS will attempt per OID before
   marking the transfer as failed, if the object has a verification action
-  assosciated with it. Must be an integer which is at least one. If the value is
+  associated with it. Must be an integer which is at least one. If the value is
   not an integer, is less than one, or is not given, a default value of three
   will be used instead.
 

--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -102,6 +102,14 @@ lfs option can be scoped inside the configuration for a remote.
   not an integer, is less than one, or is not given, a value of eight will be
   used instead.
 
+* `lfs.transfer.maxverifies`
+
+  Specifies how many verification requests LFS will attempt per OID before
+  marking the transfer as failed, if the object has a verification action
+  assosciated with it. Must be an integer which is at least one. If the value is
+  not an integer, is less than one, or is not given, a default value of three
+  will be used instead.
+
 ### Fetch settings
 
 * `lfs.fetchinclude`

--- a/test/test-verify.sh
+++ b/test/test-verify.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+. "test/testlib.sh"
+
+begin_test "verify with retries"
+(
+  set -e
+
+  reponame="verify-fail-2-times"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  contents="send-verify-action"
+  contents_oid="$(calc_oid "$contents")"
+  contents_short_oid="$(echo "$contents_oid" | head -c 7)"
+  printf "$contents" > a.dat
+
+  git add a.dat
+  git commit -m "add a.dat"
+
+  GIT_TRACE=1 git push origin master 2>&1 | tee push.log
+
+  [ "0" -eq "${PIPESTATUS[0]}" ]
+  [ "2" -eq "$(grep -c "verify $contents_short_oid attempt" push.log)" ]
+)
+end_test
+
+begin_test "verify with retries (success without retry)"
+(
+  set -e
+
+  reponame="verify-fail-0-times"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  contents="send-verify-action"
+  contents_oid="$(calc_oid "$contents")"
+  contents_short_oid="$(echo "$contents_oid" | head -c 7)"
+  printf "$contents" > a.dat
+
+  git add a.dat
+  git commit -m "add a.dat"
+
+  GIT_TRACE=1 git push origin master 2>&1 | tee push.log
+
+  [ "0" -eq "${PIPESTATUS[0]}" ]
+  [ "1" -eq "$(grep -c "verify $contents_short_oid attempt" push.log)" ]
+)
+end_test
+
+begin_test "verify with retries (insufficient retries)"
+(
+  set -e
+
+  reponame="verify-fail-10-times"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  contents="send-verify-action"
+  contents_oid="$(calc_oid "$contents")"
+  contents_short_oid="$(echo "$contents_oid" | head -c 7)"
+  printf "$contents" > a.dat
+
+  git add a.dat
+  git commit -m "add a.dat"
+
+  set +e
+  GIT_TRACE=1 git push origin master 2>&1 | tee push.log
+  if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+    echo >&2 "verify: expected \"git push\" to fail, didn't ..."
+    exit 1
+  fi
+  set -e
+
+  [ "3" -eq "$(grep -c "verify $contents_short_oid attempt" push.log)" ]
+)
+end_test
+
+begin_test "verify with retries (bad .gitconfig)"
+(
+  set -e
+
+  reponame="bad-config-verify-fail-2-times"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  # Invalid `lfs.transfer.maxverifies` will default to 3.
+  git config "lfs.transfer.maxverifies" "-1"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  contents="send-verify-action"
+  contents_oid="$(calc_oid "$contents")"
+  contents_short_oid="$(echo "$contents_oid" | head -c 7)"
+  printf "$contents" > a.dat
+
+  git add a.dat
+  git commit -m "add a.dat"
+
+  GIT_TRACE=1 git push origin master 2>&1 | tee push.log
+
+  [ "0" -eq "${PIPESTATUS[0]}" ]
+  [ "2" -eq "$(grep -c "verify $contents_short_oid attempt" push.log)" ]
+)
+end_test

--- a/tq/verify.go
+++ b/tq/verify.go
@@ -4,6 +4,13 @@ import (
 	"net/http"
 
 	"github.com/git-lfs/git-lfs/lfsapi"
+	"github.com/git-lfs/git-lfs/tools"
+	"github.com/rubyist/tracerx"
+)
+
+const (
+	maxVerifiesConfigKey     = "lfs.transfer.maxverifies"
+	defaultMaxVerifyAttempts = 3
 )
 
 func verifyUpload(c *lfsapi.Client, t *Transfer) error {
@@ -33,10 +40,18 @@ func verifyUpload(c *lfsapi.Client, t *Transfer) error {
 	}
 	req.Header.Set("Content-Type", "application/vnd.git-lfs+json")
 
-	res, err := c.Do(req)
-	if err != nil {
-		return err
-	}
+	mv := c.GitEnv().Int(maxVerifiesConfigKey, defaultMaxVerifyAttempts)
+	mv = tools.MaxInt(defaultMaxVerifyAttempts, mv)
 
-	return res.Body.Close()
+	for i := 1; i <= mv; i++ {
+		tracerx.Printf("tq: verify %s attempt #%d (max: %d)", t.Oid[:7], i, mv)
+
+		var res *http.Response
+
+		if res, err = c.Do(req); err == nil {
+			err = res.Body.Close()
+			break
+		}
+	}
+	return err
 }

--- a/tq/verify.go
+++ b/tq/verify.go
@@ -48,7 +48,9 @@ func verifyUpload(c *lfsapi.Client, t *Transfer) error {
 
 		var res *http.Response
 
-		if res, err = c.Do(req); err == nil {
+		if res, err = c.Do(req); err != nil {
+			tracerx.Printf("tq: verify err: %+v", err.Error())
+		} else {
 			err = res.Body.Close()
 			break
 		}

--- a/tq/verify_test.go
+++ b/tq/verify_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/git-lfs/git-lfs/lfsapi"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestVerifyWithoutAction(t *testing.T) {
@@ -33,19 +34,22 @@ func TestVerifySuccess(t *testing.T) {
 
 		assert.Equal(t, "POST", r.Method)
 		assert.Equal(t, "bar", r.Header.Get("Foo"))
-		assert.Equal(t, "24", r.Header.Get("Content-Length"))
+		assert.Equal(t, "29", r.Header.Get("Content-Length"))
 		assert.Equal(t, "application/vnd.git-lfs+json", r.Header.Get("Content-Type"))
 
 		var tr Transfer
 		assert.Nil(t, json.NewDecoder(r.Body).Decode(&tr))
-		assert.Equal(t, "abc", tr.Oid)
+		assert.Equal(t, "abcd1234", tr.Oid)
 		assert.EqualValues(t, 123, tr.Size)
 	}))
 	defer srv.Close()
 
-	c := &lfsapi.Client{}
+	c, err := lfsapi.NewClient(nil, lfsapi.TestEnv{
+		"lfs.transfer.maxverifies": "1",
+	})
+	require.Nil(t, err)
 	tr := &Transfer{
-		Oid:  "abc",
+		Oid:  "abcd1234",
 		Size: 123,
 		Actions: map[string]*Action{
 			"verify": &Action{


### PR DESCRIPTION
This pull-request implements `lfs.transfer.maxverifies`, a `.gitconfig` setting to retry verify requests at the end of an upload a configurable number of times.

Closes: #1781.

---

/cc @git-lfs/core 