### PR TITLE
commands: include error in `LoggedError()`

### DIFF
--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -20,7 +20,7 @@ func checkoutCommand(cmd *cobra.Command, args []string) {
 	singleCheckout := newSingleCheckout()
 	chgitscanner := lfs.NewGitScanner(func(p *lfs.WrappedPointer, err error) {
 		if err != nil {
-			LoggedError(err, "Scanner error")
+			LoggedError(err, "Scanner error: %s", err)
 			return
 		}
 

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -52,7 +52,7 @@ func pull(remote string, filter *filepathfilter.Filter) {
 	q := newDownloadQueue(singleCheckout.manifest, remote, tq.WithProgress(meter))
 	gitscanner := lfs.NewGitScanner(func(p *lfs.WrappedPointer, err error) {
 		if err != nil {
-			LoggedError(err, "Scanner error")
+			LoggedError(err, "Scanner error: %s", err)
 			return
 		}
 

--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -70,7 +70,12 @@ func smudge(to io.Writer, from io.Reader, filename string, skip bool, filter *fi
 		ptr.Encode(to)
 		// Download declined error is ok to skip if we weren't requesting download
 		if !(errors.IsDownloadDeclinedError(err) && !download) {
-			LoggedError(err, "Error downloading object: %s (%s)", filename, ptr.Oid)
+			var oid string = ptr.Oid
+			if len(oid) >= 7 {
+				oid = oid[:7]
+			}
+
+			LoggedError(err, "Error downloading object: %s (%s): %s", filename, oid)
 			if !cfg.SkipDownloadErrors() {
 				os.Exit(2)
 			}

--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -75,7 +75,7 @@ func smudge(to io.Writer, from io.Reader, filename string, skip bool, filter *fi
 				oid = oid[:7]
 			}
 
-			LoggedError(err, "Error downloading object: %s (%s): %s", filename, oid)
+			LoggedError(err, "Error downloading object: %s (%s): %s", filename, oid, err)
 			if !cfg.SkipDownloadErrors() {
 				os.Exit(2)
 			}

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -207,7 +207,7 @@ ArgsLoop:
 	lockClient := newLockClient(cfg.CurrentRemote)
 	err = lockClient.FixFileWriteFlagsInDir(relpath, readOnlyPatterns, writeablePatterns)
 	if err != nil {
-		LoggedError(err, "Error changing lockable file permissions")
+		LoggedError(err, "Error changing lockable file permissions: %s", err)
 	}
 }
 

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -196,7 +196,7 @@ ArgsLoop:
 				now := time.Now()
 				err := os.Chtimes(f, now, now)
 				if err != nil {
-					LoggedError(err, "Error marking %q modified", f)
+					LoggedError(err, "Error marking %q modified: %s", f, err)
 					continue
 				}
 			}


### PR DESCRIPTION
This pull request resolves the first concern raised in https://github.com/git-lfs/git-lfs/issues/2076:

> (1) Requiring the user to check the logfile before seeing the full text of an error seems like an unnecessary extra step that prevents quick troubleshooting. This slight obfuscation of underlying cause of errors also likely leads to vague issue reports, which is harder on the maintainers.

I was looking into the cause of this and found that the callsites in question were using the function `commands.LoggedError()`, which has the signature:

```go
func LoggedError(err error, format string, args ...interface{}) { /* ... */ }
```

What this does is effectively:

1. `fmt.Fprintf(os.Stderr, format, args...)`, (write the format string to stderr) and
2. `LogError(os.File, err)` (log the error to `git lfs logs last`)

Notably, this function does not print the error to stderr unless specified with the format string and arguments. Something like this would look like:

```go
LoggedError(err, "%s", err)
```

I think this is good behavior, since different functions will want to format errors differently. That being said, I looked at all of the callers of `LoggedError` and updated them to include the error that they are logging using the `%s` format, which is `cause: error` without a stacktrace. This should better surface errors that were previously only accessible via a `git lfs logs last`, and will resolve #2076.

Closes https://github.com/git-lfs/git-lfs/issues/2076.

---

/cc @git-lfs/core @JarrettR https://github.com/git-lfs/git-lfs/issues/2076