### PR TITLE
Introduce GIT_TRANSFER_TRACE for detailed transfer queue msgs

### DIFF
--- a/lfs/lfs.go
+++ b/lfs/lfs.go
@@ -135,6 +135,11 @@ func ScanObjectsChan() <-chan localstorage.Object {
 func init() {
 	tracerx.DefaultKey = "GIT"
 	tracerx.Prefix = "trace git-lfs: "
+	if len(os.Getenv("GIT_TRACE")) < 1 {
+		if tt := os.Getenv("GIT_TRANSFER_TRACE"); len(tt) > 0 {
+			os.Setenv("GIT_TRACE", tt)
+		}
+	}
 }
 
 const (

--- a/test/test-custom-transfers.sh
+++ b/test/test-custom-transfers.sh
@@ -25,7 +25,7 @@ begin_test "custom-transfer-wrong-path"
   git add a.dat
   git add .gitattributes
   git commit -m "add a.dat" 2>&1 | tee commit.log
-  GIT_TRACE=1 git push origin master 2>&1 | tee pushcustom.log
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git push origin master 2>&1 | tee pushcustom.log
   # use PIPESTATUS otherwise we get exit code from tee
   res=${PIPESTATUS[0]}
   grep "xfer: adapter \"testcustom\" Begin()" pushcustom.log
@@ -88,7 +88,7 @@ begin_test "custom-transfer-upload-download"
   }
   ]" | lfstest-testutils addcommits
 
-  GIT_TRACE=1 git push origin master 2>&1 | tee pushcustom.log
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git push origin master 2>&1 | tee pushcustom.log
   # use PIPESTATUS otherwise we get exit code from tee
   [ ${PIPESTATUS[0]} = "0" ]
 
@@ -97,7 +97,7 @@ begin_test "custom-transfer-upload-download"
   grep "12 of 12 files" pushcustom.log
 
   rm -rf .git/lfs/objects
-  GIT_TRACE=1 git lfs fetch --all  2>&1 | tee fetchcustom.log
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git lfs fetch --all  2>&1 | tee fetchcustom.log
   [ ${PIPESTATUS[0]} = "0" ]
 
   grep "xfer: started custom adapter process" fetchcustom.log

--- a/test/test-resume-tus.sh
+++ b/test/test-resume-tus.sh
@@ -23,7 +23,7 @@ begin_test "tus-upload-uninterrupted"
   git add a.dat
   git add .gitattributes
   git commit -m "add a.dat" 2>&1 | tee commit.log
-  GIT_TRACE=1 git push origin master 2>&1 | tee pushtus.log
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git push origin master 2>&1 | tee pushtus.log
   grep "xfer: tus.io uploading" pushtus.log
 
   assert_server_object "$reponame" "$contents_oid"
@@ -59,7 +59,7 @@ begin_test "tus-upload-interrupted-resume"
   git add a.dat verify.dat
   git add .gitattributes
   git commit -m "add a.dat, verify.dat" 2>&1 | tee commit.log
-  GIT_TRACE=1 git push origin master 2>&1 | tee pushtus_resume.log
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git push origin master 2>&1 | tee pushtus_resume.log
   # first attempt will start from the beginning
   grep "xfer: tus.io uploading" pushtus_resume.log
   grep "HTTP: 500" pushtus_resume.log

--- a/tq/adapterbase.go
+++ b/tq/adapterbase.go
@@ -19,6 +19,7 @@ type adapterBase struct {
 	apiClient    *lfsapi.Client
 	remote       string
 	jobChan      chan *job
+	debugging    bool
 	cb           ProgressCallback
 	// WaitGroup to sync the completion of all workers
 	workerWait sync.WaitGroup
@@ -68,9 +69,10 @@ func (a *adapterBase) Begin(cfg AdapterConfig, cb ProgressCallback) error {
 	a.remote = cfg.Remote()
 	a.cb = cb
 	a.jobChan = make(chan *job, 100)
+	a.debugging = a.apiClient.OSEnv().Bool("GIT_TRANSFER_TRACE", false)
 	maxConcurrency := cfg.ConcurrentTransfers()
 
-	tracerx.Printf("xfer: adapter %q Begin() with %d workers", a.Name(), maxConcurrency)
+	a.Trace("xfer: adapter %q Begin() with %d workers", a.Name(), maxConcurrency)
 
 	a.workerWait.Add(maxConcurrency)
 	a.authWait.Add(1)
@@ -81,7 +83,7 @@ func (a *adapterBase) Begin(cfg AdapterConfig, cb ProgressCallback) error {
 		}
 		go a.worker(i, ctx)
 	}
-	tracerx.Printf("xfer: adapter %q started", a.Name())
+	a.Trace("xfer: adapter %q started", a.Name())
 	return nil
 }
 
