### PR TITLE
Backport #2028 for v2.0.x: Some minor improvements in the locking API documentation

### DIFF
--- a/docs/api/locking.md
+++ b/docs/api/locking.md
@@ -51,10 +51,10 @@ relative to the root of the repository working directory.
 Successful responses return the created lock:
 
 * `id` - String ID of the Lock. Git LFS doesn't enforce what type of ID is used,
-as long as it's returned a string.
+as long as it's returned as a string.
 * `path` - String path name of the locked file. This should be relative to the
 root of the repository working directory.
-* `locked_at` - The string ISO 8601 formatted timestamp the lock was created.
+* `locked_at` - The timestamp the lock was created, as an ISO 8601 formatted string.
 * `owner` - The name of the user that created the Lock. This should be set from
 the user credentials posted when creating the lock.
 
@@ -131,7 +131,7 @@ errors.
 // HTTP/1.1 500 Internal server error
 // Content-Type: application/vnd.git-lfs+json
 {
-  "message": "already created lock",
+  "message": "internal server error",
   "documentation_url": "https://lfs-server.com/docs/errors",
   "request_id": "123"
 }


### PR DESCRIPTION
This backports #2028.