### PR TITLE
lfsapi: support URL-style lookups for `lfs.{url}.access`

### DIFF
--- a/lfsapi/endpoint_finder.go
+++ b/lfsapi/endpoint_finder.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/git-lfs/git-lfs/config"
 	"github.com/git-lfs/git-lfs/git"
 	"github.com/rubyist/tracerx"
 )
@@ -44,6 +45,7 @@ type endpointGitFinder struct {
 
 	accessMu  sync.Mutex
 	urlAccess map[string]Access
+	urlConfig *config.URLConfig
 }
 
 func NewEndpointFinder(git Env) EndpointFinder {
@@ -55,6 +57,7 @@ func NewEndpointFinder(git Env) EndpointFinder {
 
 	if git != nil {
 		e.git = git
+		e.urlConfig = config.NewURLConfig(e.git)
 		if v, ok := git.Get("lfs.gitprotocol"); ok {
 			e.gitProtocol = v
 		}

--- a/lfsapi/endpoint_finder.go
+++ b/lfsapi/endpoint_finder.go
@@ -200,8 +200,7 @@ func (e *endpointGitFinder) AccessFor(rawurl string) Access {
 		return cached
 	}
 
-	key := fmt.Sprintf("lfs.%s.access", accessurl)
-	e.urlAccess[accessurl] = e.fetchGitAccess(key)
+	e.urlAccess[accessurl] = e.fetchGitAccess(accessurl)
 	return e.urlAccess[accessurl]
 }
 
@@ -238,8 +237,8 @@ func urlWithoutAuth(rawurl string) string {
 	return u.String()
 }
 
-func (e *endpointGitFinder) fetchGitAccess(key string) Access {
-	if v, _ := e.git.Get(key); len(v) > 0 {
+func (e *endpointGitFinder) fetchGitAccess(rawurl string) Access {
+	if v, _ := e.urlConfig.Get("lfs", rawurl, "access"); len(v) > 0 {
 		access := Access(strings.ToLower(v))
 		if access == PrivateAccess {
 			return BasicAccess

--- a/lfsapi/endpoint_finder.go
+++ b/lfsapi/endpoint_finder.go
@@ -198,7 +198,7 @@ func (e *endpointGitFinder) AccessFor(rawurl string) Access {
 	}
 
 	key := fmt.Sprintf("lfs.%s.access", accessurl)
-	e.urlAccess[accessurl] = fetchGitAccess(e.git, key)
+	e.urlAccess[accessurl] = e.fetchGitAccess(key)
 	return e.urlAccess[accessurl]
 }
 
@@ -235,8 +235,8 @@ func urlWithoutAuth(rawurl string) string {
 	return u.String()
 }
 
-func fetchGitAccess(git Env, key string) Access {
-	if v, _ := git.Get(key); len(v) > 0 {
+func (e *endpointGitFinder) fetchGitAccess(key string) Access {
+	if v, _ := e.git.Get(key); len(v) > 0 {
 		access := Access(strings.ToLower(v))
 		if access == PrivateAccess {
 			return BasicAccess


### PR DESCRIPTION
This pull request replaces all call-sites for `lfs.{url}.access` with a call to `Get()` using the `*config.URLConfig` type.

---

/cc @git-lfs/core 