### PR TITLE
commands: cross-platform log formatting to files

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -302,7 +302,10 @@ func handlePanic(err error) string {
 }
 
 func logPanic(loggedError error) string {
-	var fmtWriter io.Writer = os.Stderr
+	var (
+		fmtWriter  io.Writer = os.Stderr
+		lineEnding string    = "\n"
+	)
 
 	now := time.Now()
 	name := now.Format("20060102T150405.999999999")
@@ -316,51 +319,52 @@ func logPanic(loggedError error) string {
 		full = ""
 		defer func() {
 			fmt.Fprintf(fmtWriter, "Unable to log panic to %s\n\n", filename)
-			logPanicToWriter(fmtWriter, err)
+			logPanicToWriter(fmtWriter, err, lineEnding)
 		}()
 	} else {
 		fmtWriter = file
+		lineEnding = gitLineEnding(cfg.Git)
 		defer file.Close()
 	}
 
-	logPanicToWriter(fmtWriter, loggedError)
+	logPanicToWriter(fmtWriter, loggedError, lineEnding)
 
 	return full
 }
 
-func logPanicToWriter(w io.Writer, loggedError error) {
+func logPanicToWriter(w io.Writer, loggedError error, le string) {
 	// log the version
 	gitV, err := git.Config.Version()
 	if err != nil {
 		gitV = "Error getting git version: " + err.Error()
 	}
 
-	fmt.Fprintln(w, config.VersionDesc)
-	fmt.Fprintln(w, gitV)
+	fmt.Fprint(w, config.VersionDesc+le)
+	fmt.Fprint(w, gitV+le)
 
 	// log the command that was run
-	fmt.Fprintln(w)
+	fmt.Fprint(w, le)
 	fmt.Fprintf(w, "$ %s", filepath.Base(os.Args[0]))
 	if len(os.Args) > 0 {
 		fmt.Fprintf(w, " %s", strings.Join(os.Args[1:], " "))
 	}
-	fmt.Fprintln(w)
+	fmt.Fprint(w, le)
 
 	// log the error message and stack trace
 	w.Write(ErrorBuffer.Bytes())
-	fmt.Fprintln(w)
+	fmt.Fprint(w, le)
 
-	fmt.Fprintf(w, "%+v\n", loggedError)
+	fmt.Fprint(w, "%+v"+le, loggedError)
 
 	for key, val := range errors.Context(err) {
-		fmt.Fprintf(w, "%s=%v\n", key, val)
+		fmt.Fprint(w, "%s=%v"+le, key, val)
 	}
 
-	fmt.Fprintln(w, "\nENV:")
+	fmt.Fprint(w, le+"ENV:"+le)
 
 	// log the environment
 	for _, env := range lfs.Environ(cfg, getTransferManifest()) {
-		fmt.Fprintln(w, env)
+		fmt.Fprint(w, env+le)
 	}
 }
 

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -350,10 +350,7 @@ func logPanicToWriter(w io.Writer, loggedError error) {
 	w.Write(ErrorBuffer.Bytes())
 	fmt.Fprintln(w)
 
-	fmt.Fprintf(w, "%s\n", loggedError)
-	for _, stackline := range errors.StackTrace(loggedError) {
-		fmt.Fprintln(w, stackline)
-	}
+	fmt.Fprintf(w, "%+v\n", loggedError)
 
 	for key, val := range errors.Context(err) {
 		fmt.Fprintf(w, "%s=%v\n", key, val)


### PR DESCRIPTION
This pull request addresses the second and third points of https://github.com/git-lfs/git-lfs/issues/2076:

> (2) On Windows, checking this logfile with an application that does not support Linux-style line endings results in this, which is unusual even for cross-platform systems:

This one required some investigation. I originally thought that the goal here was to replace all instances of printing LF (`\n`) characters sent to the terminal, but the actual fix is to just print platform-specific line ending sequences to _files on disk_, not the terminal.

To determine this, I wrote two files to my `~/github/share` directory, which is accessible via my Windows VM. Each had the words "foo" and "bar". One was separated by a LF character, and the other by a CRLF, as follows:

```
~/g/git-lfs (x-platform-logs-formatting) $ echo -n "foo\nbar" > ~/github/share/example_lf
~/g/git-lfs (x-platform-logs-formatting) $ hexdump -C < ~/github/share/example_lf
00000000  66 6f 6f 0a 62 61 72                              |foo.bar|
00000007
~/g/git-lfs (x-platform-logs-formatting) $ echo -n "foo\r\nbar" > ~/github/share/example_crlf
~/g/git-lfs (x-platform-logs-formatting) $ hexdump -C < ~/github/share/example_crlf
00000000  66 6f 6f 0d 0a 62 61 72                           |foo..bar|
00000008
```

On Windows, they render in the terminal as expected independent of the line ending sequences (tested via cmd.exe, and reproducible in Git Bash):

```
C:\Users\ttaylorr>type "\\vmware-host\Shared Folders\share\example_crlf"
foo
bar
C:\Users\ttaylorr>type "\\vmware-host\Shared Folders\share\example_lf"
foo
bar
```

So the fix in https://github.com/git-lfs/git-lfs/commit/43ec8e9a0d44ab04b4352d8376a2eb42d9f3a55b involved:

- Adding a `lineEnding` argument to the `logPanicToWriter()` func. This function is used to print to both `os.Stderr`, as well as `*os.File` instances, so it needs to be able to handle either `LF` or `CRLF`s.
- Picking the right line ending sequence for each. For this, we can lean on the existing `gitLineEnding` func, which prefers your `core.autocrlf` setting, or defaults to the platform correct sequence instead.

> (3) After converting the line endings, the relevant error message is way out on the right side of the screen, which significantly hinders reading comprehension for a user trying to parse these for the first time.

This is a larger problem with my (perhaps) excessive use of error-wrapping, but is easily solved by formatting errors with `%+v` instead of `%s`. Here's a before and after:

- With `%s` (old):

```
e3: e2: e1
<stacktrace>
```

- With `%+v` (new): 

```
e1
<snip>
github.com/git-lfs/git-lfs/errors.newWrappedError
        /Users/ttaylorr/go/src/github.com/git-lfs/git-lfs/errors/types.go:166: e2
github.com/git-lfs/git-lfs/errors.newWrappedError
        /Users/ttaylorr/go/src/github.com/git-lfs/git-lfs/errors/types.go:166: e3
```

---

Closes: https://github.com/git-lfs/git-lfs/issues/2076.

---

/cc @git-lfs/core @JarrettR https://github.com/git-lfs/git-lfs/issues/2076