### PR TITLE
lfsapi,tq: relative expiration support

### DIFF
--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -8,7 +8,8 @@ can come from the following places:
 
 Git LFS will add any HTTP headers returned from the `git-lfs-authenticate`
 command to any Batch API requests. If servers are returning expiring tokens,
-they can add an `expires_at` property to hint when the token will expire.
+they can add an `expires_in` (or `expires_at`) property to hint when the token
+will expire.
 
 ```bash
 # Called for remotes like:
@@ -19,6 +20,9 @@ $ ssh git@git-server.com git-lfs-authenticate foo/bar.git download
   "header": {
     "Authorization": "RemoteAuth some-token"
   },
+
+  # optional, for expiring tokens, preferred over expires_at
+  "expires_in": 86400000000000
 
   # optional, for expiring tokens
   "expires_at": "2016-11-10T15:29:07Z"

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -22,7 +22,7 @@ $ ssh git@git-server.com git-lfs-authenticate foo/bar.git download
   },
 
   # optional, for expiring tokens, preferred over expires_at
-  "expires_in": 86400000000000
+  "expires_in": 86400
 
   # optional, for expiring tokens
   "expires_at": "2016-11-10T15:29:07Z"

--- a/docs/api/basic-transfers.md
+++ b/docs/api/basic-transfers.md
@@ -27,7 +27,7 @@ response that looks like this:
           "header": {
             "Authorization": "Basic ..."
           },
-          "expires_in": 86400000000000,
+          "expires_in": 86400,
         }
       }
     }
@@ -68,7 +68,7 @@ are provided by an upload `action` object.
           "header": {
             "Authorization": "Basic ..."
           },
-          "expires_in": 86400000000000,
+          "expires_in": 86400,
         }
       }
     }
@@ -110,14 +110,14 @@ after a successful upload.
           "header": {
             "Authorization": "Basic ..."
           },
-          "expires_in": 86400000000000,
+          "expires_in": 86400,
         },
         "verify": {
           "href": "https://some-verify-callback.com",
           "header": {
             "Authorization": "Basic ..."
           },
-          "expires_in": 86400000000000,
+          "expires_in": 86400,
         }
       }
     }

--- a/docs/api/basic-transfers.md
+++ b/docs/api/basic-transfers.md
@@ -27,7 +27,7 @@ response that looks like this:
           "header": {
             "Authorization": "Basic ..."
           },
-          "expires_at": "2016-11-10T15:29:07Z",
+          "expires_in": 86400000000000,
         }
       }
     }
@@ -68,7 +68,7 @@ are provided by an upload `action` object.
           "header": {
             "Authorization": "Basic ..."
           },
-          "expires_at": "2016-11-10T15:29:07Z",
+          "expires_in": 86400000000000,
         }
       }
     }
@@ -110,14 +110,14 @@ after a successful upload.
           "header": {
             "Authorization": "Basic ..."
           },
-          "expires_at": "2016-11-10T15:29:07Z",
+          "expires_in": 86400000000000,
         },
         "verify": {
           "href": "https://some-verify-callback.com",
           "header": {
             "Authorization": "Basic ..."
           },
-          "expires_at": "2016-11-10T15:29:07Z",
+          "expires_in": 86400000000000,
         }
       }
     }

--- a/docs/api/batch.md
+++ b/docs/api/batch.md
@@ -6,8 +6,8 @@ The Batch API is used to request the ability to transfer LFS objects with the
 LFS server. The Batch URL is built by adding `/objects/batch` to the LFS server
 URL.
 
-Git remote: https://git-server.com/foo/bar
-LFS server: https://git-server.com/foo/bar.git/info/lfs
+Git remote: https://git-server.com/foo/bar</br>
+LFS server: https://git-server.com/foo/bar.git/info/lfs<br>
 Batch API: https://git-server.com/foo/bar.git/info/lfs/objects/batch
 
 See the [Server Discovery doc](./server-discovery.md) for more info on how LFS

--- a/docs/api/batch.md
+++ b/docs/api/batch.md
@@ -6,8 +6,8 @@ The Batch API is used to request the ability to transfer LFS objects with the
 LFS server. The Batch URL is built by adding `/objects/batch` to the LFS server
 URL.
 
-Git remote: https://git-server.com/foo/bar  
-LFS server: https://git-server.com/foo/bar.git/info/lfs  
+Git remote: https://git-server.com/foo/bar
+LFS server: https://git-server.com/foo/bar.git/info/lfs
 Batch API: https://git-server.com/foo/bar.git/info/lfs/objects/batch
 
 See the [Server Discovery doc](./server-discovery.md) for more info on how LFS
@@ -83,6 +83,8 @@ omitted.
     * `href` - String URL to download the object.
     * `header` - Optional hash of String HTTP header key/value pairs to apply
     to the request.
+    * `expires_in` - Nanoseconds after local client time when transfer will
+      expire. Preferred over `expires_at` if both are provided.
     * `expires_at` - String ISO 8601 formatted timestamp for when the given
     action expires (usually due to a temporary token).
 

--- a/docs/api/batch.md
+++ b/docs/api/batch.md
@@ -83,8 +83,9 @@ omitted.
     * `href` - String URL to download the object.
     * `header` - Optional hash of String HTTP header key/value pairs to apply
     to the request.
-    * `expires_in` - Nanoseconds after local client time when transfer will
-      expire. Preferred over `expires_at` if both are provided.
+    * `expires_in` - Whole number of seconds after local client time when
+      transfer will expire. Preferred over `expires_at` if both are provided.
+      Maximum of 9223372036, minimum of -9223372036.
     * `expires_at` - String ISO 8601 formatted timestamp for when the given
     action expires (usually due to a temporary token).
 

--- a/docs/api/batch.md
+++ b/docs/api/batch.md
@@ -85,7 +85,7 @@ omitted.
     to the request.
     * `expires_in` - Whole number of seconds after local client time when
       transfer will expire. Preferred over `expires_at` if both are provided.
-      Maximum of 9223372036, minimum of -9223372036.
+      Maximum of 2147483647, minimum of -2147483647.
     * `expires_at` - String ISO 8601 formatted timestamp for when the given
     action expires (usually due to a temporary token).
 

--- a/docs/api/server-discovery.md
+++ b/docs/api/server-discovery.md
@@ -14,16 +14,16 @@ servers.
 By default, Git LFS will append `.git/info/lfs` to the end of a Git remote url
 to build the LFS server URL it will use:
 
-Git Remote: `https://git-server.com/foo/bar`  
+Git Remote: `https://git-server.com/foo/bar`
 LFS Server: `https://git-server.com/foo/bar.git/info/lfs`
 
