### PR TITLE
Fail push if locks verify is enabled, and any locked files are updated

### DIFF
--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -125,15 +125,15 @@ func verifyLocks(remote string) (ours, theirs []locking.Lock, st verifyState) {
 		if errors.IsNotImplementedError(err) {
 			disableFor(endpoint)
 		} else if state == verifyStateUnknown || state == verifyStateEnabled {
-			if !errors.IsAuthError(err) {
+			if errors.IsAuthError(err) {
+				ExitWithError(err)
+			} else {
 				Print("Remote %q does not support the LFS locking API. Consider disabling it with:", remote)
 				Print("  $ git config 'lfs.%s.locksverify' false", endpoint.Url)
 
 				if state == verifyStateEnabled {
 					ExitWithError(err)
 				}
-			} else {
-				ExitWithError(err)
 			}
 		}
 	} else if state == verifyStateUnknown {

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -125,11 +125,12 @@ func verifyLocks(remote string) (ours, theirs []locking.Lock, st verifyState) {
 		if errors.IsNotImplementedError(err) {
 			disableFor(endpoint)
 		} else if state == verifyStateUnknown || state == verifyStateEnabled {
-			if state == verifyStateEnabled {
-				ExitWithError(err)
-			} else if !errors.IsAuthError(err) {
+			if !errors.IsAuthError(err) {
 				Print("Remote %q does not support the LFS locking API. Consider disabling it with:", remote)
 				Print("  $ git config 'lfs.%s.locksverify' false", endpoint.Url)
+				if state == verifyStateEnabled {
+					ExitWithError(err)
+				}
 			}
 		}
 	} else if state == verifyStateUnknown {

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -125,15 +125,11 @@ func verifyLocks(remote string) (ours, theirs []locking.Lock, st verifyState) {
 		if errors.IsNotImplementedError(err) {
 			disableFor(endpoint)
 		} else if state == verifyStateUnknown || state == verifyStateEnabled {
-			if errors.IsAuthError(err) {
+			if state == verifyStateEnabled {
 				ExitWithError(err)
-			} else {
+			} else if !errors.IsAuthError(err) {
 				Print("Remote %q does not support the LFS locking API. Consider disabling it with:", remote)
 				Print("  $ git config 'lfs.%s.locksverify' false", endpoint.Url)
-
-				if state == verifyStateEnabled {
-					ExitWithError(err)
-				}
 			}
 		}
 	} else if state == verifyStateUnknown {

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -125,7 +125,9 @@ func verifyLocks(remote string) (ours, theirs []locking.Lock, st verifyState) {
 		if errors.IsNotImplementedError(err) {
 			disableFor(endpoint)
 		} else if state == verifyStateUnknown || state == verifyStateEnabled {
-			if !errors.IsAuthError(err) {
+			if errors.IsAuthError(err) {
+				ExitWithError(err)
+			} else {
 				Print("Remote %q does not support the LFS locking API. Consider disabling it with:", remote)
 				Print("  $ git config 'lfs.%s.locksverify' false", endpoint.Url)
 				if state == verifyStateEnabled {

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -227,13 +227,15 @@ func (c *uploadContext) prepareUpload(unfiltered ...*lfs.WrappedPointer) (*tq.Tr
 			c.unownedLocks = append(c.unownedLocks, lock)
 			c.trackedLocksMu.Unlock()
 
-			// If the verification state is enabled or undefined,
-			// this failed locks verification means that the push
-			// should fail.
+			// If the verification state is enabled, this failed
+			// locks verification means that the push should fail.
 			//
 			// If the state is disabled, the verification error is
 			// silent and the user can upload.
-			canUpload = c.lockVerifyState == verifyStateDisabled
+			//
+			// If the state is undefined, the verification error is
+			// sent as a warning and the user can upload.
+			canUpload = c.lockVerifyState != verifyStateEnabled
 		}
 
 		if lock, ok := c.ourLocks[p.Name]; ok {

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -126,7 +126,11 @@ func verifyLocks(remote string) (ours, theirs []locking.Lock, st verifyState) {
 			disableFor(endpoint)
 		} else if state == verifyStateUnknown || state == verifyStateEnabled {
 			if errors.IsAuthError(err) {
-				ExitWithError(err)
+				if state == verifyStateUnknown {
+					Error("WARNING: Authentication error: %s", err)
+				} else if state == verifyStateEnabled {
+					Exit("ERROR: Authentication error: %s", err)
+				}
 			} else {
 				Print("Remote %q does not support the LFS locking API. Consider disabling it with:", remote)
 				Print("  $ git config 'lfs.%s.locksverify' false", endpoint.Url)

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -517,6 +517,7 @@ begin_test "pre-push with their lock on lfs file"
 
   pushd "$TRASHDIR" >/dev/null
     clone_repo "$reponame" "$reponame-assert"
+    git config lfs.locksverify true
 
     printf "unauthorized changes" >> locked_theirs.dat
     git add locked_theirs.dat
@@ -524,6 +525,11 @@ begin_test "pre-push with their lock on lfs file"
     git commit --no-verify -m "add unauthorized changes"
 
     git push origin master 2>&1 | tee push.log
+    res="${PIPESTATUS[0]}"
+    if [ "0" -eq "$res" ]; then
+      echo "push should fail"
+      exit 1
+    fi
 
     grep "Unable to push 1 locked file(s)" push.log
     grep "* locked_theirs.dat - Git LFS Tests" push.log
@@ -562,6 +568,7 @@ begin_test "pre-push with their lock on non-lfs lockable file"
 
   pushd "$TRASHDIR" >/dev/null
     clone_repo "$reponame" "$reponame-assert"
+    git config lfs.locksverify true
 
     git lfs update # manually add pre-push hook, since lfs clean hook is not used
     echo "other changes" >> readme.txt
@@ -571,6 +578,11 @@ begin_test "pre-push with their lock on non-lfs lockable file"
     git commit --no-verify -am "add unauthorized changes"
 
     git push origin master 2>&1 | tee push.log
+    res="${PIPESTATUS[0]}"
+    if [ "0" -eq "$res" ]; then
+      echo "push should fail"
+      exit 1
+    fi
 
     grep "Unable to push 2 locked file(s)" push.log
     grep "* large_locked_theirs.dat - Git LFS Tests" push.log

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -803,8 +803,9 @@ begin_test "pre-push locks verify 403 with verification enabled"
   git config "lfs.$endpoint.locksverify" true
 
   git push origin master 2>&1 | tee push.log
+  grep "Authentication required" push.log
 
-  assert_server_object "$reponame" "$contents_oid"
+  refute_server_object "$reponame" "$contents_oid"
   [ "true" = "$(git config "lfs.$endpoint.locksverify")" ]
 )
 end_test
@@ -855,8 +856,9 @@ begin_test "pre-push locks verify 403 with verification unset"
   [ -z "$(git config "lfs.$endpoint.locksverify")" ]
 
   git push origin master 2>&1 | tee push.log
+  grep "Authentication required" push.log
 
-  assert_server_object "$reponame" "$contents_oid"
+  refute_server_object "$reponame" "$contents_oid"
   [ -z "$(git config "lfs.$endpoint.locksverify")" ]
 )
 end_test

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -533,6 +533,9 @@ begin_test "pre-push with their lock on lfs file"
 
     grep "Unable to push 1 locked file(s)" push.log
     grep "* locked_theirs.dat - Git LFS Tests" push.log
+
+    grep "ERROR: Cannot update locked files." push.log
+    refute_server_object "$reponame" "$(calc_oid_file locked_theirs.dat)"
   popd >/dev/null
 )
 end_test
@@ -587,6 +590,10 @@ begin_test "pre-push with their lock on non-lfs lockable file"
     grep "Unable to push 2 locked file(s)" push.log
     grep "* large_locked_theirs.dat - Git LFS Tests" push.log
     grep "* tiny_locked_theirs.dat - Git LFS Tests" push.log
+    grep "ERROR: Cannot update locked files." push.log
+
+    refute_server_object "$reponame" "$(calc_oid_file large_locked_theirs.dat)"
+    refute_server_object "$reponame" "$(calc_oid_file tiny_locked_theirs.dat)"
   popd >/dev/null
 )
 end_test

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -803,7 +803,7 @@ begin_test "pre-push locks verify 403 with verification enabled"
   git config "lfs.$endpoint.locksverify" true
 
   git push origin master 2>&1 | tee push.log
-  grep "Authentication required" push.log
+  grep "ERROR: Authentication error" push.log
 
   refute_server_object "$reponame" "$contents_oid"
   [ "true" = "$(git config "lfs.$endpoint.locksverify")" ]
@@ -856,9 +856,9 @@ begin_test "pre-push locks verify 403 with verification unset"
   [ -z "$(git config "lfs.$endpoint.locksverify")" ]
 
   git push origin master 2>&1 | tee push.log
-  grep "Authentication required" push.log
+  grep "WARNING: Authentication error" push.log
 
-  refute_server_object "$reponame" "$contents_oid"
+  assert_server_object "$reponame" "$contents_oid"
   [ -z "$(git config "lfs.$endpoint.locksverify")" ]
 )
 end_test

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -804,7 +804,7 @@ begin_test "pre-push locks verify 403 with verification enabled"
 
   git push origin master 2>&1 | tee push.log
 
-  refute_server_object "$reponame" "$contents_oid"
+  assert_server_object "$reponame" "$contents_oid"
   [ "true" = "$(git config "lfs.$endpoint.locksverify")" ]
 )
 end_test
@@ -856,7 +856,7 @@ begin_test "pre-push locks verify 403 with verification unset"
 
   git push origin master 2>&1 | tee push.log
 
-  refute_server_object "$reponame" "$contents_oid"
+  assert_server_object "$reponame" "$contents_oid"
   [ -z "$(git config "lfs.$endpoint.locksverify")" ]
 )
 end_test


### PR DESCRIPTION
Fixes #2166, and reverses #1885 (which was needed because users were inadvertently running on a pre-release version of LFS, which blocked their pushes because no File Locking API implementations existed in the wild yet.

Question: should `locksverify` [automatically be enabled](https://github.com/git-lfs/git-lfs/blob/ab50944e2632844770c4cbf4ef8b79d5ffcfaa81/commands/uploader.go#L141-L145) if it's currently `NULL`, and the locks verify api call returned a valid result? I'm leaning towards "yes." I think our approach in LFS v2.0 is a bit too cautious. I think #2162 is a good step towards improving this situation for public LFS servers that implement the file locking API. But I think auto-enabling after successful results will remove an explicit opt-in step when using internal or custom LFS servers.