### PR TITLE
Backport #2020 for v2.0.x: Add an example on how to write a `.lfsconfig` file

### DIFF
--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -264,6 +264,12 @@ be scoped inside the configuration for a remote.
   The default is `true`; you can disable this behaviour and have all files
   writeable by setting either variable to 0, 'no' or 'false'.
 
+## EXAMPLES
+
+*  Configure a custom LFS endpoint for your repository:
+
+  `git config -f .lfsconfig lfs.url https://lfs.example.com/foo/bar/info/lfs`
+
 ## SEE ALSO
 
 git-config(1), git-lfs-install(1), gitattributes(5)


### PR DESCRIPTION
This backports #2020.