### PR TITLE
lfsapi: only reject credential helper values on 401 requests

### DIFF
--- a/lfsapi/auth.go
+++ b/lfsapi/auth.go
@@ -60,17 +60,8 @@ func (c *Client) DoWithAuth(remote string, req *http.Request) (*http.Response, e
 		}
 	}
 
-	if res == nil {
-		return nil, err
-	}
-
-	switch res.StatusCode {
-	case 401, 403:
-		credHelper.Reject(creds)
-	default:
-		if res.StatusCode < 300 && res.StatusCode > 199 {
-			credHelper.Approve(creds)
-		}
+	if res != nil && res.StatusCode < 300 && res.StatusCode > 199 {
+		credHelper.Approve(creds)
 	}
 
 	return res, err


### PR DESCRIPTION
Some of the new lock commands return 403 for legitimate reasons:

* Attempt to unlock someone else's lock.
* Attempt to create lock that already exists.
* Attempt to force unlock without proper privileges to do so.

This can also happen with the batch api, if you only have read, but not write, access to a repository.

These cases shouldn't force you to log in again. Typically, users have to confirm their settings on their git host.