### PR TITLE
commands/status: add blob info to each entry

### DIFF
--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -135,7 +135,7 @@ func blobInfo(s *lfs.CatFileBatchScanner, blobSha, name string) (sha, from strin
 		return "", "", err
 	}
 
-	return fmt.Sprintf("%x", shasum.Sum(nil)), "Git", nil
+	return fmt.Sprintf("%x", shasum.Sum(nil)), "File", nil
 }
 
 func scanIndex(ref string) (staged, unstaged []*lfs.DiffIndexEntry, err error) {

--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -60,6 +60,26 @@ func statusCommand(cmd *cobra.Command, args []string) {
 
 var z40 = regexp.MustCompile(`\^?0{40}`)
 
+func formatBlobInfo(s *lfs.CatFileBatchScanner, entry *lfs.DiffIndexEntry) string {
+	fromSha, fromSrc, err := blobInfoFrom(s, entry)
+	if err != nil {
+		ExitWithError(err)
+	}
+
+	from := fmt.Sprintf("%s: %s", fromSrc, fromSha[:7])
+	if entry.Status == lfs.StatusAddition {
+		return from
+	}
+
+	toSha, toSrc, err := blobInfoTo(s, entry)
+	if err != nil {
+		ExitWithError(err)
+	}
+	to := fmt.Sprintf("%s: %s", toSrc, toSha[:7])
+
+	return fmt.Sprintf("%s -> %s", from, to)
+}
+
 func blobInfoFrom(s *lfs.CatFileBatchScanner, entry *lfs.DiffIndexEntry) (sha, from string, err error) {
 	var blobSha string = entry.SrcSha
 	if z40.MatchString(blobSha) {

--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -109,7 +109,7 @@ func blobInfoTo(s *lfs.CatFileBatchScanner, entry *lfs.DiffIndexEntry) (sha, fro
 
 func blobInfo(s *lfs.CatFileBatchScanner, blobSha, name string) (sha, from string, err error) {
 	if !z40.MatchString(blobSha) {
-		s.Scan([]byte(blobSha))
+		s.Scan(blobSha)
 		if err := s.Err(); err != nil {
 			return "", "", err
 		}

--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -40,22 +40,31 @@ func statusCommand(cmd *cobra.Command, args []string) {
 		ExitWithError(err)
 	}
 
+	scanner, err := lfs.NewCatFileBatchScanner()
+	if err != nil {
+		ExitWithError(err)
+	}
+
 	Print("\nGit LFS objects to be committed:\n")
 	for _, entry := range staged {
 		switch entry.Status {
 		case lfs.StatusRename, lfs.StatusCopy:
-			Print("\t%s -> %s", entry.SrcName, entry.DstName)
+			Print("\t%s -> %s (%s)", entry.SrcName, entry.DstName, formatBlobInfo(scanner, entry))
 		default:
-			Print("\t%s", entry.SrcName)
+			Print("\t%s (%s)", entry.SrcName, formatBlobInfo(scanner, entry))
 		}
 	}
 
 	Print("\nGit LFS objects not staged for commit:\n")
 	for _, entry := range unstaged {
-		Print("\t%s", entry.SrcName)
+		Print("\t%s (%s)", entry.SrcName, formatBlobInfo(scanner, entry))
 	}
 
 	Print("")
+
+	if err = scanner.Close(); err != nil {
+		ExitWithError(err)
+	}
 }
 
 var z40 = regexp.MustCompile(`\^?0{40}`)

--- a/lfs/gitscanner_catfilebatch.go
+++ b/lfs/gitscanner_catfilebatch.go
@@ -27,7 +27,7 @@ func runCatFileBatch(pointerCh chan *WrappedPointer, lockableCh chan string, loc
 
 	go func() {
 		for r := range revs.Results {
-			canScan := scanner.Scan([]byte(r))
+			canScan := scanner.Scan(r)
 
 			if err := scanner.Err(); err != nil {
 				errCh <- err
@@ -113,11 +113,11 @@ func (s *CatFileBatchScanner) Err() error {
 	return s.err
 }
 
-func (s *CatFileBatchScanner) Scan(sha []byte) bool {
+func (s *CatFileBatchScanner) Scan(sha string) bool {
 	s.pointer, s.err = nil, nil
 	s.blobSha, s.contentsSha = "", ""
 
-	if s.w != nil && sha != nil {
+	if s.w != nil && len(sha) > 0 {
 		if _, err := fmt.Fprintf(s.w, "%s\n", sha); err != nil {
 			s.err = err
 			return false

--- a/lfs/gitscanner_catfilebatchscanner_test.go
+++ b/lfs/gitscanner_catfilebatchscanner_test.go
@@ -52,7 +52,7 @@ func TestCatFileBatchScannerWithValidOutput(t *testing.T) {
 		assertNextEmptyPointer(t, scanner)
 	}
 
-	assert.False(t, scanner.Scan(nil))
+	assert.False(t, scanner.Scan(""))
 	assert.Nil(t, scanner.Err())
 	assert.Nil(t, scanner.Pointer())
 }
@@ -70,17 +70,17 @@ func TestCatFileBatchScannerWithLargeBlobs(t *testing.T) {
 
 	scanner := &CatFileBatchScanner{r: bufio.NewReader(fake)}
 
-	require.True(t, scanner.Scan(nil))
+	require.True(t, scanner.Scan(""))
 	assert.Nil(t, scanner.Pointer())
 	assert.Equal(t, fmt.Sprintf("%x", sha.Sum(nil)), scanner.ContentsSha())
 
-	assert.False(t, scanner.Scan(nil))
+	assert.False(t, scanner.Scan(""))
 	assert.Nil(t, scanner.Err())
 	assert.Nil(t, scanner.Pointer())
 }
 
 func assertNextPointer(t *testing.T, scanner *CatFileBatchScanner, oid string) {
-	assert.True(t, scanner.Scan(nil))
+	assert.True(t, scanner.Scan(""))
 	assert.Nil(t, scanner.Err())
 
 	p := scanner.Pointer()
@@ -90,7 +90,7 @@ func assertNextPointer(t *testing.T, scanner *CatFileBatchScanner, oid string) {
 }
 
 func assertNextEmptyPointer(t *testing.T, scanner *CatFileBatchScanner) {
-	assert.True(t, scanner.Scan(nil))
+	assert.True(t, scanner.Scan(""))
 	assert.Nil(t, scanner.Err())
 
 	assert.Nil(t, scanner.Pointer())

--- a/lfs/gitscanner_catfilebatchscanner_test.go
+++ b/lfs/gitscanner_catfilebatchscanner_test.go
@@ -32,7 +32,7 @@ func TestCatFileBatchScannerWithValidOutput(t *testing.T) {
 		return
 	}
 
-	scanner := &catFileBatchScanner{r: bufio.NewReader(reader)}
+	scanner := &CatFileBatchScanner{r: bufio.NewReader(reader)}
 
 	for i := 0; i < 5; i++ {
 		assertNextEmptyPointer(t, scanner)
@@ -50,19 +50,25 @@ func TestCatFileBatchScannerWithValidOutput(t *testing.T) {
 		assertNextEmptyPointer(t, scanner)
 	}
 
-	assertScannerDone(t, scanner)
+	assert.False(t, scanner.Scan(nil))
+	assert.Nil(t, scanner.Err())
 	assert.Nil(t, scanner.Pointer())
 }
 
-func assertNextPointer(t *testing.T, scanner *catFileBatchScanner, oid string) {
-	assertNextScan(t, scanner)
+func assertNextPointer(t *testing.T, scanner *CatFileBatchScanner, oid string) {
+	assert.True(t, scanner.Scan(nil))
+	assert.Nil(t, scanner.Err())
+
 	p := scanner.Pointer()
+
 	assert.NotNil(t, p)
 	assert.Equal(t, oid, p.Oid)
 }
 
-func assertNextEmptyPointer(t *testing.T, scanner *catFileBatchScanner) {
-	assertNextScan(t, scanner)
+func assertNextEmptyPointer(t *testing.T, scanner *CatFileBatchScanner) {
+	assert.True(t, scanner.Scan(nil))
+	assert.Nil(t, scanner.Err())
+
 	assert.Nil(t, scanner.Pointer())
 }
 

--- a/lfs/gitscanner_tree.go
+++ b/lfs/gitscanner_tree.go
@@ -56,7 +56,7 @@ func catFileBatchTree(treeblobs *TreeBlobChannelWrapper) (*PointerChannelWrapper
 
 	go func() {
 		for t := range treeblobs.Results {
-			hasNext := scanner.Scan([]byte(t.Sha1))
+			hasNext := scanner.Scan(t.Sha1)
 			if p := scanner.Pointer(); p != nil {
 				p.Name = t.Filename
 				pointers <- p

--- a/lfs/gitscanner_tree.go
+++ b/lfs/gitscanner_tree.go
@@ -46,7 +46,7 @@ func runScanTree(cb GitScannerFoundPointer, ref string, filter *filepathfilter.F
 // a Git LFS pointer. treeblobs is a channel over which blob entries
 // will be sent. It returns a channel from which point.Pointers can be read.
 func catFileBatchTree(treeblobs *TreeBlobChannelWrapper) (*PointerChannelWrapper, error) {
-	cmd, err := startCommand("git", "cat-file", "--batch")
+	scanner, err := NewCatFileBatchScanner()
 	if err != nil {
 		return nil, err
 	}
@@ -55,11 +55,8 @@ func catFileBatchTree(treeblobs *TreeBlobChannelWrapper) (*PointerChannelWrapper
 	errchan := make(chan error, 10) // Multiple errors possible
 
 	go func() {
-		scanner := &catFileBatchScanner{r: cmd.Stdout}
 		for t := range treeblobs.Results {
-			cmd.Stdin.Write([]byte(t.Sha1 + "\n"))
-
-			hasNext := scanner.Scan()
+			hasNext := scanner.Scan([]byte(t.Sha1))
 			if p := scanner.Pointer(); p != nil {
 				p.Name = t.Filename
 				pointers <- p
@@ -80,14 +77,10 @@ func catFileBatchTree(treeblobs *TreeBlobChannelWrapper) (*PointerChannelWrapper
 			errchan <- err
 		}
 
-		cmd.Stdin.Close()
-
-		// also errors from our command
-		stderr, _ := ioutil.ReadAll(cmd.Stderr)
-		err = cmd.Wait()
-		if err != nil {
-			errchan <- fmt.Errorf("Error in git cat-file: %v %v", err, string(stderr))
+		if err = scanner.Close(); err != nil {
+			errchan <- err
 		}
+
 		close(pointers)
 		close(errchan)
 	}()

--- a/test/test-status.sh
+++ b/test/test-status.sh
@@ -49,8 +49,8 @@ Git LFS objects to be committed:
 
 Git LFS objects not staged for commit:
 
-	file1.dat (LFS: $file_1_oid_short -> Git: $file_1_new_oid_short)
-	file3.dat (Git: $file_3_new_oid_short)"
+	file1.dat (LFS: $file_1_oid_short -> File: $file_1_new_oid_short)
+	file3.dat (File: $file_3_new_oid_short)"
 
   [ "$expected" = "$(git lfs status)" ]
 )
@@ -189,7 +189,7 @@ Git LFS objects to be committed:
 
 Git LFS objects not staged for commit:
 
-	a.dat (Git: $contents_2_oid_short)"
+	a.dat (File: $contents_2_oid_short)"
   actual="$(git lfs status)"
 
   diff -u <(echo "$expected") <(echo "$actual")

--- a/test/test-status.sh
+++ b/test/test-status.sh
@@ -10,30 +10,47 @@ begin_test "status"
   cd repo-1
   git init
   git lfs track "*.dat"
-  echo "some data" > file1.dat
+
+  file_1="some data"
+  file_1_oid="$(calc_oid "$file_1")"
+  file_1_oid_short="$(echo "$file_1_oid" | head -c 7)"
+  printf "$file_1" > file1.dat
   git add file1.dat
   git commit -m "file1.dat"
 
-  echo "other data" > file1.dat
-  echo "file2 data" > file2.dat
+  file_1_new="other data"
+  file_1_new_oid="$(calc_oid "$file_1_new")"
+  file_1_new_oid_short="$(echo "$file_1_new_oid" | head -c 7)"
+  printf "$file_1_new" > file1.dat
+
+  file_2="file2 data"
+  file_2_oid="$(calc_oid "$file_2")"
+  file_2_oid_short="$(echo "$file_2_oid" | head -c 7)"
+  printf "$file_2" > file2.dat
   git add file2.dat
 
-  echo "file3 data" > file3.dat
+  file_3="file3 data"
+  file_3_oid="$(calc_oid "$file_3")"
+  file_3_oid_short="$(echo "$file_3_oid" | head -c 7)"
+  printf "$file_3" > file3.dat
   git add file3.dat
 
-  echo "file3 other data" > file3.dat
+  file_3_new="file3 other data"
+  file_3_new_oid="$(calc_oid "$file_3_new")"
+  file_3_new_oid_short="$(echo "$file_3_new_oid" | head -c 7)"
+  printf "$file_3_new" > file3.dat
 
   expected="On branch master
 
 Git LFS objects to be committed:
 
-	file2.dat
-	file3.dat
+	file2.dat (LFS: $file_2_oid_short)
+	file3.dat (LFS: $file_3_oid_short)
 
 Git LFS objects not staged for commit:
 
-	file1.dat
-	file3.dat"
+	file1.dat (LFS: $file_1_oid_short -> Git: $file_1_new_oid_short)
+	file3.dat (Git: $file_3_new_oid_short)"
 
   [ "$expected" = "$(git lfs status)" ]
 )
@@ -96,13 +113,17 @@ begin_test "status - before initial commit"
   # should not fail when nothing to display (ignore output, will be blank)
   git lfs status
 
-  echo "some data" > file1.dat
+  contents="some data"
+  contents_oid="$(calc_oid "$contents")"
+  contents_oid_short="$(echo "$contents_oid" | head -c 7)"
+
+  printf "$contents" > file1.dat
   git add file1.dat
 
   expected="
 Git LFS objects to be committed:
 
-	file1.dat
+	file1.dat (LFS: $contents_oid_short)
 
 Git LFS objects not staged for commit:"
 
@@ -147,6 +168,8 @@ begin_test "status shows multiple copies of partially staged files"
   git commit -m "initial commit"
 
   contents_1="part 1"
+  contents_1_oid="$(calc_oid "$contents_1")"
+  contents_1_oid_short="$(echo "$contents_1_oid" | head -c 7)"
   printf "$contents_1" > a.dat
 
   # "$contents_1" changes are staged
@@ -154,17 +177,19 @@ begin_test "status shows multiple copies of partially staged files"
 
   # "$contents_2" changes are unstaged
   contents_2="part 2"
-  printf "$contents_2" >> a.dat
+  contents_2_oid="$(calc_oid "$contents_2")"
+  contents_2_oid_short="$(echo "$contents_2_oid" | head -c 7)"
+  printf "$contents_2" > a.dat
 
   expected="On branch master
 
 Git LFS objects to be committed:
 
-	a.dat
+	a.dat (LFS: $contents_1_oid_short)
 
 Git LFS objects not staged for commit:
 
-	a.dat"
+	a.dat (Git: $contents_2_oid_short)"
   actual="$(git lfs status)"
 
   diff -u <(echo "$expected") <(echo "$actual")


### PR DESCRIPTION
This pull-request makes it easier to diagnose why certain files are modified by LFS by adding blob info to each status line entry in the `git lfs status` command.

Here's what the output looks like:

```
On branch master

Git LFS objects to be committed:

    file2.dat (LFS: eeaf82b)
    file3.dat (LFS: a12942e)

Git LFS objects not staged for commit:

    file1.dat (LFS: 1307990 -> Git: 8735179)
    file3.dat (Git: 0dc8537)
```

The `()` shows some meta information about each entry's source and destination. For each end, it shows whether the file is tracked by Git or LFS, and the contents SHA of each. The contents SHA is either the `shasum -a 256` of the blob's contents (NB: _not_ the blob SHA itself), or the pointer's OID (if the file is tracked by LFS).

The extra info contained between the `()` comes from the following rules:

1. If the file is new (marked as `A` for addition), show a) the source (either `Git:` or `LFS:`) & the blob contents SHA.
2. If the file is not new, is a copy, a modification, or etc., show both the source and destination (either: `Git:` or `LFS:`) as well as the blob contents SHA for each.

The blob contents SHA is defined as:

- If the file is handled by LFS and is _currently_ parse-able as an LFS pointer, mark it as LFS. A file is parse-able as an LFS pointer if it wasn't checked out (using the `-I` or `-X` flags), or is staged into the index and tracked with the LFS `filter` in your repository's `.gitattributes`.
- If the file is not tracked by LFS, or is tracked by LFS and is not yet staged into the index (meaning the LFS has not yet `clean`-ed the file) the file is tracked by Git. If the file is tracked by LFS, but isn't parse-able as an LFS pointer (meaning the `clean`/`smudge` filters were skipped, or the file was already committed as a large object into the Git history), show the file as having a `Git:` source. 

A few things that I'd like to address beyond this pull-request:

1. Since #2042, we're showing _all_ files (not just those tracked by LFS) in the status output. I think this makes sense since we want to show files that are supposed to be tracked by LFS but aren't. One thing we could do is only show files which match the patterns in `.gitattributes`, but I like the complete-ness of what we have right now.
2. Files are shown as coming from `Git:` if they are tracked by LFS and not yet staged. This is technically correct, but we could show a better prefix, or try and figure out if they _would_ be tracked by LFS. I don't know offhand of a complete way to do this, since we not only have to check the contents of the repository's `.gitattributes` file(s), but also whether or not the user has a valid LFS clean/smudge/process filter installed.
3. `diff-index` doesn't show new, untracked files. This may have always been a problem with the status command, but deserves investigation nonetheless. 

---

/cc @git-lfs/core 