### PR TITLE
locks: cross-platform path normalization

### DIFF
--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -43,7 +43,7 @@ func lockCommand(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	Print("Locked %s", args[0])
+	Print("Locked %s", path)
 }
 
 // lockPaths relativizes the given filepath such that it is relative to the root

--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -50,6 +50,9 @@ func lockCommand(cmd *cobra.Command, args []string) {
 // path of the repository it is contained within, taking into account the
 // working directory of the caller.
 //
+// lockPaths also respects different filesystem directory separators, so that a
+// Windows path of "\foo\bar" will be normalized to "foo/bar".
+//
 // If the root directory, working directory, or file cannot be
 // determined/opened, an error will be returned. If the file in question is
 // actually a directory, an error will be returned. Otherwise, the cleaned path
@@ -75,13 +78,13 @@ func lockPath(file string) (string, error) {
 	path := strings.TrimPrefix(abs, repo)
 	path = strings.TrimPrefix(path, string(os.PathSeparator))
 	if stat, err := os.Stat(abs); err != nil {
-		return path, err
+		return "", err
 	} else {
 		if stat.IsDir() {
 			return path, fmt.Errorf("lfs: cannot lock directory: %s", file)
 		}
 
-		return path, nil
+		return filepath.ToSlash(path), nil
 	}
 }
 


### PR DESCRIPTION
This pull request normalizes the paths of locked files across platforms to fix the issue described in https://github.com/git-lfs/git-lfs/issues/2138.

Since Windows's `cmd.exe` [uses `\` as the path separator](https://github.com/golang/go/blob/go1.8/src/os/path_windows.go#L8) ([as opposed to `/` on non-Windows systems](https://github.com/golang/go/blob/go1.8/src/os/path_unix.go#L10)), all of the `path/filepath` operations worked as expected, except the output was a Windows-style path.

By using a `path/filepath.ToSlash()` call, we can normalize that away<sup>[[1](https://golang.org/pkg/path/filepath/#ToSlash)]</sup>:

> ToSlash returns the result of replacing each separator character in path with a slash ('/') character. Multiple separators are replaced by multiple slashes.

Where Go defines the "separator character" as the `os.PathSeparator` constant.

This pull request does not add support for Cygwin paths, but this is something that I think we should look into via a future pull request that we can land before 2.1.0.

Closes https://github.com/git-lfs/git-lfs/issues/2138.

---

/cc @git-lfs/core https://github.com/git-lfs/git-lfs/issues/2138