### PR TITLE
lfsapi/auth: optionally prepend an empty scheme to Git remote URLs

### DIFF
--- a/lfsapi/auth.go
+++ b/lfsapi/auth.go
@@ -215,7 +215,9 @@ func getCredURLForAPI(ef EndpointFinder, operation, remote string, apiEndpoint E
 
 	if len(remote) > 0 {
 		if u := ef.GitRemoteURL(remote, operation == "upload"); u != "" {
-			gitRemoteURL, err := url.Parse(u)
+			schemedUrl, _ := prependEmptySchemeIfAbsent(u)
+
+			gitRemoteURL, err := url.Parse(schemedUrl)
 			if err != nil {
 				return nil, err
 			}
@@ -233,6 +235,46 @@ func getCredURLForAPI(ef EndpointFinder, operation, remote string, apiEndpoint E
 	}
 
 	return apiURL, nil
+}
+
+// prependEmptySchemeIfAbsent prepends an empty scheme "//" if none was found in
+// the URL in order to satisfy RFC 3986 §3.3, and `net/url.Parse()`.
+//
+// It returns a string parse-able with `net/url.Parse()` and a boolean whether
+// or not an empty scheme was added.
+func prependEmptySchemeIfAbsent(u string) (string, bool) {
+	if hasScheme(u) {
+		return u, false
+	}
+
+	colon := strings.Index(u, ":")
+	slash := strings.Index(u, "/")
+
+	if colon >= 0 && (slash < 0 || colon < slash) {
+		// First path segment has a colon, assumed that it's a
+		// scheme-less URL. Append an empty scheme on top to
+		// satisfy RFC 3986 §3.3, and `net/url.Parse()`.
+		return fmt.Sprintf("//%s", u), true
+	}
+	return u, true
+}
+
+var (
+	// supportedSchemes is the list of URL schemes the `lfsapi` package
+	// supports.
+	supportedSchemes = []string{"ssh", "http", "https"}
+)
+
+// hasScheme returns whether or not a given string (taken to represent a RFC
+// 3986 URL) has a scheme that is supported by the `lfsapi` package.
+func hasScheme(what string) bool {
+	for _, scheme := range supportedSchemes {
+		if strings.HasPrefix(what, fmt.Sprintf("%s://", scheme)) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func requestHasAuth(req *http.Request) bool {

--- a/lfsapi/auth_test.go
+++ b/lfsapi/auth_test.go
@@ -492,6 +492,30 @@ func TestGetCreds(t *testing.T) {
 				},
 			},
 		},
+		"bare ssh URI": getCredsTest{
+			Remote: "origin",
+			Method: "POST",
+			Href:   "https://git-server.com/repo/lfs/objects/batch",
+			Config: map[string]string{
+				"lfs.url": "https://git-server.com/repo/lfs",
+				"lfs.https://git-server.com/repo/lfs.access": "basic",
+
+				"remote.origin.url": "git@git-server.com:repo.git",
+			},
+			Expected: getCredsExpected{
+				Access:        BasicAccess,
+				Endpoint:      "https://git-server.com/repo/lfs",
+				Authorization: basicAuth("git-server.com", "monkey"),
+				CredsURL:      "https://git-server.com/repo/lfs",
+				Creds: map[string]string{
+					"host":     "git-server.com",
+					"password": "monkey",
+					"path":     "repo/lfs",
+					"protocol": "https",
+					"username": "git-server.com",
+				},
+			},
+		},
 	}
 
 	credHelper := &fakeCredentialFiller{}


### PR DESCRIPTION
This pull request fixes a regression where Git remote URLs were scheme-less and have a `:` in the first path segment. This behavior was allowed in Go prior to 1.8 (the first tag to include https://github.com/golang/go/commit/c5ccbdd22bdbdc43d541b7e7d4ed66ceb559030e), but was since corrected in order to comply with [RFC 3986 §3.3](https://www.ietf.org/rfc/rfc3986.txt):

> In addition, a URI reference (Section 4.1) may be a relative-path reference, in which case the first path segment cannot contain a colon (":") character.

Since Git hosts use the `git@host.com:repo.git` convention, this is an illegal URL according to that section of the RFC.

In Go 1.7, this used to be parsed as:

```bash
~/g/git-lfs (parse-git-remotes!) $ go version
go version go1.7.5 darwin/amd64
~/g/git-lfs (parse-git-remotes!) $ go run schemeless.go
Scheme: "", URL: git@github.com:git-lfs/git-lfs.git
```

But as of Go 1.8, this is not parse-able as a `*net/url.URL`, and an error is returned instead:

```bash
~/g/git-lfs (parse-git-remotes!) $ go version
go version go1.8 darwin/amd64
~/g/git-lfs (parse-git-remotes!) $ go run schemeless.go
2017/03/27 17:26:02 parse git@github.com:git-lfs/git-lfs.git: first path segment in URL cannot contain colon
exit status 1
```

using this Go program:

```go
package main

import (
	"fmt"
	"log"
	"net/url"
)

func main() {
	u, err := url.Parse("git@github.com:git-lfs/git-lfs.git")
	if err != nil {
		log.Fatal(err)
	}

	fmt.Printf("Scheme: %q, URL: %v\n", u.Scheme, u)
}
```

This pull request introduces a `prependEmptySchemeIfAbsent` to turn non-compliant URLs like `git@github.com:repo.git` into `//git@github.com:repo.git` instead. This is semantically equivalent to the behavior prior to https://github.com/golang/go/commit/c5ccbdd22bdbdc43d541b7e7d4ed66ceb559030e.

---

/cc @git-lfs/core #2029 