### PR TITLE
config: add prefix to URLConfig type

### DIFF
--- a/config/url_config.go
+++ b/config/url_config.go
@@ -11,6 +11,10 @@ type URLConfig struct {
 }
 
 func NewURLConfig(git Environment) *URLConfig {
+	if git == nil {
+		git = EnvironmentOf(make(mapFetcher))
+	}
+
 	return &URLConfig{
 		git: git,
 	}

--- a/config/url_config.go
+++ b/config/url_config.go
@@ -20,7 +20,7 @@ func NewURLConfig(git Environment) *URLConfig {
 // rules in https://git-scm.com/docs/git-config#git-config-httplturlgt.
 // The value for `http.{key}` is returned as a fallback if no config keys are
 // set for the given urls.
-func (c *URLConfig) Get(prefix, key string, rawurl string) (string, bool) {
+func (c *URLConfig) Get(prefix, rawurl, key string) (string, bool) {
 	key = strings.ToLower(key)
 	prefix = strings.ToLower(prefix)
 	if v := c.getAll(prefix, rawurl, key); len(v) > 0 {
@@ -29,7 +29,7 @@ func (c *URLConfig) Get(prefix, key string, rawurl string) (string, bool) {
 	return c.git.Get(strings.Join([]string{prefix, key}, "."))
 }
 
-func (c *URLConfig) GetAll(prefix, key string, rawurl string) []string {
+func (c *URLConfig) GetAll(prefix, rawurl, key string) []string {
 	key = strings.ToLower(key)
 	prefix = strings.ToLower(prefix)
 	if v := c.getAll(prefix, rawurl, key); len(v) > 0 {

--- a/config/url_config.go
+++ b/config/url_config.go
@@ -23,7 +23,7 @@ func NewURLConfig(git Environment) *URLConfig {
 func (c *URLConfig) Get(prefix, key string, rawurl string) (string, bool) {
 	key = strings.ToLower(key)
 	prefix = strings.ToLower(prefix)
-	if v := c.getAll(key, rawurl); len(v) > 0 {
+	if v := c.getAll(prefix, rawurl, key); len(v) > 0 {
 		return v[len(v)-1], true
 	}
 	return c.git.Get(strings.Join([]string{prefix, key}, "."))
@@ -32,32 +32,32 @@ func (c *URLConfig) Get(prefix, key string, rawurl string) (string, bool) {
 func (c *URLConfig) GetAll(prefix, key string, rawurl string) []string {
 	key = strings.ToLower(key)
 	prefix = strings.ToLower(prefix)
-	if v := c.getAll(key, rawurl); len(v) > 0 {
+	if v := c.getAll(prefix, rawurl, key); len(v) > 0 {
 		return v
 	}
 	return c.git.GetAll(strings.Join([]string{prefix, key}, "."))
 }
 
-func (c *URLConfig) getAll(key, rawurl string) []string {
+func (c *URLConfig) getAll(prefix, rawurl, key string) []string {
 	hosts, paths := c.hostsAndPaths(rawurl)
 
 	for i := len(paths); i > 0; i-- {
 		for _, host := range hosts {
 			path := strings.Join(paths[:i], "/")
-			if v := c.git.GetAll(fmt.Sprintf("http.%s/%s.%s", host, path, key)); len(v) > 0 {
+			if v := c.git.GetAll(fmt.Sprintf("%s.%s/%s.%s", prefix, host, path, key)); len(v) > 0 {
 				return v
 			}
-			if v := c.git.GetAll(fmt.Sprintf("http.%s/%s/.%s", host, path, key)); len(v) > 0 {
+			if v := c.git.GetAll(fmt.Sprintf("%s.%s/%s/.%s", prefix, host, path, key)); len(v) > 0 {
 				return v
 			}
 		}
 	}
 
 	for _, host := range hosts {
-		if v := c.git.GetAll(fmt.Sprintf("http.%s.%s", host, key)); len(v) > 0 {
+		if v := c.git.GetAll(fmt.Sprintf("%s.%s.%s", prefix, host, key)); len(v) > 0 {
 			return v
 		}
-		if v := c.git.GetAll(fmt.Sprintf("http.%s/.%s", host, key)); len(v) > 0 {
+		if v := c.git.GetAll(fmt.Sprintf("%s.%s/.%s", prefix, host, key)); len(v) > 0 {
 			return v
 		}
 	}

--- a/config/url_config_test.go
+++ b/config/url_config_test.go
@@ -26,7 +26,7 @@ func TestURLConfig(t *testing.T) {
 	}
 
 	for rawurl, expected := range getOne {
-		value, _ := u.Get("http", "key", rawurl)
+		value, _ := u.Get("http", rawurl, "key")
 		assert.Equal(t, expected, value, rawurl)
 	}
 
@@ -40,7 +40,7 @@ func TestURLConfig(t *testing.T) {
 	}
 
 	for rawurl, expected := range getAll {
-		values := u.GetAll("http", "key", rawurl)
+		values := u.GetAll("http", rawurl, "key")
 		assert.Equal(t, expected, values, rawurl)
 	}
 }


### PR DESCRIPTION
This pull request fixes an oversight I made in https://github.com/git-lfs/git-lfs/pull/1912 where the prefix of a `*config.URLConfig` lookup wasn't passed correctly into the `getAll()` function.

This pull request is based off of #2156, which should be merged into master before this branch. __In the meantime, here's an inter-diff__: https://github.com/git-lfs/git-lfs/compare/lfsapi-config-cycle...url-config-prefix.

I snuck a second change in here, to reorder the arguments from:

```diff
-func (c *URLConfig) Get(prefix, key string, rawurl string) (string, bool) {
+func (c *URLConfig) Get(prefix, rawurl, key string) (string, bool) {
```

Which more closely matches the `{prefix}.{url}.{key}` ordering that is actually present in the config entry.

---

/cc @git-lfs/core 