-Git Remote: `https://git-server.com/foo/bar.git`  
+Git Remote: `https://git-server.com/foo/bar.git`
 LFS Server: `https://git-server.com/foo/bar.git/info/lfs`
 
-Git Remote: `git@git-server.com:foo/bar.git`  
+Git Remote: `git@git-server.com:foo/bar.git`
 LFS Server: `https://git-server.com/foo/bar.git/info/lfs`
 
-Git Remote: `ssh://git-server.com/foo/bar.git`  
+Git Remote: `ssh://git-server.com/foo/bar.git`
 LFS Server: `https://git-server.com/foo/bar.git/info/lfs`
 
 ## SSH
@@ -59,7 +59,7 @@ $ ssh git@git-server.com git-lfs-authenticate foo/bar.git download
   "header": {
     "Authorization": "RemoteAuth some-token"
   },
-  "expires_at": "2016-11-10T15:29:07Z"
+  "expires_in": 86400000000000
 }
 ```
 

--- a/docs/api/server-discovery.md
+++ b/docs/api/server-discovery.md
@@ -59,7 +59,7 @@ $ ssh git@git-server.com git-lfs-authenticate foo/bar.git download
   "header": {
     "Authorization": "RemoteAuth some-token"
   },
-  "expires_in": 86400000000000
+  "expires_in": 86400
 }
 ```
 

--- a/docs/api/server-discovery.md
+++ b/docs/api/server-discovery.md
@@ -14,16 +14,16 @@ servers.
 By default, Git LFS will append `.git/info/lfs` to the end of a Git remote url
 to build the LFS server URL it will use:
 
-Git Remote: `https://git-server.com/foo/bar`
+Git Remote: `https://git-server.com/foo/bar`<br>
 LFS Server: `https://git-server.com/foo/bar.git/info/lfs`
 
