### PR TITLE
config: support multi-value lookup on URLConfig

### DIFF
--- a/config/url_config.go
+++ b/config/url_config.go
@@ -35,11 +35,7 @@ func (c *URLConfig) get(key, rawurl string) (string, bool) {
 		return "", false
 	}
 
-	hosts := make([]string, 0)
-	if u.User != nil {
-		hosts = append(hosts, fmt.Sprintf("%s://%s@%s", u.Scheme, u.User.Username(), u.Host))
-	}
-	hosts = append(hosts, fmt.Sprintf("%s://%s", u.Scheme, u.Host))
+	hosts := c.hosts(u)
 
 	pLen := len(u.Path)
 	if pLen > 2 {
@@ -72,4 +68,15 @@ func (c *URLConfig) get(key, rawurl string) (string, bool) {
 	}
 	return "", false
 
+}
+
+func (c *URLConfig) hosts(u *url.URL) []string {
+	hosts := make([]string, 0, 1)
+
+	if u.User != nil {
+		hosts = append(hosts, fmt.Sprintf("%s://%s@%s", u.Scheme, u.User.Username(), u.Host))
+	}
+	hosts = append(hosts, fmt.Sprintf("%s://%s", u.Scheme, u.Host))
+
+	return hosts
 }

--- a/config/url_config.go
+++ b/config/url_config.go
@@ -36,24 +36,16 @@ func (c *URLConfig) get(key, rawurl string) (string, bool) {
 	}
 
 	hosts := c.hosts(u)
+	paths := c.paths(u.Path)
 
