### PR TITLE
lfsapi/certs: use *config.URLConfig to do per-host config lookup

### DIFF
--- a/lfsapi/certs.go
+++ b/lfsapi/certs.go
@@ -7,13 +7,14 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
+	"github.com/git-lfs/git-lfs/config"
 	"github.com/rubyist/tracerx"
 )
 
 // isCertVerificationDisabledForHost returns whether SSL certificate verification
 // has been disabled for the given host, or globally
 func isCertVerificationDisabledForHost(c *Client, host string) bool {
-	hostSslVerify, _ := c.gitEnv.Get(fmt.Sprintf("http.https://%v/.sslverify", host))
+	hostSslVerify, _ := c.uc.Get("http", fmt.Sprintf("https://%v", host), "sslverify")
 	if hostSslVerify == "false" {
 		return true
 	}
@@ -24,8 +25,8 @@ func isCertVerificationDisabledForHost(c *Client, host string) bool {
 // isClientCertEnabledForHost returns whether client certificate
 // are configured for the given host
 func isClientCertEnabledForHost(c *Client, host string) bool {
-	_, hostSslKeyOk := c.gitEnv.Get(fmt.Sprintf("http.https://%v/.sslKey", host))
-	_, hostSslCertOk := c.gitEnv.Get(fmt.Sprintf("http.https://%v/.sslCert", host))
+	_, hostSslKeyOk := c.uc.Get("http", fmt.Sprintf("https://%v/", host), "sslKey")
+	_, hostSslCertOk := c.uc.Get("http", fmt.Sprintf("https://%v/", host), "sslCert")
 
 	return hostSslKeyOk && hostSslCertOk
 }
@@ -33,8 +34,8 @@ func isClientCertEnabledForHost(c *Client, host string) bool {
 // getClientCertForHost returns a client certificate for a specific host (which may
 // be "host:port" loaded from the gitconfig
 func getClientCertForHost(c *Client, host string) tls.Certificate {
-	hostSslKey, _ := c.gitEnv.Get(fmt.Sprintf("http.https://%v/.sslKey", host))
-	hostSslCert, _ := c.gitEnv.Get(fmt.Sprintf("http.https://%v/.sslCert", host))
+	hostSslKey, _ := c.uc.Get("http", fmt.Sprintf("https://%v/", host), "sslKey")
+	hostSslCert, _ := c.uc.Get("http", fmt.Sprintf("https://%v/", host), "sslCert")
 	cert, err := tls.LoadX509KeyPair(hostSslCert, hostSslKey)
 	if err != nil {
 		tracerx.Printf("Error reading client cert/key %v", err)
@@ -65,17 +66,8 @@ func appendRootCAsForHostFromGitconfig(osEnv Env, gitEnv Env, pool *x509.CertPoo
 		return appendCertsFromFile(pool, cafile)
 	}
 	// http.<url>/.sslcainfo or http.<url>.sslcainfo
-	// we know we have simply "host" or "host:port"
-	hostKeyWithSlash := fmt.Sprintf("http.https://%v/.sslcainfo", host)
-	if cafile, ok := gitEnv.Get(hostKeyWithSlash); ok {
-		return appendCertsFromFile(pool, cafile)
-	}
-	hostKeyWithoutSlash := fmt.Sprintf("http.https://%v.sslcainfo", host)
-	if cafile, ok := gitEnv.Get(hostKeyWithoutSlash); ok {
-		return appendCertsFromFile(pool, cafile)
-	}
-	// http.sslcainfo
-	if cafile, ok := gitEnv.Get("http.sslcainfo"); ok {
+	uc := config.NewURLConfig(gitEnv)
+	if cafile, ok := uc.Get("http", fmt.Sprintf("https://%v/", host), "sslcainfo"); ok {
 		return appendCertsFromFile(pool, cafile)
 	}
 	// GIT_SSL_CAPATH


### PR DESCRIPTION
This pull request updates all remaining `http.{url}.*` key lookups to use the new `*config.URLConfig` type.

I did a search via:

```bash
~/g/git-lfs (master) $ find . -type f | grep -v "\.\/vendor" | grep "\.go$" | xargs ack 'http\.'
```

and trimmed those down which yielded the changes made in this pull request. The only other `http.*` key lookup we have is [here](https://github.com/git-lfs/git-lfs/blob/v2.0.2/lfsapi/proxy.go#L51) for the `http.proxy` config, but Git itself does not support per-host/url `http.proxy`-ing.

---

/cc @git-lfs/core 