### PR TITLE
all: build on Go 1.8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # http://docs.travis-ci.com/user/languages/go/
 language: go
 
-go: 1.8
+go: 1.8.1
 
 os:
   - linux

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ preferences.
 * Mac users can install from [Homebrew](https://github.com/Homebrew/homebrew) with `brew install git-lfs`, or from [MacPorts](https://www.macports.org) with `port install git-lfs`.
 * Windows users can install from [Chocolatey](https://chocolatey.org/) with `choco install git-lfs`.
 * [Binary packages are available][rel] for Windows, Mac, Linux, and FreeBSD.
-* You can build it with Go 1.7.3+. See the [Contributing Guide](./CONTRIBUTING.md) for instructions.
+* You can build it with Go 1.8.1+. See the [Contributing Guide](./CONTRIBUTING.md) for instructions.
 
 [rel]: https://github.com/git-lfs/git-lfs/releases
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,8 @@ environment:
 clone_folder: $(GOPATH)\src\github.com\git-lfs\git-lfs
 
 install:
+  - rd C:\Go /s /q
+  - cinst golang --version 1.8.1 -y
   - cinst InnoSetup -y
   - refreshenv
   - ps: |


### PR DESCRIPTION
This pull request resolves https://github.com/git-lfs/git-lfs/issues/2141 by building Git LFS on Go 1.8.1.

In terms of CI, we have:

1. Travis, which was upgraded in the `.travis.yml`.
2. CircleCI, which receives whatever the latest `golang` bottle is on Homebrew, which was updated in https://github.com/Homebrew/homebrew-core/pull/12201.
3. AppVeyor, which @sschuberth pointed out is 👍 to go via https://github.com/git-lfs/git-lfs/issues/2141#issuecomment-292698702.

I also noticed that our README recommends that you have a Go higher than 1.7.3. I think this is technically correct, since we don't use any of the latest Go APIs, but I think now is as good a time as any to bump that version.

Closes https://github.com/git-lfs/git-lfs/issues/2141.

---

/cc @git-lfs/core https://github.com/git-lfs/git-lfs/issues/2141