### PR TITLE
git: implement `*git.ObjectScanner` type 

### DIFF
--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -40,7 +40,7 @@ func statusCommand(cmd *cobra.Command, args []string) {
 		ExitWithError(err)
 	}
 
-	scanner, err := lfs.NewCatFileBatchScanner()
+	scanner, err := lfs.NewPointerScanner()
 	if err != nil {
 		ExitWithError(err)
 	}
@@ -69,7 +69,7 @@ func statusCommand(cmd *cobra.Command, args []string) {
 
 var z40 = regexp.MustCompile(`\^?0{40}`)
 
-func formatBlobInfo(s *lfs.CatFileBatchScanner, entry *lfs.DiffIndexEntry) string {
+func formatBlobInfo(s *lfs.PointerScanner, entry *lfs.DiffIndexEntry) string {
 	fromSha, fromSrc, err := blobInfoFrom(s, entry)
 	if err != nil {
 		ExitWithError(err)
@@ -89,7 +89,7 @@ func formatBlobInfo(s *lfs.CatFileBatchScanner, entry *lfs.DiffIndexEntry) strin
 	return fmt.Sprintf("%s -> %s", from, to)
 }
 
-func blobInfoFrom(s *lfs.CatFileBatchScanner, entry *lfs.DiffIndexEntry) (sha, from string, err error) {
+func blobInfoFrom(s *lfs.PointerScanner, entry *lfs.DiffIndexEntry) (sha, from string, err error) {
 	var blobSha string = entry.SrcSha
 	if z40.MatchString(blobSha) {
 		blobSha = entry.DstSha
@@ -98,7 +98,7 @@ func blobInfoFrom(s *lfs.CatFileBatchScanner, entry *lfs.DiffIndexEntry) (sha, f
 	return blobInfo(s, blobSha, entry.SrcName)
 }
 
-func blobInfoTo(s *lfs.CatFileBatchScanner, entry *lfs.DiffIndexEntry) (sha, from string, err error) {
+func blobInfoTo(s *lfs.PointerScanner, entry *lfs.DiffIndexEntry) (sha, from string, err error) {
 	var name string = entry.DstName
 	if len(name) == 0 {
 		name = entry.SrcName
@@ -107,7 +107,7 @@ func blobInfoTo(s *lfs.CatFileBatchScanner, entry *lfs.DiffIndexEntry) (sha, fro
 	return blobInfo(s, entry.DstSha, name)
 }
 
-func blobInfo(s *lfs.CatFileBatchScanner, blobSha, name string) (sha, from string, err error) {
+func blobInfo(s *lfs.PointerScanner, blobSha, name string) (sha, from string, err error) {
 	if !z40.MatchString(blobSha) {
 		s.Scan(blobSha)
 		if err := s.Err(); err != nil {

--- a/git/object_scanner.go
+++ b/git/object_scanner.go
@@ -1,0 +1,216 @@
+package git
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os/exec"
+	"strconv"
+
+	"github.com/git-lfs/git-lfs/errors"
+	"github.com/rubyist/tracerx"
+)
+
+// object represents a generic Git object of any type.
+type object struct {
+	// Contents reads Git's internal object representation.
+	Contents *io.LimitedReader
+	// Oid is the ID of the object.
+	Oid string
+	// Size is the size in bytes of the object.
+	Size int64
+	// Type is the type of the object being held.
+	Type string
+}
+
+// ObjectScanner is a scanner type that scans for Git objects reference-able in
+// Git's object database by their unique OID.
+type ObjectScanner struct {
+	// object is the object that the ObjectScanner last scanned, or nil.
+	object *object
+	// err is the error (if any) that the ObjectScanner encountered during
+	// its last scan, or nil.
+	err error
+
+	// from is the buffered source of input to the *ObjectScanner. It
+	// expects input in the form described by
+	// https://git-scm.com/docs/git-cat-file.
+	from *bufio.Reader
+	// to is a writer which accepts the object's OID to be scanned.
+	to io.Writer
+	// closeFn is an optional function that is run before the ObjectScanner
+	// is closed. It is designated to clean up and close any resources held
+	// by the ObjectScanner during runtime.
+	closeFn func() error
+}
+
+// NewObjectScanner constructs a new instance of the `*ObjectScanner` type and
+// returns it. It backs the ObjectScanner with an invocation of the `git
+// cat-file --batch` command. If any errors were encountered while starting that
+// command, they will be returned immediately.
+//
+// Otherwise, an `*ObjectScanner` is returned with no error.
+func NewObjectScanner() (*ObjectScanner, error) {
+	cmd := exec.Command("git", "cat-file", "--batch")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, errors.Wrap(err, "open stdout")
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, errors.Wrap(err, "open stdin")
+	}
+
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, errors.Wrap(err, "open stderr")
+	}
+
+	closeFn := func() error {
+		if err := stdin.Close(); err != nil {
+			return err
+		}
+
+		msg, _ := ioutil.ReadAll(stderr)
+		if err = cmd.Wait(); err != nil {
+			return errors.Errorf("Error in git cat-file --batch: %v %v", err, string(msg))
+		}
+
+		return nil
+	}
+
+	tracerx.Printf("run_command: git cat-file --batch")
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	return &ObjectScanner{
+		from: bufio.NewReaderSize(stdout, 16384),
+		to:   stdin,
+
+		closeFn: closeFn,
+	}, nil
+}
+
+// NewObjectScannerFrom returns a new `*ObjectScanner` populated with data from
+// the given `io.Reader`, "r". It supplies no close function, and discards any
+// input given to the Scan() function.
+func NewObjectScannerFrom(r io.Reader) *ObjectScanner {
+	return &ObjectScanner{
+		from: bufio.NewReader(r),
+		to:   ioutil.Discard,
+	}
+}
+
+// Scan scans for a particular object given by the "oid" parameter. Once the
+// scan is complete, the Contents(), Sha1(), Size() and Type() functions may be
+// called and will return data corresponding to the given OID.
+//
+// Scan() returns whether the scan was successful, or in other words, whether or
+// not the scanner can continue to progress.
+func (s *ObjectScanner) Scan(oid string) bool {
+	if err := s.reset(); err != nil {
+		s.err = err
+		return false
+	}
+
+	obj, err := s.scan(oid)
+	s.object = obj
+
+	if err != nil {
+		if err != io.EOF {
+			s.err = err
+		}
+		return false
+	}
+	return true
+}
+
+// Close closes and frees any resources owned by the *ObjectScanner that it is
+// called upon. If there were any errors in freeing that (those) resource(s), it
+// it will be returned, otherwise nil.
+func (s *ObjectScanner) Close() error {
+	if s.closeFn != nil {
+		return s.closeFn()
+	}
+	return nil
+}
+
+// Contents returns an io.Reader which reads Git's representation of the object
+// that was last scanned for.
+func (s *ObjectScanner) Contents() io.Reader {
+	return s.object.Contents
+}
+
+// Sha1 returns the SHA1 object ID of the object that was last scanned for.
+func (s *ObjectScanner) Sha1() string {
+	return s.object.Oid
+}
+
+// Size returns the size in bytes of the object that was last scanned for.
+func (s *ObjectScanner) Size() int64 {
+	return s.object.Size
+}
+
+// Type returns the type of the object that was last scanned for.
+func (s *ObjectScanner) Type() string {
+	return s.object.Type
+}
+
+// Err returns the error (if any) that was encountered during the last Scan()
+// operation.
+func (s *ObjectScanner) Err() error { return s.err }
+
+// reset resets the `*ObjectScanner` to scan again by advancing the reader (if
+// necessary) and clearing both the object and error fields on the
+// `*ObjectScanner` instance.
+func (s *ObjectScanner) reset() error {
+	if s.object != nil {
+		if s.object.Contents != nil {
+			remaining := s.object.Contents.N
+			if _, err := io.CopyN(ioutil.Discard, s.object.Contents, remaining); err != nil {
+				return errors.Wrap(err, "unwind contents")
+			}
+		}
+
+		// Consume extra LF inserted by cat-file
+		if _, err := s.from.ReadByte(); err != nil {
+			return err
+		}
+	}
+
+	s.object, s.err = nil, nil
+
+	return nil
+}
+
+// scan scans for and populates a new Git object given an OID.
+func (s *ObjectScanner) scan(oid string) (*object, error) {
+	if _, err := fmt.Fprintln(s.to, oid); err != nil {
+		return nil, err
+	}
+
+	l, err := s.from.ReadBytes('\n')
+	if err != nil {
+		return nil, err
+	}
+
+	fields := bytes.Fields(l)
+	if len(fields) < 3 {
+		return nil, errors.Errorf("invalid line: %q", l)
+	}
+
+	oid = string(fields[0])
+	typ := string(fields[1])
+	size, _ := strconv.Atoi(string(fields[2]))
+	contents := io.LimitReader(s.from, int64(size))
+
+	return &object{
+		Contents: contents.(*io.LimitedReader),
+		Oid:      oid,
+		Size:     int64(size),
+		Type:     typ,
+	}, nil
+}

--- a/lfs/gitscanner_catfilebatch.go
+++ b/lfs/gitscanner_catfilebatch.go
@@ -17,7 +17,7 @@ import (
 // if that blob is for a locked file. Any errors are sent to errCh. An error is
 // returned if the 'git cat-file' command fails to start.
 func runCatFileBatch(pointerCh chan *WrappedPointer, lockableCh chan string, lockableSet *lockableNameSet, revs *StringChannelWrapper, errCh chan error) error {
-	scanner, err := NewCatFileBatchScanner()
+	scanner, err := NewPointerScanner()
 	if err != nil {
 		return err
 	}
@@ -57,7 +57,7 @@ func runCatFileBatch(pointerCh chan *WrappedPointer, lockableCh chan string, loc
 	return nil
 }
 
-type CatFileBatchScanner struct {
+type PointerScanner struct {
 	scanner *git.ObjectScanner
 
 	blobSha     string
@@ -66,32 +66,32 @@ type CatFileBatchScanner struct {
 	err         error
 }
 
-func NewCatFileBatchScanner() (*CatFileBatchScanner, error) {
+func NewPointerScanner() (*PointerScanner, error) {
 	scanner, err := git.NewObjectScanner()
 	if err != nil {
 		return nil, err
 	}
 
-	return &CatFileBatchScanner{scanner: scanner}, nil
+	return &PointerScanner{scanner: scanner}, nil
 }
 
-func (s *CatFileBatchScanner) BlobSHA() string {
+func (s *PointerScanner) BlobSHA() string {
 	return s.blobSha
 }
 
-func (s *CatFileBatchScanner) ContentsSha() string {
+func (s *PointerScanner) ContentsSha() string {
 	return s.contentsSha
 }
 
-func (s *CatFileBatchScanner) Pointer() *WrappedPointer {
+func (s *PointerScanner) Pointer() *WrappedPointer {
 	return s.pointer
 }
 
-func (s *CatFileBatchScanner) Err() error {
+func (s *PointerScanner) Err() error {
 	return s.err
 }
 
-func (s *CatFileBatchScanner) Scan(sha string) bool {
+func (s *PointerScanner) Scan(sha string) bool {
 	s.pointer, s.err = nil, nil
 	s.blobSha, s.contentsSha = "", ""
 
@@ -110,11 +110,11 @@ func (s *CatFileBatchScanner) Scan(sha string) bool {
 	return true
 }
 
-func (s *CatFileBatchScanner) Close() error {
+func (s *PointerScanner) Close() error {
 	return s.scanner.Close()
 }
 
-func (s *CatFileBatchScanner) next(blob string) (string, string, *WrappedPointer, error) {
+func (s *PointerScanner) next(blob string) (string, string, *WrappedPointer, error) {
 	if !s.scanner.Scan(blob) {
 		if err := s.scanner.Err(); err != nil {
 			return "", "", nil, err

--- a/lfs/gitscanner_catfilebatch.go
+++ b/lfs/gitscanner_catfilebatch.go
@@ -107,7 +107,6 @@ func (s *CatFileBatchScanner) Scan(sha string) bool {
 		return false
 	}
 
-	fmt.Println("returning true with blobsha:", b, "contents:", c, err)
 	return true
 }
 

--- a/lfs/gitscanner_catfilebatchscanner_test.go
+++ b/lfs/gitscanner_catfilebatchscanner_test.go
@@ -1,7 +1,6 @@
 package lfs
 
 import (
-	"bufio"
 	"bytes"
 	"crypto/sha256"
 	"fmt"
@@ -9,6 +8,7 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/git-lfs/git-lfs/git"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -34,7 +34,9 @@ func TestCatFileBatchScannerWithValidOutput(t *testing.T) {
 		return
 	}
 
-	scanner := &CatFileBatchScanner{r: bufio.NewReader(reader)}
+	scanner := &CatFileBatchScanner{
+		scanner: git.NewObjectScannerFrom(reader),
+	}
 
 	for i := 0; i < 5; i++ {
 		assertNextEmptyPointer(t, scanner)
@@ -68,7 +70,9 @@ func TestCatFileBatchScannerWithLargeBlobs(t *testing.T) {
 	fake := bytes.NewBuffer(nil)
 	writeFakeBuffer(t, fake, buf.Bytes(), buf.Len())
 
-	scanner := &CatFileBatchScanner{r: bufio.NewReader(fake)}
+	scanner := &CatFileBatchScanner{
+		scanner: git.NewObjectScannerFrom(fake),
+	}
 
 	require.True(t, scanner.Scan(""))
 	assert.Nil(t, scanner.Pointer())

--- a/lfs/gitscanner_pointerscanner_test.go
+++ b/lfs/gitscanner_pointerscanner_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCatFileBatchScannerWithValidOutput(t *testing.T) {
+func TestPointerScannerWithValidOutput(t *testing.T) {
 	blobs := []*Pointer{
 		&Pointer{
 			Version: "https://git-lfs.github.com/spec/v1",
@@ -34,7 +34,7 @@ func TestCatFileBatchScannerWithValidOutput(t *testing.T) {
 		return
 	}
 
-	scanner := &CatFileBatchScanner{
+	scanner := &PointerScanner{
 		scanner: git.NewObjectScannerFrom(reader),
 	}
 
@@ -59,7 +59,7 @@ func TestCatFileBatchScannerWithValidOutput(t *testing.T) {
 	assert.Nil(t, scanner.Pointer())
 }
 
-func TestCatFileBatchScannerWithLargeBlobs(t *testing.T) {
+func TestPointerScannerWithLargeBlobs(t *testing.T) {
 	buf := bytes.NewBuffer(make([]byte, 0, 1025))
 	sha := sha256.New()
 	rng := rand.New(rand.NewSource(0))
@@ -70,7 +70,7 @@ func TestCatFileBatchScannerWithLargeBlobs(t *testing.T) {
 	fake := bytes.NewBuffer(nil)
 	writeFakeBuffer(t, fake, buf.Bytes(), buf.Len())
 
-	scanner := &CatFileBatchScanner{
+	scanner := &PointerScanner{
 		scanner: git.NewObjectScannerFrom(fake),
 	}
 
@@ -83,7 +83,7 @@ func TestCatFileBatchScannerWithLargeBlobs(t *testing.T) {
 	assert.Nil(t, scanner.Pointer())
 }
 
-func assertNextPointer(t *testing.T, scanner *CatFileBatchScanner, oid string) {
+func assertNextPointer(t *testing.T, scanner *PointerScanner, oid string) {
 	assert.True(t, scanner.Scan(""))
 	assert.Nil(t, scanner.Err())
 
@@ -93,7 +93,7 @@ func assertNextPointer(t *testing.T, scanner *CatFileBatchScanner, oid string) {
 	assert.Equal(t, oid, p.Oid)
 }
 
-func assertNextEmptyPointer(t *testing.T, scanner *CatFileBatchScanner) {
+func assertNextEmptyPointer(t *testing.T, scanner *PointerScanner) {
 	assert.True(t, scanner.Scan(""))
 	assert.Nil(t, scanner.Err())
 

--- a/lfs/gitscanner_tree.go
+++ b/lfs/gitscanner_tree.go
@@ -46,7 +46,7 @@ func runScanTree(cb GitScannerFoundPointer, ref string, filter *filepathfilter.F
 // a Git LFS pointer. treeblobs is a channel over which blob entries
 // will be sent. It returns a channel from which point.Pointers can be read.
 func catFileBatchTree(treeblobs *TreeBlobChannelWrapper) (*PointerChannelWrapper, error) {
-	scanner, err := NewCatFileBatchScanner()
+	scanner, err := NewPointerScanner()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This pull request makes the `*lfs.CatFileBatchScanner` type responsible for only parsing LFS-specific data, and defers reading Git object data to a new type called `*git.ObjectScanner.`

In particular, this is required for #2122 in order to read object contents without running the Git plumbing command: `git-checkout-index.1`.

---

/cc @git-lfs/core for review 👀 