### PR TITLE
tq: trace retriable errors

### DIFF
--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -487,7 +487,7 @@ func (q *TransferQueue) handleTransferResult(
 			// If the object can be retried, send it on the retries
 			// channel, where it will be read at the call-site and
 			// its retry count will be incremented.
-			tracerx.Printf("tq: retrying object %s", oid)
+			tracerx.Printf("tq: retrying object %s: %s", oid, res.Error)
 
 			q.trMutex.Lock()
 			t, ok := q.transfers[oid]

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -341,7 +341,7 @@ func (q *TransferQueue) enqueueAndCollectRetriesFor(batch batch) (batch, error) 
 					q.rc.Increment(tr.Oid)
 					count := q.rc.CountFor(tr.Oid)
 
-					tracerx.Printf("tq: enqueue retry #%d for %q (size: %d)", count, tr.Oid, tr.Size)
+					tracerx.Printf("tq: enqueue retry #%d for %q (size: %d): %s", count, tr.Oid, tr.Size, err)
 					next = append(next, t)
 				} else {
 					q.errorc <- errors.Errorf("[%v] %v", tr.Name, err)


### PR DESCRIPTION
This pull requests expands the amount of information we trace (`GIT_TRACE=1`) when transferring objects and dealing with failed/retried transfers.

There are two occasions upon which the `*tq.TransferQueue` will retry transfers:

1. Failed/un-parseable batch API request/response<sup>[[1](https://github.com/git-lfs/git-lfs/blob/v2.0.2/tq/transfer_queue.go#L341-L345)]</sup>.
2. Error(s) during upload/download itself (or faked transfers results for missing objects)<sup>[[2](https://github.com/git-lfs/git-lfs/blob/v2.0.2/tq/transfer_queue.go#L490)]</sup>.

This pull requests follows the same thought pattern as #2179 and adds the shorthand error to the trace output via the `%s` format string.

This should help surface underlying transfer issues like those occurring in https://github.com/git-lfs/git-lfs/issues/2030. Previously, these issues would only be surfaced when transfers exceeded their retry budget, or encountered a non-retriable error. This leaves a debugger to have to manually inspect the output with `GIT_TRACE=1` and/or `GIT_CURL_VERBOSE=1` to determine the underlying cause. 

---

/cc @git-lfs/core https://github.com/git-lfs/git-lfs/issues/2030