### PR TITLE
commands: support URL-style lookups for `lfs.{url}.locksverify`

### DIFF
--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -135,12 +136,41 @@ func verifyLocks(remote string) (ours, theirs []locking.Lock) {
 		} else {
 			ExitWithError(err)
 		}
-	} else if state == verifyStateUnknown {
+	} else if state == verifyStateUnknown && !supportsLockingAPI(endpoint) {
 		Print("Locking support detected on remote %q. Consider enabling it with:", remote)
 		Print("  $ git config 'lfs.%s.locksverify' true", endpoint.Url)
 	}
 
 	return ours, theirs
+}
+
+var (
+	// hostsWithKnownLockingSupport is a list of scheme-less hostnames
+	// (without port numbers) that are known to implement the LFS locking
+	// API.
+	//
+	// Additions are welcome.
+	hostsWithKnownLockingSupport = []string{
+		"github.com",
+	}
+)
+
+// supportsLockingAPI returns whether or not a given lfsapi.Endpoint "e"
+// is known to support the LFS locking API by whether or not its hostname is
+// included in the list above.
+func supportsLockingAPI(e lfsapi.Endpoint) bool {
+	u, err := url.Parse(e.Url)
+	if err != nil {
+		tracerx.Printf("commands: unable to parse %q to determine locking support: %v", e.Url, err)
+		return false
+	}
+
+	for _, host := range hostsWithKnownLockingSupport {
+		if u.Hostname() == host {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *uploadContext) scannerError() error {

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -136,7 +136,7 @@ func verifyLocks(remote string) (ours, theirs []locking.Lock) {
 		} else {
 			ExitWithError(err)
 		}
-	} else if state == verifyStateUnknown && !supportsLockingAPI(endpoint) {
+	} else if state == verifyStateUnknown {
 		Print("Locking support detected on remote %q. Consider enabling it with:", remote)
 		Print("  $ git config 'lfs.%s.locksverify' true", endpoint.Url)
 	}
@@ -368,6 +368,9 @@ func getVerifyStateFor(endpoint lfsapi.Endpoint) verifyState {
 
 	v, ok := uc.Get("lfs", endpoint.Url, "locksverify")
 	if !ok {
+		if supportsLockingAPI(endpoint.Url) {
+			return verifyStateEnabled
+		}
 		return verifyStateUnknown
 	}
 

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -350,7 +350,7 @@ func getVerifyStateFor(endpoint lfsapi.Endpoint) verifyState {
 
 	v, ok := uc.Get("lfs", endpoint.Url, "locksverify")
 	if !ok {
-		if supportsLockingAPI(endpoint.Url) {
+		if supportsLockingAPI(endpoint) {
 			return verifyStateEnabled
 		}
 		return verifyStateUnknown

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/git-lfs/git-lfs/config"
 	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/git"
 	"github.com/git-lfs/git-lfs/lfs"
@@ -333,9 +334,9 @@ func (c *uploadContext) Await() {
 // given "endpoint". If no state has been explicitly set, an "unknown" state
 // will be returned instead.
 func getVerifyStateFor(endpoint lfsapi.Endpoint) verifyState {
-	key := strings.Join([]string{"lfs", endpoint.Url, "locksverify"}, ".")
+	uc := config.NewURLConfig(cfg.Git)
 
-	v, ok := cfg.Git.Get(key)
+	v, ok := uc.Get("lfs", endpoint.Url, "locksverify")
 	if !ok {
 		return verifyStateUnknown
 	}

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -144,35 +144,6 @@ func verifyLocks(remote string) (ours, theirs []locking.Lock) {
 	return ours, theirs
 }
 
-var (
-	// hostsWithKnownLockingSupport is a list of scheme-less hostnames
-	// (without port numbers) that are known to implement the LFS locking
-	// API.
-	//
-	// Additions are welcome.
-	hostsWithKnownLockingSupport = []string{
-		"github.com",
-	}
-)
-
-// supportsLockingAPI returns whether or not a given lfsapi.Endpoint "e"
-// is known to support the LFS locking API by whether or not its hostname is
-// included in the list above.
-func supportsLockingAPI(e lfsapi.Endpoint) bool {
-	u, err := url.Parse(e.Url)
-	if err != nil {
-		tracerx.Printf("commands: unable to parse %q to determine locking support: %v", e.Url, err)
-		return false
-	}
-
-	for _, host := range hostsWithKnownLockingSupport {
-		if u.Hostname() == host {
-			return true
-		}
-	}
-	return false
-}
-
 func (c *uploadContext) scannerError() error {
 	c.errMu.Lock()
 	defer c.errMu.Unlock()
@@ -360,6 +331,17 @@ func (c *uploadContext) Await() {
 	}
 }
 
+var (
+	// hostsWithKnownLockingSupport is a list of scheme-less hostnames
+	// (without port numbers) that are known to implement the LFS locking
+	// API.
+	//
+	// Additions are welcome.
+	hostsWithKnownLockingSupport = []string{
+		"github.com",
+	}
+)
+
 // getVerifyStateFor returns whether or not lock verification is enabled for the
 // given "endpoint". If no state has been explicitly set, an "unknown" state
 // will be returned instead.
@@ -378,6 +360,24 @@ func getVerifyStateFor(endpoint lfsapi.Endpoint) verifyState {
 		return verifyStateEnabled
 	}
 	return verifyStateDisabled
+}
+
+// supportsLockingAPI returns whether or not a given lfsapi.Endpoint "e"
+// is known to support the LFS locking API by whether or not its hostname is
+// included in the list above.
+func supportsLockingAPI(e lfsapi.Endpoint) bool {
+	u, err := url.Parse(e.Url)
+	if err != nil {
+		tracerx.Printf("commands: unable to parse %q to determine locking support: %v", e.Url, err)
+		return false
+	}
+
+	for _, host := range hostsWithKnownLockingSupport {
+		if u.Hostname() == host {
+			return true
+		}
+	}
+	return false
 }
 
 // disableFor disables lock verification for the given lfsapi.Endpoint,

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -332,13 +332,16 @@ func (c *uploadContext) Await() {
 }
 
 var (
+	githubHttps, _ = url.Parse("https://github.com")
+	githubSsh, _   = url.Parse("ssh://github.com")
+
 	// hostsWithKnownLockingSupport is a list of scheme-less hostnames
 	// (without port numbers) that are known to implement the LFS locking
 	// API.
 	//
 	// Additions are welcome.
-	hostsWithKnownLockingSupport = []string{
-		"github.com",
+	hostsWithKnownLockingSupport = []*url.URL{
+		githubHttps, githubSsh,
 	}
 )
 
@@ -372,8 +375,10 @@ func supportsLockingAPI(e lfsapi.Endpoint) bool {
 		return false
 	}
 
-	for _, host := range hostsWithKnownLockingSupport {
-		if u.Hostname() == host {
+	for _, supported := range hostsWithKnownLockingSupport {
+		if supported.Scheme == u.Scheme &&
+			supported.Hostname() == u.Hostname() &&
+			strings.HasPrefix(u.Path, supported.Path) {
 			return true
 		}
 	}

--- a/commands/uploader_test.go
+++ b/commands/uploader_test.go
@@ -1,0 +1,36 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/git-lfs/git-lfs/lfsapi"
+	"github.com/stretchr/testify/assert"
+)
+
+type LockingSupportTestCase struct {
+	Given           string
+	ExpectedToMatch bool
+}
+
+func (l *LockingSupportTestCase) Assert(t *testing.T) {
+	ep := lfsapi.Endpoint{
+		Url: l.Given,
+	}
+
+	assert.Equal(t, l.ExpectedToMatch, supportsLockingAPI(ep))
+}
+
+func TestSupportedLockingHosts(t *testing.T) {
+	for desc, c := range map[string]*LockingSupportTestCase{
+		"https with path prefix":        {"https://github.com/ttaylorr/dotfiles.git/info/lfs", true},
+		"https with root":               {"https://github.com/ttaylorr/dotfiles", true},
+		"http with path prefix":         {"http://github.com/ttaylorr/dotfiles.git/info/lfs", false},
+		"http with root":                {"http://github.com/ttaylorr/dotfiles", false},
+		"ssh with path prefix":          {"ssh://github.com/ttaylorr/dotfiles.git/info/lfs", true},
+		"ssh with root":                 {"ssh://github.com/ttaylorr/dotfiles", true},
+		"ssh with user and path prefix": {"ssh://git@github.com/ttaylorr/dotfiles.git/info/lfs", true},
+		"ssh with user and root":        {"ssh://git@github.com/ttaylorr/dotfiles", true},
+	} {
+		t.Run(desc, c.Assert)
+	}
+}

--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -222,6 +222,10 @@ be scoped inside the configuration for a remote.
   You should set this if you're not using File Locking, or your Git server
   verifies locked files on pushes automatically.
 
+  Supports URL config lookup as described in:
+  https://git-scm.com/docs/git-config#git-config-httplturlgt. To set this value
+  per-host: `git config lfs.https://github.com/.locksverify 0`.
+
 * `lfs.skipdownloaderrors`
 
   Causes Git LFS not to abort the smudge filter when a download error is

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -762,6 +762,7 @@ begin_test "pre-push locks verify 200"
   grep "git config 'lfs.$endpoint.locksverify' true" push.log
   assert_server_object "$reponame" "$contents_oid"
 )
+end_test
 
 begin_test "pre-push locks verify 403 with verification enabled"
 (


### PR DESCRIPTION
This pull request implements support for URL-style lookups for the `lfs.{url}.locksverify` config value and resolves https://github.com/git-lfs/git-lfs/issues/2093.

When writing this, I was wondering if we should change the suggested `git config` commands to use a site's host, instead of the fully qualified path. @technoweenie wisely points out that we can't accurately determine whether or not the hostname is the "root" of the LFS API, so the messages were left unchanged.

To partially mitigate this, I added a `hostsWithKnownLockingSupport`, which skips printing out the suggested `git config` message if it's known that a host supports the LFS locking API. I skipped testing this in the integration suite since there's not an accurate way to do this without making a network call to one of the sites in the list.

At the time of writing, GitHub is the only host I know of that completely supports the File Locking API. As additional hosts add support, they should feel free to file a PR to add themselves to that list.

Closes: https://github.com/git-lfs/git-lfs/issues/2093.

---

/cc @git-lfs/core https://github.com/git-lfs/git-lfs/issues/2093