### PR TITLE
More msg tweaks

### DIFF
--- a/commands/command_locks.go
+++ b/commands/command_locks.go
@@ -35,20 +35,33 @@ func locksCommand(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	var maxlen int
+	var maxPathLen int
+	var maxNameLen int
 	lockPaths := make([]string, 0, len(locks))
 	locksByPath := make(map[string]locking.Lock)
 	for _, lock := range locks {
 		lockPaths = append(lockPaths, lock.Path)
 		locksByPath[lock.Path] = lock
-		maxlen = tools.MaxInt(maxlen, len(lock.Path))
+		maxPathLen = tools.MaxInt(maxPathLen, len(lock.Path))
+		if lock.Owner != nil {
+			maxNameLen = tools.MaxInt(maxNameLen, len(lock.Owner.Name))
+		}
 	}
 
 	sort.Strings(lockPaths)
 	for _, lockPath := range lockPaths {
+		var ownerName string
 		lock := locksByPath[lockPath]
-		padding := tools.MaxInt(maxlen-len(lock.Path), 0)
-		Print("%s%s\t%s", lock.Path, strings.Repeat(" ", padding), lock.Owner)
+		if lock.Owner != nil {
+			ownerName = lock.Owner.Name
+		}
+
+		pathPadding := tools.MaxInt(maxPathLen-len(lock.Path), 0)
+		namePadding := tools.MaxInt(maxNameLen-len(ownerName), 0)
+		Print("%s%s\t%s%s\tID:%s", lock.Path, strings.Repeat(" ", pathPadding),
+			ownerName, strings.Repeat(" ", namePadding),
+			lock.Id,
+		)
 	}
 
 	if err != nil {

--- a/lfsapi/errors.go
+++ b/lfsapi/errors.go
@@ -20,16 +20,6 @@ func IsHTTP(err error) (*http.Response, bool) {
 	return nil, false
 }
 
-func ClientErrorMessage(msg, docURL, reqID string) string {
-	if len(docURL) > 0 {
-		msg += "\nDocs: " + docURL
-	}
-	if len(reqID) > 0 {
-		msg += "\nRequest ID: " + reqID
-	}
-	return msg
-}
-
 type ClientError struct {
 	Message          string `json:"message"`
 	DocumentationUrl string `json:"documentation_url,omitempty"`
@@ -42,7 +32,7 @@ func (e *ClientError) HTTPResponse() *http.Response {
 }
 
 func (e *ClientError) Error() string {
-	return ClientErrorMessage(e.Message, e.DocumentationUrl, e.RequestId)
+	return e.Message
 }
 
 func (c *Client) handleResponse(res *http.Response) error {

--- a/locking/locks.go
+++ b/locking/locks.go
@@ -95,12 +95,10 @@ func (c *Client) LockFile(path string) (Lock, error) {
 	}
 
 	if len(lockRes.Message) > 0 {
-		return Lock{}, fmt.Errorf("Server unable to create lock: %s",
-			lfsapi.ClientErrorMessage(
-				lockRes.Message,
-				lockRes.DocumentationURL,
-				lockRes.RequestID,
-			))
+		if len(lockRes.RequestID) > 0 {
+			tracerx.Printf("Server Request ID: %s", lockRes.RequestID)
+		}
+		return Lock{}, fmt.Errorf("Server unable to create lock: %s", lockRes.Message)
 	}
 
 	lock := *lockRes.Lock
@@ -147,12 +145,10 @@ func (c *Client) UnlockFileById(id string, force bool) error {
 	}
 
 	if len(unlockRes.Message) > 0 {
-		return fmt.Errorf("Server unable to unlock: %s",
-			lfsapi.ClientErrorMessage(
-				unlockRes.Message,
-				unlockRes.DocumentationURL,
-				unlockRes.RequestID,
-			))
+		if len(unlockRes.RequestID) > 0 {
+			tracerx.Printf("Server Request ID: %s", unlockRes.RequestID)
+		}
+		return fmt.Errorf("Server unable to unlock: %s", unlockRes.Message)
 	}
 
 	if err := c.cache.RemoveById(id); err != nil {
@@ -205,12 +201,10 @@ func (c *Client) VerifiableLocks(limit int) (ourLocks, theirLocks []Lock, err er
 		}
 
 		if list.Message != "" {
-			return ourLocks, theirLocks, fmt.Errorf("Server error searching locks: %s",
-				lfsapi.ClientErrorMessage(
-					list.Message,
-					list.DocumentationURL,
-					list.RequestID,
-				))
+			if len(list.RequestID) > 0 {
+				tracerx.Printf("Server Request ID: %s", list.RequestID)
+			}
+			return ourLocks, theirLocks, fmt.Errorf("Server error searching locks: %s", list.Message)
 		}
 
 		for _, l := range list.Ours {
@@ -273,12 +267,10 @@ func (c *Client) searchRemoteLocks(filter map[string]string, limit int) ([]Lock,
 		}
 
 		if list.Message != "" {
-			return locks, fmt.Errorf("Server error searching for locks: %s",
-				lfsapi.ClientErrorMessage(
-					list.Message,
-					list.DocumentationURL,
-					list.RequestID,
-				))
+			if len(list.RequestID) > 0 {
+				tracerx.Printf("Server Request ID: %s", list.RequestID)
+			}
+			return locks, fmt.Errorf("Server error searching for locks: %s", list.Message)
 		}
 
 		for _, l := range list.Locks {

--- a/test/test-unlock.sh
+++ b/test/test-unlock.sh
@@ -76,7 +76,7 @@ begin_test "unlocking a lock by id"
   id=$(assert_lock lock.log d.dat)
   assert_server_lock "$reponame" "$id"
 
-  git lfs unlock --id="$id" 2>&1 | tee unlock.log
+  git lfs unlock --id="$id"
   refute_server_lock "$reponame" "$id"
 )
 end_test


### PR DESCRIPTION
Three small things:

1. I thought printing the doc url and request id for every error was too noisy. Especially, when some are common errors like attempting to unlock someone else's file.
2. Added IDs to the `git lfs locks` output.

        $ git lfs locks
        collabocats.txt	ttaylorr	ID:1
        supportocat.txt	technoweenie   	ID:2

3. `git lfs unlock --id={id}` was causing Go to panic since `args` is nil. Fixed that, and updated the test that let the error slide by piping the contents to `tee`.