### PR TITLE
commands/{,un}track: extract {,un}EscapeTrackPattern()

### DIFF
--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -242,6 +242,7 @@ func blocklistItem(name string) string {
 var (
 	trackEscapePatterns = map[string]string{
 		" ": "[[:space:]]",
+		"#": "\\#",
 	}
 )
 

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -71,7 +71,7 @@ ArgsLoop:
 				((trackLockableFlag && known.Lockable) || // enabling lockable & already lockable (no change)
 					(trackNotLockableFlag && !known.Lockable) || // disabling lockable & not lockable (no change)
 					(!trackLockableFlag && !trackNotLockableFlag)) { // leave lockable as-is in all cases
-				Print("%s already supported", pattern)
+				Print("%q already supported", pattern)
 				continue ArgsLoop
 			}
 		}
@@ -91,7 +91,7 @@ ArgsLoop:
 			writeablePatterns = append(writeablePatterns, pattern)
 		}
 
-		Print("Tracking %s", pattern)
+		Print("Tracking %q", pattern)
 	}
 
 	// Now read the whole local attributes file and iterate over the contents,
@@ -178,7 +178,7 @@ ArgsLoop:
 
 		for _, f := range gittracked {
 			if trackVerboseLoggingFlag || trackDryRunFlag {
-				Print("Git LFS: touching %s", f)
+				Print("Git LFS: touching %q", f)
 			}
 
 			if !trackDryRunFlag {

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -77,7 +77,7 @@ ArgsLoop:
 		}
 
 		// Generate the new / changed attrib line for merging
-		encodedArg := strings.Replace(pattern, " ", "[[:space:]]", -1)
+		encodedArg := escapeTrackPattern(pattern)
 		lockableArg := ""
 		if trackLockableFlag { // no need to test trackNotLockableFlag, if we got here we're disabling
 			lockableArg = " " + git.LockableAttrib

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -239,6 +239,32 @@ func blocklistItem(name string) string {
 	return ""
 }
 
+var (
+	trackEscapePatterns = map[string]string{
+		" ": "[[:space:]]",
+	}
+)
+
+func escapeTrackPattern(unescaped string) string {
+	var escaped string = unescaped
+
+	for from, to := range trackEscapePatterns {
+		escaped = strings.Replace(escaped, from, to, -1)
+	}
+
+	return escaped
+}
+
+func unescapeTrackPattern(escaped string) string {
+	var unescaped string = escaped
+
+	for to, from := range trackEscapePatterns {
+		unescaped = strings.Replace(unescaped, from, to, -1)
+	}
+
+	return unescaped
+}
+
 func init() {
 	RegisterCommand("track", trackCommand, func(cmd *cobra.Command) {
 		cmd.Flags().BoolVarP(&trackLockableFlag, "lockable", "l", false, "make pattern lockable, i.e. read-only unless locked")

--- a/commands/command_untrack.go
+++ b/commands/command_untrack.go
@@ -57,7 +57,7 @@ func untrackCommand(cmd *cobra.Command, args []string) {
 
 		path := strings.Fields(line)[0]
 		if removePath(path, args) {
-			Print("Untracking %s", path)
+			Print("Untracking %s", unescapeTrackPattern(path))
 		} else {
 			attributesFile.WriteString(line + "\n")
 		}
@@ -66,7 +66,7 @@ func untrackCommand(cmd *cobra.Command, args []string) {
 
 func removePath(path string, args []string) bool {
 	for _, t := range args {
-		if path == t {
+		if path == escapeTrackPattern(t) {
 			return true
 		}
 	}

--- a/commands/command_untrack.go
+++ b/commands/command_untrack.go
@@ -57,7 +57,7 @@ func untrackCommand(cmd *cobra.Command, args []string) {
 
 		path := strings.Fields(line)[0]
 		if removePath(path, args) {
-			Print("Untracking %s", unescapeTrackPattern(path))
+			Print("Untracking %q", unescapeTrackPattern(path))
 		} else {
 			attributesFile.WriteString(line + "\n")
 		}

--- a/test/test-batch-error-handling.sh
+++ b/test/test-batch-error-handling.sh
@@ -24,7 +24,7 @@ begin_test "batch error handling"
 
   # This executes Git LFS from the local repo that was just cloned.
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   contents="a"
   contents_oid=$(calc_oid "$contents")

--- a/test/test-batch-transfer.sh
+++ b/test/test-batch-transfer.sh
@@ -26,7 +26,7 @@ begin_test "batch transfer"
 
   # This executes Git LFS from the local repo that was just cloned.
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   contents="a"
   contents_oid=$(calc_oid "$contents")

--- a/test/test-checkout.sh
+++ b/test/test-checkout.sh
@@ -12,7 +12,7 @@ begin_test "checkout"
   clone_repo "$reponame" repo
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   contents="something something"
   contentsize=19

--- a/test/test-chunked-transfer-encoding.sh
+++ b/test/test-chunked-transfer-encoding.sh
@@ -24,7 +24,7 @@ begin_test "chunked transfer encoding"
 
   # This executes Git LFS from the local repo that was just cloned.
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   contents="a"
   contents_oid=$(calc_oid "$contents")

--- a/test/test-clone.sh
+++ b/test/test-clone.sh
@@ -13,7 +13,7 @@ begin_test "clone"
   clone_repo "$reponame" repo
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   # generate some test data & commits with random LFS data
   echo "[
@@ -95,7 +95,7 @@ begin_test "cloneSSL"
   clone_repo_ssl "$reponame" "$reponame"
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   # generate some test data & commits with random LFS data
   echo "[
@@ -154,7 +154,7 @@ begin_test "clone ClientCert"
   fi
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   # generate some test data & commits with random LFS data
   echo "[
@@ -211,7 +211,7 @@ begin_test "clone with flags"
   clone_repo "$reponame" "$reponame"
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   # generate some test data & commits with random LFS data
   echo "[
@@ -298,7 +298,7 @@ begin_test "clone (with include/exclude args)"
   clone_repo "$reponame" "$reponame"
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   contents_a="a"
   contents_a_oid=$(calc_oid "$contents_a")
@@ -359,7 +359,7 @@ begin_test "clone (with .lfsconfig)"
   clone_repo "$reponame" "$reponame"
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   contents_a="a"
   contents_a_oid=$(calc_oid "$contents_a")
@@ -472,7 +472,7 @@ begin_test "clone with submodules"
 
   clone_repo "$submodname2" submod2
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   contents_sub2="Inception. Now, before you bother telling me it's impossible..."
   contents_sub2_oid=$(calc_oid "$contents_sub2")
@@ -484,7 +484,7 @@ begin_test "clone with submodules"
 
   clone_repo "$submodname1" submod1
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   contents_sub1="We're dreaming?"
   contents_sub1_oid=$(calc_oid "$contents_sub1")
@@ -499,7 +499,7 @@ begin_test "clone with submodules"
 
   clone_repo "$reponame" rootrepo
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   contents_root="Downwards is the only way forwards."
   contents_root_oid=$(calc_oid "$contents_root")
@@ -546,7 +546,7 @@ begin_test "clone in current directory"
   clone_repo "$reponame" $reponame
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   contents="contents"
   contents_oid="$(calc_oid "$contents")"

--- a/test/test-credentials.sh
+++ b/test/test-credentials.sh
@@ -18,7 +18,7 @@ begin_test "credentials without useHttpPath, with bad path password"
   git checkout -b without-path
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   contents="a"
   contents_oid=$(calc_oid "$contents")
@@ -46,7 +46,7 @@ begin_test "credentials with useHttpPath, with wrong password"
   git checkout -b with-path-wrong-pass
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   contents="a"
   contents_oid=$(calc_oid "$contents")
@@ -74,7 +74,7 @@ begin_test "credentials with useHttpPath, with correct password"
   git checkout -b with-path-correct-pass
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   # creating new branch does not re-send any objects existing on other
   # remote branches anymore, generate new object, different from prev tests

--- a/test/test-custom-transfers.sh
+++ b/test/test-custom-transfers.sh
@@ -16,7 +16,7 @@ begin_test "custom-transfer-wrong-path"
   git config lfs.customtransfer.testcustom.path path-to-nothing
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   contents="jksgdfljkgsdlkjafg lsjdgf alkjgsd lkfjag sldjkgf alkjsgdflkjagsd kljfg asdjgf kalsd"
   contents_oid=$(calc_oid "$contents")
@@ -52,7 +52,7 @@ begin_test "custom-transfer-upload-download"
   git config lfs.customtransfer.testcustom.path lfstest-customadapter
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
   git add .gitattributes
   git commit -m "Tracking"
 

--- a/test/test-fetch-paths.sh
+++ b/test/test-fetch-paths.sh
@@ -14,7 +14,7 @@ begin_test "init fetch unclean paths"
   clone_repo $reponame repo
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   mkdir dir
   printf "$contents" > dir/a.dat

--- a/test/test-fetch-recent.sh
+++ b/test/test-fetch-recent.sh
@@ -26,7 +26,7 @@ begin_test "init fetch-recent"
   clone_repo "$reponame" "$reponame"
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   echo "[
   {

--- a/test/test-fetch.sh
+++ b/test/test-fetch.sh
@@ -17,7 +17,7 @@ begin_test "init for fetch tests"
   clone_repo "$reponame" repo
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
 
   printf "$contents" > a.dat
@@ -254,7 +254,7 @@ begin_test "fetch-all"
   clone_repo "$reponame" "$reponame"
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   NUMFILES=12
   # generate content we'll use
@@ -395,7 +395,7 @@ begin_test "fetch with no origin remote"
   clone_repo "$reponame" no-remote-repo
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   contents="a"
   contents_oid=$(calc_oid "$contents")
@@ -459,7 +459,7 @@ begin_test "fetch --prune"
   clone_repo "remote_$reponame" "clone_$reponame"
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   content_head="HEAD content"
   content_commit2="Content for commit 2 (prune)"

--- a/test/test-happy-path.sh
+++ b/test/test-happy-path.sh
@@ -24,7 +24,7 @@ begin_test "happy path"
 
   # This executes Git LFS from the local repo that was just cloned.
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   contents="a"
   contents_oid=$(calc_oid "$contents")

--- a/test/test-ls-files.sh
+++ b/test/test-ls-files.sh
@@ -9,7 +9,7 @@ begin_test "ls-files"
   mkdir repo
   cd repo
   git init
-  git lfs track "*.dat" | grep "Tracking \*.dat"
+  git lfs track "*.dat" | grep "Tracking \"\*.dat\""
   echo "some data" > some.dat
   echo "some text" > some.txt
   echo "missing" > missing.dat
@@ -74,7 +74,7 @@ begin_test "ls-files: show duplicate files"
   cd dupRepoShort
   git init
 
-  git lfs track "*.tgz" | grep "Tracking \*.tgz"
+  git lfs track "*.tgz" | grep "Tracking \"\*.tgz\""
   echo "test content" > one.tgz
   echo "test content" > two.tgz
   git add one.tgz
@@ -96,7 +96,7 @@ begin_test "ls-files: show duplicate files with long OID"
   cd dupRepoLong
   git init
 
-  git lfs track "*.tgz" | grep "Tracking \*.tgz"
+  git lfs track "*.tgz" | grep "Tracking \"\*.tgz\""
   echo "test content" > one.tgz
   echo "test content" > two.tgz
   git add one.tgz

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -248,7 +248,7 @@ begin_test "pre-push multiple branches"
 
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   NUMFILES=6
   # generate content we'll use
@@ -334,7 +334,7 @@ begin_test "pre-push unfetched deleted remote branch & server GC"
 
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   NUMFILES=4
   # generate content we'll use
@@ -407,7 +407,7 @@ begin_test "pre-push delete branch"
 
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   NUMFILES=4
   # generate content we'll use

--- a/test/test-prune-worktree.sh
+++ b/test/test-prune-worktree.sh
@@ -15,7 +15,7 @@ begin_test "prune worktree"
   clone_repo "remote_$reponame" "$reponame"
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   content_head="First checkout HEAD"
   content_worktree1head="Worktree 1 head"
@@ -39,7 +39,7 @@ begin_test "prune worktree"
   },
   {
     \"CommitDate\":\"$(get_date -35d)\",
-    \"NewBranch\":\"branch1\",    
+    \"NewBranch\":\"branch1\",
     \"Files\":[
       {\"Filename\":\"file.dat\",\"Size\":${#content_oldcommit2}, \"Data\":\"$content_oldcommit2\"}]
   },
@@ -51,7 +51,7 @@ begin_test "prune worktree"
   {
     \"CommitDate\":\"$(get_date -30d)\",
     \"ParentBranches\":[\"master\"],
-    \"NewBranch\":\"branch2\",    
+    \"NewBranch\":\"branch2\",
     \"Files\":[
       {\"Filename\":\"file.dat\",\"Size\":${#content_oldcommit3}, \"Data\":\"$content_oldcommit3\"}]
   },
@@ -74,7 +74,7 @@ begin_test "prune worktree"
   # don't keep any recent, just checkouts
   git config lfs.fetchrecentrefsdays 0
   git config lfs.fetchrecentremoterefs true
-  git config lfs.fetchrecentcommitsdays 0 
+  git config lfs.fetchrecentcommitsdays 0
 
   # before worktree, everything except current checkout would be pruned
   git lfs prune --dry-run 2>&1 | tee prune.log

--- a/test/test-prune.sh
+++ b/test/test-prune.sh
@@ -12,7 +12,7 @@ begin_test "prune unreferenced and old"
   clone_repo "remote_$reponame" "clone_$reponame"
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   # generate content we'll use
   content_unreferenced="To delete: unreferenced"
@@ -50,7 +50,7 @@ begin_test "prune unreferenced and old"
   },
   {
     \"CommitDate\":\"$(get_date -4d)\",
-    \"NewBranch\":\"branch_to_delete\",    
+    \"NewBranch\":\"branch_to_delete\",
     \"Files\":[
       {\"Filename\":\"unreferenced.dat\",\"Size\":${#content_unreferenced}, \"Data\":\"$content_unreferenced\"}]
   },
@@ -111,7 +111,7 @@ begin_test "prune keep unpushed"
   clone_repo "remote_$reponame" "clone_$reponame"
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
 
   content_keepunpushedhead1="Keep: unpushed HEAD 1"
@@ -138,7 +138,7 @@ begin_test "prune keep unpushed"
   {
     \"CommitDate\":\"$(get_date -31d)\",
     \"ParentBranches\":[\"master\"],
-    \"NewBranch\":\"branch_unpushed\",    
+    \"NewBranch\":\"branch_unpushed\",
     \"Files\":[
       {\"Filename\":\"file.dat\",\"Size\":${#content_keepunpushedbranch1}, \"Data\":\"$content_keepunpushedbranch1\"}]
   },
@@ -185,7 +185,7 @@ begin_test "prune keep unpushed"
   refute_local_object "$oid_keepunpushedhead2"
 
 
-  # MERGE the secondary branch, delete the branch then push master, then make sure 
+  # MERGE the secondary branch, delete the branch then push master, then make sure
   # we delete the intermediate commits but also make sure they're on server
   # resolve conflicts by taking other branch
   git merge -Xtheirs branch_unpushed
@@ -220,7 +220,7 @@ begin_test "prune keep recent"
   clone_repo "remote_$reponame" "clone_$reponame"
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   content_keephead="Keep: HEAD"
   content_keeprecentbranch1tip="Keep: Recent branch 1 tip"
@@ -264,7 +264,7 @@ begin_test "prune keep recent"
   },
   {
     \"CommitDate\":\"$(get_date -8d)\",
-    \"NewBranch\":\"branch_old\",    
+    \"NewBranch\":\"branch_old\",
     \"Files\":[
       {\"Filename\":\"file.dat\",\"Size\":${#content_prunecommitoldbranch1}, \"Data\":\"$content_prunecommitoldbranch1\"}]
   },
@@ -276,7 +276,7 @@ begin_test "prune keep recent"
   {
     \"CommitDate\":\"$(get_date -9d)\",
     \"ParentBranches\":[\"master\"],
-    \"NewBranch\":\"branch1\",    
+    \"NewBranch\":\"branch1\",
     \"Files\":[
       {\"Filename\":\"file.dat\",\"Size\":${#content_prunecommitbranch1}, \"Data\":\"$content_prunecommitbranch1\"}]
   },
@@ -293,7 +293,7 @@ begin_test "prune keep recent"
   {
     \"CommitDate\":\"$(get_date -17d)\",
     \"ParentBranches\":[\"master\"],
-    \"NewBranch\":\"branch2\",    
+    \"NewBranch\":\"branch2\",
     \"Files\":[
       {\"Filename\":\"file.dat\",\"Size\":${#content_prunecommitbranch2}, \"Data\":\"$content_prunecommitbranch2\"}]
   },
@@ -318,7 +318,7 @@ begin_test "prune keep recent"
   # keep refs for 6 days & any prev commit that overlaps 2 days before tip (recent + offset)
   git config lfs.fetchrecentrefsdays 5
   git config lfs.fetchrecentremoterefs true
-  git config lfs.fetchrecentcommitsdays 1 
+  git config lfs.fetchrecentcommitsdays 1
   git config lfs.pruneoffsetdays 1
 
   # push everything so that's not a reason to retain
@@ -380,7 +380,7 @@ begin_test "prune remote tests"
   cd "$reponame"
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   echo "[
   {
@@ -408,7 +408,7 @@ begin_test "prune remote tests"
   # set no recents so max ability to prune normally
   git config lfs.fetchrecentrefsdays 0
   git config lfs.fetchrecentremoterefs true
-  git config lfs.fetchrecentcommitsdays 0 
+  git config lfs.fetchrecentcommitsdays 0
   git config lfs.pruneoffsetdays 1
 
   # can never prune with no remote
@@ -452,7 +452,7 @@ begin_test "prune verify"
   clone_repo "remote_$reponame" "clone_$reponame"
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   content_head="HEAD content"
   content_commit3="Content for commit 3 (prune)"
@@ -492,7 +492,7 @@ begin_test "prune verify"
   # set no recents so max ability to prune normally
   git config lfs.fetchrecentrefsdays 0
   git config lfs.fetchrecentremoterefs true
-  git config lfs.fetchrecentcommitsdays 0 
+  git config lfs.fetchrecentcommitsdays 0
   git config lfs.pruneoffsetdays 1
 
   # confirm that it would prune with verify when no issues
@@ -549,7 +549,7 @@ begin_test "prune verify large numbers of refs"
   clone_repo "remote_$reponame" "clone_$reponame"
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   content_head="HEAD content"
   content_commit1="Recent commit"

--- a/test/test-pull.sh
+++ b/test/test-pull.sh
@@ -14,7 +14,7 @@ begin_test "pull"
   clone_repo "$reponame" repo
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   contents="a"
   contents_oid=$(calc_oid "$contents")

--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -443,7 +443,7 @@ begin_test "push ambiguous branch name"
 
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   NUMFILES=5
   # generate content we'll use

--- a/test/test-resume-http-range.sh
+++ b/test/test-resume-http-range.sh
@@ -12,7 +12,7 @@ begin_test "resume-http-range"
   clone_repo "$reponame" $reponame
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   # this string announces to server that we want a test that
   # interrupts the transfer when started from 0 to cause resume
@@ -23,7 +23,7 @@ begin_test "resume-http-range"
   git add a.dat
   git add .gitattributes
   git commit -m "add a.dat" 2>&1 | tee commit.log
-  git push origin master 
+  git push origin master
 
   assert_server_object "$reponame" "$contents_oid"
 
@@ -53,7 +53,7 @@ begin_test "resume-http-range-fallback"
   clone_repo "$reponame" $reponame
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   # this string announces to server that we want it to abort the download part
   # way, but reject the Range: header and fall back on re-downloading instead
@@ -64,7 +64,7 @@ begin_test "resume-http-range-fallback"
   git add a.dat
   git add .gitattributes
   git commit -m "add a.dat" 2>&1 | tee commit.log
-  git push origin master 
+  git push origin master
 
   assert_server_object "$reponame" "$contents_oid"
 

--- a/test/test-resume-tus.sh
+++ b/test/test-resume-tus.sh
@@ -14,7 +14,7 @@ begin_test "tus-upload-uninterrupted"
   git config lfs.tustransfers true
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   contents="send-verify-action"
   contents_oid=$(calc_oid "$contents")
@@ -44,7 +44,7 @@ begin_test "tus-upload-interrupted-resume"
   git config lfs.tustransfers true
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   contents_verify="send-verify-action"
   contents_verify_oid="$(calc_oid "$contents_verify")"

--- a/test/test-smudge.sh
+++ b/test/test-smudge.sh
@@ -147,7 +147,7 @@ begin_test "smudge clone with include/exclude"
   clone_repo "$reponame" "repo_$reponame"
 
   git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \*.dat" track.log
+  grep "Tracking \"\*.dat\"" track.log
 
   contents="a"
   contents_oid=$(calc_oid "$contents")

--- a/test/test-track-wildcards.sh
+++ b/test/test-track-wildcards.sh
@@ -69,15 +69,15 @@ begin_test "track files using filename pattern with leading slash"
 
   # These are added by git.GetTrackedFiles
   git lfs track "/a.dat" | tee track.log
-  grep "Tracking /a.dat" track.log
+  grep "Tracking \"/a.dat\"" track.log
   git lfs track "/dir/b.dat" | tee track.log
-  grep "Tracking /dir/b.dat" track.log
+  grep "Tracking \"/dir/b.dat\"" track.log
 
   # These are added by Git's `clean` filter
   git lfs track "/c.dat" | tee track.log
-  grep "Tracking /c.dat" track.log
+  grep "Tracking \"/c.dat\"" track.log
   git lfs track "/dir/d.dat" | tee track.log
-  grep "Tracking /dir/d.dat" track.log
+  grep "Tracking \"/dir/d.dat\"" track.log
 
   cat .gitattributes
 

--- a/test/test-track.sh
+++ b/test/test-track.sh
@@ -20,11 +20,11 @@ begin_test "track"
 #*.cs     diff=csharp" > .gitattributes
 
   # track *.jpg once
-  git lfs track "*.jpg" | grep "Tracking \*.jpg"
+  git lfs track "*.jpg" | grep "Tracking \"\*.jpg\""
   assert_attributes_count "jpg" "filter=lfs" 1
 
   # track *.jpg again
-  git lfs track "*.jpg" | grep "*.jpg already supported"
+  git lfs track "*.jpg" | grep "\"*.jpg\" already supported"
   assert_attributes_count "jpg" "filter=lfs" 1
 
   mkdir -p a/b
@@ -61,7 +61,7 @@ begin_test "track --verbose"
   git add foo.dat
 
   git lfs track --verbose "foo.dat" 2>&1 > track.log
-  grep "touching foo.dat" track.log
+  grep "touching \"foo.dat\"" track.log
 )
 end_test
 
@@ -78,8 +78,8 @@ begin_test "track --dry-run"
   git add foo.dat
 
   git lfs track --dry-run "foo.dat" 2>&1 > track.log
-  grep "Tracking foo.dat" track.log
-  grep "Git LFS: touching foo.dat" track.log
+  grep "Tracking \"foo.dat\"" track.log
+  grep "Git LFS: touching \"foo.dat\"" track.log
 
   git status --porcelain 2>&1 > status.log
   grep "A  foo.dat" status.log
@@ -241,7 +241,7 @@ begin_test "track representation"
   cd a
   out3=$(git lfs track "test.file")
 
-  if [ "$out3" != "test.file already supported" ]; then
+  if [ "$out3" != "\"test.file\" already supported" ]; then
     echo "Track didn't recognize duplicate path"
     cat .gitattributes
     exit 1
@@ -250,7 +250,7 @@ begin_test "track representation"
   git lfs track "file.bin"
   cd ..
   out4=$(git lfs track "a/file.bin")
-  if [ "$out4" != "a/file.bin already supported" ]; then
+  if [ "$out4" != "\"a/file.bin\" already supported" ]; then
     echo "Track didn't recognize duplicate path"
     cat .gitattributes
     exit 1
@@ -366,25 +366,25 @@ begin_test "track lockable"
   git init
 
   # track *.jpg once, lockable
-  git lfs track --lockable "*.jpg" | grep "Tracking \*.jpg"
+  git lfs track --lockable "*.jpg" | grep "Tracking \"\*.jpg\""
   assert_attributes_count "jpg" "lockable" 1
   # track *.jpg again, don't change anything. Should retain lockable
-  git lfs track "*.jpg" | grep "*.jpg already supported"
+  git lfs track "*.jpg" | grep "\"*.jpg\" already supported"
   assert_attributes_count "jpg" "lockable" 1
 
 
   # track *.png once, not lockable yet
-  git lfs track "*.png" | grep "Tracking \*.png"
+  git lfs track "*.png" | grep "Tracking \"\*.png\""
   assert_attributes_count "png" "filter=lfs" 1
   assert_attributes_count "png" "lockable" 0
 
   # track png again, enable lockable, should replace
-  git lfs track --lockable "*.png" | grep "Tracking \*.png"
+  git lfs track --lockable "*.png" | grep "Tracking \"\*.png\""
   assert_attributes_count "png" "filter=lfs" 1
   assert_attributes_count "png" "lockable" 1
 
   # track png again, disable lockable, should replace
-  git lfs track --not-lockable "*.png" | grep "Tracking \*.png"
+  git lfs track --not-lockable "*.png" | grep "Tracking \"\*.png\""
   assert_attributes_count "png" "filter=lfs" 1
   assert_attributes_count "png" "lockable" 0
 
@@ -417,9 +417,9 @@ begin_test "track lockable read-only/read-write"
   assert_file_writable subfolder/test.dat
 
   # track *.bin, not lockable yet
-  git lfs track "*.bin" | grep "Tracking \*.bin"
+  git lfs track "*.bin" | grep "Tracking \"\*.bin\""
   # track *.dat, lockable immediately
-  git lfs track --lockable "*.dat" | grep "Tracking \*.dat"
+  git lfs track --lockable "*.dat" | grep "Tracking \"\*.dat\""
 
   # bin should remain writeable, dat should have been made read-only
 
@@ -435,13 +435,13 @@ begin_test "track lockable read-only/read-write"
   assert_file_writable test.bin
   assert_file_writable subfolder/test.bin
   # now make bin lockable
-  git lfs track --lockable "*.bin" | grep "Tracking \*.bin"
+  git lfs track --lockable "*.bin" | grep "Tracking \"\*.bin\""
   # bin should now be read-only
   refute_file_writable test.bin
   refute_file_writable subfolder/test.bin
 
   # remove lockable again
-  git lfs track --not-lockable "*.bin" | grep "Tracking \*.bin"
+  git lfs track --not-lockable "*.bin" | grep "Tracking \"\*.bin\""
   # bin should now be writeable again
   assert_file_writable test.bin
   assert_file_writable subfolder/test.bin
@@ -456,10 +456,10 @@ begin_test "track escaped pattern"
   git init "$reponame"
   cd "$reponame"
 
-  git lfs track " " | grep "Tracking  "
+  git lfs track " " | grep "Tracking \" \""
   assert_attributes_count "[[:space:]]" "filter=lfs" 1
 
-  git lfs track "#" | grep "Tracking #"
+  git lfs track "#" | grep "Tracking \"#\""
   assert_attributes_count "\\#" "filter=lfs" 1
 )
 end_test

--- a/test/test-track.sh
+++ b/test/test-track.sh
@@ -447,3 +447,16 @@ begin_test "track lockable read-only/read-write"
   assert_file_writable subfolder/test.bin
 )
 end_test
+
+begin_test "track escaped pattern"
+(
+  set -e
+
+  reponame="track-escaped-pattern"
+  git init "$reponame"
+  cd "$reponame"
+
+  git lfs track " " | grep "Tracking  "
+  assert_attributes_count "[[:space:]]" "filter=lfs" 1
+)
+end_test

--- a/test/test-track.sh
+++ b/test/test-track.sh
@@ -458,5 +458,8 @@ begin_test "track escaped pattern"
 
   git lfs track " " | grep "Tracking  "
   assert_attributes_count "[[:space:]]" "filter=lfs" 1
+
+  git lfs track "#" | grep "Tracking #"
+  assert_attributes_count "\\#" "filter=lfs" 1
 )
 end_test

--- a/test/test-untrack.sh
+++ b/test/test-untrack.sh
@@ -64,5 +64,11 @@ begin_test "untrack removes escape sequences"
 
   git lfs untrack " " | grep "Untracking  "
   assert_attributes_count "[[:space:]]" "filter=lfs" 0
+
+  git lfs track "#" | grep "Tracking #"
+  assert_attributes_count "\\#" "filter=lfs" 1
+
+  git lfs untrack "#" | grep "Untracking #"
+  assert_attributes_count "\\#" "filter=lfs" 0
 )
 end_test

--- a/test/test-untrack.sh
+++ b/test/test-untrack.sh
@@ -50,3 +50,19 @@ begin_test "untrack outside git repo"
   fi
 )
 end_test
+
+begin_test "untrack removes escape sequences"
+(
+  set -e
+
+  reponame="untrack-remove-escape-sequence"
+  git init "$reponame"
+  cd "$reponame"
+
+  git lfs track " " | grep "Tracking  "
+  assert_attributes_count "[[:space:]]" "filter=lfs" 1
+
+  git lfs untrack " " | grep "Untracking  "
+  assert_attributes_count "[[:space:]]" "filter=lfs" 0
+)
+end_test

--- a/test/test-untrack.sh
+++ b/test/test-untrack.sh
@@ -13,7 +13,7 @@ begin_test "untrack"
   cd $reponame
 
   # track *.jpg once
-  git lfs track "*.jpg" | grep "Tracking \*.jpg"
+  git lfs track "*.jpg" | grep "Tracking \"\*.jpg\""
   echo "* annex.backend=SHA512E" >> .gitattributes
 
   git lfs untrack "*.jpg"
@@ -59,16 +59,16 @@ begin_test "untrack removes escape sequences"
   git init "$reponame"
   cd "$reponame"
 
-  git lfs track " " | grep "Tracking  "
+  git lfs track " " | grep "Tracking \" \""
   assert_attributes_count "[[:space:]]" "filter=lfs" 1
 
-  git lfs untrack " " | grep "Untracking  "
+  git lfs untrack " " | grep "Untracking \" \""
   assert_attributes_count "[[:space:]]" "filter=lfs" 0
 
-  git lfs track "#" | grep "Tracking #"
+  git lfs track "#" | grep "Tracking \"#\""
   assert_attributes_count "\\#" "filter=lfs" 1
 
-  git lfs untrack "#" | grep "Untracking #"
+  git lfs untrack "#" | grep "Untracking \"#\""
   assert_attributes_count "\\#" "filter=lfs" 0
 )
 end_test

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -176,7 +176,7 @@ assert_attributes_count() {
   local attrib="$2"
   local count="$3"
 
-  pattern="\*.$fileext.*$attrib"
+  pattern="\(*.\)\?$fileext\(.*\)$attrib"
   actual=$(grep -e "$pattern" .gitattributes | wc -l)
   if [ "$(printf "%d" "$actual")" != "$count" ]; then
     echo "wrong number of $attrib entries for $fileext"


### PR DESCRIPTION
This pull request extracts two functions: `escapeTrackPattern()` and `unescapeTrackPattern()` which correctly handles both spaces (`" "` -> `"[[:space]]"`) and the pound symbol (`"#"` -> `"\#"`).

It also fixes an incorrect regex in `assert_attributes_count` and un-escapes patterns when calling `git lfs untrack`, so that instead of:

```bash
$ git lfs untrack " "
Untracked [[:space:]]
```

you get instead:

```bash
$ git lfs untrack " "
Untracked  
```

I'm thinking that we should quote the pattern that comes out to make it clear what's going on with whitespace-only patterns.

This PR also fixes https://github.com/git-lfs/git-lfs/issues/2041.

---

/cc @git-lfs/core https://github.com/git-lfs/git-lfs/issues/2041