### PR TITLE
debian/control: we need golang 1.8

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: git-lfs
 Section: vcs
 Priority: optional
 Maintainer: Stephen Gelman <gelman@getbraintree.com>
-Build-Depends: debhelper (>= 9), dh-golang, golang-go:native (>= 1.3.0), git (>= 1.8.2), ruby-ronn
+Build-Depends: debhelper (>= 9), dh-golang, golang-go:native (>= 2:1.8), git (>= 1.8.2), ruby-ronn
 Standards-Version: 3.9.6
 
 Package: git-lfs


### PR DESCRIPTION
Little tweak to match distro versioning for golang.  Should fix #2176 
Only tested on ubuntu 16.04 (see notes in commit log), but the real target is ubuntu 17.04.