### PR TITLE
tq: use initialized lfsapi.Client instances in transfer adapters

### DIFF
--- a/test/test-custom-transfers.sh
+++ b/test/test-custom-transfers.sh
@@ -61,6 +61,7 @@ begin_test "custom-transfer-upload-download"
   {
     \"CommitDate\":\"$(get_date -10d)\",
     \"Files\":[
+      {\"Filename\":\"verify.dat\",\"Size\":18,\"Data\":\"send-verify-action\"},
       {\"Filename\":\"file1.dat\",\"Size\":1024},
       {\"Filename\":\"file2.dat\",\"Size\":750}]
   },
@@ -93,7 +94,7 @@ begin_test "custom-transfer-upload-download"
 
   grep "xfer: started custom adapter process" pushcustom.log
   grep "xfer\[lfstest-customadapter\]:" pushcustom.log
-  grep "11 of 11 files" pushcustom.log
+  grep "12 of 12 files" pushcustom.log
 
   rm -rf .git/lfs/objects
   GIT_TRACE=1 git lfs fetch --all  2>&1 | tee fetchcustom.log
@@ -101,11 +102,11 @@ begin_test "custom-transfer-upload-download"
 
   grep "xfer: started custom adapter process" fetchcustom.log
   grep "xfer\[lfstest-customadapter\]:" fetchcustom.log
-  grep "11 of 11 files" fetchcustom.log
+  grep "12 of 12 files" fetchcustom.log
 
   grep "Terminating test custom adapter gracefully" fetchcustom.log
 
   objectlist=`find .git/lfs/objects -type f`
-  [ "$(echo "$objectlist" | wc -l)" -eq 11 ]
+  [ "$(echo "$objectlist" | wc -l)" -eq 12 ]
 )
 end_test

--- a/tq/custom.go
+++ b/tq/custom.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/git-lfs/git-lfs/errors"
-	"github.com/git-lfs/git-lfs/lfsapi"
 	"github.com/git-lfs/git-lfs/tools"
 
 	"github.com/git-lfs/git-lfs/subprocess"
@@ -316,8 +315,7 @@ func (a *customAdapter) DoTransfer(ctx interface{}, t *Transfer, cb ProgressCall
 					return fmt.Errorf("Failed to copy downloaded file: %v", err)
 				}
 			} else if a.direction == Upload {
-				cli := &lfsapi.Client{}
-				if err = verifyUpload(cli, t); err != nil {
+				if err = verifyUpload(a.apiClient, t); err != nil {
 					return err
 				}
 			}

--- a/tq/tus_upload.go
+++ b/tq/tus_upload.go
@@ -160,8 +160,7 @@ func (a *tusUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb ProgressC
 	io.Copy(ioutil.Discard, res.Body)
 	res.Body.Close()
 
-	cli := &lfsapi.Client{}
-	return verifyUpload(cli, t)
+	return verifyUpload(a.apiClient, t)
 }
 
 func configureTusAdapter(m *Manifest) {


### PR DESCRIPTION
This pull request fixes a bug introduced in https://github.com/git-lfs/git-lfs/commit/0677bdd06a97b60455dac2cfa19d54ff697a1e17 (via: [this blame view][1]) where un-initialized `lfsapi.Client` instances were used in place of the [real one][2].

Previously, this wasn't a problem, but since I added #1971 (which uses the API client), this caused a nil pointer de-reference `panic()` on pushes with verify actions using the Tus and custom transfer adapters.

@git-lfs/releases I think that this warrants being backported and released as v2.0.2. In the interim, or if we decided that this isn't worth it, we can always have users set the `lfs.basictransfersonly`. What do you think?

---

/cc @git-lfs/core https://github.com/git-lfs/git-lfs/issues/2046

[1]: https://github.com/git-lfs/git-lfs/blame/v2.0.1/tq/custom.go#L318-L323
[2]: https://github.com/git-lfs/git-lfs/blob/v2.0.1/tq/adapterbase.go#L67-L67