-Git Remote: `https://git-server.com/foo/bar.git`
+Git Remote: `https://git-server.com/foo/bar.git`<br>
 LFS Server: `https://git-server.com/foo/bar.git/info/lfs`
 
-Git Remote: `git@git-server.com:foo/bar.git`
+Git Remote: `git@git-server.com:foo/bar.git`<br>
 LFS Server: `https://git-server.com/foo/bar.git/info/lfs`
 
-Git Remote: `ssh://git-server.com/foo/bar.git`
+Git Remote: `ssh://git-server.com/foo/bar.git`<br>
 LFS Server: `https://git-server.com/foo/bar.git/info/lfs`
 
 ## SSH

--- a/lfsapi/ssh.go
+++ b/lfsapi/ssh.go
@@ -58,11 +58,11 @@ type sshAuthResponse struct {
 	Href      string            `json:"href"`
 	Header    map[string]string `json:"header"`
 	ExpiresAt time.Time         `json:"expires_at"`
-	ExpiresIn time.Duration     `json:"expires_in"`
+	ExpiresIn int64             `json:"expires_in"`
 }
 
 func (r *sshAuthResponse) IsExpiredWithin(d time.Duration) (time.Time, bool) {
-	return tools.IsExpiredAtOrIn(d, r.ExpiresAt, r.ExpiresIn)
+	return tools.IsExpiredAtOrIn(d, r.ExpiresAt, time.Duration(r.ExpiresIn)*time.Second)
 }
 
 type sshAuthClient struct {

--- a/lfsapi/ssh.go
+++ b/lfsapi/ssh.go
@@ -58,7 +58,7 @@ type sshAuthResponse struct {
 	Href      string            `json:"href"`
 	Header    map[string]string `json:"header"`
 	ExpiresAt time.Time         `json:"expires_at"`
-	ExpiresIn int64             `json:"expires_in"`
+	ExpiresIn int               `json:"expires_in"`
 }
 
 func (r *sshAuthResponse) IsExpiredWithin(d time.Duration) (time.Time, bool) {

--- a/lfsapi/ssh_test.go
+++ b/lfsapi/ssh_test.go
@@ -14,7 +14,8 @@ func TestSSHCacheResolveFromCache(t *testing.T) {
 	ssh := newFakeResolver()
 	cache := withSSHCache(ssh).(*sshCache)
 	cache.endpoints["userandhost//1//path//post"] = &sshAuthResponse{
-		Href: "cache",
+		Href:      "cache",
+		createdAt: time.Now(),
 	}
 	ssh.responses["userandhost"] = sshAuthResponse{Href: "real"}
 
@@ -35,6 +36,7 @@ func TestSSHCacheResolveFromCacheWithFutureExpiresAt(t *testing.T) {
 	cache.endpoints["userandhost//1//path//post"] = &sshAuthResponse{
 		Href:      "cache",
 		ExpiresAt: time.Now().Add(time.Duration(1) * time.Hour),
+		createdAt: time.Now(),
 	}
 	ssh.responses["userandhost"] = sshAuthResponse{Href: "real"}
 
@@ -55,6 +57,7 @@ func TestSSHCacheResolveFromCacheWithPastExpiresAt(t *testing.T) {
 	cache.endpoints["userandhost//1//path//post"] = &sshAuthResponse{
 		Href:      "cache",
 		ExpiresAt: time.Now().Add(time.Duration(-1) * time.Hour),
+		createdAt: time.Now(),
 	}
 	ssh.responses["userandhost"] = sshAuthResponse{Href: "real"}
 
@@ -138,6 +141,9 @@ func (r *fakeResolver) Resolve(e Endpoint, method string) (sshAuthResponse, erro
 	if len(res.Message) > 0 {
 		err = errors.New(res.Message)
 	}
+
+	res.createdAt = time.Now()
+
 	return res, err
 }
 

--- a/test/cmd/lfstest-gitserver.go
+++ b/test/cmd/lfstest-gitserver.go
@@ -180,7 +180,7 @@ type lfsLink struct {
 	Href      string            `json:"href"`
 	Header    map[string]string `json:"header,omitempty"`
 	ExpiresAt time.Time         `json:"expires_at,omitempty"`
-	ExpiresIn time.Duration     `json:"expires_in,omitempty"`
+	ExpiresIn int64             `json:"expires_in,omitempty"`
 }
 
 type lfsError struct {
@@ -484,10 +484,10 @@ func serveExpired(a *lfsLink, repo, handler string) *lfsLink {
 	case "expired-absolute":
 		a.ExpiresAt = at
 	case "expired-relative":
-		a.ExpiresIn = dur
+		a.ExpiresIn = -5
 	case "expired-both":
 		a.ExpiresAt = at
-		a.ExpiresIn = dur
+		a.ExpiresIn = -5
 	}
 
 	return a

--- a/test/cmd/lfstest-gitserver.go
+++ b/test/cmd/lfstest-gitserver.go
@@ -180,7 +180,7 @@ type lfsLink struct {
 	Href      string            `json:"href"`
 	Header    map[string]string `json:"header,omitempty"`
 	ExpiresAt time.Time         `json:"expires_at,omitempty"`
-	ExpiresIn int64             `json:"expires_in,omitempty"`
+	ExpiresIn int               `json:"expires_in,omitempty"`
 }
 
 type lfsError struct {

--- a/test/cmd/ssh-echo.go
+++ b/test/cmd/ssh-echo.go
@@ -14,7 +14,7 @@ type sshResponse struct {
 	Href      string            `json:"href"`
 	Header    map[string]string `json:"header"`
 	ExpiresAt time.Time         `json:"expires_at,omitempty"`
-	ExpiresIn int64             `json:"expires_in,omitempty"`
+	ExpiresIn int               `json:"expires_in,omitempty"`
 }
 
 func main() {

--- a/test/cmd/ssh-echo.go
+++ b/test/cmd/ssh-echo.go
@@ -14,7 +14,7 @@ type sshResponse struct {
 	Href      string            `json:"href"`
 	Header    map[string]string `json:"header"`
 	ExpiresAt time.Time         `json:"expires_at,omitempty"`
-	ExpiresIn time.Duration     `json:"expires_in,omitempty"`
+	ExpiresIn int64             `json:"expires_in,omitempty"`
 }
 
 func main() {
@@ -40,10 +40,10 @@ func main() {
 	case "ssh-expired-absolute":
 		r.ExpiresAt = time.Now().Add(-5 * time.Minute)
 	case "ssh-expired-relative":
-		r.ExpiresIn = -5 * time.Minute
+		r.ExpiresIn = -5
 	case "ssh-expired-both":
 		r.ExpiresAt = time.Now().Add(-5 * time.Minute)
-		r.ExpiresIn = -5 * time.Minute
+		r.ExpiresIn = -5
 	}
 
 	json.NewEncoder(os.Stdout).Encode(r)

--- a/test/cmd/ssh-echo.go
+++ b/test/cmd/ssh-echo.go
@@ -7,11 +7,14 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 )
 
 type sshResponse struct {
-	Href   string            `json:"href"`
-	Header map[string]string `json:"header"`
+	Href      string            `json:"href"`
+	Header    map[string]string `json:"header"`
+	ExpiresAt time.Time         `json:"expires_at,omitempty"`
+	ExpiresIn time.Duration     `json:"expires_in,omitempty"`
 }
 
 func main() {
@@ -28,7 +31,20 @@ func main() {
 		fmt.Fprintf(os.Stderr, "bad git-lfs-authenticate line: %s\nargs: %v", authLine, os.Args)
 	}
 
-	json.NewEncoder(os.Stdout).Encode(sshResponse{
-		Href: fmt.Sprintf("http://127.0.0.1:%s/%s.git/info/lfs", os.Args[2], authLine[1]),
-	})
+	repo := authLine[1]
+
+	r := &sshResponse{
+		Href: fmt.Sprintf("http://127.0.0.1:%s/%s.git/info/lfs", os.Args[2], repo),
+	}
+	switch repo {
+	case "ssh-expired-absolute":
+		r.ExpiresAt = time.Now().Add(-5 * time.Minute)
+	case "ssh-expired-relative":
+		r.ExpiresIn = -5 * time.Minute
+	case "ssh-expired-both":
+		r.ExpiresAt = time.Now().Add(-5 * time.Minute)
+		r.ExpiresIn = -5 * time.Minute
+	}
+
+	json.NewEncoder(os.Stdout).Encode(r)
 }

--- a/test/test-expired.sh
+++ b/test/test-expired.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+. "test/testlib.sh"
+
+declare -a expiration_types=("absolute" "relative" "both")
+
+for typ in "${expiration_types[@]}"; do
+  begin_test "expired action ($typ time)"
+  (
+    set -e
+
+    reponame="expired-$typ"
+    setup_remote_repo "$reponame"
+    clone_repo "$reponame" "$reponame"
+
+    contents="contents"
+    contents_oid="$(calc_oid "$contents")"
+
+    git lfs track "*.dat"
+    git add .gitattributes
+    git commit -m "initial commit"
+
+    printf "$contents" > a.dat
+
+    git add a.dat
+    git commit -m "add a.dat"
+
+    GIT_TRACE=1 git push origin master 2>&1 | tee push.log
+    if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+      echo >&2 "fatal: expected push to fail, didn't"
+      exit 1
+    fi
+
+    refute_server_object "$reponame" "$contents_oid"
+  )
+  end_test
+done

--- a/tools/time_tools.go
+++ b/tools/time_tools.go
@@ -1,0 +1,13 @@
+package tools
+
+import "time"
+
+// TimeAtOrIn returns either "at", or the "in" duration added to the current
+// time. TimeAtOrIn prefers to add a duration rather than return the "at"
+// parameter.
+func TimeAtOrIn(at time.Time, in time.Duration) time.Time {
+	if in == 0 {
+		return at
+	}
+	return time.Now().Add(in)
+}

--- a/tools/time_tools.go
+++ b/tools/time_tools.go
@@ -4,21 +4,21 @@ import "time"
 
 // IsExpiredAtOrIn returns whether or not the result of calling TimeAtOrIn is
 // "expired" within "until" units of time from now.
-func IsExpiredAtOrIn(until time.Duration, at time.Time, in time.Duration) (time.Time, bool) {
-	expiration := TimeAtOrIn(at, in)
+func IsExpiredAtOrIn(now time.Time, until time.Duration, at time.Time, in time.Duration) (time.Time, bool) {
+	expiration := TimeAtOrIn(now, at, in)
 	if expiration.IsZero() {
 		return expiration, false
 	}
 
-	return expiration, expiration.Before(time.Now().Add(until))
+	return expiration, expiration.Before(now.Add(until))
 }
 
 // TimeAtOrIn returns either "at", or the "in" duration added to the current
 // time. TimeAtOrIn prefers to add a duration rather than return the "at"
 // parameter.
-func TimeAtOrIn(at time.Time, in time.Duration) time.Time {
+func TimeAtOrIn(now, at time.Time, in time.Duration) time.Time {
 	if in == 0 {
 		return at
 	}
-	return time.Now().Add(in)
+	return now.Add(in)
 }

--- a/tools/time_tools.go
+++ b/tools/time_tools.go
@@ -2,6 +2,17 @@ package tools
 
 import "time"
 
+// IsExpiredAtOrIn returns whether or not the result of calling TimeAtOrIn is
+// "expired" within "until" units of time from now.
+func IsExpiredAtOrIn(until time.Duration, at time.Time, in time.Duration) (time.Time, bool) {
+	expiration := TimeAtOrIn(at, in)
+	if expiration.IsZero() {
+		return expiration, false
+	}
+
+	return expiration, expiration.Before(time.Now().Add(until))
+}
+
 // TimeAtOrIn returns either "at", or the "in" duration added to the current
 // time. TimeAtOrIn prefers to add a duration rather than return the "at"
 // parameter.

--- a/tools/time_tools_test.go
+++ b/tools/time_tools_test.go
@@ -1,0 +1,36 @@
+package tools
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimeAtOrInNoDuration(t *testing.T) {
+	now := time.Now()
+	then := time.Now().Add(24 * time.Hour)
+
+	got := TimeAtOrIn(now, then, time.Duration(0))
+
+	assert.Equal(t, then, got)
+}
+
+func TestTimeAtOrInWithDuration(t *testing.T) {
+	now := time.Now()
+	duration := 5 * time.Minute
+	expected := now.Add(duration)
+
+	got := TimeAtOrIn(now, now, duration)
+
+	assert.Equal(t, expected, got)
+}
+
+func TestTimeAtOrInZeroTime(t *testing.T) {
+	now := time.Now()
+	zero := time.Time{}
+
+	got := TimeAtOrIn(now, zero, 0)
+
+	assert.Equal(t, zero, got)
+}

--- a/tools/time_tools_test.go
+++ b/tools/time_tools_test.go
@@ -34,3 +34,63 @@ func TestTimeAtOrInZeroTime(t *testing.T) {
 
 	assert.Equal(t, zero, got)
 }
+
+func TestIsExpiredAtOrInWithNonZeroTime(t *testing.T) {
+	now := time.Now()
+	within := 5 * time.Minute
+	at := now.Add(10 * time.Minute)
+	in := time.Duration(0)
+
+	expired, ok := IsExpiredAtOrIn(now, within, at, in)
+
+	assert.False(t, ok)
+	assert.Equal(t, at, expired)
+}
+
+func TestIsExpiredAtOrInWithNonZeroDuration(t *testing.T) {
+	now := time.Now()
+	within := 5 * time.Minute
+	at := time.Time{}
+	in := 10 * time.Minute
+
+	expired, ok := IsExpiredAtOrIn(now, within, at, in)
+
+	assert.Equal(t, now.Add(in), expired)
+	assert.False(t, ok)
+}
+
+func TestIsExpiredAtOrInWithNonZeroTimeExpired(t *testing.T) {
+	now := time.Now()
+	within := 5 * time.Minute
+	at := now.Add(3 * time.Minute)
+	in := time.Duration(0)
+
+	expired, ok := IsExpiredAtOrIn(now, within, at, in)
+
+	assert.True(t, ok)
+	assert.Equal(t, at, expired)
+}
+
+func TestIsExpiredAtOrInWithNonZeroDurationExpired(t *testing.T) {
+	now := time.Now()
+	within := 5 * time.Minute
+	at := time.Time{}
+	in := -10 * time.Minute
+
+	expired, ok := IsExpiredAtOrIn(now, within, at, in)
+
+	assert.Equal(t, now.Add(in), expired)
+	assert.True(t, ok)
+}
+
+func TestIsExpiredAtOrInWithAmbiguousTime(t *testing.T) {
+	now := time.Now()
+	within := 5 * time.Minute
+	at := now.Add(-10 * time.Minute)
+	in := 10 * time.Minute
+
+	expired, ok := IsExpiredAtOrIn(now, within, at, in)
+
+	assert.Equal(t, now.Add(in), expired)
+	assert.False(t, ok)
+}

--- a/tq/api.go
+++ b/tq/api.go
@@ -1,6 +1,8 @@
 package tq
 
 import (
+	"time"
+
 	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/lfsapi"
 	"github.com/rubyist/tracerx"
@@ -45,6 +47,8 @@ func (c *tqClient) Batch(remote string, bReq *batchRequest) (*BatchResponse, err
 	}
 
 	bRes.endpoint = c.Endpoints.Endpoint(bReq.Operation, remote)
+	requestedAt := time.Now()
+
 	req, err := c.NewRequest("POST", bRes.endpoint, "objects/batch", bReq)
 	if err != nil {
 		return nil, errors.Wrap(err, "batch request")
@@ -65,6 +69,12 @@ func (c *tqClient) Batch(remote string, bReq *batchRequest) (*BatchResponse, err
 
 	if res.StatusCode != 200 {
 		return nil, lfsapi.NewStatusCodeError(res)
+	}
+
+	for _, obj := range bRes.Objects {
+		for _, a := range obj.Actions {
+			a.createdAt = requestedAt
+		}
 	}
 
 	return bRes, nil

--- a/tq/schemas/http-batch-response-schema.json
+++ b/tq/schemas/http-batch-response-schema.json
@@ -14,6 +14,11 @@
           "type": "object",
           "additionalProperties": true
         },
+        "expires_in": {
+            "type": "number",
+            "maximum": 9223372036,
+            "minimum": -9223372036
+        },
         "expires_at": {
           "type": "string"
         }

--- a/tq/schemas/http-batch-response-schema.json
+++ b/tq/schemas/http-batch-response-schema.json
@@ -16,8 +16,8 @@
         },
         "expires_in": {
             "type": "number",
-            "maximum": 9223372036,
-            "minimum": -9223372036
+            "maximum": 2147483647,
+            "minimum": -2147483647
         },
         "expires_at": {
           "type": "string"

--- a/tq/transfer.go
+++ b/tq/transfer.go
@@ -113,7 +113,7 @@ type Action struct {
 	Href      string            `json:"href"`
 	Header    map[string]string `json:"header,omitempty"`
 	ExpiresAt time.Time         `json:"expires_at,omitempty"`
-	ExpiresIn int64             `json:"expires_in,omitempty"`
+	ExpiresIn int               `json:"expires_in,omitempty"`
 }
 
 func (a *Action) IsExpiredWithin(d time.Duration) (time.Time, bool) {

--- a/tq/transfer.go
+++ b/tq/transfer.go
@@ -113,11 +113,11 @@ type Action struct {
 	Href      string            `json:"href"`
 	Header    map[string]string `json:"header,omitempty"`
 	ExpiresAt time.Time         `json:"expires_at,omitempty"`
-	ExpiresIn time.Duration     `json:"expires_in,omitempty"`
+	ExpiresIn int64             `json:"expires_in,omitempty"`
 }
 
 func (a *Action) IsExpiredWithin(d time.Duration) (time.Time, bool) {
-	return tools.IsExpiredAtOrIn(d, a.ExpiresAt, a.ExpiresIn)
+	return tools.IsExpiredAtOrIn(d, a.ExpiresAt, time.Duration(a.ExpiresIn)*time.Second)
 }
 
 type ActionSet map[string]*Action

--- a/tq/transfer.go
+++ b/tq/transfer.go
@@ -90,6 +90,7 @@ func newTransfer(tr *Transfer, name string, path string) *Transfer {
 			Header:    action.Header,
 			ExpiresAt: action.ExpiresAt,
 			ExpiresIn: action.ExpiresIn,
+			createdAt: action.createdAt,
 		}
 	}
 
@@ -102,6 +103,7 @@ func newTransfer(tr *Transfer, name string, path string) *Transfer {
 				Header:    link.Header,
 				ExpiresAt: link.ExpiresAt,
 				ExpiresIn: link.ExpiresIn,
+				createdAt: link.createdAt,
 			}
 		}
 	}
@@ -114,10 +116,12 @@ type Action struct {
 	Header    map[string]string `json:"header,omitempty"`
 	ExpiresAt time.Time         `json:"expires_at,omitempty"`
 	ExpiresIn int               `json:"expires_in,omitempty"`
+
+	createdAt time.Time `json:"-"`
 }
 
 func (a *Action) IsExpiredWithin(d time.Duration) (time.Time, bool) {
-	return tools.IsExpiredAtOrIn(d, a.ExpiresAt, time.Duration(a.ExpiresIn)*time.Second)
+	return tools.IsExpiredAtOrIn(a.createdAt, d, a.ExpiresAt, time.Duration(a.ExpiresIn)*time.Second)
 }
 
 type ActionSet map[string]*Action


### PR DESCRIPTION
This pull-request implements the idea proposed in #2125 to allow an optional `expires_in` property in both the SSH auth API and the batch API. It is introduced as a non-breaking change.

Both the SSH auth response and batch API response types have been expanded as described in https://github.com/git-lfs/git-lfs/issues/2125#issuecomment-291539131:

```go
type T struct {
        // ...
        ExpiresAt time.Time `json:"expires_at,omitempty"`
        ExpiresIn time.Duration `json:"expires_in,omitempty"` 
}
```

and have gained a new helper method:

```go
func (t *T) IsExpiredWithin(d time.Duration) (time.Time, bool) { ... }
```

which returns whether or not the action/SSH auth response is expired, and if so, when.

The behavior for the batch API remains the same, and the SSH auth behavior only changes when `lfs.cachecredentials` which will cause a cached SSH auth response to be invalidated if it is expired.

Closes #2125.

---

/cc @git-lfs/core #2125