### PR TITLE
Cache git-lfs-authenticate repsonse

### DIFF
--- a/lfsapi/auth_test.go
+++ b/lfsapi/auth_test.go
@@ -86,7 +86,7 @@ func TestDoWithAuthApprove(t *testing.T) {
 	err = MarshalToRequest(req, &authRequest{Test: "Approve"})
 	require.Nil(t, err)
 
-	res, err := c.DoWithAuth("", req)
+	res, err := c.DoWithAuth("", NewRequestWrapper(req))
 	require.Nil(t, err)
 
 	assert.Equal(t, http.StatusOK, res.StatusCode)
@@ -154,7 +154,7 @@ func TestDoWithAuthReject(t *testing.T) {
 	err = MarshalToRequest(req, &authRequest{Test: "Reject"})
 	require.Nil(t, err)
 
-	res, err := c.DoWithAuth("", req)
+	res, err := c.DoWithAuth("", NewRequestWrapper(req))
 	require.Nil(t, err)
 
 	assert.Equal(t, http.StatusOK, res.StatusCode)

--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -64,9 +64,9 @@ func (f *sshRequestFactory) NewRequest() (*http.Request, error) {
 }
 
 func (f *sshRequestFactory) InvalidateAuthorization() bool {
-	_, ok := f.c.sshAuthCache[f.e.SshUserAndHost]
+	_, ok := f.c.sshAuthCache[f.e.SshUserAndHost+f.method]
 	if ok {
-		delete(f.c.sshAuthCache, f.e.SshUserAndHost)
+		delete(f.c.sshAuthCache, f.e.SshUserAndHost+f.method)
 	}
 	return ok
 }

--- a/lfsapi/client_test.go
+++ b/lfsapi/client_test.go
@@ -175,7 +175,7 @@ func TestNewRequest(t *testing.T) {
 		}))
 		require.Nil(t, err)
 
-		req, err := c.NewRequest("POST", c.Endpoints.Endpoint("", ""), test[1], nil)
+		req, err := c.NewRequest("POST", c.Endpoints.Endpoint("", ""), test[1], nil).NewRequest()
 		require.Nil(t, err)
 		assert.Equal(t, "POST", req.Method)
 		assert.Equal(t, test[2], req.URL.String(), fmt.Sprintf("endpoint: %s, suffix: %s, expected: %s", test[0], test[1], test[2]))
