### PR TITLE
commands/status: show partially staged files twice

### DIFF
--- a/test/test-status.sh
+++ b/test/test-status.sh
@@ -32,7 +32,8 @@ Git LFS objects to be committed:
 
 Git LFS objects not staged for commit:
 
-	file1.dat"
+	file1.dat
+	file3.dat"
 
   [ "$expected" = "$(git lfs status)" ]
 )
@@ -60,8 +61,8 @@ begin_test "status --porcelain"
   echo "file3 other data" > file3.dat
 
   expected=" M file1.dat
-A  file2.dat
-A  file3.dat"
+A  file3.dat
+A  file2.dat"
 
   [ "$expected" = "$(git lfs status --porcelain)" ]
 )
@@ -130,5 +131,42 @@ begin_test "status shows multiple files with identical contents"
 
   [ "1" -eq "$(grep -c "a.dat" status.log)" ]
   [ "1" -eq "$(grep -c "b.dat" status.log)" ]
+)
+end_test
+
+begin_test "status shows multiple copies of partially staged files"
+(
+  set -e
+
+  reponame="status-partially-staged"
+  git init "$reponame"
+  cd "$reponame"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  contents_1="part 1"
+  printf "$contents_1" > a.dat
+
+  # "$contents_1" changes are staged
+  git add a.dat
+
+  # "$contents_2" changes are unstaged
+  contents_2="part 2"
+  printf "$contents_2" >> a.dat
+
+  expected="On branch master
+
+Git LFS objects to be committed:
+
+	a.dat
+
+Git LFS objects not staged for commit:
+
+	a.dat"
+  actual="$(git lfs status)"
+
+  diff -u <(echo "$expected") <(echo "$actual")
 )
 end_test


### PR DESCRIPTION
This pull request updates our unique-ness check in the `git lfs status` command to correctly display partially staged files.

Here's an example. When `git status` shows:

```bash
~/g/git-lfs-test (master!) $ git status
On branch master
Your branch is up-to-date with 'origin/master'.
Changes to be committed:
  (use "git reset HEAD <file>..." to unstage)

        modified:   gif/droidtocat.gif

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

        modified:   gif/droidtocat.gif
```

`git lfs status` used to show:

```bash
~/g/git-lfs-test (master!) $ git lfs status
On branch master
Git LFS objects to be pushed to origin/master:


Git LFS objects to be committed:


Git LFS objects not staged for commit:

        gif/droidtocat.gif
```

but now shows:

```bash
~/g/git-lfs-test (master!) $ git lfs status
On branch master
Git LFS objects to be pushed to origin/master:


Git LFS objects to be committed:

        gif/droidtocat.gif

Git LFS objects not staged for commit:

        gif/droidtocat.gif
```

The term "partially staged" doesn't often apply in the traditional sense when talking about large files. A much more likely scenario, however, is:

1. Modify (or add) an LFS-tracked file
2. Stage that file
3. Add or replace contents of staged LFS-tracked
4. Have both staged and unstaged changes

Since the staged changes are already reflected as an LFS pointer in the index, it is technically correct to say that the file is both staged and un-staged. In addition, this makes the proposed `status` changes of displaying `(Git: sha1 -> LFS: sha2)` much more clear when we can see both halves of "staged" and "un-staged". 

A bit of background: Since https://github.com/git-lfs/git-lfs/pull/137 (the introduction of the `status` command), we've taken the set-intersection of `git diff-index -M --cached` and `diff-index -M` by _file name_. This gets us around showing the same file twice in the status list, but isn't quite right.

Since we now partition into staged and un-staged changes as of #2042, we can show the same file twice if that file is both staged and un-staged. The way that we do this is by generating a unique key as:

```go
func KeyForEntry(e *lfs.DiffIndexEntry) string {
        var name string = e.DstName
        if len(name) == 0 {
                name = e.SrcName
        }

        return strings.Join([]string{e.SrcSha, e.DstSha, name}, ":")
}
```

which makes files unique by their _diff of their contents_ when they were marked staged or un-staged.

---

/cc @git-lfs/core