### PR TITLE
status: use DiffIndexScanner to populate results

### DIFF
--- a/commands/command_prune.go
+++ b/commands/command_prune.go
@@ -461,6 +461,26 @@ func pruneTaskGetReachableObjects(gitscanner *lfs.GitScanner, outObjectSet *tool
 	}
 }
 
+var byteUnits = []string{"B", "KB", "MB", "GB", "TB"}
+
+func humanizeBytes(bytes int64) string {
+	var output string
+	size := float64(bytes)
+
+	if bytes < 1024 {
+		return fmt.Sprintf("%d B", bytes)
+	}
+
+	for _, unit := range byteUnits {
+		if size < 1024.0 {
+			output = fmt.Sprintf("%3.1f %s", size, unit)
+			break
+		}
+		size /= 1024.0
+	}
+	return output
+}
+
 func init() {
 	RegisterCommand("prune", pruneCommand, func(cmd *cobra.Command) {
 		cmd.Flags().BoolVarP(&pruneDryRunArg, "dry-run", "d", false, "Don't delete anything, just report")

--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -1,8 +1,6 @@
 package commands
 
 import (
-	"fmt"
-
 	"github.com/git-lfs/git-lfs/git"
 	"github.com/git-lfs/git-lfs/lfs"
 	"github.com/spf13/cobra"
@@ -41,11 +39,11 @@ func statusCommand(cmd *cobra.Command, args []string) {
 
 		switch p.Status {
 		case "R", "C":
-			Print("\t%s -> %s (%s)", p.SrcName, p.Name, humanizeBytes(p.Size))
+			Print("\t%s -> %s", p.SrcName, p.Name)
 		case "M":
 			unstagedPointers = append(unstagedPointers, p)
 		default:
-			Print("\t%s (%s)", p.Name, humanizeBytes(p.Size))
+			Print("\t%s", p.Name)
 		}
 	})
 
@@ -83,7 +81,7 @@ func statusScanRefRange(ref *git.Ref) {
 			return
 		}
 
-		Print("\t%s (%s)", p.Name, humanizeBytes(p.Size))
+		Print("\t%s (%s)", p.Name)
 	})
 	defer gitscanner.Close()
 
@@ -102,11 +100,11 @@ func porcelainStagedPointers(ref string) {
 
 		switch p.Status {
 		case "R", "C":
-			Print("%s  %s -> %s %d", p.Status, p.SrcName, p.Name, p.Size)
+			Print("%s  %s -> %s", p.Status, p.SrcName, p.Name)
 		case "M":
-			Print(" %s %s %d", p.Status, p.Name, p.Size)
+			Print(" %s %s", p.Status, p.Name)
 		default:
-			Print("%s  %s %d", p.Status, p.Name, p.Size)
+			Print("%s  %s", p.Status, p.Name)
 		}
 	})
 	defer gitscanner.Close()
@@ -114,26 +112,6 @@ func porcelainStagedPointers(ref string) {
 	if err := gitscanner.ScanIndex(ref, nil); err != nil {
 		ExitWithError(err)
 	}
-}
-
-var byteUnits = []string{"B", "KB", "MB", "GB", "TB"}
-
-func humanizeBytes(bytes int64) string {
-	var output string
-	size := float64(bytes)
-
-	if bytes < 1024 {
-		return fmt.Sprintf("%d B", bytes)
-	}
-
-	for _, unit := range byteUnits {
-		if size < 1024.0 {
-			output = fmt.Sprintf("%3.1f %s", size, unit)
-			break
-		}
-		size /= 1024.0
-	}
-	return output
 }
 
 func init() {

--- a/lfs/diff_index_scanner.go
+++ b/lfs/diff_index_scanner.go
@@ -2,6 +2,7 @@ package lfs
 
 import (
 	"bufio"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -48,6 +49,27 @@ func (s DiffIndexStatus) String() string {
 		return "unknown"
 	}
 	return "<unknown>"
+}
+
+// Format implements fmt.Formatter. If printed as "%+d", "%+s", or "%+v", the
+// status will be written out as an English word: i.e., "addition", "copy",
+// "deletion", etc.
+//
+// If the '+' flag is not given, the shorthand will be used instead: 'A', 'C',
+// and 'D', respectively.
+//
+// If any other format verb is given, this function will panic().
+func (s DiffIndexStatus) Format(state fmt.State, c rune) {
+	switch c {
+	case 'd', 's', 'v':
+		if state.Flag('+') {
+			state.Write([]byte(s.String()))
+		} else {
+			state.Write([]byte{byte(rune(s))})
+		}
+	default:
+		panic(fmt.Sprintf("cannot format %v for DiffIndexStatus", c))
+	}
 }
 
 // DiffIndexEntry holds information about a single item in the results of a `git

--- a/test/test-status.sh
+++ b/test/test-status.sh
@@ -27,8 +27,8 @@ begin_test "status"
 
 Git LFS objects to be committed:
 
-	file2.dat (11 B)
-	file3.dat (11 B)
+	file2.dat
+	file3.dat
 
 Git LFS objects not staged for commit:
 
@@ -59,9 +59,9 @@ begin_test "status --porcelain"
 
   echo "file3 other data" > file3.dat
 
-  expected=" M file1.dat 10
-A  file2.dat 11
-A  file3.dat 11"
+  expected=" M file1.dat
+A  file2.dat
+A  file3.dat"
 
   [ "$expected" = "$(git lfs status --porcelain)" ]
 )
@@ -101,7 +101,7 @@ begin_test "status - before initial commit"
   expected="
 Git LFS objects to be committed:
 
-	file1.dat (10 B)
+	file1.dat
 
 Git LFS objects not staged for commit:"
 


### PR DESCRIPTION
This pull-request brings us another step closer to adding additional information to the output of the `status` command by using the new `*lfs.DiffIndexScanner` instead of the `gitscanner`.

By doing so, we give the status command direct access to the `*lfs.DiffIndexScanner` instance, which will eventually receive methods that can answer and provide additional information about why certain files are modified. 

---

/cc @git-lfs/core 