-	pLen := len(u.Path)
-	if pLen > 2 {
-		end := pLen
-		if strings.HasSuffix(u.Path, "/") {
-			end -= 1
-		}
-
-		paths := strings.Split(u.Path[1:end], "/")
-		for i := len(paths); i > 0; i-- {
-			for _, host := range hosts {
-				path := strings.Join(paths[:i], "/")
-				if v, ok := c.git.Get(fmt.Sprintf("http.%s/%s.%s", host, path, key)); ok {
-					return v, ok
-				}
-				if v, ok := c.git.Get(fmt.Sprintf("http.%s/%s/.%s", host, path, key)); ok {
-					return v, ok
-				}
+	for i := len(paths); i > 0; i-- {
+		for _, host := range hosts {
+			path := strings.Join(paths[:i], "/")
+			if v, ok := c.git.Get(fmt.Sprintf("http.%s/%s.%s", host, path, key)); ok {
+				return v, ok
+			}
+			if v, ok := c.git.Get(fmt.Sprintf("http.%s/%s/.%s", host, path, key)); ok {
+				return v, ok
 			}
 		}
 	}
@@ -79,4 +71,17 @@ func (c *URLConfig) hosts(u *url.URL) []string {
 	hosts = append(hosts, fmt.Sprintf("%s://%s", u.Scheme, u.Host))
 
 	return hosts
+}
+
+func (c *URLConfig) paths(path string) []string {
+	pLen := len(path)
+	if pLen <= 2 {
+		return nil
+	}
+
+	end := pLen
+	if strings.HasSuffix(path, "/") {
+		end -= 1
+	}
+	return strings.Split(path[1:end], "/")
 }

--- a/config/url_config.go
+++ b/config/url_config.go
@@ -30,13 +30,7 @@ func (c *URLConfig) Get(prefix, key string, rawurl string) (string, bool) {
 }
 
 func (c *URLConfig) get(key, rawurl string) (string, bool) {
-	u, err := url.Parse(rawurl)
-	if err != nil {
-		return "", false
-	}
-
-	hosts := c.hosts(u)
-	paths := c.paths(u.Path)
+	hosts, paths := c.hostsAndPaths(rawurl)
 
 	for i := len(paths); i > 0; i-- {
 		for _, host := range hosts {
@@ -60,6 +54,15 @@ func (c *URLConfig) get(key, rawurl string) (string, bool) {
 	}
 	return "", false
 
+}
+
+func (c *URLConfig) hostsAndPaths(rawurl string) (hosts, paths []string) {
+	u, err := url.Parse(rawurl)
+	if err != nil {
+		return nil, nil
+	}
+
+	return c.hosts(u), c.paths(u.Path)
 }
 
 func (c *URLConfig) hosts(u *url.URL) []string {

--- a/config/url_config.go
+++ b/config/url_config.go
@@ -24,7 +24,7 @@ func (c *URLConfig) Get(prefix, key string, rawurl string) (string, bool) {
 	key = strings.ToLower(key)
 	prefix = strings.ToLower(prefix)
 	if v := c.getAll(key, rawurl); len(v) > 0 {
-		return v[0], true
+		return v[len(v)-1], true
 	}
 	return c.git.Get(strings.Join([]string{prefix, key}, "."))
 }

--- a/config/url_config_test.go
+++ b/config/url_config_test.go
@@ -17,12 +17,12 @@ func TestURLConfig(t *testing.T) {
 	})))
 
 	getOne := map[string]string{
-		"https://root.com/a/b/c":           "root",
-		"https://host.com/":                "host",
-		"https://host.com/a/b/c":           "host-a",
-		"https://user:pass@host.com/a/b/c": "user-a",
-		"https://user:pass@host.com/z/b/c": "user",
-		"https://host.com:8080/a":          "port",
+		"https://root.com/a/b/c":           "root-2",
+		"https://host.com/":                "host-2",
+		"https://host.com/a/b/c":           "host-b",
+		"https://user:pass@host.com/a/b/c": "user-b",
+		"https://user:pass@host.com/z/b/c": "user-2",
+		"https://host.com:8080/a":          "port-2",
 	}
 
 	for rawurl, expected := range getOne {

--- a/config/url_config_test.go
+++ b/config/url_config_test.go
@@ -8,15 +8,15 @@ import (
 
 func TestURLConfig(t *testing.T) {
 	u := NewURLConfig(EnvironmentOf(MapFetcher(map[string][]string{
-		"http.key":                         []string{"root"},
-		"http.https://host.com.key":        []string{"host"},
-		"http.https://user@host.com/a.key": []string{"user-a"},
-		"http.https://user@host.com.key":   []string{"user"},
-		"http.https://host.com/a.key":      []string{"host-a"},
-		"http.https://host.com:8080.key":   []string{"port"},
+		"http.key":                         []string{"root", "root-2"},
+		"http.https://host.com.key":        []string{"host", "host-2"},
+		"http.https://user@host.com/a.key": []string{"user-a", "user-b"},
+		"http.https://user@host.com.key":   []string{"user", "user-2"},
+		"http.https://host.com/a.key":      []string{"host-a", "host-b"},
+		"http.https://host.com:8080.key":   []string{"port", "port-2"},
 	})))
 
-	tests := map[string]string{
+	getOne := map[string]string{
 		"https://root.com/a/b/c":           "root",
 		"https://host.com/":                "host",
 		"https://host.com/a/b/c":           "host-a",
@@ -25,8 +25,22 @@ func TestURLConfig(t *testing.T) {
 		"https://host.com:8080/a":          "port",
 	}
 
-	for rawurl, expected := range tests {
+	for rawurl, expected := range getOne {
 		value, _ := u.Get("http", "key", rawurl)
 		assert.Equal(t, expected, value, rawurl)
+	}
+
+	getAll := map[string][]string{
+		"https://root.com/a/b/c":           []string{"root", "root-2"},
+		"https://host.com/":                []string{"host", "host-2"},
+		"https://host.com/a/b/c":           []string{"host-a", "host-b"},
+		"https://user:pass@host.com/a/b/c": []string{"user-a", "user-b"},
+		"https://user:pass@host.com/z/b/c": []string{"user", "user-2"},
+		"https://host.com:8080/a":          []string{"port", "port-2"},
+	}
+
+	for rawurl, expected := range getAll {
+		values := u.GetAll("http", "key", rawurl)
+		assert.Equal(t, expected, values, rawurl)
 	}
 }


### PR DESCRIPTION
This pull request teaches the `*config.URLConfig` type to fetch multiple values matching a given `prefix.<url>.key`.

This is supporting work for the http.extraHeaders support as defined in #1500.

Right now, it's based off the work done in https://github.com/git-lfs/git-lfs/pull/2152. Once that branch gets merged, this diff should become more readable. In the meantime, **here's an inter-diff**: https://github.com/git-lfs/git-lfs/compare/fetcher-get-all...url-config-many-headers.

To implement this, I changed the `get` function to `getAll`, which replaces the internal `c.git.Get()` with `c.git.GetAll()` calls, which will return _all_ matching values for a given config key, if any were found. What this means for behavior, is that the public `config.URLConfig.GetAll()` function will return more than one value _only_ if it's in the same keyspace.

For instance, given a git config:

```
http.http://example.com/foo.bar=baz
http.http://example.com/.bar=baz2
```

Only a value of `[]string{"baz"}` will be returned. I _think_ this is the right behavior, but we could turn those `return`s into `append`s and roll up the values of `baz` and `baz2`. Either would work.

Here's a quick breakdown of what happened:

1. https://github.com/git-lfs/git-lfs/commit/fdbf3041f965275419cee6a93063f121d81a3596, https://github.com/git-lfs/git-lfs/commit/0b95e7c8b52ceca93661babf6995aaf0455987b5 & https://github.com/git-lfs/git-lfs/commit/473ccb7a17634bfd3225219d4250c005d3852643: some light refactoring
2. https://github.com/git-lfs/git-lfs/commit/5936cf4f29a07272ede29ed8578097e56582b294: rename `get()` to `getAll()` and use that for multi-valued lookups.

---

/cc @git-lfs/core 