### PR TITLE
commands,locking: don't disable locking for auth errors during verify

### DIFF
--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -124,13 +124,15 @@ func verifyLocks(remote string) (ours, theirs []locking.Lock) {
 	if err != nil {
 		if errors.IsNotImplementedError(err) {
 			disableFor(endpoint)
-		} else {
+		} else if !errors.IsAuthError(err) {
 			Print("Remote %q does not support the LFS locking API. Consider disabling it with:", remote)
 			Print("  $ git config 'lfs.%s.locksverify' false", endpoint.Url)
 
 			if state == verifyStateEnabled {
 				ExitWithError(err)
 			}
+		} else {
+			ExitWithError(err)
 		}
 	} else if state == verifyStateUnknown {
 		Print("Locking support detected on remote %q. Consider enabling it with:", remote)

--- a/locking/locks.go
+++ b/locking/locks.go
@@ -196,6 +196,8 @@ func (c *Client) VerifiableLocks(limit int) (ourLocks, theirLocks []Lock, err er
 			switch res.StatusCode {
 			case http.StatusNotFound, http.StatusNotImplemented:
 				return ourLocks, theirLocks, errors.NewNotImplementedError(err)
+			case http.StatusForbidden:
+				return ourLocks, theirLocks, errors.NewAuthError(err)
 			}
 		}
 

--- a/locking/locks.go
+++ b/locking/locks.go
@@ -192,8 +192,11 @@ func (c *Client) VerifiableLocks(limit int) (ourLocks, theirLocks []Lock, err er
 
 	for {
 		list, res, err := c.client.SearchVerifiable(c.Remote, body)
-		if res != nil && res.StatusCode == http.StatusNotImplemented {
-			return ourLocks, theirLocks, errors.NewNotImplementedError(err)
+		if res != nil {
+			switch res.StatusCode {
+			case http.StatusNotFound, http.StatusNotImplemented:
+				return ourLocks, theirLocks, errors.NewNotImplementedError(err)
+			}
 		}
 
 		if err != nil {

--- a/test/cmd/lfstest-gitserver.go
+++ b/test/cmd/lfstest-gitserver.go
@@ -1044,6 +1044,10 @@ func locksHandler(w http.ResponseWriter, r *http.Request, repo string) {
 				w.WriteHeader(501)
 				return
 			}
+			if strings.HasSuffix(repo, "verify-403") {
+				w.WriteHeader(403)
+				return
+			}
 
 			switch repo {
 			case "pre_push_locks_verify_404":


### PR DESCRIPTION
This pull request special-cases authentication errors when printing out the:

```
Remote ... does not support the LFS locking API. 
```

message.

When implementing this change, I started with a `errors.IsUserError(...)` helper function to separate the two cases:

1. The server doesn't support locking and returned an error, or...
2. The server returned an error because of a problem in the request at the client end.

`IsUserError()` felt overly generic, so I started narrowing down what cases could actually cause that, and found that authentication was the only one that came to mind. This check purposefully excludes 401s from the list of auth-based HTTP response codes.

It also checks for 404s when constructing an `errors.NewNotImplementedError(...)`, since that is a valid signal that the server doesn't support the locking API, according to [our most recent documentation](https://github.com/git-lfs/git-lfs/blob/v2.0.1/docs/api/locking.md#not-found-response).

Closes: https://github.com/git-lfs/git-lfs/issues/2104

---

/cc @git-lfs/core https://github.com/git-lfs/git-lfs/issues/2104