### PR TITLE
lfsapi: support for http.<url>.extraHeader

### DIFF
--- a/config/url_config.go
+++ b/config/url_config.go
@@ -25,6 +25,10 @@ func NewURLConfig(git Environment) *URLConfig {
 // The value for `http.{key}` is returned as a fallback if no config keys are
 // set for the given urls.
 func (c *URLConfig) Get(prefix, rawurl, key string) (string, bool) {
+	if c == nil {
+		return "", false
+	}
+
 	key = strings.ToLower(key)
 	prefix = strings.ToLower(prefix)
 	if v := c.getAll(prefix, rawurl, key); len(v) > 0 {
@@ -34,6 +38,10 @@ func (c *URLConfig) Get(prefix, rawurl, key string) (string, bool) {
 }
 
 func (c *URLConfig) GetAll(prefix, rawurl, key string) []string {
+	if c == nil {
+		return nil
+	}
+
 	key = strings.ToLower(key)
 	prefix = strings.ToLower(prefix)
 	if v := c.getAll(prefix, rawurl, key); len(v) > 0 {

--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -76,7 +76,25 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	return res, c.handleResponse(res)
 }
 
+func (c *Client) setExtraHeaders(req *http.Request) http.Header {
+	var copy http.Header = make(http.Header)
+	for k, vs := range req.Header {
+		copy[k] = vs
+	}
+
+	for k, vs := range c.extraHeaders(req.URL) {
+		for _, v := range vs {
+			copy[k] = append(copy[k], v)
+		}
+	}
+	return copy
+}
+
 func (c *Client) extraHeaders(u *url.URL) map[string][]string {
+	if c.uc == nil {
+		c.uc = config.NewURLConfig(c.GitEnv())
+	}
+
 	hdrs := c.uc.GetAll("http", u.String(), "extraHeader")
 	m := make(map[string][]string, len(hdrs))
 

--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -66,7 +66,7 @@ func joinURL(prefix, suffix string) string {
 }
 
 func (c *Client) Do(req *http.Request) (*http.Response, error) {
-	req.Header = c.setExtraHeaders(req)
+	req.Header = c.extraHeadersFor(req)
 	req.Header.Set("User-Agent", UserAgent)
 
 	res, err := c.doWithRedirects(c.httpClient(req.Host), req, nil)
@@ -77,7 +77,7 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	return res, c.handleResponse(res)
 }
 
-func (c *Client) setExtraHeaders(req *http.Request) http.Header {
+func (c *Client) extraHeadersFor(req *http.Request) http.Header {
 	copy := make(http.Header, len(req.Header))
 	for k, vs := range req.Header {
 		copy[k] = vs

--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -66,6 +66,7 @@ func joinURL(prefix, suffix string) string {
 }
 
 func (c *Client) Do(req *http.Request) (*http.Response, error) {
+	req.Header = c.setExtraHeaders(req)
 	req.Header.Set("User-Agent", UserAgent)
 
 	res, err := c.doWithRedirects(c.httpClient(req.Host), req, nil)

--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -100,12 +100,12 @@ func (c *Client) extraHeaders(u *url.URL) map[string][]string {
 	m := make(map[string][]string, len(hdrs))
 
 	for _, hdr := range hdrs {
-		parts := strings.SplitN(hdr, ": ", 2)
+		parts := strings.SplitN(hdr, ":", 2)
 		if len(parts) < 2 {
 			continue
 		}
 
-		k, v := parts[0], parts[1]
+		k, v := parts[0], strings.TrimSpace(parts[1])
 
 		m[k] = append(m[k], v)
 	}

--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -92,10 +92,6 @@ func (c *Client) setExtraHeaders(req *http.Request) http.Header {
 }
 
 func (c *Client) extraHeaders(u *url.URL) map[string][]string {
-	if c.uc == nil {
-		c.uc = config.NewURLConfig(c.GitEnv())
-	}
-
 	hdrs := c.uc.GetAll("http", u.String(), "extraHeader")
 	m := make(map[string][]string, len(hdrs))
 

--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -76,6 +76,23 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	return res, c.handleResponse(res)
 }
 
+func (c *Client) extraHeaders(u *url.URL) map[string][]string {
+	hdrs := c.uc.GetAll("http", u.String(), "extraHeader")
+	m := make(map[string][]string, len(hdrs))
+
+	for _, hdr := range hdrs {
+		parts := strings.SplitN(hdr, ": ", 2)
+		if len(parts) < 2 {
+			continue
+		}
+
+		k, v := parts[0], parts[1]
+
+		m[k] = append(m[k], v)
+	}
+	return m
+}
+
 func (c *Client) doWithRedirects(cli *http.Client, req *http.Request, via []*http.Request) (*http.Response, error) {
 	c.traceRequest(req)
 	if err := c.prepareRequestBody(req); err != nil {

--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -78,7 +78,7 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 }
 
 func (c *Client) setExtraHeaders(req *http.Request) http.Header {
-	var copy http.Header = make(http.Header)
+	copy := make(http.Header, len(req.Header))
 	for k, vs := range req.Header {
 		copy[k] = vs
 	}

--- a/lfsapi/lfsapi.go
+++ b/lfsapi/lfsapi.go
@@ -101,6 +101,7 @@ func NewClient(osEnv Env, gitEnv Env) (*Client, error) {
 		NoProxy:             noProxy,
 		gitEnv:              gitEnv,
 		osEnv:               osEnv,
+		uc:                  config.NewURLConfig(gitEnv),
 	}
 
 	return c, nil

--- a/lfsapi/lfsapi.go
+++ b/lfsapi/lfsapi.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/ThomsonReutersEikon/go-ntlm/ntlm"
+	"github.com/git-lfs/git-lfs/config"
 	"github.com/git-lfs/git-lfs/errors"
 )
 
@@ -53,6 +54,7 @@ type Client struct {
 	// only used for per-host ssl certs
 	gitEnv Env
 	osEnv  Env
+	uc     *config.URLConfig
 }
 
 func NewClient(osEnv Env, gitEnv Env) (*Client, error) {

--- a/test/test-extra-header.sh
+++ b/test/test-extra-header.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+. "test/testlib.sh"
+
+begin_test "http.<url>.extraHeader"
+(
+  set -e
+
+  reponame="copy-headers"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  url="$(git config remote.origin.url).git/info/lfs"
+  git config --add "http.$url.extraHeader" "X-Foo: bar"
+  git config --add "http.$url.extraHeader" "X-Foo: baz"
+
+  git lfs track "*.dat"
+  printf "contents" > a.dat
+  git add .gitattributes a.dat
+  git commit -m "initial commit"
+
+  GIT_CURL_VERBOSE=1 GIT_TRACE=1 git push origin master 2>&1 | tee curl.log
+
+  grep "> X-Foo: bar" curl.log
+  grep "> X-Foo: baz" curl.log
+)
+end_test


### PR DESCRIPTION
This pull request resolves the proposal made in #1500 by implementing support for `http.<url>.extraHeader`.

This pull request is based off of https://github.com/git-lfs/git-lfs/pull/2158, and that should be merged before this one. In the meantime, __here's an inter-diff__: https://github.com/git-lfs/git-lfs/compare/url-config-prefix...lfsapi-extra-headers.

When making any HTTP(S) request from the lfsapi package, LFS will first look for matching `http.{url}.extraHeader` config entries, where `url` is the request URL. LFS currently adds one extra header to each request it makes, which is the `User-Agent: ` header. The `lfsapi` package looks for `extraHeaders` _before_ adding the User-Agent header, so it cannot be overridden.

As per https://github.com/git-lfs/git-lfs/pull/2152 & https://github.com/git-lfs/git-lfs/pull/2154, multiple extraHeaders can be added to a particular request. The following configuration is valid:

```bash
$ git config http.https://github.com/user/repo.git/info/lfs.extraHeader "X-Foo: bar"
$ git config http.https://github.com/user/repo.git/info/lfs.extraHeader "X-Non-Unique: bar2"
$ git config http.https://github.com/user/repo.git/info/lfs.extraHeader "X-Non-Unique: bar3"
```

would send a request with the headers equal to:

```curl
> GET /user/repo.git/info/lfs HTTP/1.1
> Host: github.com
> X-Foo: bar
> X-Non-Unique: bar2
> X-Non-Unique: bar3
```

Closes: #1500.

---

/cc @git-lfs/core #1500 