@@ -191,7 +191,7 @@ func TestNewRequestWithBody(t *testing.T) {
 	body := struct {
 		Test string
 	}{Test: "test"}
-	req, err := c.NewRequest("POST", c.Endpoints.Endpoint("", ""), "body", body)
+	req, err := c.NewRequest("POST", c.Endpoints.Endpoint("", ""), "body", body).NewRequest()
 	require.Nil(t, err)
 
 	assert.NotNil(t, req.Body)

--- a/lfsapi/lfsapi.go
+++ b/lfsapi/lfsapi.go
@@ -49,6 +49,8 @@ type Client struct {
 	transfers        map[*http.Response]*httpTransfer
 	transferMu       sync.Mutex
 
+	sshAuthCache map[string]sshAuthResponse
+
 	// only used for per-host ssl certs
 	gitEnv Env
 	osEnv  Env
@@ -89,6 +91,7 @@ func NewClient(osEnv Env, gitEnv Env) (*Client, error) {
 		NoProxy:             noProxy,
 		gitEnv:              gitEnv,
 		osEnv:               osEnv,
+		sshAuthCache:        make(map[string]sshAuthResponse),
 	}
 
 	return c, nil

--- a/lfsapi/ntlm_test.go
+++ b/lfsapi/ntlm_test.go
@@ -96,7 +96,7 @@ func TestNTLMAuth(t *testing.T) {
 	}
 	credHelper.Approve(creds)
 
-	res, err := cli.DoWithAuth("remote", req)
+	res, err := cli.DoWithAuth("remote", NewRequestWrapper(req))
 	require.Nil(t, err)
 	assert.Equal(t, 200, res.StatusCode)
 	assert.True(t, credHelper.IsApproved(creds))

--- a/lfsapi/ssh.go
+++ b/lfsapi/ssh.go
@@ -44,7 +44,7 @@ func (c *Client) resolveSSHEndpoint(e Endpoint, method string) (sshAuthResponse,
 	}
 
 	if err == nil {
-		c.sshAuthCache[e.SshUserAndHost] = res
+		c.sshAuthCache[e.SshUserAndHost+method] = res
 	}
 
 	return res, err

--- a/lfsapi/ssh.go
+++ b/lfsapi/ssh.go
@@ -18,6 +18,10 @@ func (c *Client) resolveSSHEndpoint(e Endpoint, method string) (sshAuthResponse,
 		return res, nil
 	}
 
+	if cached, ok := c.sshAuthCache[e.SshUserAndHost]; ok {
+		return cached, nil
+	}
+
 	exe, args := sshGetLFSExeAndArgs(c.osEnv, e, method)
 	cmd := exec.Command(exe, args...)
 
@@ -37,6 +41,10 @@ func (c *Client) resolveSSHEndpoint(e Endpoint, method string) (sshAuthResponse,
 		res.Message = strings.TrimSpace(errbuf.String())
 	} else {
 		err = json.Unmarshal(outbuf.Bytes(), &res)
+	}
+
+	if err == nil {
+		c.sshAuthCache[e.SshUserAndHost] = res
 	}
 
 	return res, err

--- a/test/cmd/lfstest-customadapter.go
+++ b/test/cmd/lfstest-customadapter.go
@@ -116,7 +116,7 @@ func performDownload(apiClient *lfsapi.Client, oid string, size int64, a *action
 		req.Header.Set(k, a.Header[k])
 	}
 
-	res, err := apiClient.DoWithAuth("origin", req)
+	res, err := apiClient.DoWithAuth("origin", lfsapi.NewRequestWrapper(req))
 	if err != nil {
 		sendTransferError(oid, res.StatusCode, err.Error(), writer, errWriter)
 		return
@@ -194,7 +194,7 @@ func performUpload(apiClient *lfsapi.Client, oid string, size int64, a *action, 
 	}
 	req.Body = progress.NewBodyWithCallback(f, size, cb)
 
-	res, err := apiClient.DoWithAuth("origin", req)
+	res, err := apiClient.DoWithAuth("origin", lfsapi.NewRequestWrapper(req))
 	if err != nil {
 		sendTransferError(oid, res.StatusCode, fmt.Sprintf("Error uploading data for %s: %v", oid, err), writer, errWriter)
 		return

--- a/tq/adapterbase.go
+++ b/tq/adapterbase.go
@@ -193,7 +193,7 @@ func (a *adapterBase) doHTTP(t *Transfer, req *http.Request) (*http.Response, er
 	if t.Authenticated {
 		return a.apiClient.Do(req)
 	}
-	return a.apiClient.DoWithAuth(a.remote, req)
+	return a.apiClient.DoWithAuth(a.remote, lfsapi.NewRequestWrapper(req))
 }
 
 func advanceCallbackProgress(cb ProgressCallback, t *Transfer, numBytes int64) {

--- a/tq/api.go
+++ b/tq/api.go
@@ -45,10 +45,8 @@ func (c *tqClient) Batch(remote string, bReq *batchRequest) (*BatchResponse, err
 	}
 
 	bRes.endpoint = c.Endpoints.Endpoint(bReq.Operation, remote)
-	req, err := c.NewRequest("POST", bRes.endpoint, "objects/batch", bReq)
-	if err != nil {
-		return nil, errors.Wrap(err, "batch request")
-	}
+
+	req := c.NewRequest("POST", bRes.endpoint, "objects/batch", bReq)
 
 	tracerx.Printf("api: batch %d files", len(bReq.Objects))
 


### PR DESCRIPTION
Changes summary:

 * lfsapi.NewRequest now returns RequestFactory instead of (*http.Request, err);
 * RequestFactory interface have two methods:
   * NewRequest() (*http.Request, error) - generate request;
   * InvalidateAuthorization() bool - invalidate cached authentication data.
 * For simple HTTP requests RequestFactory simply wraps http.Request.
 * For SSH based HTTP requests RequestFactory generate http.Request based on
   last `git-lfs-authenticate` response.

This change for fix issue #2018