### PR TITLE
lfs: extract `DiffIndexScanner`

### DIFF
--- a/lfs/diff_index_scanner.go
+++ b/lfs/diff_index_scanner.go
@@ -135,6 +135,7 @@ func (s *DiffIndexScanner) Scan() bool {
 	}
 
 	s.next, s.err = s.scan(s.from.Text())
+	s.err = errors.Wrap(s.err, "diff-index scan")
 
 	return s.err == nil
 }

--- a/lfs/diff_index_scanner.go
+++ b/lfs/diff_index_scanner.go
@@ -99,19 +99,19 @@ type DiffIndexScanner struct {
 // If any error was encountered in starting the command or closing its `stdin`,
 // that error will be returned immediately. Otherwise, a `*DiffIndexScanner`
 // will be returned with a `nil` error.
-func NewDiffIndexScanner(ref string, cached bool) (*DiffIndexScanner, *wrappedCmd, error) {
+func NewDiffIndexScanner(ref string, cached bool) (*DiffIndexScanner, error) {
 	cmd, err := startCommand("git", diffIndexCmdArgs(ref, cached)...)
 	if err != nil {
-		return nil, cmd, errors.Wrap(err, "diff-index")
+		return nil, errors.Wrap(err, "diff-index")
 	}
 
 	if err = cmd.Stdin.Close(); err != nil {
-		return nil, cmd, errors.Wrap(err, "diff-index: close")
+		return nil, errors.Wrap(err, "diff-index: close")
 	}
 
 	return &DiffIndexScanner{
 		from: bufio.NewScanner(cmd.Stdout),
-	}, cmd, nil
+	}, nil
 }
 
 // diffIndexCmdArgs returns a string slice containing the arguments necessary

--- a/lfs/diff_index_scanner.go
+++ b/lfs/diff_index_scanner.go
@@ -8,6 +8,11 @@ import (
 	"github.com/git-lfs/git-lfs/errors"
 )
 
+// Status represents the status of a file that appears in the output of `git
+// diff-index`.
+//
+// More information about each of its valid instances can be found:
+// https://git-scm.com/docs/git-diff-index
 type Status rune
 
 const (
@@ -21,6 +26,8 @@ const (
 	StatusUnknown      Status = 'X'
 )
 
+// String implements fmt.Stringer by returning a huamn-readable name for each
+// status.
 func (s Status) String() string {
 	switch s {
 	case StatusAddition:
@@ -43,24 +50,55 @@ func (s Status) String() string {
 	return "<unknown>"
 }
 
+// DiffIndexEntry holds information about a single item in the results of a `git
+// diff-index` command.
 type DiffIndexEntry struct {
-	SrcMode     string
-	DstMode     string
-	SrcSha      string
-	DstSha      string
-	Status      Status
+	// SrcMode is the file mode of the "src" file, stored as a string-based
+	// octal.
+	SrcMode string
+	// DstMode is the file mode of the "dst" file, stored as a string-based
+	// octal.
+	DstMode string
+	// SrcSha is the Git blob ID of the "src" file.
+	SrcSha string
+	// DstSha is the Git blob ID of the "dst" file.
+	DstSha string
+	// Status is the status of the file in the index.
+	Status Status
+	// StatusScore is the optional "score" assosicated with a particular
+	// status.
 	StatusScore int
-	SrcName     string
-	DstName     string
+	// SrcName is the name of the file in it's "src" state as it appears in
+	// the index.
+	SrcName string
+	// DstName is the name of the file in it's "dst" state as it appears in
+	// the index.
+	DstName string
 }
 
+// DiffIndexScanner scans the output of the `git diff-index` command.
 type DiffIndexScanner struct {
+	// next is the next entry scanned by the Scanner.
 	next *DiffIndexEntry
-	err  error
+	// err is any error that the Scanner encountered while scanning.
+	err error
 
+	// from is the underlying scanner, scanning the `git diff-index`
+	// command's stdout.
 	from *bufio.Scanner
 }
 
+// NewDiffIndexScanner initializes a new `DiffIndexScanner` scanning at the
+// given ref, "ref".
+//
+// If "cache" is given, the DiffIndexScanner will scan for differences between
+// the given ref and the index. If "cache" is _not_ given, DiffIndexScanner will
+// scan for differences between the given ref and the currently checked out
+// tree.
+//
+// If any error was encountered in starting the command or closing its `stdin`,
+// that error will be returned immediately. Otherwise, a `*DiffIndexScanner`
+// will be returned with a `nil` error.
 func NewDiffIndexScanner(ref string, cached bool) (*DiffIndexScanner, *wrappedCmd, error) {
 	cmd, err := startCommand("git", diffIndexCmdArgs(ref, cached)...)
 	if err != nil {
@@ -76,6 +114,8 @@ func NewDiffIndexScanner(ref string, cached bool) (*DiffIndexScanner, *wrappedCm
 	}, cmd, nil
 }
 
+// diffIndexCmdArgs returns a string slice containing the arguments necessary
+// to run the diff-index command.
 func diffIndexCmdArgs(ref string, cached bool) []string {
 	args := []string{"diff-index", "-M"}
 	if cached {
@@ -86,6 +126,9 @@ func diffIndexCmdArgs(ref string, cached bool) []string {
 	return args
 }
 
+// Scan advances the scan line and yields either a new value for Entry(), or an
+// Err(). It returns true or false, whether or not it can continue scanning for
+// more entries.
 func (s *DiffIndexScanner) Scan() bool {
 	if !s.prepareScan() {
 		return false
@@ -96,9 +139,14 @@ func (s *DiffIndexScanner) Scan() bool {
 	return s.err == nil
 }
 
+// Entry returns the last entry that was Scan()'d by the DiffIndexScanner.
 func (s *DiffIndexScanner) Entry() *DiffIndexEntry { return s.next }
-func (s *DiffIndexScanner) Err() error             { return s.err }
 
+// Entry returns the last error that was encountered by the DiffIndexScanner.
+func (s *DiffIndexScanner) Err() error { return s.err }
+
+// prepareScan clears out the results from the last Scan() loop, and advances
+// the internal scanner to fetch a new line of Text().
 func (s *DiffIndexScanner) prepareScan() bool {
 	s.next, s.err = nil, nil
 	if !s.from.Scan() {
@@ -109,6 +157,8 @@ func (s *DiffIndexScanner) prepareScan() bool {
 	return true
 }
 
+// scan parses the given line and returns a `*DiffIndexEntry` or an error,
+// depending on whether or not the parse was successful.
 func (s *DiffIndexScanner) scan(line string) (*DiffIndexEntry, error) {
 	parts := strings.Split(line, "\t")
 	if len(parts) < 2 {

--- a/lfs/diff_index_scanner.go
+++ b/lfs/diff_index_scanner.go
@@ -1,0 +1,141 @@
+package lfs
+
+import (
+	"bufio"
+	"strconv"
+	"strings"
+
+	"github.com/git-lfs/git-lfs/errors"
+)
+
+type Status rune
+
+const (
+	StatusAddition     Status = 'A'
+	StatusCopy         Status = 'C'
+	StatusDeletion     Status = 'D'
+	StatusModification Status = 'M'
+	StatusRename       Status = 'R'
+	StatusTypeChange   Status = 'T'
+	StatusUnmerged     Status = 'U'
+	StatusUnknown      Status = 'X'
+)
+
+func (s Status) String() string {
+	switch s {
+	case StatusAddition:
+		return "addition"
+	case StatusCopy:
+		return "copy"
+	case StatusDeletion:
+		return "deletion"
+	case StatusModification:
+		return "modification"
+	case StatusRename:
+		return "rename"
+	case StatusTypeChange:
+		return "change"
+	case StatusUnmerged:
+		return "unmerged"
+	case StatusUnknown:
+		return "unknown"
+	}
+	return "<unknown>"
+}
+
+type DiffIndexEntry struct {
+	SrcMode     string
+	DstMode     string
+	SrcSha      string
+	DstSha      string
+	Status      Status
+	StatusScore int
+	SrcName     string
+	DstName     string
+}
+
+type DiffIndexScanner struct {
+	next *DiffIndexEntry
+	err  error
+
+	from *bufio.Scanner
+}
+
+func NewDiffIndexScanner(ref string, cached bool) (*DiffIndexScanner, *wrappedCmd, error) {
+	cmd, err := startCommand("git", diffIndexCmdArgs(ref, cached)...)
+	if err != nil {
+		return nil, cmd, errors.Wrap(err, "diff-index")
+	}
+
+	if err = cmd.Stdin.Close(); err != nil {
+		return nil, cmd, errors.Wrap(err, "diff-index: close")
+	}
+
+	return &DiffIndexScanner{
+		from: bufio.NewScanner(cmd.Stdout),
+	}, cmd, nil
+}
+
+func diffIndexCmdArgs(ref string, cached bool) []string {
+	args := []string{"diff-index", "-M"}
+	if cached {
+		args = append(args, "--cached")
+	}
+	args = append(args, ref)
+
+	return args
+}
+
+func (s *DiffIndexScanner) Scan() bool {
+	if !s.prepareScan() {
+		return false
+	}
+
+	s.next, s.err = s.scan(s.from.Text())
+
+	return s.err == nil
+}
+
+func (s *DiffIndexScanner) Entry() *DiffIndexEntry { return s.next }
+func (s *DiffIndexScanner) Err() error             { return s.err }
+
+func (s *DiffIndexScanner) prepareScan() bool {
+	s.next, s.err = nil, nil
+	if !s.from.Scan() {
+		s.err = s.from.Err()
+		return false
+	}
+
+	return true
+}
+
+func (s *DiffIndexScanner) scan(line string) (*DiffIndexEntry, error) {
+	parts := strings.Split(line, "\t")
+	if len(parts) < 2 {
+		return nil, errors.Errorf("invalid line: %s", line)
+	}
+
+	desc := strings.Fields(parts[0])
+	if len(desc) < 5 {
+		return nil, errors.Errorf("invalid description: %s", parts[0])
+	}
+
+	entry := &DiffIndexEntry{
+		SrcMode: strings.TrimPrefix(desc[0], ":"),
+		DstMode: desc[1],
+		SrcSha:  desc[2],
+		DstSha:  desc[3],
+		Status:  Status(rune(desc[4][0])),
+		SrcName: parts[1],
+	}
+
+	if score, err := strconv.Atoi(desc[4][1:]); err != nil {
+		entry.StatusScore = score
+	}
+
+	if len(parts) > 2 {
+		entry.DstName = parts[2]
+	}
+
+	return entry, nil
+}

--- a/lfs/diff_index_scanner.go
+++ b/lfs/diff_index_scanner.go
@@ -26,7 +26,7 @@ const (
 	StatusUnknown      DiffIndexStatus = 'X'
 )
 
-// String implements fmt.Stringer by returning a huamn-readable name for each
+// String implements fmt.Stringer by returning a human-readable name for each
 // status.
 func (s DiffIndexStatus) String() string {
 	switch s {
@@ -65,13 +65,13 @@ type DiffIndexEntry struct {
 	DstSha string
 	// Status is the status of the file in the index.
 	Status DiffIndexStatus
-	// StatusScore is the optional "score" assosicated with a particular
+	// StatusScore is the optional "score" associated with a particular
 	// status.
 	StatusScore int
-	// SrcName is the name of the file in it's "src" state as it appears in
+	// SrcName is the name of the file in its "src" state as it appears in
 	// the index.
 	SrcName string
-	// DstName is the name of the file in it's "dst" state as it appears in
+	// DstName is the name of the file in its "dst" state as it appears in
 	// the index.
 	DstName string
 }

--- a/lfs/diff_index_scanner.go
+++ b/lfs/diff_index_scanner.go
@@ -135,7 +135,9 @@ func (s *DiffIndexScanner) Scan() bool {
 	}
 
 	s.next, s.err = s.scan(s.from.Text())
-	s.err = errors.Wrap(s.err, "diff-index scan")
+	if s.err != nil {
+		s.err = errors.Wrap(s.err, "diff-index scan")
+	}
 
 	return s.err == nil
 }

--- a/lfs/diff_index_scanner.go
+++ b/lfs/diff_index_scanner.go
@@ -163,6 +163,10 @@ func (s *DiffIndexScanner) prepareScan() bool {
 // scan parses the given line and returns a `*DiffIndexEntry` or an error,
 // depending on whether or not the parse was successful.
 func (s *DiffIndexScanner) scan(line string) (*DiffIndexEntry, error) {
+	// Format is:
+	//   :100644 100644 c5b3d83a7542255ec7856487baa5e83d65b1624c 9e82ac1b514be060945392291b5b3108c22f6fe3 M foo.gif
+	//   :<old mode> <new mode> <old sha1> <new sha1> <status>\t<file name>[\t<file name>]
+
 	parts := strings.Split(line, "\t")
 	if len(parts) < 2 {
 		return nil, errors.Errorf("invalid line: %s", line)

--- a/lfs/diff_index_scanner.go
+++ b/lfs/diff_index_scanner.go
@@ -13,22 +13,22 @@ import (
 //
 // More information about each of its valid instances can be found:
 // https://git-scm.com/docs/git-diff-index
-type Status rune
+type DiffIndexStatus rune
 
 const (
-	StatusAddition     Status = 'A'
-	StatusCopy         Status = 'C'
-	StatusDeletion     Status = 'D'
-	StatusModification Status = 'M'
-	StatusRename       Status = 'R'
-	StatusTypeChange   Status = 'T'
-	StatusUnmerged     Status = 'U'
-	StatusUnknown      Status = 'X'
+	StatusAddition     DiffIndexStatus = 'A'
+	StatusCopy         DiffIndexStatus = 'C'
+	StatusDeletion     DiffIndexStatus = 'D'
+	StatusModification DiffIndexStatus = 'M'
+	StatusRename       DiffIndexStatus = 'R'
+	StatusTypeChange   DiffIndexStatus = 'T'
+	StatusUnmerged     DiffIndexStatus = 'U'
+	StatusUnknown      DiffIndexStatus = 'X'
 )
 
 // String implements fmt.Stringer by returning a huamn-readable name for each
 // status.
-func (s Status) String() string {
+func (s DiffIndexStatus) String() string {
 	switch s {
 	case StatusAddition:
 		return "addition"
@@ -64,7 +64,7 @@ type DiffIndexEntry struct {
 	// DstSha is the Git blob ID of the "dst" file.
 	DstSha string
 	// Status is the status of the file in the index.
-	Status Status
+	Status DiffIndexStatus
 	// StatusScore is the optional "score" assosicated with a particular
 	// status.
 	StatusScore int
@@ -175,7 +175,7 @@ func (s *DiffIndexScanner) scan(line string) (*DiffIndexEntry, error) {
 		DstMode: desc[1],
 		SrcSha:  desc[2],
 		DstSha:  desc[3],
-		Status:  Status(rune(desc[4][0])),
+		Status:  DiffIndexStatus(rune(desc[4][0])),
 		SrcName: parts[1],
 	}
 

--- a/lfs/diff_index_scanner.go
+++ b/lfs/diff_index_scanner.go
@@ -102,11 +102,11 @@ type DiffIndexScanner struct {
 func NewDiffIndexScanner(ref string, cached bool) (*DiffIndexScanner, error) {
 	cmd, err := startCommand("git", diffIndexCmdArgs(ref, cached)...)
 	if err != nil {
-		return nil, errors.Wrap(err, "diff-index")
+		return nil, err
 	}
 
 	if err = cmd.Stdin.Close(); err != nil {
-		return nil, errors.Wrap(err, "diff-index: close")
+		return nil, err
 	}
 
 	return &DiffIndexScanner{
@@ -136,7 +136,7 @@ func (s *DiffIndexScanner) Scan() bool {
 
 	s.next, s.err = s.scan(s.from.Text())
 	if s.err != nil {
-		s.err = errors.Wrap(s.err, "diff-index scan")
+		s.err = errors.Wrap(s.err, "scan")
 	}
 
 	return s.err == nil

--- a/lfs/gitscanner_index.go
+++ b/lfs/gitscanner_index.go
@@ -1,7 +1,6 @@
 package lfs
 
 import (
-	"bufio"
 	"strings"
 	"sync"
 )
@@ -106,67 +105,46 @@ func scanIndex(cb GitScannerFoundPointer, ref string) error {
 // for in the indexf. It returns a channel from which sha1 strings can be read.
 // The namMap will be filled indexFile pointers mapping sha1s to indexFiles.
 func revListIndex(atRef string, cache bool, indexMap *indexFileMap) (*StringChannelWrapper, error) {
-	cmdArgs := []string{"diff-index", "-M"}
-	if cache {
-		cmdArgs = append(cmdArgs, "--cached")
-	}
-	cmdArgs = append(cmdArgs, atRef)
-
-	cmd, err := startCommand("git", cmdArgs...)
+	scanner, cmd, err := NewDiffIndexScanner(atRef, cache)
 	if err != nil {
 		return nil, err
 	}
 
-	cmd.Stdin.Close()
-
 	revs := make(chan string, chanBufSize)
-	errchan := make(chan error, 1)
+	errs := make(chan error, 1)
 
 	go func() {
-		scanner := bufio.NewScanner(cmd.Stdout)
 		for scanner.Scan() {
-			// Format is:
-			// :100644 100644 c5b3d83a7542255ec7856487baa5e83d65b1624c 9e82ac1b514be060945392291b5b3108c22f6fe3 M foo.gif
-			// :<old mode> <new mode> <old sha1> <new sha1> <status>\t<file name>[\t<file name>]
-			line := scanner.Text()
-			parts := strings.Split(line, "\t")
-			if len(parts) < 2 {
-				continue
+			var name string = scanner.Entry().DstName
+			if len(name) == 0 {
+				name = scanner.Entry().SrcName
 			}
 
-			description := strings.Split(parts[0], " ")
-			files := parts[1:len(parts)]
-
-			if len(description) >= 5 {
-				status := description[4][0:1]
-				sha1 := description[3]
-				if status == "M" {
-					sha1 = description[2] // This one is modified but not added
-				}
-
-				indexMap.Add(sha1, &indexFile{
-					Name:    files[len(files)-1],
-					SrcName: files[0],
-					Status:  status,
-				})
-				revs <- sha1
+			var sha string = scanner.Entry().DstSha
+			if scanner.Entry().Status == StatusModification {
+				sha = scanner.Entry().SrcSha
 			}
+
+			indexMap.Add(sha, &indexFile{
+				Name:    name,
+				SrcName: scanner.Entry().SrcName,
+				Status:  string(scanner.Entry().Status),
+			})
+
+			revs <- sha
 		}
 
-		// Note: deliberately not checking result code here, because doing that
-		// can fail fsck process too early since clean filter will detect errors
-		// and set this to non-zero. How to cope with this better?
-		// stderr, _ := ioutil.ReadAll(cmd.Stderr)
-		// err := cmd.Wait()
-		// if err != nil {
-		// 	errchan <- fmt.Errorf("Error in git diff-index: %v %v", err, string(stderr))
-		// }
+		if err := scanner.Err(); err != nil {
+			errs <- err
+		}
+
 		cmd.Wait()
+
 		close(revs)
-		close(errchan)
+		close(errs)
 	}()
 
-	return NewStringChannelWrapper(revs, errchan), nil
+	return NewStringChannelWrapper(revs, errs), nil
 }
 
 // indexFile is used when scanning the index. It stores the name of

--- a/lfs/gitscanner_index.go
+++ b/lfs/gitscanner_index.go
@@ -105,7 +105,7 @@ func scanIndex(cb GitScannerFoundPointer, ref string) error {
 // for in the indexf. It returns a channel from which sha1 strings can be read.
 // The namMap will be filled indexFile pointers mapping sha1s to indexFiles.
 func revListIndex(atRef string, cache bool, indexMap *indexFileMap) (*StringChannelWrapper, error) {
-	scanner, cmd, err := NewDiffIndexScanner(atRef, cache)
+	scanner, err := NewDiffIndexScanner(atRef, cache)
 	if err != nil {
 		return nil, err
 	}
@@ -137,8 +137,6 @@ func revListIndex(atRef string, cache bool, indexMap *indexFileMap) (*StringChan
 		if err := scanner.Err(); err != nil {
 			errs <- err
 		}
-
-		cmd.Wait()
 
 		close(revs)
 		close(errs)


### PR DESCRIPTION
This pull request extracts a `DiffIndexScanner` type that will be used by the `status` command to yield more helpful information about why certain files are modified.

Since both the proposed changes to the status command _and_ the `ScanIndex()` operation of the new gitscanner require scanning the output of the `diff-index` command, this PR is only mean to extract that common functionality.

---

/cc @git-lfs/core 