### PR TITLE
config: remove dependency on lfsapi package

### DIFF
--- a/commands/command_env.go
+++ b/commands/command_env.go
@@ -28,7 +28,7 @@ func envCommand(cmd *cobra.Command, args []string) {
 	}
 
 	for _, remote := range cfg.Remotes() {
-		remoteEndpoint := cfg.RemoteEndpoint(remote, "download")
+		remoteEndpoint := apiClient.Endpoints.RemoteEndpoint("download", remote)
 		Print("Endpoint (%s)=%s (auth=%s)", remote, remoteEndpoint.Url, cfg.EndpointAccess(remoteEndpoint))
 		if len(remoteEndpoint.SshUserAndHost) > 0 {
 			Print("  SSH=%s:%s", remoteEndpoint.SshUserAndHost, remoteEndpoint.SshPath)

--- a/commands/command_env.go
+++ b/commands/command_env.go
@@ -9,7 +9,7 @@ import (
 
 func envCommand(cmd *cobra.Command, args []string) {
 	config.ShowConfigWarnings = true
-	endpoint := cfg.Endpoint("download")
+	endpoint := getAPIClient().Endpoints.Endpoint("download", cfg.CurrentRemote)
 
 	gitV, err := git.Config.Version()
 	if err != nil {

--- a/commands/command_env.go
+++ b/commands/command_env.go
@@ -21,15 +21,17 @@ func envCommand(cmd *cobra.Command, args []string) {
 	Print("")
 
 	if len(endpoint.Url) > 0 {
-		Print("Endpoint=%s (auth=%s)", endpoint.Url, cfg.EndpointAccess(endpoint))
+		access := getAPIClient().Endpoints.AccessFor(endpoint.Url)
+		Print("Endpoint=%s (auth=%s)", endpoint.Url, access)
 		if len(endpoint.SshUserAndHost) > 0 {
 			Print("  SSH=%s:%s", endpoint.SshUserAndHost, endpoint.SshPath)
 		}
 	}
 
 	for _, remote := range cfg.Remotes() {
-		remoteEndpoint := apiClient.Endpoints.RemoteEndpoint("download", remote)
-		Print("Endpoint (%s)=%s (auth=%s)", remote, remoteEndpoint.Url, cfg.EndpointAccess(remoteEndpoint))
+		remoteEndpoint := getAPIClient().Endpoints.RemoteEndpoint("download", remote)
+		remoteAccess := getAPIClient().Endpoints.AccessFor(remoteEndpoint.Url)
+		Print("Endpoint (%s)=%s (auth=%s)", remote, remoteEndpoint.Url, remoteAccess)
 		if len(remoteEndpoint.SshUserAndHost) > 0 {
 			Print("  SSH=%s:%s", remoteEndpoint.SshUserAndHost, remoteEndpoint.SshPath)
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -182,10 +182,6 @@ func (c *Configuration) parseTag(tag reflect.StructTag) (key string, env Environ
 	return
 }
 
-func (c *Configuration) Endpoint(operation string) lfsapi.Endpoint {
-	return c.endpointConfig().Endpoint(operation, c.CurrentRemote)
-}
-
 // BasicTransfersOnly returns whether to only allow "basic" HTTP transfers.
 // Default is false, including if the lfs.basictransfersonly is invalid
 func (c *Configuration) BasicTransfersOnly() bool {

--- a/config/config.go
+++ b/config/config.go
@@ -198,11 +198,6 @@ func (c *Configuration) TusTransfersAllowed() bool {
 	return c.Git.Bool("lfs.tustransfers", false)
 }
 
-// Access returns the access auth type.
-func (c *Configuration) Access(operation string) lfsapi.Access {
-	return c.EndpointAccess(c.Endpoint(operation))
-}
-
 func (c *Configuration) EndpointAccess(e lfsapi.Endpoint) lfsapi.Access {
 	return c.endpointConfig().AccessFor(e.Url)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -184,12 +184,6 @@ func (c *Configuration) parseTag(tag reflect.StructTag) (key string, env Environ
 	return
 }
 
-// GitRemoteUrl returns the git clone/push url for a given remote (blank if not found)
-// the forpush argument is to cater for separate remote.name.pushurl settings
-func (c *Configuration) GitRemoteUrl(remote string, forpush bool) string {
-	return c.endpointConfig().GitRemoteURL(remote, forpush)
-}
-
 // Manually set an Endpoint to use instead of deriving from Git config
 func (c *Configuration) SetManualEndpoint(e lfsapi.Endpoint) {
 	c.manualEndpoint = &e

--- a/config/config.go
+++ b/config/config.go
@@ -8,7 +8,6 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/git-lfs/git-lfs/lfsapi"
 	"github.com/git-lfs/git-lfs/tools"
 )
 
@@ -53,11 +52,9 @@ type Configuration struct {
 
 	CurrentRemote string
 
-	loading        sync.Mutex // guards initialization of gitConfig and remotes
-	remotes        []string
-	extensions     map[string]Extension
-	endpointFinder lfsapi.EndpointFinder
-	endpointMu     sync.Mutex
+	loading    sync.Mutex // guards initialization of gitConfig and remotes
+	remotes    []string
+	extensions map[string]Extension
 }
 
 func New() *Configuration {
@@ -208,17 +205,6 @@ func (c *Configuration) Remotes() []string {
 	c.loadGitConfig()
 
 	return c.remotes
-}
-
-func (c *Configuration) endpointConfig() lfsapi.EndpointFinder {
-	c.endpointMu.Lock()
-	defer c.endpointMu.Unlock()
-
-	if c.endpointFinder == nil {
-		c.endpointFinder = lfsapi.NewEndpointFinder(c.Git)
-	}
-
-	return c.endpointFinder
 }
 
 func (c *Configuration) Extensions() map[string]Extension {

--- a/config/config.go
+++ b/config/config.go
@@ -57,7 +57,6 @@ type Configuration struct {
 	loading        sync.Mutex // guards initialization of gitConfig and remotes
 	remotes        []string
 	extensions     map[string]Extension
-	manualEndpoint *lfsapi.Endpoint
 	endpointFinder lfsapi.EndpointFinder
 	endpointMu     sync.Mutex
 }
@@ -184,15 +183,7 @@ func (c *Configuration) parseTag(tag reflect.StructTag) (key string, env Environ
 	return
 }
 
-// Manually set an Endpoint to use instead of deriving from Git config
-func (c *Configuration) SetManualEndpoint(e lfsapi.Endpoint) {
-	c.manualEndpoint = &e
-}
-
 func (c *Configuration) Endpoint(operation string) lfsapi.Endpoint {
-	if c.manualEndpoint != nil {
-		return *c.manualEndpoint
-	}
 	return c.endpointConfig().Endpoint(operation, c.CurrentRemote)
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -197,7 +197,7 @@ func (c *Configuration) Endpoint(operation string) lfsapi.Endpoint {
 }
 
 func (c *Configuration) ConcurrentTransfers() int {
-	if c.NtlmAccess("download") {
+	if c.Access("download") == lfsapi.NTLMAccess {
 		return 1
 	}
 
@@ -223,10 +223,6 @@ func (c *Configuration) BasicTransfersOnly() bool {
 // Default is false, including if the lfs.tustransfers is invalid
 func (c *Configuration) TusTransfersAllowed() bool {
 	return c.Git.Bool("lfs.tustransfers", false)
-}
-
-func (c *Configuration) NtlmAccess(operation string) bool {
-	return c.Access(operation) == lfsapi.NTLMAccess
 }
 
 // Access returns the access auth type.

--- a/config/config.go
+++ b/config/config.go
@@ -254,10 +254,6 @@ func (c *Configuration) FetchExcludePaths() []string {
 	return tools.CleanPaths(patterns, ",")
 }
 
-func (c *Configuration) RemoteEndpoint(remote, operation string) lfsapi.Endpoint {
-	return c.endpointConfig().RemoteEndpoint(operation, remote)
-}
-
 func (c *Configuration) Remotes() []string {
 	c.loadGitConfig()
 

--- a/config/config.go
+++ b/config/config.go
@@ -198,10 +198,6 @@ func (c *Configuration) TusTransfersAllowed() bool {
 	return c.Git.Bool("lfs.tustransfers", false)
 }
 
-func (c *Configuration) EndpointAccess(e lfsapi.Endpoint) lfsapi.Access {
-	return c.endpointConfig().AccessFor(e.Url)
-}
-
 func (c *Configuration) FetchIncludePaths() []string {
 	patterns, _ := c.Git.Get("lfs.fetchinclude")
 	return tools.CleanPaths(patterns, ",")

--- a/config/config.go
+++ b/config/config.go
@@ -264,10 +264,6 @@ func (c *Configuration) Remotes() []string {
 	return c.remotes
 }
 
-func (c *Configuration) GitProtocol() string {
-	return c.endpointConfig().GitProtocol()
-}
-
 func (c *Configuration) endpointConfig() lfsapi.EndpointFinder {
 	c.endpointMu.Lock()
 	defer c.endpointMu.Unlock()

--- a/config/config.go
+++ b/config/config.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"strconv"
 	"sync"
 
 	"github.com/git-lfs/git-lfs/lfsapi"
@@ -185,23 +184,6 @@ func (c *Configuration) parseTag(tag reflect.StructTag) (key string, env Environ
 
 func (c *Configuration) Endpoint(operation string) lfsapi.Endpoint {
 	return c.endpointConfig().Endpoint(operation, c.CurrentRemote)
-}
-
-func (c *Configuration) ConcurrentTransfers() int {
-	if c.Access("download") == lfsapi.NTLMAccess {
-		return 1
-	}
-
-	uploads := 3
-
-	if v, ok := c.Git.Get("lfs.concurrenttransfers"); ok {
-		n, err := strconv.Atoi(v)
-		if err == nil && n > 0 {
-			uploads = n
-		}
-	}
-
-	return uploads
 }
 
 // BasicTransfersOnly returns whether to only allow "basic" HTTP transfers.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -7,57 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestConcurrentTransfersSetValue(t *testing.T) {
-	cfg := NewFrom(Values{
-		Git: map[string]string{
-			"lfs.concurrenttransfers": "5",
-		},
-	})
-
-	n := cfg.ConcurrentTransfers()
-	assert.Equal(t, 5, n)
-}
-
-func TestConcurrentTransfersDefault(t *testing.T) {
-	cfg := NewFrom(Values{})
-
-	n := cfg.ConcurrentTransfers()
-	assert.Equal(t, 3, n)
-}
-
-func TestConcurrentTransfersZeroValue(t *testing.T) {
-	cfg := NewFrom(Values{
-		Git: map[string]string{
-			"lfs.concurrenttransfers": "0",
-		},
-	})
-
-	n := cfg.ConcurrentTransfers()
-	assert.Equal(t, 3, n)
-}
-
-func TestConcurrentTransfersNonNumeric(t *testing.T) {
-	cfg := NewFrom(Values{
-		Git: map[string]string{
-			"lfs.concurrenttransfers": "elephant",
-		},
-	})
-
-	n := cfg.ConcurrentTransfers()
-	assert.Equal(t, 3, n)
-}
-
-func TestConcurrentTransfersNegativeValue(t *testing.T) {
-	cfg := NewFrom(Values{
-		Git: map[string]string{
-			"lfs.concurrenttransfers": "-5",
-		},
-	})
-
-	n := cfg.ConcurrentTransfers()
-	assert.Equal(t, 3, n)
-}
-
 func TestBasicTransfersOnlySetValue(t *testing.T) {
 	cfg := NewFrom(Values{
 		Git: map[string]string{

--- a/config/version.go
+++ b/config/version.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
-
-	"github.com/git-lfs/git-lfs/lfsapi"
 )
 
 var (
@@ -29,6 +27,4 @@ func init() {
 		strings.Replace(runtime.Version(), "go", "", 1),
 		gitCommit,
 	)
-
-	lfsapi.UserAgent = VersionDesc
 }

--- a/lfs/lfs.go
+++ b/lfs/lfs.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/git-lfs/git-lfs/config"
+	"github.com/git-lfs/git-lfs/lfsapi"
 	"github.com/git-lfs/git-lfs/localstorage"
 	"github.com/git-lfs/git-lfs/tools"
 	"github.com/git-lfs/git-lfs/tq"
@@ -67,6 +68,12 @@ func Environ(cfg *config.Configuration, manifest *tq.Manifest) []string {
 	osEnviron := os.Environ()
 	env := make([]string, 0, len(osEnviron)+7)
 
+	api, err := lfsapi.NewClient(cfg.Os, cfg.Git)
+	if err != nil {
+		// TODO(@ttaylorr): don't panic
+		panic(err.Error())
+	}
+
 	dltransfers := manifest.GetDownloadAdapterNames()
 	sort.Strings(dltransfers)
 	ultransfers := manifest.GetUploadAdapterNames()
@@ -81,7 +88,7 @@ func Environ(cfg *config.Configuration, manifest *tq.Manifest) []string {
 		fmt.Sprintf("LocalMediaDir=%s", LocalMediaDir()),
 		fmt.Sprintf("LocalReferenceDir=%s", config.LocalReferenceDir),
 		fmt.Sprintf("TempDir=%s", TempDir()),
-		fmt.Sprintf("ConcurrentTransfers=%d", cfg.ConcurrentTransfers()),
+		fmt.Sprintf("ConcurrentTransfers=%d", api.ConcurrentTransfers),
 		fmt.Sprintf("TusTransfers=%v", cfg.TusTransfersAllowed()),
 		fmt.Sprintf("BasicTransfersOnly=%v", cfg.BasicTransfersOnly()),
 		fmt.Sprintf("SkipDownloadErrors=%v", cfg.SkipDownloadErrors()),

--- a/lfs/lfs.go
+++ b/lfs/lfs.go
@@ -74,6 +74,9 @@ func Environ(cfg *config.Configuration, manifest *tq.Manifest) []string {
 		panic(err.Error())
 	}
 
+	download := api.Endpoints.AccessFor(api.Endpoints.Endpoint("download", cfg.CurrentRemote).Url)
+	upload := api.Endpoints.AccessFor(api.Endpoints.Endpoint("upload", cfg.CurrentRemote).Url)
+
 	dltransfers := manifest.GetDownloadAdapterNames()
 	sort.Strings(dltransfers)
 	ultransfers := manifest.GetUploadAdapterNames()
@@ -99,8 +102,8 @@ func Environ(cfg *config.Configuration, manifest *tq.Manifest) []string {
 		fmt.Sprintf("PruneOffsetDays=%d", fetchPruneConfig.PruneOffsetDays),
 		fmt.Sprintf("PruneVerifyRemoteAlways=%v", fetchPruneConfig.PruneVerifyRemoteAlways),
 		fmt.Sprintf("PruneRemoteName=%s", fetchPruneConfig.PruneRemoteName),
-		fmt.Sprintf("AccessDownload=%s", cfg.Access("download")),
-		fmt.Sprintf("AccessUpload=%s", cfg.Access("upload")),
+		fmt.Sprintf("AccessDownload=%s", download),
+		fmt.Sprintf("AccessUpload=%s", upload),
 		fmt.Sprintf("DownloadTransfers=%s", strings.Join(dltransfers, ",")),
 		fmt.Sprintf("UploadTransfers=%s", strings.Join(ultransfers, ",")),
 	)

--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/git-lfs/git-lfs/config"
 	"github.com/git-lfs/git-lfs/errors"
 	"github.com/rubyist/tracerx"
 )
@@ -221,4 +222,8 @@ func newRequestForRetry(req *http.Request, location string) (*http.Request, erro
 	newReq.Body = req.Body
 	newReq.ContentLength = req.ContentLength
 	return newReq, nil
+}
+
+func init() {
+	UserAgent = config.VersionDesc
 }

--- a/lfsapi/lfsapi.go
+++ b/lfsapi/lfsapi.go
@@ -89,7 +89,7 @@ func NewClient(osEnv Env, gitEnv Env) (*Client, error) {
 		DialTimeout:         gitEnv.Int("lfs.dialtimeout", 0),
 		KeepaliveTimeout:    gitEnv.Int("lfs.keepalive", 0),
 		TLSTimeout:          gitEnv.Int("lfs.tlstimeout", 0),
-		ConcurrentTransfers: gitEnv.Int("lfs.concurrenttransfers", 0),
+		ConcurrentTransfers: gitEnv.Int("lfs.concurrenttransfers", 3),
 		SkipSSLVerify:       !gitEnv.Bool("http.sslverify", true) || osEnv.Bool("GIT_SSL_NO_VERIFY", false),
 		Verbose:             osEnv.Bool("GIT_CURL_VERBOSE", false),
 		DebuggingVerbose:    osEnv.Bool("LFS_DEBUG_HTTP", false),

--- a/test/git-lfs-test-server-api/main.go
+++ b/test/git-lfs-test-server-api/main.go
@@ -149,6 +149,20 @@ func buildManifest() (*tq.Manifest, error) {
 	return tq.NewManifestWithClient(apiClient), nil
 }
 
+type constantEndpoint struct {
+	e lfsapi.Endpoint
+
+	lfsapi.EndpointFinder
+}
+
+func (c *constantEndpoint) NewEndpointFromCloneURL(rawurl string) lfsapi.Endpoint { return c.e }
+
+func (c *constantEndpoint) NewEndpoint(rawurl string) lfsapi.Endpoint { return c.e }
+
+func (c *constantEndpoint) Endpoint(operation, remote string) lfsapi.Endpoint { return c.e }
+
+func (c *constantEndpoint) RemoteEndpoint(operation, remote string) lfsapi.Endpoint { return c.e }
+
 func buildTestData(manifest *tq.Manifest) (oidsExist, oidsMissing []TestObject, err error) {
 	const oidCount = 50
 	oidsExist = make([]TestObject, 0, oidCount)


### PR DESCRIPTION
This pull request removes a dependency drawn from the `github.com/git-lfs/git-lfs/config` package to the `github.com/git-lfs/git-lfs/lfsapi` package, where several of the `Endpoint()`-related functions returned `lfsapi.<T>` types.

This work supports the proposal in #1500, where I need to import the `config` package from `lfsapi` in order to maintain an instance of the `*config.URLConfig` type.

---

/cc @git-lfs/core 