### PR TITLE
locking: send locks limit to server

### DIFF
--- a/locking/locks.go
+++ b/locking/locks.go
@@ -259,7 +259,7 @@ func (c *Client) searchRemoteLocks(filter map[string]string, limit int) ([]Lock,
 	for k, v := range filter {
 		apifilters = append(apifilters, lockFilter{Property: k, Value: v})
 	}
-	query := &lockSearchRequest{Filters: apifilters}
+	query := &lockSearchRequest{Filters: apifilters, Limit: limit}
 	for {
 		list, _, err := c.client.Search(c.Remote, query)
 		if err != nil {

--- a/test/cmd/lfstest-gitserver.go
+++ b/test/cmd/lfstest-gitserver.go
@@ -938,9 +938,8 @@ func getFilteredLocks(repo, path, cursor, limit string) ([]Lock, string, error) 
 			return nil, "", nil
 		}
 
-		locks = locks[:size]
 		if size+1 < len(locks) {
-			return locks, locks[size+1].Id, nil
+			return locks[:size], locks[size+1].Id, nil
 		}
 	}
 


### PR DESCRIPTION
This pull request attaches the client-specified limit of the number of locks it'd like returned to the LFS server.

This is in conjunction with the [client-side logic]() we have to prevent returning too many locks. These two behaviors work fine together, since the client limiting wont kick in until the server sends more than the expected number of locks.

Closes: https://github.com/git-lfs/git-lfs/issues/2106

---

/cc @git-lfs/core https://github.com/git-lfs/git-lfs/issues/2106