### PR TITLE
commands,tq: specialized logging for missing/corrupt objects

### DIFF
--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -286,7 +286,7 @@ func (c *uploadContext) Await() {
 	}
 
 	if len(missing) > 0 || len(corrupt) > 0 {
-		Print("Push completed with missing objects:")
+		Print("LFS upload failed:")
 		for name, oid := range missing {
 			Print("  (missing) %s (%s)", name, oid)
 		}

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -183,7 +183,9 @@ begin_test "pre-push with missing pointer not on server"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" missing-pointer
 
-  echo "$(pointer "7aa7a5359173d05b63cfd682e3c38487f3cb4f7f1d60659fe59fab1505977d4c" 4)" > new.dat
+  oid="7aa7a5359173d05b63cfd682e3c38487f3cb4f7f1d60659fe59fab1505977d4c"
+
+  echo "$(pointer "$oid" 4)" > new.dat
   git add new.dat
   git commit -m "add new pointer"
 
@@ -193,7 +195,8 @@ begin_test "pre-push with missing pointer not on server"
     git lfs pre-push origin "$GITSERVER/$reponame" 2>&1 |
     tee push.log
   set -e
-  grep "Unable to find object (7aa7a5359173d05b63cfd682e3c38487f3cb4f7f1d60659fe59fab1505977d4c) locally." push.log
+
+  grep "  (missing) new.dat ($oid)" push.log
 )
 end_test
 

--- a/test/test-push-missing.sh
+++ b/test/test-push-missing.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+. "test/testlib.sh"
+
+begin_test "push missing objects"
+(
+  set -e
+
+  reponame="push-missing-objects"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  missing="missing"
+  missing_oid="$(calc_oid "$missing")"
+  missing_len="$(printf "$missing" | wc -c | awk '{ print $1 }')"
+  printf "$missing" > missing.dat
+  git add missing.dat
+  git commit -m "add missing.dat"
+
+  corrupt="corrupt"
+  corrupt_oid="$(calc_oid "$corrupt")"
+  corrupt_len="$(printf "$corrupt" | wc -c | awk '{ print $1 }')"
+  printf "$corrupt" > corrupt.dat
+  git add corrupt.dat
+  git commit -m "add corrupt.dat"
+
+  present="present"
+  present_oid="$(calc_oid "$present")"
+  present_len="$(printf "$present" | wc -c | awk '{ print $1 }')"
+  printf "$present" > present.dat
+  git add present.dat
+  git commit -m "add present.dat"
+
+  assert_local_object "$missing_oid" "$missing_len"
+  assert_local_object "$corrupt_oid" "$corrupt_len"
+  assert_local_object "$present_oid" "$present_len"
+
+  delete_local_object "$missing_oid"
+  corrupt_local_object "$corrupt_oid"
+
+  refute_local_object "$missing_oid"
+  refute_local_object "$corrupt_oid" "$corrupt_len"
+  assert_local_object "$present_oid" "$present_len"
+
+  git push origin master 2>&1 | tee push.log
+
+  if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected 'git push origin master' to exit with non-zero code"
+    exit 1
+  fi
+
+  grep "Push completed with missing objects:" push.log
+  grep "  (missing) missing.dat ($missing_oid)" push.log
+  grep "  (corrupt) corrupt.dat ($corrupt_oid)" push.log
+
+  refute_server_object "$reponame" "$missing_oid"
+  refute_server_object "$reponame" "$corrupt_oid"
+  assert_server_object "$reponame" "$present_oid"
+)
+end_test

--- a/test/test-push-missing.sh
+++ b/test/test-push-missing.sh
@@ -53,7 +53,7 @@ begin_test "push missing objects"
     exit 1
   fi
 
-  grep "Push completed with missing objects:" push.log
+  grep "LFS upload failed:" push.log
   grep "  (missing) missing.dat ($missing_oid)" push.log
   grep "  (corrupt) corrupt.dat ($corrupt_oid)" push.log
 

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -38,15 +38,28 @@ assert_local_object() {
   fi
 }
 
-# refute_local_object confirms that an object file is NOT stored for an oid
+# refute_local_object confirms that an object file is NOT stored for an oid.
+# If "$size" is given as the second argument, assert that the file exists _and_
+# that it does _not_ the expected size
+#
 # $ refute_local_object "some-oid"