@@ -115,7 +117,7 @@ func (a *adapterBase) Add(transfers ...*Transfer) <-chan TransferResult {
 }
 
 func (a *adapterBase) End() {
-	tracerx.Printf("xfer: adapter %q End()", a.Name())
+	a.Trace("xfer: adapter %q End()", a.Name())
 
 	a.jobWait.Wait()
 	close(a.jobChan)
@@ -123,12 +125,19 @@ func (a *adapterBase) End() {
 	// wait for all transfers to complete
 	a.workerWait.Wait()
 
-	tracerx.Printf("xfer: adapter %q stopped", a.Name())
+	a.Trace("xfer: adapter %q stopped", a.Name())
+}
+
+func (a *adapterBase) Trace(format string, args ...interface{}) {
+	if !a.debugging {
+		return
+	}
+	tracerx.Printf(format, args...)
 }
 
 // worker function, many of these run per adapter
 func (a *adapterBase) worker(workerNum int, ctx interface{}) {
-	tracerx.Printf("xfer: adapter %q worker %d starting", a.Name(), workerNum)
+	a.Trace("xfer: adapter %q worker %d starting", a.Name(), workerNum)
 	waitForAuth := workerNum > 0
 	signalAuthOnResponse := workerNum == 0
 
@@ -137,9 +146,9 @@ func (a *adapterBase) worker(workerNum int, ctx interface{}) {
 	// make sure only 1 login prompt is presented if necessary
 	// Deliberately outside jobChan processing so we know worker 0 will process 1st item
 	if waitForAuth {
-		tracerx.Printf("xfer: adapter %q worker %d waiting for Auth", a.Name(), workerNum)
+		a.Trace("xfer: adapter %q worker %d waiting for Auth", a.Name(), workerNum)
 		a.authWait.Wait()
-		tracerx.Printf("xfer: adapter %q worker %d auth signal received", a.Name(), workerNum)
+		a.Trace("xfer: adapter %q worker %d auth signal received", a.Name(), workerNum)
 	}
 
 	for job := range a.jobChan {
@@ -152,7 +161,7 @@ func (a *adapterBase) worker(workerNum int, ctx interface{}) {
 				signalAuthOnResponse = false
 			}
 		}
-		tracerx.Printf("xfer: adapter %q worker %d processing job for %q", a.Name(), workerNum, t.Oid)
+		a.Trace("xfer: adapter %q worker %d processing job for %q", a.Name(), workerNum, t.Oid)
 
 		// Actual transfer happens here
 		var err error
@@ -165,13 +174,13 @@ func (a *adapterBase) worker(workerNum int, ctx interface{}) {
 		// Mark the job as completed, and alter all listeners
 		job.Done(err)
 
-		tracerx.Printf("xfer: adapter %q worker %d finished job for %q", a.Name(), workerNum, t.Oid)
+		a.Trace("xfer: adapter %q worker %d finished job for %q", a.Name(), workerNum, t.Oid)
 	}
 	// This will only happen if no jobs were submitted; just wake up all workers to finish
 	if signalAuthOnResponse {
 		a.authWait.Done()
 	}
-	tracerx.Printf("xfer: adapter %q worker %d stopping", a.Name(), workerNum)
+	a.Trace("xfer: adapter %q worker %d stopping", a.Name(), workerNum)
 	a.transferImpl.WorkerEnding(workerNum, ctx)
 	a.workerWait.Done()
 }

--- a/tq/custom.go
+++ b/tq/custom.go
@@ -123,7 +123,7 @@ func (a *customAdapter) WorkerStarting(workerNum int) (interface{}, error) {
 
 	// Start a process per worker
 	// If concurrent = false we have already dialled back workers to 1
-	tracerx.Printf("xfer: starting up custom transfer process %q for worker %d", a.name, workerNum)
+	a.Trace("xfer: starting up custom transfer process %q for worker %d", a.name, workerNum)
 	cmd := subprocess.ExecCommand(a.path, a.args)
 	outp, err := cmd.StdoutPipe()
 	if err != nil {
@@ -156,7 +156,7 @@ func (a *customAdapter) WorkerStarting(workerNum int) (interface{}, error) {
 		return nil, fmt.Errorf("Error initializing custom adapter %q worker %d: %v", a.name, workerNum, resp.Error)
 	}
 
-	tracerx.Printf("xfer: started custom adapter process %q for worker %d OK", a.path, workerNum)
+	a.Trace("xfer: started custom adapter process %q for worker %d OK", a.path, workerNum)
 
 	// Save this process context and use in future callbacks
 	return ctx, nil
@@ -175,7 +175,7 @@ func (a *customAdapter) sendMessage(ctx *customAdapterWorkerContext, req interfa
 	if err != nil {
 		return err
 	}
-	tracerx.Printf("xfer: Custom adapter worker %d sending message: %v", ctx.workerNum, string(b))
+	a.Trace("xfer: Custom adapter worker %d sending message: %v", ctx.workerNum, string(b))
 	// Line oriented JSON
 	b = append(b, '\n')
 	_, err = ctx.stdin.Write(b)
@@ -187,7 +187,7 @@ func (a *customAdapter) readResponse(ctx *customAdapterWorkerContext) (*customAd
 	if err != nil {
 		return nil, err
 	}
-	tracerx.Printf("xfer: Custom adapter worker %d received response: %v", ctx.workerNum, strings.TrimSpace(line))
+	a.Trace("xfer: Custom adapter worker %d received response: %v", ctx.workerNum, strings.TrimSpace(line))
 	resp := &customAdapterResponseMessage{}
 	err = json.Unmarshal([]byte(line), resp)
 	return resp, err
@@ -209,7 +209,7 @@ func (a *customAdapter) exchangeMessage(ctx *customAdapterWorkerContext, req int
 func (a *customAdapter) shutdownWorkerProcess(ctx *customAdapterWorkerContext) error {
 	defer ctx.errTracer.Flush()
 
-	tracerx.Printf("xfer: Shutting down adapter worker %d", ctx.workerNum)
+	a.Trace("xfer: Shutting down adapter worker %d", ctx.workerNum)
 
 	finishChan := make(chan error, 1)
 	go func() {
@@ -232,7 +232,7 @@ func (a *customAdapter) shutdownWorkerProcess(ctx *customAdapterWorkerContext) e
 
 // abortWorkerProcess terminates & aborts untidily, most probably breakdown of comms or internal error
 func (a *customAdapter) abortWorkerProcess(ctx *customAdapterWorkerContext) {
-	tracerx.Printf("xfer: Aborting worker process: %d", ctx.workerNum)
+	a.Trace("xfer: Aborting worker process: %d", ctx.workerNum)
 	ctx.stdin.Close()
 	ctx.stdout.Close()
 	ctx.cmd.Process.Kill()

--- a/tq/tus_upload.go
+++ b/tq/tus_upload.go
@@ -11,7 +11,6 @@ import (
 	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/lfsapi"
 	"github.com/git-lfs/git-lfs/progress"
-	"github.com/rubyist/tracerx"
 )
 
 const (
@@ -49,7 +48,7 @@ func (a *tusUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb ProgressC
 
 	// 1. Send HEAD request to determine upload start point
 	//    Request must include Tus-Resumable header (version)
-	tracerx.Printf("xfer: sending tus.io HEAD request for %q", t.Oid)
+	a.Trace("xfer: sending tus.io HEAD request for %q", t.Oid)
 	req, err := a.newHTTPRequest("HEAD", rel)
 	if err != nil {
 		return err
@@ -74,7 +73,7 @@ func (a *tusUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb ProgressC
 	// Upload-Offset=size means already completed (skip)
 	// Batch API will probably already detect this, but handle just in case
 	if offset >= t.Size {
-		tracerx.Printf("xfer: tus.io HEAD offset %d indicates %q is already fully uploaded, skipping", offset, t.Oid)
+		a.Trace("xfer: tus.io HEAD offset %d indicates %q is already fully uploaded, skipping", offset, t.Oid)
 		advanceCallbackProgress(cb, t, t.Size)
 		return nil
 	}
@@ -88,9 +87,9 @@ func (a *tusUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb ProgressC
 
 	// Upload-Offset=0 means start from scratch, but still send PATCH
 	if offset == 0 {
-		tracerx.Printf("xfer: tus.io uploading %q from start", t.Oid)
+		a.Trace("xfer: tus.io uploading %q from start", t.Oid)
 	} else {
-		tracerx.Printf("xfer: tus.io resuming upload %q from %d", t.Oid, offset)
+		a.Trace("xfer: tus.io resuming upload %q from %d", t.Oid, offset)
 		advanceCallbackProgress(cb, t, offset)
 	}
 
@@ -99,7 +98,7 @@ func (a *tusUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb ProgressC
 	//    Response Upload-Offset must be request Upload-Offset plus sent bytes
 	//    Response may include Upload-Expires header in which case check not passed
 
-	tracerx.Printf("xfer: sending tus.io PATCH request for %q", t.Oid)
+	a.Trace("xfer: sending tus.io PATCH request for %q", t.Oid)
 	req, err = a.newHTTPRequest("PATCH", rel)
 	if err != nil {
 		return err


### PR DESCRIPTION
I'm tired of seeing these detailed transfer queue trace messages. Most of these are only relevant if you're debugging a transfer queue bug. This PR disables most of it (unless it's reporting an error) unless `GIT_TRANSFER_TRACE` is set.

## CURRENT v2.0.1 trace

```
$ rm -rf .git/lfs/objects && GIT_TRACE=1 git lfs fetch --all
10:31:09.552814 git.c:600               trace: exec: 'git-lfs' 'fetch' '--all'
10:31:09.553235 run-command.c:350       trace: run_command: 'git-lfs' 'fetch' '--all'
trace git-lfs: run_command: 'git' config -l
Scanning for all objects ever referenced...
trace git-lfs: run_command: git rev-list --objects --all --
trace git-lfs: run_command: git cat-file --batch-check
trace git-lfs: run_command: git cat-file --batch
✔ 7 objects found
Fetching objects...
trace git-lfs: run_command: 'git' rev-parse HEAD --symbolic-full-name HEAD
trace git-lfs: run_command: 'git' config branch.master.remote
trace git-lfs: tq: running as batched queue, batch size of 100
trace git-lfs: fetch bin/b.bin [0263829989b6fd954f72baaf2fc64bc2e2f01d692d4de72986ea808f6e99813f]
trace git-lfs: fetch bin/hi.bin [98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4]
trace git-lfs: fetch gif/atom-undo.gif [b9f86fab477109565871ced361ba69f2425a91fbe6057fa7a9629a8d536d7c71]
trace git-lfs: fetch gif/droidtocat.gif [d1c8fab51418ef587fcf5dd8e73c60b9700704e2f8f5292ea12ec27c285b23a3]
trace git-lfs: fetch jpg/kabuki-tattoo-left.JPG [e1732d149d262963996ca77a47a5d3c51c85c6e97187afad370a8bef2828b6b7]
trace git-lfs: fetch png/render.png [55d51edb307ed7bf4a1bbca3867d132a07f76828d57f37e0f31f712c02ceafe0]
trace git-lfs: fetch render.png [124733b36d098353ad16bb11646643709e87c4746e0d97913a9826829e0477a3]
trace git-lfs: tq: sending batch of size 7
trace git-lfs: ssh: git@github.com git-lfs-authenticate github/git-lfs-test download
trace git-lfs: api: batch 7 files
trace git-lfs: HTTP: POST https://lfs.github.com/github/git-lfs-test/objects/batch
trace git-lfs: HTTP: 200
trace git-lfs: HTTP: LOTS OF JSON
trace git-lfs: tq: starting transfer adapter "basic"
trace git-lfs: xfer: adapter "basic" Begin() with 15 workers
trace git-lfs: xfer: adapter "basic" started
Git LFS: (0 of 7 files) 0 B / 879.11 KB                                                                                                                                                                                                                                                                                                                                    trace git-lfs: xfer: adapter "basic" worker 8 starting
trace git-lfs: xfer: adapter "basic" worker 8 waiting for Auth
trace git-lfs: xfer: adapter "basic" worker 9 starting
trace git-lfs: xfer: adapter "basic" worker 9 waiting for Auth
trace git-lfs: xfer: adapter "basic" worker 0 starting
trace git-lfs: xfer: adapter "basic" worker 3 starting
trace git-lfs: xfer: adapter "basic" worker 3 waiting for Auth
trace git-lfs: xfer: adapter "basic" worker 0 processing job for "b9f86fab477109565871ced361ba69f2425a91fbe6057fa7a9629a8d536d7c71"
trace git-lfs: xfer: adapter "basic" worker 7 starting
trace git-lfs: xfer: adapter "basic" worker 10 starting
trace git-lfs: xfer: adapter "basic" worker 7 waiting for Auth
trace git-lfs: xfer: adapter "basic" worker 10 waiting for Auth
trace git-lfs: xfer: adapter "basic" worker 6 starting
trace git-lfs: xfer: adapter "basic" worker 6 waiting for Auth
trace git-lfs: xfer: adapter "basic" worker 1 starting
trace git-lfs: xfer: adapter "basic" worker 13 starting
trace git-lfs: xfer: adapter "basic" worker 13 waiting for Auth
trace git-lfs: xfer: adapter "basic" worker 1 waiting for Auth
trace git-lfs: xfer: adapter "basic" worker 2 starting
trace git-lfs: xfer: adapter "basic" worker 5 starting
trace git-lfs: xfer: adapter "basic" worker 2 waiting for Auth
trace git-lfs: xfer: adapter "basic" worker 12 starting
trace git-lfs: xfer: adapter "basic" worker 5 waiting for Auth
trace git-lfs: xfer: adapter "basic" worker 14 starting
trace git-lfs: xfer: adapter "basic" worker 4 starting
trace git-lfs: xfer: adapter "basic" worker 14 waiting for Auth
trace git-lfs: xfer: adapter "basic" worker 12 waiting for Auth
trace git-lfs: xfer: adapter "basic" worker 4 waiting for Auth
trace git-lfs: xfer: adapter "basic" worker 11 starting
trace git-lfs: xfer: adapter "basic" worker 11 waiting for Auth
trace git-lfs: HTTP: GET https://github-cloud.s3.amazonaws.com/alambic/media/111976139/b9/f8/b9f86fab477109565871ced361ba69f2425a91fbe6057fa7a9629a8d536d7c71
Git LFS: (0 of 7 files) 0 B / 879.11 KB                                                                                                                                                                                                                                                                                                                                    trace git-lfs: HTTP: 200
trace git-lfs: xfer: adapter "basic" worker 13 auth signal received
trace git-lfs: xfer: adapter "basic" worker 13 processing job for "e1732d149d262963996ca77a47a5d3c51c85c6e97187afad370a8bef2828b6b7"
trace git-lfs: xfer: adapter "basic" worker 14 auth signal received
trace git-lfs: xfer: adapter "basic" worker 12 auth signal received
trace git-lfs: xfer: adapter "basic" worker 14 processing job for "124733b36d098353ad16bb11646643709e87c4746e0d97913a9826829e0477a3"
trace git-lfs: xfer: adapter "basic" worker 12 processing job for "55d51edb307ed7bf4a1bbca3867d132a07f76828d57f37e0f31f712c02ceafe0"
trace git-lfs: xfer: adapter "basic" worker 1 auth signal received
trace git-lfs: xfer: adapter "basic" worker 1 processing job for "d1c8fab51418ef587fcf5dd8e73c60b9700704e2f8f5292ea12ec27c285b23a3"
trace git-lfs: xfer: adapter "basic" worker 11 auth signal received
trace git-lfs: xfer: adapter "basic" worker 11 processing job for "98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4"
trace git-lfs: xfer: adapter "basic" worker 2 auth signal received
trace git-lfs: xfer: adapter "basic" worker 2 processing job for "0263829989b6fd954f72baaf2fc64bc2e2f01d692d4de72986ea808f6e99813f"
trace git-lfs: xfer: adapter "basic" worker 7 auth signal received
trace git-lfs: xfer: adapter "basic" worker 8 auth signal received
trace git-lfs: xfer: adapter "basic" worker 9 auth signal received
trace git-lfs: xfer: adapter "basic" worker 4 auth signal received
trace git-lfs: xfer: adapter "basic" worker 6 auth signal received
trace git-lfs: xfer: adapter "basic" worker 5 auth signal received
trace git-lfs: xfer: adapter "basic" worker 10 auth signal received
trace git-lfs: xfer: adapter "basic" worker 3 auth signal received
trace git-lfs: HTTP: GET https://github-cloud.s3.amazonaws.com/alambic/media/111976139/e1/73/e1732d149d262963996ca77a47a5d3c51c85c6e97187afad370a8bef2828b6b7
trace git-lfs: HTTP: GET https://github-cloud.s3.amazonaws.com/alambic/media/111976139/55/d5/55d51edb307ed7bf4a1bbca3867d132a07f76828d57f37e0f31f712c02ceafe0
trace git-lfs: HTTP: GET https://github-cloud.s3.amazonaws.com/alambic/media/111976139/d1/c8/d1c8fab51418ef587fcf5dd8e73c60b9700704e2f8f5292ea12ec27c285b23a3
trace git-lfs: HTTP: GET https://github-cloud.s3.amazonaws.com/alambic/media/111976139/98/ea/98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4
trace git-lfs: HTTP: GET https://github-cloud.s3.amazonaws.com/alambic/media/111976139/12/47/124733b36d098353ad16bb11646643709e87c4746e0d97913a9826829e0477a3
trace git-lfs: HTTP: GET https://github-cloud.s3.amazonaws.com/alambic/media/111976139/02/63/0263829989b6fd954f72baaf2fc64bc2e2f01d692d4de72986ea808f6e99813f
Git LFS: (0 of 7 files) 220.63 KB / 879.11 KB                                                                                                                                                                                                                                                                                                                              trace git-lfs: HTTP: 200
trace git-lfs: HTTP: 200
trace git-lfs: HTTP: 200
trace git-lfs: HTTP: 200
trace git-lfs: xfer: adapter "basic" worker 2 finished job for "0263829989b6fd954f72baaf2fc64bc2e2f01d692d4de72986ea808f6e99813f"
trace git-lfs: xfer: adapter "basic" worker 11 finished job for "98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4"
trace git-lfs: HTTP: 200
trace git-lfs: HTTP: 200
trace git-lfs: xfer: adapter "basic" worker 1 finished job for "d1c8fab51418ef587fcf5dd8e73c60b9700704e2f8f5292ea12ec27c285b23a3"
trace git-lfs: xfer: adapter "basic" worker 14 finished job for "124733b36d098353ad16bb11646643709e87c4746e0d97913a9826829e0477a3"
trace git-lfs: xfer: adapter "basic" worker 12 finished job for "55d51edb307ed7bf4a1bbca3867d132a07f76828d57f37e0f31f712c02ceafe0"
trace git-lfs: xfer: adapter "basic" worker 0 finished job for "b9f86fab477109565871ced361ba69f2425a91fbe6057fa7a9629a8d536d7c71"
Git LFS: (6 of 7 files) 873.22 KB / 879.11 KB                                                                                                                                                                                                                                                                                                                              trace git-lfs: xfer: adapter "basic" worker 13 finished job for "e1732d149d262963996ca77a47a5d3c51c85c6e97187afad370a8bef2828b6b7"
trace git-lfs: xfer: adapter "basic" End()
trace git-lfs: xfer: adapter "basic" worker 7 stopping
trace git-lfs: xfer: adapter "basic" worker 4 stopping
trace git-lfs: xfer: adapter "basic" worker 2 stopping
trace git-lfs: xfer: adapter "basic" worker 9 stopping
trace git-lfs: xfer: adapter "basic" worker 6 stopping
trace git-lfs: xfer: adapter "basic" worker 8 stopping
trace git-lfs: xfer: adapter "basic" worker 13 stopping
trace git-lfs: xfer: adapter "basic" worker 3 stopping
trace git-lfs: xfer: adapter "basic" worker 14 stopping
trace git-lfs: xfer: adapter "basic" worker 10 stopping
trace git-lfs: xfer: adapter "basic" worker 0 stopping
trace git-lfs: xfer: adapter "basic" worker 1 stopping
trace git-lfs: xfer: adapter "basic" worker 12 stopping
trace git-lfs: xfer: adapter "basic" worker 11 stopping
trace git-lfs: xfer: adapter "basic" worker 5 stopping
trace git-lfs: xfer: adapter "basic" stopped
Git LFS: (7 of 7 files) 879.11 KB / 879.11 KB
```

## THIS PR WITH GIT_TRACE

```
$ rm -rf .git/lfs/objects && GIT_TRACE=1 git lfs fetch --all
10:32:42.028891 git.c:600               trace: exec: 'git-lfs' 'fetch' '--all'
10:32:42.029409 run-command.c:350       trace: run_command: 'git-lfs' 'fetch' '--all'
trace git-lfs: run_command: 'git' config -l
Scanning for all objects ever referenced...
trace git-lfs: run_command: git rev-list --objects --all --
trace git-lfs: run_command: git cat-file --batch-check
trace git-lfs: run_command: git cat-file --batch
✔ 7 objects found
Fetching objects...
trace git-lfs: run_command: 'git' rev-parse HEAD --symbolic-full-name HEAD
trace git-lfs: run_command: 'git' config branch.master.remote
trace git-lfs: tq: running as batched queue, batch size of 100
trace git-lfs: fetch bin/b.bin [0263829989b6fd954f72baaf2fc64bc2e2f01d692d4de72986ea808f6e99813f]
trace git-lfs: fetch bin/hi.bin [98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4]
trace git-lfs: fetch gif/atom-undo.gif [b9f86fab477109565871ced361ba69f2425a91fbe6057fa7a9629a8d536d7c71]
trace git-lfs: fetch gif/droidtocat.gif [d1c8fab51418ef587fcf5dd8e73c60b9700704e2f8f5292ea12ec27c285b23a3]
trace git-lfs: fetch jpg/kabuki-tattoo-left.JPG [e1732d149d262963996ca77a47a5d3c51c85c6e97187afad370a8bef2828b6b7]
trace git-lfs: fetch png/render.png [55d51edb307ed7bf4a1bbca3867d132a07f76828d57f37e0f31f712c02ceafe0]
trace git-lfs: fetch render.png [124733b36d098353ad16bb11646643709e87c4746e0d97913a9826829e0477a3]
trace git-lfs: tq: sending batch of size 7
trace git-lfs: ssh: git@github.com git-lfs-authenticate github/git-lfs-test download
trace git-lfs: api: batch 7 files
trace git-lfs: HTTP: POST https://lfs.github.com/github/git-lfs-test/objects/batch
trace git-lfs: HTTP: 200
trace git-lfs: HTTP:  LOTS OF JSON
trace git-lfs: tq: starting transfer adapter "basic"
Git LFS: (0 of 7 files) 0 B / 879.11 KB                                                                                                                                                                                                                                                                                                                                    trace git-lfs: HTTP: GET https://github-cloud.s3.amazonaws.com/alambic/media/111976139/b9/f8/b9f86fab477109565871ced361ba69f2425a91fbe6057fa7a9629a8d536d7c71
Git LFS: (0 of 7 files) 0 B / 879.11 KB                                                                                                                                                                                                                                                                                                                                    trace git-lfs: HTTP: 200
trace git-lfs: HTTP: GET https://github-cloud.s3.amazonaws.com/alambic/media/111976139/12/47/124733b36d098353ad16bb11646643709e87c4746e0d97913a9826829e0477a3
trace git-lfs: HTTP: GET https://github-cloud.s3.amazonaws.com/alambic/media/111976139/d1/c8/d1c8fab51418ef587fcf5dd8e73c60b9700704e2f8f5292ea12ec27c285b23a3
trace git-lfs: HTTP: GET https://github-cloud.s3.amazonaws.com/alambic/media/111976139/98/ea/98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4
trace git-lfs: HTTP: GET https://github-cloud.s3.amazonaws.com/alambic/media/111976139/55/d5/55d51edb307ed7bf4a1bbca3867d132a07f76828d57f37e0f31f712c02ceafe0
trace git-lfs: HTTP: GET https://github-cloud.s3.amazonaws.com/alambic/media/111976139/02/63/0263829989b6fd954f72baaf2fc64bc2e2f01d692d4de72986ea808f6e99813f
trace git-lfs: HTTP: GET https://github-cloud.s3.amazonaws.com/alambic/media/111976139/e1/73/e1732d149d262963996ca77a47a5d3c51c85c6e97187afad370a8bef2828b6b7
Git LFS: (0 of 7 files) 118.63 KB / 879.11 KB                                                                                                                                                                                                                                                                                                                              trace git-lfs: HTTP: 200
trace git-lfs: HTTP: 200
trace git-lfs: HTTP: 200
trace git-lfs: HTTP: 200
trace git-lfs: HTTP: 200
trace git-lfs: HTTP: 200
Git LFS: (7 of 7 files) 879.11 KB / 879.11 KB
```

## THIS PR WITH GIT_TRANSFER_TRACE

```
$ rm -rf .git/lfs/objects && GIT_TRANSFER_TRACE=1 git lfs fetch --all
trace git-lfs: run_command: 'git' config -l
Scanning for all objects ever referenced...
trace git-lfs: run_command: git rev-list --objects --all --
trace git-lfs: run_command: git cat-file --batch-check
trace git-lfs: run_command: git cat-file --batch
✔ 7 objects found
Fetching objects...
trace git-lfs: run_command: 'git' rev-parse HEAD --symbolic-full-name HEAD
trace git-lfs: run_command: 'git' config branch.master.remote
trace git-lfs: tq: running as batched queue, batch size of 100
trace git-lfs: fetch bin/b.bin [0263829989b6fd954f72baaf2fc64bc2e2f01d692d4de72986ea808f6e99813f]
trace git-lfs: fetch bin/hi.bin [98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4]
trace git-lfs: fetch gif/atom-undo.gif [b9f86fab477109565871ced361ba69f2425a91fbe6057fa7a9629a8d536d7c71]
trace git-lfs: fetch gif/droidtocat.gif [d1c8fab51418ef587fcf5dd8e73c60b9700704e2f8f5292ea12ec27c285b23a3]
trace git-lfs: fetch jpg/kabuki-tattoo-left.JPG [e1732d149d262963996ca77a47a5d3c51c85c6e97187afad370a8bef2828b6b7]
trace git-lfs: fetch png/render.png [55d51edb307ed7bf4a1bbca3867d132a07f76828d57f37e0f31f712c02ceafe0]
trace git-lfs: fetch render.png [124733b36d098353ad16bb11646643709e87c4746e0d97913a9826829e0477a3]
trace git-lfs: tq: sending batch of size 7
trace git-lfs: ssh: git@github.com git-lfs-authenticate github/git-lfs-test download
trace git-lfs: api: batch 7 files
trace git-lfs: HTTP: POST https://lfs.github.com/github/git-lfs-test/objects/batch
trace git-lfs: HTTP: 200
trace git-lfs: HTTP: LOTS OF JSON
trace git-lfs: tq: starting transfer adapter "basic"
trace git-lfs: xfer: adapter "basic" Begin() with 15 workers
trace git-lfs: xfer: adapter "basic" started
trace git-lfs: xfer: adapter "basic" worker 2 starting
trace git-lfs: xfer: adapter "basic" worker 2 waiting for Auth
trace git-lfs: xfer: adapter "basic" worker 1 starting
trace git-lfs: xfer: adapter "basic" worker 1 waiting for Auth
trace git-lfs: xfer: adapter "basic" worker 9 starting
trace git-lfs: xfer: adapter "basic" worker 9 waiting for Auth
trace git-lfs: xfer: adapter "basic" worker 5 starting
trace git-lfs: xfer: adapter "basic" worker 5 waiting for Auth
trace git-lfs: xfer: adapter "basic" worker 8 starting
trace git-lfs: xfer: adapter "basic" worker 10 starting
trace git-lfs: xfer: adapter "basic" worker 8 waiting for Auth
trace git-lfs: xfer: adapter "basic" worker 10 waiting for Auth
trace git-lfs: xfer: adapter "basic" worker 3 starting
trace git-lfs: xfer: adapter "basic" worker 3 waiting for Auth
trace git-lfs: xfer: adapter "basic" worker 6 starting
trace git-lfs: xfer: adapter "basic" worker 13 starting
trace git-lfs: xfer: adapter "basic" worker 6 waiting for Auth
trace git-lfs: xfer: adapter "basic" worker 13 waiting for Auth
trace git-lfs: xfer: adapter "basic" worker 14 starting
trace git-lfs: xfer: adapter "basic" worker 11 starting
trace git-lfs: xfer: adapter "basic" worker 14 waiting for Auth
trace git-lfs: xfer: adapter "basic" worker 11 waiting for Auth
trace git-lfs: xfer: adapter "basic" worker 4 starting
trace git-lfs: xfer: adapter "basic" worker 4 waiting for Auth
Git LFS: (0 of 7 files) 0 B / 879.11 KB                                                                                                                                                                                                                                                                                                                                    trace git-lfs: xfer: adapter "basic" worker 12 starting
trace git-lfs: xfer: adapter "basic" worker 12 waiting for Auth
trace git-lfs: xfer: adapter "basic" worker 0 starting
trace git-lfs: xfer: adapter "basic" worker 7 starting
trace git-lfs: xfer: adapter "basic" worker 7 waiting for Auth
trace git-lfs: xfer: adapter "basic" worker 0 processing job for "b9f86fab477109565871ced361ba69f2425a91fbe6057fa7a9629a8d536d7c71"
trace git-lfs: HTTP: GET https://github-cloud.s3.amazonaws.com/alambic/media/111976139/b9/f8/b9f86fab477109565871ced361ba69f2425a91fbe6057fa7a9629a8d536d7c71
Git LFS: (0 of 7 files) 0 B / 879.11 KB                                                                                                                                                                                                                                                                                                                                    trace git-lfs: HTTP: 200
trace git-lfs: xfer: adapter "basic" worker 3 auth signal received
trace git-lfs: xfer: adapter "basic" worker 3 processing job for "e1732d149d262963996ca77a47a5d3c51c85c6e97187afad370a8bef2828b6b7"
trace git-lfs: xfer: adapter "basic" worker 14 auth signal received
trace git-lfs: xfer: adapter "basic" worker 14 processing job for "124733b36d098353ad16bb11646643709e87c4746e0d97913a9826829e0477a3"
trace git-lfs: xfer: adapter "basic" worker 4 auth signal received
trace git-lfs: xfer: adapter "basic" worker 4 processing job for "55d51edb307ed7bf4a1bbca3867d132a07f76828d57f37e0f31f712c02ceafe0"
trace git-lfs: xfer: adapter "basic" worker 6 auth signal received
trace git-lfs: xfer: adapter "basic" worker 7 auth signal received
trace git-lfs: xfer: adapter "basic" worker 7 processing job for "98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4"
trace git-lfs: xfer: adapter "basic" worker 6 processing job for "d1c8fab51418ef587fcf5dd8e73c60b9700704e2f8f5292ea12ec27c285b23a3"
trace git-lfs: xfer: adapter "basic" worker 12 auth signal received
trace git-lfs: xfer: adapter "basic" worker 13 auth signal received
trace git-lfs: xfer: adapter "basic" worker 12 processing job for "0263829989b6fd954f72baaf2fc64bc2e2f01d692d4de72986ea808f6e99813f"
trace git-lfs: xfer: adapter "basic" worker 9 auth signal received
trace git-lfs: xfer: adapter "basic" worker 2 auth signal received
trace git-lfs: xfer: adapter "basic" worker 1 auth signal received
trace git-lfs: xfer: adapter "basic" worker 11 auth signal received
trace git-lfs: xfer: adapter "basic" worker 8 auth signal received
trace git-lfs: xfer: adapter "basic" worker 10 auth signal received
trace git-lfs: xfer: adapter "basic" worker 5 auth signal received
trace git-lfs: HTTP: GET https://github-cloud.s3.amazonaws.com/alambic/media/111976139/e1/73/e1732d149d262963996ca77a47a5d3c51c85c6e97187afad370a8bef2828b6b7
trace git-lfs: HTTP: GET https://github-cloud.s3.amazonaws.com/alambic/media/111976139/55/d5/55d51edb307ed7bf4a1bbca3867d132a07f76828d57f37e0f31f712c02ceafe0
trace git-lfs: HTTP: GET https://github-cloud.s3.amazonaws.com/alambic/media/111976139/12/47/124733b36d098353ad16bb11646643709e87c4746e0d97913a9826829e0477a3
trace git-lfs: HTTP: GET https://github-cloud.s3.amazonaws.com/alambic/media/111976139/d1/c8/d1c8fab51418ef587fcf5dd8e73c60b9700704e2f8f5292ea12ec27c285b23a3
trace git-lfs: HTTP: GET https://github-cloud.s3.amazonaws.com/alambic/media/111976139/98/ea/98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4
trace git-lfs: HTTP: GET https://github-cloud.s3.amazonaws.com/alambic/media/111976139/02/63/0263829989b6fd954f72baaf2fc64bc2e2f01d692d4de72986ea808f6e99813f
Git LFS: (0 of 7 files) 67.63 KB / 879.11 KB                                                                                                                                                                                                                                                                                                                               trace git-lfs: HTTP: 200
trace git-lfs: HTTP: 200
trace git-lfs: xfer: adapter "basic" worker 12 finished job for "0263829989b6fd954f72baaf2fc64bc2e2f01d692d4de72986ea808f6e99813f"
trace git-lfs: HTTP: 200
trace git-lfs: HTTP: 200
trace git-lfs: HTTP: 200
trace git-lfs: xfer: adapter "basic" worker 7 finished job for "98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4"
trace git-lfs: HTTP: 200
Git LFS: (2 of 7 files) 643.52 KB / 879.11 KB                                                                                                                                                                                                                                                                                                                              trace git-lfs: xfer: adapter "basic" worker 6 finished job for "d1c8fab51418ef587fcf5dd8e73c60b9700704e2f8f5292ea12ec27c285b23a3"
trace git-lfs: xfer: adapter "basic" worker 4 finished job for "55d51edb307ed7bf4a1bbca3867d132a07f76828d57f37e0f31f712c02ceafe0"
trace git-lfs: xfer: adapter "basic" worker 14 finished job for "124733b36d098353ad16bb11646643709e87c4746e0d97913a9826829e0477a3"
trace git-lfs: xfer: adapter "basic" worker 0 finished job for "b9f86fab477109565871ced361ba69f2425a91fbe6057fa7a9629a8d536d7c71"
trace git-lfs: xfer: adapter "basic" worker 3 finished job for "e1732d149d262963996ca77a47a5d3c51c85c6e97187afad370a8bef2828b6b7"
trace git-lfs: xfer: adapter "basic" End()
trace git-lfs: xfer: adapter "basic" worker 12 stopping
trace git-lfs: xfer: adapter "basic" worker 13 stopping
trace git-lfs: xfer: adapter "basic" worker 14 stopping
trace git-lfs: xfer: adapter "basic" worker 5 stopping
trace git-lfs: xfer: adapter "basic" worker 4 stopping
trace git-lfs: xfer: adapter "basic" worker 10 stopping
trace git-lfs: xfer: adapter "basic" worker 0 stopping
trace git-lfs: xfer: adapter "basic" worker 8 stopping
trace git-lfs: xfer: adapter "basic" worker 6 stopping
trace git-lfs: xfer: adapter "basic" worker 3 stopping
trace git-lfs: xfer: adapter "basic" worker 11 stopping
trace git-lfs: xfer: adapter "basic" worker 7 stopping
trace git-lfs: xfer: adapter "basic" worker 2 stopping
trace git-lfs: xfer: adapter "basic" worker 1 stopping
trace git-lfs: xfer: adapter "basic" worker 9 stopping
trace git-lfs: xfer: adapter "basic" stopped
Git LFS: (7 of 7 files) 879.11 KB / 879.11 KB
```