### PR TITLE
tq/verify: authenticate verify requests if required

### DIFF
--- a/test/test-verify.sh
+++ b/test/test-verify.sh
@@ -22,7 +22,9 @@ begin_test "verify with retries"
   git add a.dat
   git commit -m "add a.dat"
 
-  GIT_TRACE=1 git push origin master 2>&1 | tee push.log
+  GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push origin master 2>&1 | tee push.log
+
+  grep "Authorization: Basic * * * * *" push.log
 
   [ "0" -eq "${PIPESTATUS[0]}" ]
   [ "2" -eq "$(grep -c "verify $contents_short_oid attempt" push.log)" ]
@@ -49,7 +51,9 @@ begin_test "verify with retries (success without retry)"
   git add a.dat
   git commit -m "add a.dat"
 
-  GIT_TRACE=1 git push origin master 2>&1 | tee push.log
+  GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push origin master 2>&1 | tee push.log
+
+  grep "Authorization: Basic * * * * *" push.log
 
   [ "0" -eq "${PIPESTATUS[0]}" ]
   [ "1" -eq "$(grep -c "verify $contents_short_oid attempt" push.log)" ]
@@ -111,7 +115,9 @@ begin_test "verify with retries (bad .gitconfig)"
   git add a.dat
   git commit -m "add a.dat"
 
-  GIT_TRACE=1 git push origin master 2>&1 | tee push.log
+  GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push origin master 2>&1 | tee push.log
+
+  grep "Authorization: Basic * * * * *" push.log
 
   [ "0" -eq "${PIPESTATUS[0]}" ]
   [ "2" -eq "$(grep -c "verify $contents_short_oid attempt" push.log)" ]

--- a/tq/basic_upload.go
+++ b/tq/basic_upload.go
@@ -131,7 +131,7 @@ func (a *basicUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb Progres
 	io.Copy(ioutil.Discard, res.Body)
 	res.Body.Close()
 
-	return verifyUpload(a.apiClient, t)
+	return verifyUpload(a.apiClient, a.remote, t)
 }
 
 // startCallbackReader is a reader wrapper which calls a function as soon as the

--- a/tq/custom.go
+++ b/tq/custom.go
@@ -315,7 +315,7 @@ func (a *customAdapter) DoTransfer(ctx interface{}, t *Transfer, cb ProgressCall
 					return fmt.Errorf("Failed to copy downloaded file: %v", err)
 				}
 			} else if a.direction == Upload {
-				if err = verifyUpload(a.apiClient, t); err != nil {
+				if err = verifyUpload(a.apiClient, a.remote, t); err != nil {
 					return err
 				}
 			}

--- a/tq/tus_upload.go
+++ b/tq/tus_upload.go
@@ -159,7 +159,7 @@ func (a *tusUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb ProgressC
 	io.Copy(ioutil.Discard, res.Body)
 	res.Body.Close()
 
-	return verifyUpload(a.apiClient, t)
+	return verifyUpload(a.apiClient, a.remote, t)
 }
 
 func configureTusAdapter(m *Manifest) {

--- a/tq/verify.go
+++ b/tq/verify.go
@@ -47,8 +47,13 @@ func verifyUpload(c *lfsapi.Client, remote string, t *Transfer) error {
 		tracerx.Printf("tq: verify %s attempt #%d (max: %d)", t.Oid[:7], i, mv)
 
 		var res *http.Response
+		if t.Authenticated {
+			res, err = c.Do(req)
+		} else {
+			res, err = c.DoWithAuth(remote, req)
+		}
 
-		if res, err = c.Do(req); err != nil {
+		if err != nil {
 			tracerx.Printf("tq: verify err: %+v", err.Error())
 		} else {
 			err = res.Body.Close()

--- a/tq/verify.go
+++ b/tq/verify.go
@@ -13,7 +13,7 @@ const (
 	defaultMaxVerifyAttempts = 3
 )
 
-func verifyUpload(c *lfsapi.Client, t *Transfer) error {
+func verifyUpload(c *lfsapi.Client, remote string, t *Transfer) error {
 	action, err := t.Actions.Get("verify")
 	if err != nil {
 		return err

--- a/tq/verify_test.go
+++ b/tq/verify_test.go
@@ -19,7 +19,7 @@ func TestVerifyWithoutAction(t *testing.T) {
 		Size: 123,
 	}
 
-	assert.Nil(t, verifyUpload(c, tr))
+	assert.Nil(t, verifyUpload(c, "origin", tr))
 }
 
 func TestVerifySuccess(t *testing.T) {
@@ -61,6 +61,6 @@ func TestVerifySuccess(t *testing.T) {
 		},
 	}
 
-	assert.Nil(t, verifyUpload(c, tr))
+	assert.Nil(t, verifyUpload(c, "origin", tr))
 	assert.EqualValues(t, 1, called)
 }


### PR DESCRIPTION
This pull request authenticates verify requests from `tq.verifyUpload()` if the transfer is not already authenticated.

---

/cc @git-lfs/core https://github.com/git-lfs/git-lfs/issues/2016
Closes: https://github.com/git-lfs/git-lfs/issues/2016