+# $ refute_local_object "some-oid" "123"
 refute_local_object() {
   local oid="$1"
+  local size="$2"
   local cfg=`git lfs env | grep LocalMediaDir`
   local regex="LocalMediaDir=(\S+)"
   local f="${cfg:14}/${oid:0:2}/${oid:2:2}/$oid"
   if [ -e $f ]; then
-    exit 1
+    if [ -z "$size" ]; then
+      exit 1
+    fi
+
+    actual_size="$(wc -c < "$f" | awk '{ print $1 }')"
+    if [ "$size" -eq "$actual_size" ]; then
+      echo >&2 "fatal: expected object $oid not to have size: $size"
+      exit 1
+    fi
   fi
 }
 

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -72,6 +72,15 @@ delete_local_object() {
   rm "$f"
 }
 
+# corrupt_local_object corrupts the local storage for an oid
+# $ corrupt_local_object "some-oid"
+corrupt_local_object() {
+  local oid="$1"
+  local cfg=`git lfs env | grep LocalMediaDir`
+  local f="${cfg:14}/${oid:0:2}/${oid:2:2}/$oid"
+  cp /dev/null "$f"
+}
+
 
 # check that the object does not exist in the git lfs server. HTTP log is
 # written to http.log. JSON output is written to http.json.

--- a/tq/errors.go
+++ b/tq/errors.go
@@ -1,0 +1,29 @@
+package tq
+
+import "fmt"
+
+type MalformedObjectError struct {
+	Name string
+	Oid  string
+
+	missing bool
+}
+
+func newObjectMissingError(name, oid string) error {
+	return &MalformedObjectError{Name: name, Oid: oid, missing: true}
+}
+
+func newCorruptObjectError(name, oid string) error {
+	return &MalformedObjectError{Name: name, Oid: oid, missing: false}
+}
+
+func (e MalformedObjectError) Missing() bool { return e.missing }
+
+func (e MalformedObjectError) Corrupt() bool { return !e.Missing() }
+
+func (e MalformedObjectError) Error() string {
+	if e.Corrupt() {
+		return fmt.Sprintf("corrupt object: %s (%s)", e.Name, e.Oid)
+	}
+	return fmt.Sprintf("missing object: %s (%s)", e.Name, e.Oid)
+}

--- a/tq/errors_test.go
+++ b/tq/errors_test.go
@@ -1,0 +1,23 @@
+package tq
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMissingObjectErrorsAreRecognizable(t *testing.T) {
+	err := newObjectMissingError("some-name", "some-oid").(*MalformedObjectError)
+
+	assert.Equal(t, "some-name", err.Name)
+	assert.Equal(t, "some-oid", err.Oid)
+	assert.True(t, err.Missing())
+}
+
+func TestCorruptObjectErrorsAreRecognizable(t *testing.T) {
+	err := newCorruptObjectError("some-name", "some-oid").(*MalformedObjectError)
+
+	assert.Equal(t, "some-name", err.Name)
+	assert.Equal(t, "some-oid", err.Oid)
+	assert.True(t, err.Corrupt())
+}


### PR DESCRIPTION
This pull request is a continuation of https://github.com/git-lfs/git-lfs/pull/2078 following up on https://github.com/git-lfs/git-lfs/pull/2078#issuecomment-289071404 with https://github.com/git-lfs/git-lfs/pull/2078#issuecomment-289078761.

Turns out that our `*tq.TransferQueue` already had some early returns built in for objects that are a) missing or b) corrupt. I taught the `*tq.TransferQueue` and the `*commands.uploader` types to recognize and log them appropriately.

From https://github.com/git-lfs/git-lfs/pull/2078#issuecomment-289078761, this allows:

> - All of the LFS objects that do exist to travel to the remote as early as possible
> - A user to see all of the missing objects in one push instead of getting one error at a time
> - A user to "fix" the missing object later, and have a smaller push size when they complete the fix.

With three files, `missing.dat`, `corrupted.dat`, and `present.dat`, the output looks like this:

```bash
~/g/git-lfs-test (master) $ git push origin master
Locking support detected on remote "origin". Consider enabling it with:
  $ git config 'lfs.http://127.0.0.1:61507/push-missing-objects.git/info/lfs.locksverify' true
Git LFS: (1 of 3 files) 7 B / 21 B
Push completed with missing objects:
  (missing) missing.dat (ffa63583dfa6706b87d284b86b0d693a161e4840aad2c5cf6b5d27c3b9621f7d)
  (corrupt) corrupt.dat (11d510e067d2cdcd7559bd86d27a2f4c20babd43670346b97af99b522c1f0075)
error: failed to push some refs to 'http://127.0.0.1:61507/push-missing-objects'
```

- `missing.dat` & `corrupted.dat` are not uploaded
- `present.dat` is uploaded to the LFS server
- No Git blobs are uploaded to the Git server

---

/cc @git-lfs/core @shana