### PR TITLE
test: add assert_file_writable() and refute_file_writable()

### DIFF
--- a/test/test-post-checkout.sh
+++ b/test/test-post-checkout.sh
@@ -16,7 +16,6 @@ begin_test "post-checkout"
   git add .gitattributes
   git commit -m "add git attributes"
 
-
   echo "[
   {
     \"CommitDate\":\"$(get_date -10d)\",
@@ -39,7 +38,7 @@ begin_test "post-checkout"
   },
   {
     \"CommitDate\":\"$(get_date -3d)\",
-    \"NewBranch\":\"branch2\",    
+    \"NewBranch\":\"branch2\",
     \"Files\":[
       {\"Filename\":\"file5.dat\",\"Data\":\"file 5 creation in branch2\"},
       {\"Filename\":\"file6.big\",\"Data\":\"file 6 creation in branch2\"}]
@@ -70,21 +69,21 @@ begin_test "post-checkout"
   [ ! -e file5.dat ]
   [ ! -e file6.big ]
   # without the post-checkout hook, any changed files would now be writeable
-  [ ! -w file1.dat ]
-  [ ! -w file2.dat ]
-  [ -w file3.big ]
-  [ -w file4.big ]
+  refute_file_writable file1.dat
+  refute_file_writable file2.dat
+  assert_file_writable file3.big
+  assert_file_writable file4.big
 
   # checkout branch
   git checkout branch2
   [ -e file5.dat ]
   [ -e file6.big ]
-  [ ! -w file1.dat ]
-  [ ! -w file2.dat ]
-  [ ! -w file5.dat ]
-  [ -w file3.big ]
-  [ -w file4.big ]
-  [ -w file6.big ]
+  refute_file_writable file1.dat
+  refute_file_writable file2.dat
+  refute_file_writable file5.dat
+  assert_file_writable file3.big
+  assert_file_writable file4.big
+  assert_file_writable file6.big
 
   # Confirm that contents of existing files were updated even though were read-only
   [ "$(cat file2.dat)" == "file 2 updated in branch2" ]
@@ -100,21 +99,20 @@ begin_test "post-checkout"
   [ "$(cat file1.dat)" == "file 1 updated commit 2" ]
   [ "$(cat file2.dat)" == "file 2 updated in branch2" ]
   [ "$(cat file5.dat)" == "file 5 creation in branch2" ]
-  [ ! -w file1.dat ]
-  [ ! -w file2.dat ]
-  [ ! -w file5.dat ]
+  refute_file_writable file1.dat
+  refute_file_writable file2.dat
+  refute_file_writable file5.dat
 
   # now lock files, then remove & restore
-  git lfs lock file1.dat 
+  git lfs lock file1.dat
   git lfs lock file2.dat
-  [ -w file1.dat ]
-  [ -w file2.dat ]
+  assert_file_writable file1.dat
+  assert_file_writable file2.dat
   rm -f *.dat
   git checkout file1.dat file2.dat file5.dat
-  [ -w file1.dat ]
-  [ -w file2.dat ]
-  [ ! -w file5.dat ]
+  assert_file_writable file1.dat
+  assert_file_writable file2.dat
+  refute_file_writable file5.dat
 
 )
 end_test
-

--- a/test/test-post-commit.sh
+++ b/test/test-post-commit.sh
@@ -25,15 +25,15 @@ begin_test "post-commit"
   git commit -m "Committed large files"
 
   # New lockable files should have been made read-only now since not locked
-  [ ! -w pcfile1.dat ]
-  [ ! -w pcfile2.dat ]
-  [ -w pcfile3.big ]
-  [ -w pcfile4.big ]
+  refute_file_writable pcfile1.dat
+  refute_file_writable pcfile2.dat
+  assert_file_writable pcfile3.big
+  assert_file_writable pcfile4.big
 
   git push -u origin master
 
   # now lock files, then edit
-  git lfs lock pcfile1.dat 
+  git lfs lock pcfile1.dat
   git lfs lock pcfile2.dat
 
   echo "Take a look" > pcfile1.dat
@@ -43,9 +43,8 @@ begin_test "post-commit"
   git commit -m "Updated"
 
   # files should remain writeable since locked
-  [ -w pcfile1.dat ]
-  [ -w pcfile2.dat ]
+  assert_file_writable pcfile1.dat
+  assert_file_writable pcfile2.dat 
 
 )
 end_test
-

--- a/test/test-post-merge.sh
+++ b/test/test-post-merge.sh
@@ -39,7 +39,7 @@ begin_test "post-merge"
   },
   {
     \"CommitDate\":\"$(get_date -3d)\",
-    \"NewBranch\":\"branch2\",    
+    \"NewBranch\":\"branch2\",
     \"Files\":[
       {\"Filename\":\"file5.dat\",\"Data\":\"file 5 creation in branch2\"},
       {\"Filename\":\"file6.big\",\"Data\":\"file 6 creation in branch2\"}]
@@ -70,31 +70,28 @@ begin_test "post-merge"
   [ ! -e file5.dat ]
   [ ! -e file6.big ]
   # without the post-checkout hook, any changed files would now be writeable
-  [ ! -w file1.dat ]
-  [ ! -w file2.dat ]
-  [ -w file3.big ]
-  [ -w file4.big ]
+  refute_file_writable file1.dat
+  refute_file_writable file2.dat
+  assert_file_writable file3.big
+  assert_file_writable file4.big
 
   # merge branch, with readonly option disabled to demonstrate what would happen
   GIT_LFS_SET_LOCKABLE_READONLY=0 git merge origin/branch2
   # branch2 had hanges to file2.dat and file5.dat which were lockable
   # but because we disabled the readonly feature they will be writeable now
-  [ -w file2.dat ]
-  [ -w file5.dat ]
+  assert_file_writable file2.dat
+  assert_file_writable file5.dat
 
   # now let's do it again with the readonly option enabled
   git reset --hard HEAD^
   git merge origin/branch2
 
   # This time they should be read-only
-  [ ! -w file2.dat ]
-  [ ! -w file5.dat ]
+  refute_file_writable file2.dat
+  refute_file_writable file5.dat
 
   # Confirm that contents of existing files were updated even though were read-only
   [ "$(cat file2.dat)" == "file 2 updated in branch2" ]
   [ "$(cat file5.dat)" == "file 5 creation in branch2" ]
-
-
 )
 end_test
-

--- a/test/test-track.sh
+++ b/test/test-track.sh
@@ -411,10 +411,10 @@ begin_test "track lockable read-only/read-write"
   echo "sub blah blah" > subfolder/test.bin
   echo "sub foo bar" > subfolder/test.dat
   # should start writeable
-  [ -w test.bin ]
-  [ -w test.dat ]
-  [ -w subfolder/test.bin ]
-  [ -w subfolder/test.dat ]
+  assert_file_writable test.bin
+  assert_file_writable test.dat
+  assert_file_writable subfolder/test.bin
+  assert_file_writable subfolder/test.dat
 
   # track *.bin, not lockable yet
   git lfs track "*.bin" | grep "Tracking \*.bin"
@@ -422,28 +422,28 @@ begin_test "track lockable read-only/read-write"
   git lfs track --lockable "*.dat" | grep "Tracking \*.dat"
 
   # bin should remain writeable, dat should have been made read-only
-  [ -w test.bin ]
-  [ ! -w test.dat ]
-  [ -w subfolder/test.bin ]
-  [ ! -w subfolder/test.dat ]
+
+  assert_file_writable test.bin
+  refute_file_writable test.dat
+  assert_file_writable subfolder/test.bin
+  refute_file_writable subfolder/test.dat
 
   git add .gitattributes test.bin test.dat
   git commit -m "First commit"
 
   # bin should still be writeable
-  [ -w test.bin ]
-  [ -w subfolder/test.bin ]
+  assert_file_writable test.bin
+  assert_file_writable subfolder/test.bin
   # now make bin lockable
   git lfs track --lockable "*.bin" | grep "Tracking \*.bin"
   # bin should now be read-only
-  [ ! -w test.bin ]
-  [ ! -w subfolder/test.bin ]
+  refute_file_writable test.bin
+  refute_file_writable subfolder/test.bin
 
   # remove lockable again
   git lfs track --not-lockable "*.bin" | grep "Tracking \*.bin"
   # bin should now be writeable again
-  [ -w test.bin ]
-  [ -w subfolder/test.bin ]
-
+  assert_file_writable test.bin
+  assert_file_writable subfolder/test.bin
 )
 end_test

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -186,6 +186,14 @@ assert_attributes_count() {
   fi
 }
 
+assert_file_writable() {
+  ls -l "$1" | grep -e "^-rw"
+}
+
+refute_file_writable() {
+  ls -l "$1" | grep -e "^-r-"
+}
+
 # pointer returns a string Git LFS pointer file.
 #
 #   $ pointer abc-some-oid 123 <version>


### PR DESCRIPTION
This is the only way I could get the rpm docker builds to pass :( These tests have been working in CI for weeks, but the first attempt to build with `./docker/run_dockers.bsh centos_6` failed:

```
test: post-merge ...                                               FAILED
-- stdout --
    set up remote git repository: test-post-merge
    Initialized empty Git repository in /tmp/docker_run/src/github.com/git-lfs/git-lfs/rpm/BUILD/git-lfs-2.0.0/test/remote/test-post-merge.git/
    clone local git repository test-post-merge to test-post-merge
    Cloning into 'test-post-merge'...
...
    Downloading file1.dat (23 B)
    Downloading file2.dat (23 B)
    Downloading file3.big (15 B)
    Downloading file4.big (15 B)
-- stderr --
    + set -e
    ++ basename test/test-post-merge.sh .sh
    + reponame=test-post-merge
    + setup_remote_repo test-post-merge
    + local reponame=test-post-merge
    + echo 'set up remote git repository: test-post-merge'
    + repodir=/tmp/docker_run/src/github.com/git-lfs/git-lfs/rpm/BUILD/git-lfs-2.0.0/test/remote/test-post-merge.git
    + mkdir -p /tmp/docker_run/src/github.com/git-lfs/git-lfs/rpm/BUILD/git-lfs-2.0.0/test/remote/test-post-merge.git
    + cd /tmp/docker_run/src/github.com/git-lfs/git-lfs/rpm/BUILD/git-lfs-2.0.0/test/remote/test-post-merge.git
    + git init --bare
    + git config http.receivepack true
    + git config receive.denyCurrentBranch ignore
    + clone_repo test-post-merge test-post-merge
    + cd /tmp/tmp.WbUxi0lPQl/test-post-merge.sh-28893
    + local reponame=test-post-merge
    + local dir=test-post-merge
    + echo 'clone local git repository test-post-merge to test-post-merge'
    ++ git clone http://127.0.0.1:46217/test-post-merge test-post-merge
...
    + echo 'Cloning into '\''test-post-merge'\''...
    Downloading file1.dat (23 B)
    Downloading file2.dat (23 B)
    Downloading file3.big (15 B)
    Downloading file4.big (15 B)'
    ++ cat file1.dat
    + '[' 'file 1 updated commit 2' == 'file 1 updated commit 2' ']'
    ++ cat file2.dat
    + '[' 'file 2 updated commit 3' == 'file 2 updated commit 3' ']'
    ++ cat file3.big
    + '[' 'file 3 creation' == 'file 3 creation' ']'
    ++ cat file4.big
    + '[' 'file 4 creation' == 'file 4 creation' ']'
    + '[' '!' -e file5.dat ']'
    + '[' '!' -e file6.big ']'
    + '[' '!' -w file1.dat ']'
    + test_status=1
```

This is clearly a hack, but at least now all of the calls are in helper functions that can be fixed once we find the underlying cause.