### PR TITLE
commands/{pre-,}push: allow missing objects

### DIFF
--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -12,6 +12,7 @@ import (
 
 var (
 	prePushDryRun       = false
+	prePushRequireAll   = false
 	prePushDeleteBranch = strings.Repeat("0", 40)
 )
 
@@ -50,7 +51,7 @@ func prePushCommand(cmd *cobra.Command, args []string) {
 		Exit("Invalid remote name %q", args[0])
 	}
 
-	ctx := newUploadContext(args[0], prePushDryRun)
+	ctx := newUploadContext(args[0], prePushDryRun, prePushRequireAll)
 
 	gitscanner, err := ctx.buildGitScanner()
 	if err != nil {
@@ -104,5 +105,6 @@ func decodeRefs(input string) (string, string) {
 func init() {
 	RegisterCommand("pre-push", prePushCommand, func(cmd *cobra.Command) {
 		cmd.Flags().BoolVarP(&prePushDryRun, "dry-run", "d", false, "Do everything except actually send the updates")
+		cmd.Flags().BoolVar(&prePushRequireAll, "strict-mode", false, "Require all objects to be present.")
 	})
 }

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -11,10 +11,11 @@ import (
 )
 
 var (
-	pushDryRun    = false
-	pushObjectIDs = false
-	pushAll       = false
-	useStdin      = false
+	pushDryRun     = false
+	pushObjectIDs  = false
+	pushAll        = false
+	pushRequireAll = false
+	useStdin       = false
 
 	// shares some global vars and functions with command_pre_push.go
 )
@@ -117,7 +118,7 @@ func pushCommand(cmd *cobra.Command, args []string) {
 		Exit("Invalid remote name %q", args[0])
 	}
 
-	ctx := newUploadContext(args[0], pushDryRun)
+	ctx := newUploadContext(args[0], pushDryRun, pushRequireAll)
 
 	if pushObjectIDs {
 		if len(args) < 2 {
@@ -141,5 +142,6 @@ func init() {
 		cmd.Flags().BoolVarP(&pushDryRun, "dry-run", "d", false, "Do everything except actually send the updates")
 		cmd.Flags().BoolVarP(&pushObjectIDs, "object-id", "o", false, "Push LFS object ID(s)")
 		cmd.Flags().BoolVarP(&pushAll, "all", "a", false, "Push all objects for the current ref to the remote.")
+		cmd.Flags().BoolVar(&pushRequireAll, "strict-mode", false, "Require all objects to be present.")
 	})
 }

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -82,7 +82,7 @@ const (
 	verifyStateDisabled
 )
 
-func newUploadContext(remote string, dryRun bool) *uploadContext {
+func newUploadContext(remote string, dryRun, requireAll bool) *uploadContext {
 	cfg.CurrentRemote = remote
 
 	ctx := &uploadContext{
@@ -96,7 +96,7 @@ func newUploadContext(remote string, dryRun bool) *uploadContext {
 	}
 
 	ctx.meter = buildProgressMeter(ctx.DryRun)
-	ctx.tq = newUploadQueue(ctx.Manifest, ctx.Remote, tq.WithProgress(ctx.meter), tq.DryRun(ctx.DryRun))
+	ctx.tq = newUploadQueue(ctx.Manifest, ctx.Remote, tq.WithProgress(ctx.meter), tq.DryRun(ctx.DryRun), tq.RequireAllObjects(requireAll))
 	ctx.committerName, ctx.committerEmail = cfg.CurrentCommitter()
 
 	ourLocks, theirLocks := verifyLocks(remote)

--- a/docs/man/git-lfs-pre-push.1.ronn
+++ b/docs/man/git-lfs-pre-push.1.ronn
@@ -14,6 +14,14 @@ the following format:
 
 It also takes the remote name and URL as arguments.
 
+## OPTIONS
+
+* `--strict-mode`:
+    This enforces that all LFS objects in the push exist in the local cache and
+    have the right size. If given and an object is missing or has the wrong
+    size, the subsequent `git push` will be cancelled and no more LFS objects
+    will be uploaded. Not given by default.
+
 ## SEE ALSO
 
 git-lfs-clean(1), git-lfs-push(1).

--- a/docs/man/git-lfs-push.1.ronn
+++ b/docs/man/git-lfs-push.1.ronn
@@ -27,6 +27,12 @@ of the remote.
     This pushes only the object OIDs listed at the end of the command, separated
     by spaces.
 
+* `--strict-mode`:
+    This enforces that all LFS objects in the push exist in the local cache and
+    have the right size. If given and an object is missing or has the wrong
+    size, the push will be halted and subsequent objects will not be uploaded.
+    Not given by default.
+
 ## SEE ALSO
 
 git-lfs-pre-push(1).

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -190,7 +190,7 @@ begin_test "pre-push with missing pointer not on server"
   # assert that push fails
   set +e
   echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
-    git lfs pre-push origin "$GITSERVER/$reponame" 2>&1 |
+    git lfs pre-push --strict-mode origin "$GITSERVER/$reponame" 2>&1 |
     tee push.log
   set -e
   grep "Unable to find object (7aa7a5359173d05b63cfd682e3c38487f3cb4f7f1d60659fe59fab1505977d4c) locally." push.log

--- a/test/test-push-missing.sh
+++ b/test/test-push-missing.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+
+. "test/testlib.sh"
+
+begin_test "push missing objects"
+(
+  set -e
+
+  reponame="push-missing-objects"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "track *.dat files with LFS"
+
+  missing="missing"
+  missing_oid="$(calc_oid "$missing")"
+  printf "$missing" > missing.dat
+
+  present="present"
+  present_oid="$(calc_oid "$present")"
+  printf "$present" > present.dat
+
+  git add missing.dat present.dat
+  git commit -m "add two files"
+
+  rm ".git/lfs/objects/${missing_oid:0:2}/${missing_oid:2:2}/$missing_oid"
+
+  git lfs push origin master 2>&1 | tee push.log
+
+  grep "Missing: missing.dat ($missing_oid)" push.log
+
+  assert_server_object "$reponame" "$present_oid"
+  refute_server_object "$reponame" "$missing_oid"
+)
+end_test
+
+begin_test "push missing objects (--strict-mode)"
+(
+  set -e
+
+  reponame="push-missing-objects-strict-mode"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "track *.dat files with LFS"
+
+  missing="missing"
+  missing_oid="$(calc_oid "$missing")"
+  printf "$missing" > missing.dat
+
+  present="present"
+  present_oid="$(calc_oid "$present")"
+  printf "$present" > present.dat
+
+  git add missing.dat present.dat
+  git commit -m "add two files"
+
+  rm ".git/lfs/objects/${missing_oid:0:2}/${missing_oid:2:2}/$missing_oid"
+
+  git lfs push --strict-mode origin master 2>&1 | tee push.log
+  if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected \"git lfs push --strict-mode\" to fail, didn't ..."
+    exit 1
+  fi
+)
+end_test
+
+begin_test "push objects wrong size"
+(
+  set -e
+
+  reponame="push-objects-wrong-size"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "track *.dat files with LFS"
+
+  missing="missing"
+  missing_oid="$(calc_oid "$missing")"
+  printf "$missing" > missing.dat
+
+  present="present"
+  present_oid="$(calc_oid "$present")"
+  printf "$present" > present.dat
+
+  git add missing.dat present.dat
+  git commit -m "add two files"
+
+  cp /dev/null ".git/lfs/objects/${missing_oid:0:2}/${missing_oid:2:2}/$missing_oid"
+
+  git lfs push origin master 2>&1 | tee push.log
+
+  grep "Missing: missing.dat ($missing_oid)" push.log
+
+  assert_server_object "$reponame" "$present_oid"
+  refute_server_object "$reponame" "$missing_oid"
+)
+end_test
+
+begin_test "push objects wrong size (--strict-mode)"
+(
+  set -e
+
+  reponame="push-objects-wrong-size-strict-mode"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "track *.dat files with LFS"
+
+  missing="missing"
+  missing_oid="$(calc_oid "$missing")"
+  printf "$missing" > missing.dat
+
+  present="present"
+  present_oid="$(calc_oid "$present")"
+  printf "$present" > present.dat
+
+  git add missing.dat present.dat
+  git commit -m "add two files"
+
+  cp /dev/null ".git/lfs/objects/${missing_oid:0:2}/${missing_oid:2:2}/$missing_oid"
+
+  git lfs push --strict-mode origin master 2>&1 | tee push.log
+  if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected \"git lfs push --strict-mode\" to fail, didn't ..."
+    exit 1
+  fi
+)
+end_test

--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -572,7 +572,7 @@ begin_test "push (with invalid object size)"
   grep "create mode 100644 .gitattributes" commit.log
 
   set +e
-  git push origin master 2>&1 2> push.log
+  git lfs push --strict-mode origin master 2>&1 2> push.log
   res="$?"
   set -e
 


### PR DESCRIPTION
This pull request teaches the `git lfs push` & `git lfs pre-push` commands to allow missing objects by default, and enforce that they exist with the `--strict-mode` flag.

From https://github.com/git-lfs/git-lfs/issues/2063:

> The commands should still return with a non-zero exit code, but at least the other objects have a chance to be uploaded. 

I think printing a warning and exiting cleanly is OK in this scenario, where `--strict-mode` is not given, because the command did what it was supposed to do given the expectations set by the caller.

> Finally, double check that upload retries reset the progress meter properly.

I verified that this is what happens, but I'm unsure if it's required that I `q.meter.Pause()` and `q.meter.Start()` in order to log to stderr. I think that it is, but perhaps not? (cc @technoweenie)

Lastly, I think that this was originally targeted for v2.0.2 (from #2063), but perhaps it should just ship in 2.1.0 since `--strict-mode` is a new flag and this is technically a breaking change?

---

/cc @git-lfs/core #2063 
Closes: #2063