### PR TITLE
Backport #2090 for v2.0.x: lfsapi/auth: optionally prepend an empty scheme to Git remote URLs

### DIFF
--- a/lfsapi/auth.go
+++ b/lfsapi/auth.go
@@ -215,7 +215,9 @@ func getCredURLForAPI(ef EndpointFinder, operation, remote string, apiEndpoint E
 
 	if len(remote) > 0 {
 		if u := ef.GitRemoteURL(remote, operation == "upload"); u != "" {
-			gitRemoteURL, err := url.Parse(u)
+			schemedUrl, _ := prependEmptySchemeIfAbsent(u)
+
+			gitRemoteURL, err := url.Parse(schemedUrl)
 			if err != nil {
 				return nil, err
 			}
@@ -233,6 +235,46 @@ func getCredURLForAPI(ef EndpointFinder, operation, remote string, apiEndpoint E
 	}
 
 	return apiURL, nil
+}
+
+// prependEmptySchemeIfAbsent prepends an empty scheme "//" if none was found in
+// the URL in order to satisfy RFC 3986 §3.3, and `net/url.Parse()`.
+//
+// It returns a string parse-able with `net/url.Parse()` and a boolean whether
+// or not an empty scheme was added.
+func prependEmptySchemeIfAbsent(u string) (string, bool) {
+	if hasScheme(u) {
+		return u, false
+	}
+
+	colon := strings.Index(u, ":")
+	slash := strings.Index(u, "/")
+
+	if colon >= 0 && (slash < 0 || colon < slash) {
+		// First path segment has a colon, assumed that it's a
+		// scheme-less URL. Append an empty scheme on top to
+		// satisfy RFC 3986 §3.3, and `net/url.Parse()`.
+		return fmt.Sprintf("//%s", u), true
+	}
+	return u, true
+}
+
+var (
+	// supportedSchemes is the list of URL schemes the `lfsapi` package
+	// supports.
+	supportedSchemes = []string{"ssh", "http", "https"}
+)
+
+// hasScheme returns whether or not a given string (taken to represent a RFC
+// 3986 URL) has a scheme that is supported by the `lfsapi` package.
+func hasScheme(what string) bool {
+	for _, scheme := range supportedSchemes {
+		if strings.HasPrefix(what, fmt.Sprintf("%s://", scheme)) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func requestHasAuth(req *http.Request) bool {

--- a/lfsapi/auth_test.go
+++ b/lfsapi/auth_test.go
@@ -492,6 +492,30 @@ func TestGetCreds(t *testing.T) {
 				},
 			},
 		},
+		"bare ssh URI": getCredsTest{
+			Remote: "origin",
+			Method: "POST",
+			Href:   "https://git-server.com/repo/lfs/objects/batch",
+			Config: map[string]string{
+				"lfs.url": "https://git-server.com/repo/lfs",
+				"lfs.https://git-server.com/repo/lfs.access": "basic",
+
+				"remote.origin.url": "git@git-server.com:repo.git",
+			},
+			Expected: getCredsExpected{
+				Access:        BasicAccess,
+				Endpoint:      "https://git-server.com/repo/lfs",
+				Authorization: basicAuth("git-server.com", "monkey"),
+				CredsURL:      "https://git-server.com/repo/lfs",
+				Creds: map[string]string{
+					"host":     "git-server.com",
+					"password": "monkey",
+					"path":     "repo/lfs",
+					"protocol": "https",
+					"username": "git-server.com",
+				},
+			},
+		},
 	}
 
 	credHelper := &fakeCredentialFiller{}


### PR DESCRIPTION
This backports #2090.