### PR TITLE
commands,lfs: prevent process leaks

### DIFF
--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -91,6 +91,8 @@ func pull(remote string, filter *filepathfilter.Filter) {
 
 	processQueue := time.Now()
 	if err := gitscanner.ScanTree(ref.Sha); err != nil {
+		singleCheckout.Close()
+
 		ExitWithError(err)
 	}
 

--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -42,6 +42,8 @@ func statusCommand(cmd *cobra.Command, args []string) {
 
 	scanner, err := lfs.NewPointerScanner()
 	if err != nil {
+		scanner.Close()
+
 		ExitWithError(err)
 	}
 

--- a/lfs/gitscanner_catfilebatch.go
+++ b/lfs/gitscanner_catfilebatch.go
@@ -19,6 +19,8 @@ import (
 func runCatFileBatch(pointerCh chan *WrappedPointer, lockableCh chan string, lockableSet *lockableNameSet, revs *StringChannelWrapper, errCh chan error) error {
 	scanner, err := NewPointerScanner()
 	if err != nil {
+		scanner.Close()
+
 		return err
 	}
 

--- a/lfs/gitscanner_tree.go
+++ b/lfs/gitscanner_tree.go
@@ -48,6 +48,8 @@ func runScanTree(cb GitScannerFoundPointer, ref string, filter *filepathfilter.F
 func catFileBatchTree(treeblobs *TreeBlobChannelWrapper) (*PointerChannelWrapper, error) {
 	scanner, err := NewPointerScanner()
 	if err != nil {
+		scanner.Close()
+
 		return nil, err
 	}
 


### PR DESCRIPTION
This pull request represents a complete audit of all calls to the `exec` standard library package as well as the `github.com/git-lfs/git-lfs/subprocess` package to ensure that no subcommands are orphaned when LFS quits.

There are two cases where we can leak processes:

1. Forgetting to call (or not having) a `(*T) Close() error` function to free resources and kill commands.
2. `defer`-ing that call, and not having the defer execute because of a `commands.Exit` or `commands.Panic`.

The issue with calling those `commands.*` helpers is that they use `os.Exit()` calls underneath, which causes an immediate termination of all goroutines, which prevents the calling function from returning thus the scheduler never executes the deferred function calls. From the documentation<sup>[[1](https://golang.org/pkg/os/#Exit)]</sup>: 

> The program terminates immediately; deferred functions are not run.

There are a few potential solutions to this, but by far the simplest is to just ensure that deferred function calls are executed imperatively before a `commands.ExitWithError()`. In other words, that turns this:

```go
defer s.Close()

if err := s.Err(); err != nil {
        ExitWithError(err)
}
```

into:

```go
defer s.Close()

if err := s.Err(); err != nil {
        s.Close()
        ExitWithError(err)
}
```

With those conditions set out, I identified all call-sites into the `exec` and `github.com/git-lfs/git-lfs/subprocess` packages. Those are outlined here:

<ul>
<li><details>
<summary><code>exec</code> package call-sites:</summary>
<pre>
commands/command_pointer.go:120:	cmd := exec.Command("git", "hash-object", "--stdin")
commands/commands.go:266:	cmd := exec.Command(name, args...)
commands/pull.go:88:	cmd    *exec.Cmd
commands/pull.go:100:		i.cmd = exec.Command("git", "update-index", "-q", "--refresh", "--stdin")
git/object_scanner.go:56:	cmd := exec.Command("git", "cat-file", "--batch")
lfs/extension.go:36:	cmd    *exec.Cmd
lfs/extension.go:62:		cmd := exec.Command(name, args...)
lfs/gitscanner_cmd.go:16:	*exec.Cmd
lfs/gitscanner_cmd.go:23:	cmd := exec.Command(command, args...)
lfsapi/creds.go:104:	cmd := exec.Command("git", "credential", subcommand)
lfsapi/creds.go:121:	if _, ok := err.(*exec.ExitError); ok {
lfsapi/ssh.go:81:	cmd := exec.Command(exe, args...)
subprocess/cmd.go:43:func newCmd(cmd *exec.Cmd) *Cmd {
subprocess/pty.go:13:	cmd    *exec.Cmd
subprocess/pty_nix.go:14:func NewTty(cmd *exec.Cmd) *Tty {
subprocess/pty_windows.go:7:func NewTty(cmd *exec.Cmd) *Tty {
subprocess/subprocess.go:16:// SimpleExec is a small wrapper around os/exec.Command.
subprocess/subprocess_nix.go:11:	cmd := exec.Command(name, arg...)
subprocess/subprocess_windows.go:12:	cmd := exec.Command(name, arg...)
</pre>
</details>
</li>
<li>
<details>
<summary><code>github.com/git-lfs/git-lfs/subprocess</code> call-sites:</summary>
<pre>
commands/command_clone.go:114:	cmd := subprocess.ExecCommand("git", "submodule", "foreach", "--recursive",
commands/path_windows.go:50:		cmd := subprocess.ExecCommand("pwd")
git/git.go:67:		return subprocess.SimpleExec("git", "ls-remote", remote)
git/git.go:70:	return subprocess.SimpleExec("git", "ls-remote", remote, remoteRef)
git/git.go:74:	outp, err := subprocess.SimpleExec("git", "rev-parse", ref, "--symbolic-full-name", ref)
git/git.go:177:	cmd := subprocess.ExecCommand("git", "remote")
git/git.go:199:	cmd := subprocess.ExecCommand("git", "show-ref", "--heads", "--tags")
git/git.go:311:	_, err := subprocess.SimpleExec("git", "update-index", "-q", "--refresh", file)
git/git.go:324:	output, _ := subprocess.SimpleExec("git", "config", val)
git/git.go:330:	output, _ := subprocess.SimpleExec("git", "config", "--global", val)
git/git.go:336:	output, _ := subprocess.SimpleExec("git", "config", "--system", val)
git/git.go:342:	output, _ := subprocess.SimpleExec("git", "config", "--local", val)
git/git.go:348:	return subprocess.SimpleExec("git", "config", "--global", key, val)
git/git.go:353:	return subprocess.SimpleExec("git", "config", "--system", key, val)
git/git.go:358:	return subprocess.SimpleExec("git", "config", "--global", "--unset", key)
git/git.go:363:	return subprocess.SimpleExec("git", "config", "--system", "--unset", key)
git/git.go:368:	return subprocess.SimpleExec("git", "config", "--global", "--remove-section", key)
git/git.go:373:	return subprocess.SimpleExec("git", "config", "--system", "--remove-section", key)
git/git.go:378:	return subprocess.SimpleExec("git", "config", "--local", "--remove-section", key)
git/git.go:389:	return subprocess.SimpleExec("git", args...)
git/git.go:400:	return subprocess.SimpleExec("git", args...)
git/git.go:405:	return subprocess.SimpleExec("git", "config", "-l")
git/git.go:410:	return subprocess.SimpleExec("git", "config", "-l", "-f", f)
git/git.go:419:		v, err := subprocess.SimpleExec("git", "version")
git/git.go:446:	cmd := subprocess.ExecCommand("git", "for-each-ref",
git/git.go:549:	cmd := subprocess.ExecCommand("git", "show", "-s",
git/git.go:584:	cmd := subprocess.ExecCommand("git", "rev-parse", "--git-dir", "--show-toplevel")
git/git.go:619:	cmd := subprocess.ExecCommand("git", "rev-parse", "--show-toplevel")
git/git.go:635:	cmd := subprocess.ExecCommand("git", "rev-parse", "--git-dir")
git/git.go:904:	cmd := subprocess.ExecCommand("git", cmdargs...)
git/git.go:928:	cmd := subprocess.ExecCommand("git", "show-ref")
git/git.go:957:	cmd := subprocess.ExecCommand("git", "ls-remote", "--heads", "--tags", "-q", remoteName)
git/git.go:995:	cmd := subprocess.ExecCommand("git",
git/git.go:1054:	cmd := subprocess.ExecCommand("git", args...)
git/git.go:1085:	cmd := subprocess.ExecCommand("git", args...)
lfsapi/certs_darwin.go:22:	cmd := subprocess.ExecCommand("/usr/bin/security", "list-keychains")
lfsapi/certs_darwin.go:57:	cmd := subprocess.ExecCommand("/usr/bin/security", "find-certificate", "-a", "-p", "-c", name, keychain)
tools/cygwin_windows.go:40:	cmd := subprocess.ExecCommand("uname")
tools/filetools_test.go:107:	subprocess.SimpleExec("git", "init", mainDir)
tools/os_tools.go:30:	cmd := subprocess.ExecCommand("cygpath", "-w", path)
tq/custom.go:54:	cmd         *subprocess.Cmd
tq/custom.go:127:	cmd := subprocess.ExecCommand(a.path, a.args)
</pre>
</details>
</li>
</ol>

The union of the above lists represents all available locations where we could leak processes. I performed a manual audit of each (and all call-site parents) throughout the entire codebase and made the following notes:

<details>
<summary>Notes</summary>
<pre>
github.com/git-lfs/git-lfs/subprocess:
  SAFE: subprocess.SimpleExec: uses ExecCommand().Output()

github.com/git-lfs/git-lfs/commands:
  SAFE: gitHashObject: uses exec.Command().Output()
  SAFE: PipeCommand: uses exec.Command().Run()
      : *gitIndexer: holds reference to *exec.Cmd (cmd)
                   : calls start
   ->              : ExitWithError unsafe! (commands/command_pull.go:94)

github.com/git-lfs/git-lfs/git:
  SAFE: *ObjectScanner: closed via closeFn()
                      : used via *lfs.PointerScanner, called by Close()
                          - safe in lfs.catFileBatchTree
                          - unsafe via commands/command_status.go:{40,47}
                          - unsafe via lfs/gitscanner_tree.go:51

github.com/git-lfs/git-lfs/lfs:
  UNSAFE: pipeExtensions leaks processes in the case of early returns
  NOOP: startCommand... uses wrappedCmd, calls Start(). callers must be aware
    SAFE: scanUnpushed -> parseScannerLogOutput
    SAFE: refListShas -> closed via goroutine
    SAFE: runCatFileBatchCheck -> closed via goroutine
      NewDiffIndexScanner UNSAFE! added closeFn to help
    SAFE: lsTreeBlobs -> closed via goroutine
    SAFE: runCatFileBatchCheck -> closed via goroutine
    SAFE: scanUnpushed -> parseScannerLogOutput -> closed via goroutine

github.com/git-lfs/git-lfs/lfsapi:
  SAFE: *commandCredentialHelper.exec -> closed via cmd.Wait()
  SAFE: *sshAuthClient.Resolve() -> closed via cmd.Wait()

github.com/git-lfs/git-lfs/subprocess:
  SAFE: newCmd -> called everywhere (safe if corresp. Close() call exists)
    SAFE: ExecCommand (from subprocess_nix.go), if corresp. Close() call exists
      SAFE: git.RootDir() -> closed via cmd.Output()
      SAFE: customAdapter.WorkerStarting -> closed via abort
      SAFE: tools.translateCygwinPath -> closed via cmd.Output()
      SAFE: git.GitDir() -> closed via cmd.Output()
      SAFE: git.RecentBranches() -> closed via deferred cmd.Wait()
      SAFE: git.CloneWithoutFilters() -> closed cmd.Wait()
      SAFE: git.postCloneSubmodules() -> closed via cmd.Run()
      SAFE: git.GitAndRootDirs() -> closed via cmd.Output()
      SAFE: git.RemoteRefs() -> closed via cmd.Wait()
      SAFE: git.appendRootCAsFromKeychain() -> closed via cmd.Output()
      SAFE: git.appendRootCAsFromHostFromPlatform() -> closed via cmd.Output()
      SAFE: git.GetCommitSummary() -> closed via cmd.CombinedOutput()
      SAFE: git.RemoteList() -> closed via deferred cmd.Wait()
      SAFE: git.IsFileModified() -> closed via cmd.Wait()
      SAFE: git.CachedRemoteRefs() -> closed via cmd.Wait()
      SAFE: subprocess.SimpleExec() -> closed via cmd.Output()
      SAFE: git.LocalRefs() -> closed via cmd.Wait()
      SAFE: git.GetTrackedfiles() -> closed via cmd.Wait()

### AXIOMS:
  SAFE: *exec.Command: Output() is blocking and waits for termination
  SAFE: *exec.Command: Wait() is blocking and waits for termination
</pre>
</details>

---

/cc @git-lfs/core 