### PR TITLE
ssh auth and credential helper caching

### DIFF
--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -45,6 +45,11 @@ be scoped inside the configuration for a remote.
   Sets the maximum time, in seconds, for the HTTP client to maintain keepalive
   connections. Default: 30 minutes.
 
+* `lfs.cachecredentials`
+
+  Enables in-memory SSH and Git Credential caching for a single 'git lfs'
+  command. Default: false. This will default to true in v2.1.0.
+
 ### Transfer (upload / download) settings
 
   These settings control how the upload and download of LFS content occurs.

--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -18,7 +18,7 @@ var UserAgent = "git-lfs"
 const MediaType = "application/vnd.git-lfs+json; charset=utf-8"
 
 func (c *Client) NewRequest(method string, e Endpoint, suffix string, body interface{}) (*http.Request, error) {
-	sshRes, err := c.sshResolver.Resolve(e, method)
+	sshRes, err := c.SSH.Resolve(e, method)
 	if err != nil {
 		tracerx.Printf("ssh: %s failed, error: %s, message: %s",
 			e.SshUserAndHost, err.Error(), sshRes.Message,

--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -18,7 +18,7 @@ var UserAgent = "git-lfs"
 const MediaType = "application/vnd.git-lfs+json; charset=utf-8"
 
 func (c *Client) NewRequest(method string, e Endpoint, suffix string, body interface{}) (*http.Request, error) {
-	sshRes, err := c.resolveSSHEndpoint(e, method)
+	sshRes, err := c.sshResolver.Resolve(e, method)
 	if err != nil {
 		tracerx.Printf("ssh: %s failed, error: %s, message: %s",
 			e.SshUserAndHost, err.Error(), sshRes.Message,

--- a/lfsapi/creds_test.go
+++ b/lfsapi/creds_test.go
@@ -1,0 +1,268 @@
+package lfsapi
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// test that cache satisfies Fill() without looking at creds
+func TestCredsCacheFillFromCache(t *testing.T) {
+	creds := newFakeCreds()
+	cache := withCredentialCache(creds).(*credentialCacher)
+	cache.creds["http//lfs.test//foo/bar"] = Creds{
+		"protocol": "http",
+		"host":     "lfs.test",
+		"path":     "foo/bar",
+		"username": "u",
+		"password": "p",
+	}
+
+	filled, err := cache.Fill(Creds{
+		"protocol": "http",
+		"host":     "lfs.test",
+		"path":     "foo/bar",
+	})
+	assert.Nil(t, err)
+	require.NotNil(t, filled)
+	assert.Equal(t, "u", filled["username"])
+	assert.Equal(t, "p", filled["password"])
+
+	assert.Equal(t, 1, len(cache.creds))
+	cached, ok := cache.creds["http//lfs.test//foo/bar"]
+	assert.True(t, ok)
+	assert.Equal(t, "u", cached["username"])
+	assert.Equal(t, "p", cached["password"])
+}
+
+// test that cache caches Fill() value from creds
+func TestCredsCacheFillFromValidHelperFill(t *testing.T) {
+	creds := newFakeCreds()
+	cache := withCredentialCache(creds).(*credentialCacher)
+
+	creds.list = append(creds.list, Creds{
+		"protocol": "http",
+		"host":     "lfs.test",
+		"path":     "foo/bar",
+		"username": "u",
+		"password": "p",
+	})
+
+	assert.Equal(t, 0, len(cache.creds))
+
+	filled, err := cache.Fill(Creds{
+		"protocol": "http",
+		"host":     "lfs.test",
+		"path":     "foo/bar",
+	})
+	assert.Nil(t, err)
+	require.NotNil(t, filled)
+	assert.Equal(t, "u", filled["username"])
+	assert.Equal(t, "p", filled["password"])
+
+	assert.Equal(t, 1, len(cache.creds))
+	cached, ok := cache.creds["http//lfs.test//foo/bar"]
+	assert.True(t, ok)
+	assert.Equal(t, "u", cached["username"])
+	assert.Equal(t, "p", cached["password"])
+
+	creds.list = make([]Creds, 0)
+	filled2, err := cache.Fill(Creds{
+		"protocol": "http",
+		"host":     "lfs.test",
+		"path":     "foo/bar",
+	})
+	assert.Nil(t, err)
+	require.NotNil(t, filled2)
+	assert.Equal(t, "u", filled2["username"])
+	assert.Equal(t, "p", filled2["password"])
+}
+
+// test that cache ignores Fill() value from creds with missing username+password
+func TestCredsCacheFillFromInvalidHelperFill(t *testing.T) {
+	creds := newFakeCreds()
+	cache := withCredentialCache(creds).(*credentialCacher)
+
+	creds.list = append(creds.list, Creds{
+		"protocol": "http",
+		"host":     "lfs.test",
+		"path":     "foo/bar",
+		"username": "no-password",
+	})
+
+	assert.Equal(t, 0, len(cache.creds))
+
+	filled, err := cache.Fill(Creds{
+		"protocol": "http",
+		"host":     "lfs.test",
+		"path":     "foo/bar",
+		"username": "u",
+		"password": "p",
+	})
+	assert.Nil(t, err)
+	require.NotNil(t, filled)
+	assert.Equal(t, "no-password", filled["username"])
+	assert.Equal(t, "", filled["password"])
+
+	assert.Equal(t, 0, len(cache.creds))
+}
+
+// test that cache ignores Fill() value from creds with error
+func TestCredsCacheFillFromErroringHelperFill(t *testing.T) {
+	creds := newFakeCreds()
+	cache := withCredentialCache(&erroringCreds{creds}).(*credentialCacher)
+
+	creds.list = append(creds.list, Creds{
+		"protocol": "http",
+		"host":     "lfs.test",
+		"path":     "foo/bar",
+		"username": "u",
+		"password": "p",
+	})
+
+	assert.Equal(t, 0, len(cache.creds))
+
+	filled, err := cache.Fill(Creds{
+		"protocol": "http",
+		"host":     "lfs.test",
+		"path":     "foo/bar",
+	})
+	assert.NotNil(t, err)
+	require.NotNil(t, filled)
+	assert.Equal(t, "u", filled["username"])
+	assert.Equal(t, "p", filled["password"])
+
+	assert.Equal(t, 0, len(cache.creds))
+}
+
+func TestCredsCacheRejectWithoutError(t *testing.T) {
+	creds := newFakeCreds()
+	cache := withCredentialCache(creds).(*credentialCacher)
+
+	cache.creds["http//lfs.test//foo/bar"] = Creds{
+		"protocol": "http",
+		"host":     "lfs.test",
+		"path":     "foo/bar",
+		"username": "u",
+		"password": "p",
+	}
+
+	err := cache.Reject(Creds{
+		"protocol": "http",
+		"host":     "lfs.test",
+		"path":     "foo/bar",
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(cache.creds))
+}
+
+func TestCredsCacheRejectWithError(t *testing.T) {
+	creds := newFakeCreds()
+	cache := withCredentialCache(&erroringCreds{creds}).(*credentialCacher)
+
+	cache.creds["http//lfs.test//foo/bar"] = Creds{
+		"protocol": "http",
+		"host":     "lfs.test",
+		"path":     "foo/bar",
+		"username": "u",
+		"password": "p",
+	}
+
+	err := cache.Reject(Creds{
+		"protocol": "http",
+		"host":     "lfs.test",
+		"path":     "foo/bar",
+	})
+	assert.NotNil(t, err)
+	assert.Equal(t, 0, len(cache.creds))
+}
+
+func TestCredsCacheApproveWithoutError(t *testing.T) {
+	creds := newFakeCreds()
+	cache := withCredentialCache(creds).(*credentialCacher)
+
+	assert.Equal(t, 0, len(cache.creds))
+
+	err := cache.Approve(Creds{
+		"protocol": "http",
+		"host":     "lfs.test",
+		"path":     "foo/bar",
+		"username": "U",
+		"password": "P",
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(cache.creds))
+	cached, ok := cache.creds["http//lfs.test//foo/bar"]
+	assert.True(t, ok)
+	assert.Equal(t, "U", cached["username"])
+	assert.Equal(t, "P", cached["password"])
+}
+
+func TestCredsCacheApproveWithError(t *testing.T) {
+	creds := newFakeCreds()
+	cache := withCredentialCache(&erroringCreds{creds}).(*credentialCacher)
+
+	assert.Equal(t, 0, len(cache.creds))
+
+	err := cache.Approve(Creds{
+		"protocol": "http",
+		"host":     "lfs.test",
+		"path":     "foo/bar",
+		"username": "u",
+		"password": "p",
+	})
+	assert.NotNil(t, err)
+	assert.Equal(t, 0, len(cache.creds))
+}
+
+func newFakeCreds() *fakeCreds {
+	return &fakeCreds{list: make([]Creds, 0)}
+}
+
+type erroringCreds struct {
+	helper CredentialHelper
+}
+
+func (e *erroringCreds) Fill(creds Creds) (Creds, error) {
+	c, _ := e.helper.Fill(creds)
+	return c, errors.New("fill error")
+}
+
+func (e *erroringCreds) Reject(creds Creds) error {
+	e.helper.Reject(creds)
+	return errors.New("reject error")
+}
+
+func (e *erroringCreds) Approve(creds Creds) error {
+	e.helper.Approve(creds)
+	return errors.New("approve error")
+}
+
+type fakeCreds struct {
+	list []Creds
+}
+
+func credsMatch(c1, c2 Creds) bool {
+	return c1["protocol"] == c2["protocol"] &&
+		c1["host"] == c2["host"] &&
+		c1["path"] == c2["path"]
+}
+
+func (f *fakeCreds) Fill(creds Creds) (Creds, error) {
+	for _, saved := range f.list {
+		if credsMatch(creds, saved) {
+			return saved, nil
+		}
+	}
+	return creds, nil
+}
+
+func (f *fakeCreds) Reject(creds Creds) error {
+	return nil
+}
+
+func (f *fakeCreds) Approve(creds Creds) error {
+	return nil
+}

--- a/lfsapi/lfsapi.go
+++ b/lfsapi/lfsapi.go
@@ -74,7 +74,7 @@ func NewClient(osEnv Env, gitEnv Env) (*Client, error) {
 	creds := &commandCredentialHelper{
 		SkipPrompt: !osEnv.Bool("GIT_TERMINAL_PROMPT", true),
 	}
-	sshResolver := &sshAuthClient{os: osEnv}
+	sshResolver := withSSHCache(&sshAuthClient{os: osEnv})
 
 	c := &Client{
 		Endpoints:           NewEndpointFinder(gitEnv),

--- a/lfsapi/lfsapi.go
+++ b/lfsapi/lfsapi.go
@@ -71,9 +71,9 @@ func NewClient(osEnv Env, gitEnv Env) (*Client, error) {
 
 	httpsProxy, httpProxy, noProxy := getProxyServers(osEnv, gitEnv)
 
-	creds := &commandCredentialHelper{
+	creds := withCredentialCache(&commandCredentialHelper{
 		SkipPrompt: !osEnv.Bool("GIT_TERMINAL_PROMPT", true),
-	}
+	})
 	sshResolver := withSSHCache(&sshAuthClient{os: osEnv})
 
 	c := &Client{

--- a/lfsapi/lfsapi.go
+++ b/lfsapi/lfsapi.go
@@ -41,6 +41,8 @@ type Client struct {
 	hostClients map[string]*http.Client
 	clientMu    sync.Mutex
 
+	sshResolver sshResolver
+
 	ntlmSessions map[string]ntlm.ClientSession
 	ntlmMu       sync.Mutex
 
@@ -89,6 +91,7 @@ func NewClient(osEnv Env, gitEnv Env) (*Client, error) {
 		NoProxy:             noProxy,
 		gitEnv:              gitEnv,
 		osEnv:               osEnv,
+		sshResolver:         &sshAuthClient{os: osEnv},
 	}
 
 	return c, nil

--- a/lfsapi/lfsapi.go
+++ b/lfsapi/lfsapi.go
@@ -71,10 +71,15 @@ func NewClient(osEnv Env, gitEnv Env) (*Client, error) {
 
 	httpsProxy, httpProxy, noProxy := getProxyServers(osEnv, gitEnv)
 
-	creds := withCredentialCache(&commandCredentialHelper{
+	var creds CredentialHelper = &commandCredentialHelper{
 		SkipPrompt: !osEnv.Bool("GIT_TERMINAL_PROMPT", true),
-	})
-	sshResolver := withSSHCache(&sshAuthClient{os: osEnv})
+	}
+	var sshResolver SSHResolver = &sshAuthClient{os: osEnv}
+
+	if gitEnv.Bool("lfs.cachecredentials", false) {
+		creds = withCredentialCache(creds)
+		sshResolver = withSSHCache(sshResolver)
+	}
 
 	c := &Client{
 		Endpoints:           NewEndpointFinder(gitEnv),

--- a/lfsapi/ssh.go
+++ b/lfsapi/ssh.go
@@ -29,8 +29,14 @@ type sshCache struct {
 }
 
 func (c *sshCache) Resolve(e Endpoint, method string) (sshAuthResponse, error) {
+	if len(e.SshUserAndHost) == 0 {
+		return sshAuthResponse{}, nil
+	}
+
 	key := strings.Join([]string{e.SshUserAndHost, e.SshPort, e.SshPath, method}, "//")
 	if res, ok := c.endpoints[key]; ok {
+		tracerx.Printf("ssh cache: %s git-lfs-authenticate %s %s",
+			e.SshUserAndHost, e.SshPath, endpointOperation(e, method))
 		return *res, nil
 	}
 

--- a/lfsapi/ssh.go
+++ b/lfsapi/ssh.go
@@ -12,7 +12,7 @@ import (
 	"github.com/rubyist/tracerx"
 )
 
-type sshResolver interface {
+type SSHResolver interface {
 	Resolve(Endpoint, string) (sshAuthResponse, error)
 }
 

--- a/lfsapi/ssh.go
+++ b/lfsapi/ssh.go
@@ -35,7 +35,7 @@ func (c *sshCache) Resolve(e Endpoint, method string) (sshAuthResponse, error) {
 	}
 
 	key := strings.Join([]string{e.SshUserAndHost, e.SshPort, e.SshPath, method}, "//")
-	if res, ok := c.endpoints[key]; ok && (res.ExpiresAt.IsZero() || res.ExpiresAt.After(time.Now().Add(5*time.Second))) {
+	if res, ok := c.endpoints[key]; ok && (res.ExpiresAt.IsZero() || time.Until(res.ExpiresAt) > 5*time.Second) {
 		tracerx.Printf("ssh cache: %s git-lfs-authenticate %s %s",
 			e.SshUserAndHost, e.SshPath, endpointOperation(e, method))
 		return *res, nil

--- a/lfsapi/ssh_test.go
+++ b/lfsapi/ssh_test.go
@@ -1,12 +1,103 @@
 package lfsapi
 
 import (
+	"errors"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestSSHCacheResolveFromCache(t *testing.T) {
+	ssh := newFakeResolver()
+	cache := withSSHCache(ssh).(*sshCache)
+	cache.endpoints["userandhost//1//path//post"] = &sshAuthResponse{
+		Href: "cache",
+	}
+
+	e := Endpoint{
+		SshUserAndHost: "userandhost",
+		SshPort:        "1",
+		SshPath:        "path",
+	}
+
+	res, err := cache.Resolve(e, "post")
+	assert.Nil(t, err)
+	assert.Equal(t, "cache", res.Href)
+}
+
+func TestSSHCacheResolveWithoutError(t *testing.T) {
+	ssh := newFakeResolver()
+	cache := withSSHCache(ssh).(*sshCache)
+
+	assert.Equal(t, 0, len(cache.endpoints))
+
+	ssh.responses["userandhost"] = sshAuthResponse{Href: "real"}
+
+	e := Endpoint{
+		SshUserAndHost: "userandhost",
+		SshPort:        "1",
+		SshPath:        "path",
+	}
+
+	res, err := cache.Resolve(e, "post")
+	assert.Nil(t, err)
+	assert.Equal(t, "real", res.Href)
+
+	assert.Equal(t, 1, len(cache.endpoints))
+	cacheres, ok := cache.endpoints["userandhost//1//path//post"]
+	assert.True(t, ok)
+	assert.NotNil(t, cacheres)
+	assert.Equal(t, "real", cacheres.Href)
+
+	delete(ssh.responses, "userandhost")
+	res2, err := cache.Resolve(e, "post")
+	assert.Nil(t, err)
+	assert.Equal(t, "real", res2.Href)
+}
+
+func TestSSHCacheResolveWithError(t *testing.T) {
+	ssh := newFakeResolver()
+	cache := withSSHCache(ssh).(*sshCache)
+
+	assert.Equal(t, 0, len(cache.endpoints))
+
+	ssh.responses["userandhost"] = sshAuthResponse{Message: "resolve error", Href: "real"}
+
+	e := Endpoint{
+		SshUserAndHost: "userandhost",
+		SshPort:        "1",
+		SshPath:        "path",
+	}
+
+	res, err := cache.Resolve(e, "post")
+	assert.NotNil(t, err)
+	assert.Equal(t, "real", res.Href)
+
+	assert.Equal(t, 0, len(cache.endpoints))
+	delete(ssh.responses, "userandhost")
+	res2, err := cache.Resolve(e, "post")
+	assert.Nil(t, err)
+	assert.Equal(t, "", res2.Href)
+}
+
+func newFakeResolver() *fakeResolver {
+	return &fakeResolver{responses: make(map[string]sshAuthResponse)}
+}
+
+type fakeResolver struct {
+	responses map[string]sshAuthResponse
+}
+
+func (r *fakeResolver) Resolve(e Endpoint, method string) (sshAuthResponse, error) {
+	res := r.responses[e.SshUserAndHost]
+	var err error
+	if len(res.Message) > 0 {
+		err = errors.New(res.Message)
+	}
+	return res, err
+}
 
 func TestSSHGetLFSExeAndArgs(t *testing.T) {
 	cli, err := NewClient(TestEnv(map[string]string{}), nil)


### PR DESCRIPTION
This is another approach to #2045. It adds implementations of `lfsapi.CredentialHelper` and `lfsapi.SSHResolver` that cache the results in-memory to prevent multiple calls over the span of a single `git lfs` call. While this is the same idea as #2045, it's implemented by wrapping some go interfaces, instead of changing `lfsapi.Client` call signatures. This is more idiomatic go, and doesn't require any changes to callers.

In the interest of testing this out for v2.0.2, the cachers are disabled until `git config lfs.cachecredentials 1` is run.

To highlight the difference, I hacked the batch size to just 1 to simulate multiple batches. Output has important lines in bold to show the difference.

## HTTP REMOTE

Here's the uncached output for an HTTP remote `fetch`:

> $ git config --unset lfs.cachecredentials
$ rm -rf .git/lfs/objects && GIT_TRACE=1 git lfs fetch
...
**trace git-lfs: creds: git credential fill ("https", "github.com", "github/git-lfs-test")**
**trace git-lfs: Filled credentials for https://github.com/github/git-lfs-test**
trace git-lfs: HTTP: POST https://github.com/github/git-lfs-test.git/info/lfs/objects/batch
trace git-lfs: HTTP: 200
trace git-lfs: HTTP: LOTS OF JSON
trace git-lfs: tq: starting transfer adapter "basic"
Git LFS: (0 of 6 files) 0 B / 818.95 KB                                                                                                                                                                                                                                                                                                                                    trace git-lfs: HTTP: GET https://github-cloud.s3.amazonaws.com/alambic/media/111976139/02/63/0263829989b6fd954f72baaf2fc64bc2e2f01d692d4de72986ea808f6e99813f
Git LFS: (0 of 6 files) 0 B / 818.95 KB                                                                                                                                                                                                                                                                                                                                    trace git-lfs: HTTP: 200
**trace git-lfs: tq: sending batch of size 1**
trace git-lfs: fetch gif/droidtocat.gif [d1c8fab51418ef587fcf5dd8e73c60b9700704e2f8f5292ea12ec27c285b23a3]
**trace git-lfs: api: batch 1 files**
**trace git-lfs: creds: git credential fill ("https", "github.com", "github/git-lfs-test")**
**trace git-lfs: Filled credentials for https://github.com/github/git-lfs-test**
trace git-lfs: HTTP: POST https://github.com/github/git-lfs-test.git/info/lfs/objects/batch
trace git-lfs: HTTP: 200
trace git-lfs: HTTP: LOTS OF JSON

Here's the cached output:

> $ git config lfs.cachecredentials 1
$ rm -rf .git/lfs/objects && GIT_TRACE=1 git lfs fetch
...
**trace git-lfs: creds: git credential fill ("https", "github.com", "github/git-lfs-test")**
**trace git-lfs: Filled credentials for https://github.com/github/git-lfs-test**
trace git-lfs: HTTP: POST https://github.com/github/git-lfs-test.git/info/lfs/objects/batch
trace git-lfs: HTTP: 200
trace git-lfs: HTTP: LOTS OF JSON
trace git-lfs: tq: starting transfer adapter "basic"
Git LFS: (0 of 6 files) 0 B / 818.95 KB                                                                                                                                                                                                                                                                                                                                    trace git-lfs: HTTP: GET https://github-cloud.s3.amazonaws.com/alambic/media/111976139/02/63/0263829989b6fd954f72baaf2fc64bc2e2f01d692d4de72986ea808f6e99813f
Git LFS: (0 of 6 files) 0 B / 818.95 KB                                                                                                                                                                                                                                                                                                                                    trace git-lfs: HTTP: 200
**trace git-lfs: tq: sending batch of size 1**
trace git-lfs: fetch gif/droidtocat.gif [d1c8fab51418ef587fcf5dd8e73c60b9700704e2f8f5292ea12ec27c285b23a3]
**trace git-lfs: api: batch 1 files**
**trace git-lfs: creds: git credential cache ("https", "github.com", "github/git-lfs-test")**
**trace git-lfs: Filled credentials for https://github.com/github/git-lfs-test**
trace git-lfs: HTTP: POST https://github.com/github/git-lfs-test.git/info/lfs/objects/batch
trace git-lfs: HTTP: 200
trace git-lfs: HTTP: LOTS OF JSON

Notice the `git credential cache` call here ^

## SSH REMOTE

Here's the uncached output for an SSH remote:

> $ git config --unset lfs.cachecredentials
$ rm -rf .git/lfs/objects && GIT_TRACE=1 git lfs fetch
...
**trace git-lfs: tq: sending batch of size 1**
trace git-lfs: fetch gif/atom-undo.gif [b9f86fab477109565871ced361ba69f2425a91fbe6057fa7a9629a8d536d7c71]
**trace git-lfs: ssh: git@github.com git-lfs-authenticate github/git-lfs-test.git download**
trace git-lfs: api: batch 1 files
trace git-lfs: HTTP: POST https://lfs.github.com/github/git-lfs-test/objects/batch
trace git-lfs: HTTP: 200
trace git-lfs: HTTP: LOTS OF JSON
trace git-lfs: tq: starting transfer adapter "basic"
Git LFS: (0 of 6 files) 0 B / 818.95 KB                                                                                                                                                                                                                                                                                                                                    trace git-lfs: HTTP: GET https://github-cloud.s3.amazonaws.com/alambic/media/111976139/02/63/0263829989b6fd954f72baaf2fc64bc2e2f01d692d4de72986ea808f6e99813f
Git LFS: (0 of 6 files) 0 B / 818.95 KB                                                                                                                                                                                                                                                                                                                                    trace git-lfs: HTTP: 200
**trace git-lfs: tq: sending batch of size 1**
trace git-lfs: fetch gif/droidtocat.gif [d1c8fab51418ef587fcf5dd8e73c60b9700704e2f8f5292ea12ec27c285b23a3]
**trace git-lfs: ssh: git@github.com git-lfs-authenticate github/git-lfs-test.git download**
trace git-lfs: api: batch 1 files
trace git-lfs: HTTP: POST https://lfs.github.com/github/git-lfs-test/objects/batch
trace git-lfs: HTTP: 200
trace git-lfs: HTTP: LOTS OF JSON

And the cached output:

> $ git config lfs.cachecredentials 1
$ rm -rf .git/lfs/objects && GIT_TRACE=1 git lfs fetch
...
**trace git-lfs: tq: sending batch of size 1**
trace git-lfs: fetch gif/atom-undo.gif [b9f86fab477109565871ced361ba69f2425a91fbe6057fa7a9629a8d536d7c71]
**trace git-lfs: ssh: git@github.com git-lfs-authenticate github/git-lfs-test.git download**
trace git-lfs: api: batch 1 files
trace git-lfs: HTTP: POST https://lfs.github.com/github/git-lfs-test/objects/batch
trace git-lfs: HTTP: 200
trace git-lfs: HTTP: LOTS OF JSON
trace git-lfs: tq: starting transfer adapter "basic"
Git LFS: (0 of 6 files) 0 B / 818.95 KB                                                                                                                                                                                                                                                                                                                                    trace git-lfs: HTTP: GET https://github-cloud.s3.amazonaws.com/alambic/media/111976139/02/63/0263829989b6fd954f72baaf2fc64bc2e2f01d692d4de72986ea808f6e99813f
Git LFS: (0 of 6 files) 0 B / 818.95 KB                                                                                                                                                                                                                                                                                                                                    trace git-lfs: HTTP: 200
**trace git-lfs: tq: sending batch of size 1**
trace git-lfs: fetch gif/droidtocat.gif [d1c8fab51418ef587fcf5dd8e73c60b9700704e2f8f5292ea12ec27c285b23a3]
**trace git-lfs: ssh cache: git@github.com git-lfs-authenticate github/git-lfs-test.git download**
trace git-lfs: api: batch 1 files
trace git-lfs: HTTP: POST https://lfs.github.com/github/git-lfs-test/objects/batch
trace git-lfs: HTTP: 200
trace git-lfs: HTTP: LOTS OF JSON

Notice the  `ssh cache:` message ^