### PR TITLE
version: bump to 2.1.0-pre

### DIFF
--- a/config/version.go
+++ b/config/version.go
@@ -14,7 +14,7 @@ var (
 )
 
 const (
-	Version = "2.0.0"
+	Version = "2.1.0-pre"
 )
 
 func init() {

--- a/rpm/SPECS/git-lfs.spec
+++ b/rpm/SPECS/git-lfs.spec
@@ -1,5 +1,5 @@
 Name:           git-lfs
-Version:        2.0.0
+Version:        2.1.0-pre
 Release:        1%{?dist}
 Summary:        Git extension for versioning large files
 

--- a/versioninfo.json
+++ b/versioninfo.json
@@ -13,6 +13,6 @@
 		"FileDescription": "Git LFS",
 		"LegalCopyright": "GitHub, Inc. and Git LFS contributors",
 		"ProductName": "Git Large File Storage (LFS)",
-		"ProductVersion": "2.0.0"
+		"ProductVersion": "2.1.0-pre"
 	}
 }


### PR DESCRIPTION
This pull-request bumps the version on master to `v2.1.0-pre`, which should remain in place until we release `v2.1.0`, at which point we should remove the `-pre` suffix.

---

/cc @git-lfs/core 