### PR TITLE
Print error causes to stderr

### DIFF
--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/git"
 	"github.com/spf13/cobra"
 )
@@ -32,7 +33,7 @@ func lockCommand(cmd *cobra.Command, args []string) {
 
 	lock, err := lockClient.LockFile(path)
 	if err != nil {
-		Exit("Lock failed: %v", err)
+		Exit("Lock failed: %v", errors.Cause(err))
 	}
 
 	if locksCmdFlags.JSON {

--- a/commands/command_locks.go
+++ b/commands/command_locks.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/locking"
 	"github.com/git-lfs/git-lfs/tools"
 	"github.com/spf13/cobra"
@@ -51,7 +52,7 @@ func locksCommand(cmd *cobra.Command, args []string) {
 	}
 
 	if err != nil {
-		Exit("Error while retrieving locks: %v", err)
+		Exit("Error while retrieving locks: %v", errors.Cause(err))
 	}
 }
 

--- a/commands/command_unlock.go
+++ b/commands/command_unlock.go
@@ -27,9 +27,12 @@ type unlockFlags struct {
 var unlockUsage = "Usage: git lfs unlock (--id my-lock-id | <path>)"
 
 func unlockCommand(cmd *cobra.Command, args []string) {
-	if len(args) == 0 {
-		Print(unlockUsage)
-		return
+	hasPath := len(args) > 0
+	hasId := len(unlockCmdFlags.Id) > 0
+	if hasPath == hasId {
+		// If there is both an `--id` AND a `<path>`, or there is
+		// neither, print the usage and quit.
+		Exit(unlockUsage)
 	}
 
 	lockClient := newLockClient(lockRemote)

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -116,3 +116,14 @@ func Combine(errs []error) error {
 	}
 	return fmt.Errorf(buf.String())
 }
+
+func Cause(err error) error {
+	type causer interface {
+		Cause() error
+	}
+
+	if cause, ok := err.(causer); ok {
+		return Cause(cause.Cause())
+	}
+	return err
+}

--- a/lfsapi/auth.go
+++ b/lfsapi/auth.go
@@ -58,8 +58,6 @@ func (c *Client) DoWithAuth(remote string, req *http.Request) (*http.Response, e
 				return c.DoWithAuth(remote, req)
 			}
 		}
-
-		err = errors.Wrap(err, "http")
 	}
 
 	if res == nil {

--- a/lfsapi/errors.go
+++ b/lfsapi/errors.go
@@ -60,7 +60,7 @@ func (c *Client) handleResponse(res *http.Response) error {
 		if len(cliErr.Message) == 0 {
 			err = defaultError(res)
 		} else {
-			err = errors.Wrap(cliErr, "http")
+			err = cliErr
 		}
 	}
 

--- a/lfsapi/response_test.go
+++ b/lfsapi/response_test.go
@@ -33,7 +33,7 @@ func TestAuthErrWithBody(t *testing.T) {
 	_, err = c.Do(req)
 	assert.NotNil(t, err)
 	assert.True(t, errors.IsAuthError(err))
-	assert.Equal(t, "Authentication required: http: custom auth error", err.Error())
+	assert.Equal(t, "Authentication required: custom auth error", err.Error())
 	assert.EqualValues(t, 1, called)
 }
 
@@ -59,7 +59,7 @@ func TestFatalWithBody(t *testing.T) {
 	_, err = c.Do(req)
 	assert.NotNil(t, err)
 	assert.True(t, errors.IsFatalError(err))
-	assert.Equal(t, "Fatal error: http: custom fatal error", err.Error())
+	assert.Equal(t, "Fatal error: custom fatal error", err.Error())
 	assert.EqualValues(t, 1, called)
 }
 
@@ -93,7 +93,7 @@ func TestWithNonFatal500WithBody(t *testing.T) {
 		_, err = c.Do(req)
 		t.Logf("non fatal code %d", nonFatalCode)
 		assert.NotNil(t, err)
-		assert.Equal(t, "http: "+expectedErr, err.Error())
+		assert.Equal(t, expectedErr, err.Error())
 		srv.Close()
 	}
 


### PR DESCRIPTION
This adds `error.Cause()`, which removes all those error wrap prefixes when printing messages to stderr.

```
# BEFORE
$ git lfs lock path/to/file
Lock failed: api: http: http: Lock exists

# AFTER
$ git lfs lock path/to/file
Lock failed: Lock exists
```