### PR TITLE
smudge: use localstorage temp directory, not system

### DIFF
--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -36,7 +36,7 @@ var (
 func smudge(to io.Writer, from io.Reader, filename string, skip bool, filter *filepathfilter.Filter) error {
 	ptr, pbuf, perr := lfs.DecodeFrom(from)
 	if perr != nil {
-		n, err := tools.Spool(to, pbuf)
+		n, err := tools.Spool(to, pbuf, "")
 		if err != nil {
 			return errors.Wrap(err, perr.Error())
 		}

--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -8,6 +8,7 @@ import (
 	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/filepathfilter"
 	"github.com/git-lfs/git-lfs/lfs"
+	"github.com/git-lfs/git-lfs/localstorage"
 	"github.com/git-lfs/git-lfs/tools"
 	"github.com/spf13/cobra"
 )
@@ -36,7 +37,7 @@ var (
 func smudge(to io.Writer, from io.Reader, filename string, skip bool, filter *filepathfilter.Filter) error {
 	ptr, pbuf, perr := lfs.DecodeFrom(from)
 	if perr != nil {
-		n, err := tools.Spool(to, pbuf, "")
+		n, err := tools.Spool(to, pbuf, localstorage.Objects().TempDir)
 		if err != nil {
 			return errors.Wrap(err, perr.Error())
 		}

--- a/tools/iotools.go
+++ b/tools/iotools.go
@@ -101,15 +101,15 @@ func (r *RetriableReader) Read(b []byte) (int, error) {
 }
 
 // Spool spools the contents from 'from' to 'to' by buffering the entire
-// contents of 'from' into a temprorary buffer. That buffer is held in memory
-// until the file grows to larger than 'memoryBufferLimit`, then the remaining
-// contents are spooled to disk.
+// contents of 'from' into a temprorary file created in the directory "dir".
+// That buffer is held in memory until the file grows to larger than
+// 'memoryBufferLimit`, then the remaining contents are spooled to disk.
 //
 // The temporary file is cleaned up after the copy is complete.
 //
 // The number of bytes written to "to", as well as any error encountered are
 // returned.
-func Spool(to io.Writer, from io.Reader) (n int64, err error) {
+func Spool(to io.Writer, from io.Reader, dir string) (n int64, err error) {
 	// First, buffer up to `memoryBufferLimit` in memory.
 	buf := make([]byte, memoryBufferLimit)
 	if bn, err := from.Read(buf); err != nil && err != io.EOF {
@@ -122,7 +122,7 @@ func Spool(to io.Writer, from io.Reader) (n int64, err error) {
 	if err != io.EOF {
 		// If we weren't at the end of the stream, create a temporary
 		// file, and spool the remaining contents there.
-		tmp, err := ioutil.TempFile("", "")
+		tmp, err := ioutil.TempFile(dir, "")
 		if err != nil {
 			return 0, errors.Wrap(err, "spool tmp")
 		}


### PR DESCRIPTION
This pull-request expands the `tools.Smudge()` signature to include a temporary directory under which to create the spool file, and updates the call-site in the `smudge` plumbing command to use the localstorage directory and not the top-level `/tmp` directory.

Since we're still using the `io/ioutil.TempFile()` function, temporary files are created with the `os.O_EXCL` flag and are re-created with a re-seeded random number generator if a conflict exists, so files are guaranteed to be unique.

---

/cc @git-lfs/core 