### PR TITLE
tq: fallback to _links if present

### DIFF
--- a/test/git-lfs-test-server-api/testdownload.go
+++ b/test/git-lfs-test-server-api/testdownload.go
@@ -23,8 +23,8 @@ func downloadAllExist(manifest *tq.Manifest, oidsExist, oidsMissing []TestObject
 
 	var errbuf bytes.Buffer
 	for _, o := range retobjs {
-		_, ok := o.Rel("download")
-		if !ok {
+		rel, _ := o.Rel("download")
+		if rel == nil {
 			errbuf.WriteString(fmt.Sprintf("Missing download link for %s\n", o.Oid))
 		}
 	}
@@ -50,8 +50,8 @@ func downloadAllMissing(manifest *tq.Manifest, oidsExist, oidsMissing []TestObje
 
 	var errbuf bytes.Buffer
 	for _, o := range retobjs {
-		link, ok := o.Rel("download")
-		if ok {
+		link, _ := o.Rel("download")
+		if link != nil {
 			errbuf.WriteString(fmt.Sprintf("Download link should not exist for %s, was %s\n", o.Oid, link))
 		}
 		if o.Error == nil {
@@ -93,9 +93,9 @@ func downloadMixed(manifest *tq.Manifest, oidsExist, oidsMissing []TestObject) e
 
 	var errbuf bytes.Buffer
 	for _, o := range retobjs {
-		link, ok := o.Rel("download")
+		link, _ := o.Rel("download")
 		if missingSet.Contains(o.Oid) {
-			if ok {
+			if link != nil {
 				errbuf.WriteString(fmt.Sprintf("Download link should not exist for %s, was %s\n", o.Oid, link))
 			}
 			if o.Error == nil {
@@ -104,7 +104,7 @@ func downloadMixed(manifest *tq.Manifest, oidsExist, oidsMissing []TestObject) e
 				errbuf.WriteString(fmt.Sprintf("Download error code for missing object %s should be 404, got %d\n", o.Oid, o.Error.Code))
 			}
 		}
-		if existSet.Contains(o.Oid) && !ok {
+		if existSet.Contains(o.Oid) && link == nil {
 			errbuf.WriteString(fmt.Sprintf("Missing download link for %s\n", o.Oid))
 		}
 

--- a/test/git-lfs-test-server-api/testupload.go
+++ b/test/git-lfs-test-server-api/testupload.go
@@ -23,8 +23,8 @@ func uploadAllMissing(manifest *tq.Manifest, oidsExist, oidsMissing []TestObject
 
 	var errbuf bytes.Buffer
 	for _, o := range retobjs {
-		_, ok := o.Rel("upload")
-		if !ok {
+		rel, _ := o.Rel("upload")
+		if rel == nil {
 			errbuf.WriteString(fmt.Sprintf("Missing upload link for %s\n", o.Oid))
 		}
 		// verify link is optional so don't check
@@ -51,8 +51,8 @@ func uploadAllExists(manifest *tq.Manifest, oidsExist, oidsMissing []TestObject)
 
 	var errbuf bytes.Buffer
 	for _, o := range retobjs {
-		link, ok := o.Rel("upload")
-		if ok {
+		link, _ := o.Rel("upload")
+		if link == nil {
 			errbuf.WriteString(fmt.Sprintf("Upload link should not exist for %s, was %s\n", o.Oid, link))
 		}
 	}
@@ -89,13 +89,13 @@ func uploadMixed(manifest *tq.Manifest, oidsExist, oidsMissing []TestObject) err
 
 	var errbuf bytes.Buffer
 	for _, o := range retobjs {
-		link, ok := o.Rel("upload")
+		link, _ := o.Rel("upload")
 		if existSet.Contains(o.Oid) {
-			if ok {
+			if link != nil {
 				errbuf.WriteString(fmt.Sprintf("Upload link should not exist for %s, was %s\n", o.Oid, link))
 			}
 		}
-		if missingSet.Contains(o.Oid) && !ok {
+		if missingSet.Contains(o.Oid) && link == nil {
 			errbuf.WriteString(fmt.Sprintf("Missing upload link for %s\n", o.Oid))
 		}
 
@@ -162,10 +162,10 @@ func uploadEdgeCases(manifest *tq.Manifest, oidsExist, oidsMissing []TestObject)
 
 	var errbuf bytes.Buffer
 	for _, o := range retobjs {
-		link, ok := o.Rel("upload")
+		link, _ := o.Rel("upload")
 		if code, iserror := errorCodeMap[o.Oid]; iserror {
 			reason, _ := errorReasonMap[o.Oid]
-			if ok {
+			if link != nil {
 				errbuf.WriteString(fmt.Sprintf("Upload link should not exist for %s, was %s, reason %s\n", o.Oid, link, reason))
 			}
 			if o.Error == nil {
@@ -176,7 +176,7 @@ func uploadEdgeCases(manifest *tq.Manifest, oidsExist, oidsMissing []TestObject)
 
 		}
 		if reason, reasonok := validReasonMap[o.Oid]; reasonok {
-			if !ok {
+			if link == nil {
 				errbuf.WriteString(fmt.Sprintf("Missing upload link for %s, should be present because %s\n", o.Oid, reason))
 			}
 		}

--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -582,3 +582,27 @@ begin_test "push (with invalid object size)"
   refute_server_object "$reponame" "$(calc_oid "$contents")"
 )
 end_test
+
+begin_test "push with deprecated _links"
+(
+  set -e
+
+  reponame="$(basename "$0" ".sh")-deprecated"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  contents="send-deprecated-links"
+  contents_oid="$(calc_oid "$contents")"
+  printf "$contents" > a.dat
+  git add a.dat
+  git commit -m "add a.dat"
+
+  git push origin master
+
+  assert_server_object "$reponame" "$contents_oid"
+)
+end_test

--- a/tq/basic_download.go
+++ b/tq/basic_download.go
@@ -88,7 +88,7 @@ func (a *basicDownloadAdapter) download(t *Transfer, cb ProgressCallback, authOk
 		defer dlFile.Close()
 	}
 
-	rel, err := t.Actions.Get("download")
+	rel, err := t.HybridActions().Get("download")
 	if err != nil {
 		return err
 	}

--- a/tq/basic_download.go
+++ b/tq/basic_download.go
@@ -91,7 +91,9 @@ func (a *basicDownloadAdapter) download(t *Transfer, cb ProgressCallback, authOk
 	rel, err := t.Actions.Get("download")
 	if err != nil {
 		return err
-		// return errors.New("Object not found on the server.")
+	}
+	if rel == nil {
+		return errors.New("Object not found on the server.")
 	}
 
 	req, err := a.newHTTPRequest("GET", rel)

--- a/tq/basic_download.go
+++ b/tq/basic_download.go
@@ -93,7 +93,7 @@ func (a *basicDownloadAdapter) download(t *Transfer, cb ProgressCallback, authOk
 		return err
 	}
 	if rel == nil {
-		return errors.Errorf("Object %s not found on the server.", t.Oid[:7])
+		return errors.Errorf("Object %s not found on the server.", t.Oid)
 	}
 
 	req, err := a.newHTTPRequest("GET", rel)

--- a/tq/basic_download.go
+++ b/tq/basic_download.go
@@ -88,7 +88,7 @@ func (a *basicDownloadAdapter) download(t *Transfer, cb ProgressCallback, authOk
 		defer dlFile.Close()
 	}
 
-	rel, err := t.HybridActions().Get("download")
+	rel, err := t.Rel("download")
 	if err != nil {
 		return err
 	}

--- a/tq/basic_download.go
+++ b/tq/basic_download.go
@@ -93,7 +93,7 @@ func (a *basicDownloadAdapter) download(t *Transfer, cb ProgressCallback, authOk
 		return err
 	}
 	if rel == nil {
-		return errors.New("Object not found on the server.")
+		return errors.Errorf("Object %s not found on the server.", t.Oid[:7])
 	}
 
 	req, err := a.newHTTPRequest("GET", rel)

--- a/tq/basic_upload.go
+++ b/tq/basic_upload.go
@@ -43,7 +43,7 @@ func (a *basicUploadAdapter) WorkerEnding(workerNum int, ctx interface{}) {
 }
 
 func (a *basicUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb ProgressCallback, authOkFunc func()) error {
-	rel, err := t.Actions.Get("upload")
+	rel, err := t.HybridActions().Get("upload")
 	if err != nil {
 		return err
 	}

--- a/tq/basic_upload.go
+++ b/tq/basic_upload.go
@@ -43,7 +43,7 @@ func (a *basicUploadAdapter) WorkerEnding(workerNum int, ctx interface{}) {
 }
 
 func (a *basicUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb ProgressCallback, authOkFunc func()) error {
-	rel, err := t.HybridActions().Get("upload")
+	rel, err := t.Rel("upload")
 	if err != nil {
 		return err
 	}

--- a/tq/basic_upload.go
+++ b/tq/basic_upload.go
@@ -48,7 +48,7 @@ func (a *basicUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb Progres
 		return err
 	}
 	if rel == nil {
-		return errors.New("No upload action for this object.")
+		return errors.Errorf("No upload action for object: %s", t.Oid[:7])
 	}
 
 	req, err := a.newHTTPRequest("PUT", rel)

--- a/tq/basic_upload.go
+++ b/tq/basic_upload.go
@@ -48,7 +48,7 @@ func (a *basicUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb Progres
 		return err
 	}
 	if rel == nil {
-		return errors.Errorf("No upload action for object: %s", t.Oid[:7])
+		return errors.Errorf("No upload action for object: %s", t.Oid)
 	}
 
 	req, err := a.newHTTPRequest("PUT", rel)

--- a/tq/basic_upload.go
+++ b/tq/basic_upload.go
@@ -46,7 +46,9 @@ func (a *basicUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb Progres
 	rel, err := t.Actions.Get("upload")
 	if err != nil {
 		return err
-		// return fmt.Errorf("No upload action for this object.")
+	}
+	if rel == nil {
+		return errors.New("No upload action for this object.")
 	}
 
 	req, err := a.newHTTPRequest("PUT", rel)

--- a/tq/custom.go
+++ b/tq/custom.go
@@ -268,7 +268,7 @@ func (a *customAdapter) DoTransfer(ctx interface{}, t *Transfer, cb ProgressCall
 		return err
 	}
 	if rel == nil {
-		return errors.Errorf("Object %s not found on the server.", t.Oid[:7])
+		return errors.Errorf("Object %s not found on the server.", t.Oid)
 	}
 	var req *customAdapterTransferRequest
 	if a.direction == Upload {

--- a/tq/custom.go
+++ b/tq/custom.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -12,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/lfsapi"
 	"github.com/git-lfs/git-lfs/tools"
 
@@ -268,7 +268,7 @@ func (a *customAdapter) DoTransfer(ctx interface{}, t *Transfer, cb ProgressCall
 		return err
 	}
 	if rel == nil {
-		return errors.New("Object not found on the server.")
+		return errors.Errorf("Object %s not found on the server.", t.Oid[:7])
 	}
 	var req *customAdapterTransferRequest
 	if a.direction == Upload {

--- a/tq/custom.go
+++ b/tq/custom.go
@@ -263,7 +263,7 @@ func (a *customAdapter) DoTransfer(ctx interface{}, t *Transfer, cb ProgressCall
 	}
 	var authCalled bool
 
-	rel, err := t.HybridActions().Get(a.getOperationName())
+	rel, err := t.Rel(a.getOperationName())
 	if err != nil {
 		return err
 	}

--- a/tq/custom.go
+++ b/tq/custom.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -265,7 +266,9 @@ func (a *customAdapter) DoTransfer(ctx interface{}, t *Transfer, cb ProgressCall
 	rel, err := t.Actions.Get(a.getOperationName())
 	if err != nil {
 		return err
-		// return errors.New("Object not found on the server.")
+	}
+	if rel == nil {
+		return errors.New("Object not found on the server.")
 	}
 	var req *customAdapterTransferRequest
 	if a.direction == Upload {

--- a/tq/custom.go
+++ b/tq/custom.go
@@ -263,7 +263,7 @@ func (a *customAdapter) DoTransfer(ctx interface{}, t *Transfer, cb ProgressCall
 	}
 	var authCalled bool
 
-	rel, err := t.Actions.Get(a.getOperationName())
+	rel, err := t.HybridActions().Get(a.getOperationName())
 	if err != nil {
 		return err
 	}

--- a/tq/transfer.go
+++ b/tq/transfer.go
@@ -104,7 +104,7 @@ const (
 func (as ActionSet) Get(rel string) (*Action, error) {
 	a, ok := as[rel]
 	if !ok {
-		return nil, &ActionMissingError{Rel: rel}
+		return nil, nil
 	}
 
 	if !a.ExpiresAt.IsZero() && a.ExpiresAt.Before(time.Now().Add(objectExpirationToTransfer)) {
@@ -124,23 +124,8 @@ func (e ActionExpiredErr) Error() string {
 		e.Rel, e.At.In(time.Local).Format(time.RFC822))
 }
 
-type ActionMissingError struct {
-	Rel string
-}
-
-func (e ActionMissingError) Error() string {
-	return fmt.Sprintf("tq: unable to find action %q", e.Rel)
-}
-
 func IsActionExpiredError(err error) bool {
 	if _, ok := err.(*ActionExpiredErr); ok {
-		return true
-	}
-	return false
-}
-
-func IsActionMissingError(err error) bool {
-	if _, ok := err.(*ActionMissingError); ok {
 		return true
 	}
 	return false

--- a/tq/transfer.go
+++ b/tq/transfer.go
@@ -39,6 +39,15 @@ type Transfer struct {
 	Path          string       `json:"path,omitempty"`
 }
 
+// HybridActions returns an action set composed of the "actions" property, as
+// well as the "_links" property. It is implemented by a multiActionSet, and
+// therefore retains that ordering.
+func (t *Transfer) HybridActions() ActionSet {
+	return &multiActionSet{as: []ActionSet{
+		t.Actions, t.Links,
+	}}
+}
+
 func (t *Transfer) Rel(name string) (*Action, bool) {
 	if t.Actions == nil {
 		return nil, false

--- a/tq/transfer.go
+++ b/tq/transfer.go
@@ -33,7 +33,7 @@ type Transfer struct {
 	Oid           string       `json:"oid,omitempty"`
 	Size          int64        `json:"size"`
 	Authenticated bool         `json:"authenticated,omitempty"`
-	Actions       ActionSet    `json:"actions,omitempty"`
+	Actions       mapActionSet `json:"actions,omitempty"`
 	Error         *ObjectError `json:"error,omitempty"`
 	Path          string       `json:"path,omitempty"`
 }
@@ -65,7 +65,7 @@ func newTransfer(tr *Transfer, name string, path string) *Transfer {
 		Oid:           tr.Oid,
 		Size:          tr.Size,
 		Authenticated: tr.Authenticated,
-		Actions:       make(ActionSet),
+		Actions:       make(mapActionSet),
 	}
 
 	if tr.Error != nil {
@@ -92,7 +92,11 @@ type Action struct {
 	ExpiresAt time.Time         `json:"expires_at,omitempty"`
 }
 
-type ActionSet map[string]*Action
+type ActionSet interface {
+	Get(rel string) (*Action, error)
+}
+
+type mapActionSet map[string]*Action
 
 const (
 	// objectExpirationToTransfer is the duration we expect to have passed
@@ -101,7 +105,7 @@ const (
 	objectExpirationToTransfer = 5 * time.Second
 )
 
-func (as ActionSet) Get(rel string) (*Action, error) {
+func (as mapActionSet) Get(rel string) (*Action, error) {
 	a, ok := as[rel]
 	if !ok {
 		return nil, nil

--- a/tq/transfer.go
+++ b/tq/transfer.go
@@ -131,6 +131,25 @@ func (as mapActionSet) Get(rel string) (*Action, error) {
 	return a, nil
 }
 
+// multiActionSet composes multiple `ActionSet`s.
+type multiActionSet struct {
+	as []ActionSet
+}
+
+// Get implements ActionSet.Get, and returns the first "ok" result (i.e., having
+// a non-nil error, or action) from the `ActionSet`s of which it is composed, in
+// their respective order.
+func (m *multiActionSet) Get(rel string) (*Action, error) {
+	for _, what := range m.as {
+		a, err := what.Get(rel)
+		if a != nil || err != nil {
+			return a, err
+		}
+	}
+
+	return nil, nil
+}
+
 type ActionExpiredErr struct {
 	Rel string
 	At  time.Time

--- a/tq/transfer.go
+++ b/tq/transfer.go
@@ -34,6 +34,7 @@ type Transfer struct {
 	Size          int64        `json:"size"`
 	Authenticated bool         `json:"authenticated,omitempty"`
 	Actions       mapActionSet `json:"actions,omitempty"`
+	Links         mapActionSet `json:"_links,omitempty"`
 	Error         *ObjectError `json:"error,omitempty"`
 	Path          string       `json:"path,omitempty"`
 }
@@ -80,6 +81,18 @@ func newTransfer(tr *Transfer, name string, path string) *Transfer {
 			Href:      action.Href,
 			Header:    action.Header,
 			ExpiresAt: action.ExpiresAt,
+		}
+	}
+
+	if tr.Links != nil {
+		t.Links = make(mapActionSet)
+
+		for rel, link := range tr.Links {
+			t.Links[rel] = &Action{
+				Href:      link.Href,
+				Header:    link.Header,
+				ExpiresAt: link.ExpiresAt,
+			}
 		}
 	}
 

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -335,7 +335,7 @@ func (q *TransferQueue) enqueueAndCollectRetriesFor(batch batch) (batch, error) 
 		} else {
 			tr := newTransfer(o, t.Name, t.Path)
 
-			if a, err := tr.Actions.Get(q.direction.String()); err != nil {
+			if a, err := tr.HybridActions().Get(q.direction.String()); err != nil {
 				// XXX(taylor): duplication
 				if q.canRetryObject(tr.Oid, err) {
 					q.rc.Increment(tr.Oid)

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -335,7 +335,7 @@ func (q *TransferQueue) enqueueAndCollectRetriesFor(batch batch) (batch, error) 
 		} else {
 			tr := newTransfer(o, t.Name, t.Path)
 
-			if _, err := tr.Actions.Get(q.direction.String()); err != nil {
+			if a, err := tr.Actions.Get(q.direction.String()); err != nil {
 				// XXX(taylor): duplication
 				if q.canRetryObject(tr.Oid, err) {
 					q.rc.Increment(tr.Oid)
@@ -344,14 +344,14 @@ func (q *TransferQueue) enqueueAndCollectRetriesFor(batch batch) (batch, error) 
 					tracerx.Printf("tq: enqueue retry #%d for %q (size: %d)", count, tr.Oid, tr.Size)
 					next = append(next, t)
 				} else {
-					if !IsActionMissingError(err) {
-						q.errorc <- errors.Errorf("[%v] %v", tr.Name, err)
-					}
+					q.errorc <- errors.Errorf("[%v] %v", tr.Name, err)
 
 					q.Skip(o.Size)
 					q.wait.Done()
 				}
-
+			} else if a == nil {
+				q.Skip(o.Size)
+				q.wait.Done()
 			} else {
 				q.meter.StartTransfer(t.Name)
 				toTransfer = append(toTransfer, tr)

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -335,7 +335,7 @@ func (q *TransferQueue) enqueueAndCollectRetriesFor(batch batch) (batch, error) 
 		} else {
 			tr := newTransfer(o, t.Name, t.Path)
 
-			if a, err := tr.HybridActions().Get(q.direction.String()); err != nil {
+			if a, err := tr.Rel(q.direction.String()); err != nil {
 				// XXX(taylor): duplication
 				if q.canRetryObject(tr.Oid, err) {
 					q.rc.Increment(tr.Oid)

--- a/tq/tus_upload.go
+++ b/tq/tus_upload.go
@@ -36,7 +36,7 @@ func (a *tusUploadAdapter) WorkerEnding(workerNum int, ctx interface{}) {
 }
 
 func (a *tusUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb ProgressCallback, authOkFunc func()) error {
-	rel, err := t.HybridActions().Get("upload")
+	rel, err := t.Rel("upload")
 	if err != nil {
 		return err
 	}

--- a/tq/tus_upload.go
+++ b/tq/tus_upload.go
@@ -39,7 +39,9 @@ func (a *tusUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb ProgressC
 	rel, err := t.Actions.Get("upload")
 	if err != nil {
 		return err
-		// return fmt.Errorf("No upload action for this object.")
+	}
+	if rel == nil {
+		return errors.New("No upload action for this object.")
 	}
 
 	// Note not supporting the Creation extension since the batch API generates URLs

--- a/tq/tus_upload.go
+++ b/tq/tus_upload.go
@@ -41,7 +41,7 @@ func (a *tusUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb ProgressC
 		return err
 	}
 	if rel == nil {
-		return errors.Errorf("No upload action for object: %s", t.Oid[:7])
+		return errors.Errorf("No upload action for object: %s", t.Oid)
 	}
 
 	// Note not supporting the Creation extension since the batch API generates URLs

--- a/tq/tus_upload.go
+++ b/tq/tus_upload.go
@@ -36,7 +36,7 @@ func (a *tusUploadAdapter) WorkerEnding(workerNum int, ctx interface{}) {
 }
 
 func (a *tusUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb ProgressCallback, authOkFunc func()) error {
-	rel, err := t.Actions.Get("upload")
+	rel, err := t.HybridActions().Get("upload")
 	if err != nil {
 		return err
 	}

--- a/tq/tus_upload.go
+++ b/tq/tus_upload.go
@@ -41,7 +41,7 @@ func (a *tusUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb ProgressC
 		return err
 	}
 	if rel == nil {
-		return errors.New("No upload action for this object.")
+		return errors.Errorf("No upload action for object: %s", t.Oid[:7])
 	}
 
 	// Note not supporting the Creation extension since the batch API generates URLs

--- a/tq/verify.go
+++ b/tq/verify.go
@@ -16,10 +16,10 @@ const (
 func verifyUpload(c *lfsapi.Client, t *Transfer) error {
 	action, err := t.Actions.Get("verify")
 	if err != nil {
-		if IsActionMissingError(err) {
-			return nil
-		}
 		return err
+	}
+	if action == nil {
+		return nil
 	}
 
 	req, err := http.NewRequest("POST", action.Href, nil)


### PR DESCRIPTION
This pull-request teaches the `tq` package how to fallback to the deprecated `_links` property if it is given instead of `actions` in a batch response. It is intended to address https://github.com/git-lfs/git-lfs/issues/2003.

This functionality is implemented through a new, private type: `multiActionSet`, which behaves like `io.Multi{Reader,Writer}`, except that it instead implements the `ActionSet` interface. When the `HybridActions()` function is called, a `multiActionSet` is composed together, making both `actions` and `_links` accessible.

Unfortunately, the public interface for `tq.Transfer` now includes:

- `tq.Transfer.Actions`
- `tq.Transfer.Links`
- `tq.Transfer.HybridActions()`

Which, to me, feels bloated. `Actions` and `Links` are necessarily left public so as to allow the `encoding/json` package to modify those fields via the `reflect` package.  

EDIT: One thing we could do is make the `HybridActions()` function private in the interim, until this behavior is no longer supported.

Once this merges, I'll go ahead and backport this into the `release-2.0` branch, and schedule a release of v2.0.1.

---

/cc @git-lfs/core 
/xref https://github.com/git-lfs/git-lfs/issues/2003