### PR TITLE
script/changelog: rev-list through --first-parent only

### DIFF
--- a/script/changelog
+++ b/script/changelog
@@ -31,7 +31,7 @@ features=""
 bugs=""
 misc=""
 
-for rev in $(git rev-list --merges $range); do
+for rev in $(git rev-list --merges --first-parent $range); do
   git show $rev
 
   processed=0


### PR DESCRIPTION
This pull request updates the `git-rev-list(1)` command used to generate release changelogs to only visit the `--first-parent` of each merge.

This way, we avoid inner-merges when merging master back into a feature branch before merging _that_ back into master.

---

/cc @git-lfs/core 