### PR TITLE
fsck only scans current version of objects

### DIFF
--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -47,7 +47,7 @@ func fsckCommand(cmd *cobra.Command, args []string) {
 		}
 	})
 
-	if err := gitscanner.ScanRefWithDeleted(ref.Sha, nil); err != nil {
+	if err := gitscanner.ScanRef(ref.Sha, nil); err != nil {
 		ExitWithError(err)
 	}
 


### PR DESCRIPTION
I am not clear on the goal of fsck, but when I ran it on my repo it complained about missing objects that were old revisions of lfs-stored files. It then tried to move the offending objects' files to the "bad" folder and, since the files of course did not exist, it complained again.

I found this looked like a reasonable fix, and then saw #953 which seems to agree.