### PR TITLE
Streaming log stats

### DIFF
--- a/commands/run.go
+++ b/commands/run.go
@@ -65,8 +65,8 @@ func Run() {
 		}
 	}
 
-	defer getAPIClient().Close()
 	root.Execute()
+	getAPIClient().Close()
 }
 
 func gitlfsCommand(cmd *cobra.Command, args []string) {

--- a/commands/run.go
+++ b/commands/run.go
@@ -67,11 +67,6 @@ func Run() {
 
 	defer getAPIClient().Close()
 	root.Execute()
-
-	apiClient := getAPIClient()
-	if apiClient.HTTPLogger != nil {
-		apiClient.LogStats(apiClient.HTTPLogger)
-	}
 }
 
 func gitlfsCommand(cmd *cobra.Command, args []string) {
@@ -129,6 +124,6 @@ func setupHTTPLogger(c *lfsapi.Client) {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error logging http stats: %s\n", err)
 	} else {
-		c.HTTPLogger = file
+		c.LogHTTPStats(file)
 	}
 }

--- a/commands/run.go
+++ b/commands/run.go
@@ -109,7 +109,7 @@ func printHelp(commandName string) {
 }
 
 func setupHTTPLogger(c *lfsapi.Client) {
-	if c == nil || !c.LoggingStats {
+	if c == nil || len(os.Getenv("GIT_LOG_STATS")) < 1 {
 		return
 	}
 

--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -31,14 +31,20 @@ be scoped inside the configuration for a remote.
 
 * `lfs.dialtimeout`
 
-  Sets the maximum time, in seconds, that the HTTP client will wait initiate a
-  connection. This does not include the time to send a request and wait for a
+  Sets the maximum time, in seconds, that the HTTP client will wait to initiate
+  a connection. This does not include the time to send a request and wait for a
   response. Default: 30 seconds
 
 * `lfs.tlstimeout`
 
   Sets the maximum time, in seconds, that the HTTP client will wait for a TLS
   handshake. Default: 30 seconds.
+
+* `lfs.activitytimeout` / `lfs.https://<host>.activitytimeout`
+
+  Sets the maximum time, in seconds, that the HTTP client will wait for the
+  next tcp read or write. Default: 10 seconds
+  response. Default: 30 seconds
 
 * `lfs.keepalive`
 

--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -43,8 +43,8 @@ be scoped inside the configuration for a remote.
 * `lfs.activitytimeout` / `lfs.https://<host>.activitytimeout`
 
   Sets the maximum time, in seconds, that the HTTP client will wait for the
-  next tcp read or write. Default: 10 seconds
-  response. Default: 30 seconds
+  next tcp read or write. If < 1, no activity timeout is used at all.
+  Default: 10 seconds
 
 * `lfs.keepalive`
 

--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -121,11 +121,11 @@ func (c *Client) doWithRedirects(cli *http.Client, req *http.Request, via []*htt
 
 	res, err := cli.Do(req)
 	if err != nil {
-		c.traceResponse(tracedReq, nil)
+		c.traceResponse(req, tracedReq, nil)
 		return res, err
 	}
 
-	c.traceResponse(tracedReq, res)
+	c.traceResponse(req, tracedReq, res)
 
 	if res.StatusCode != 307 {
 		return res, err

--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -121,6 +121,7 @@ func (c *Client) doWithRedirects(cli *http.Client, req *http.Request, via []*htt
 
 	res, err := cli.Do(req)
 	if err != nil {
+		c.traceResponse(tracedReq, nil)
 		return res, err
 	}
 

--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -77,6 +77,13 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	return res, c.handleResponse(res)
 }
 
+func (c *Client) Close() error {
+	if c.HTTPLogger != nil {
+		return c.HTTPLogger.Close()
+	}
+	return nil
+}
+
 func (c *Client) extraHeadersFor(req *http.Request) http.Header {
 	copy := make(http.Header, len(req.Header))
 	for k, vs := range req.Header {

--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -79,10 +79,7 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 
 // Close closes any resources that this client opened.
 func (c *Client) Close() error {
-	if c.httpLogger != nil {
-		return c.httpLogger.Close()
-	}
-	return nil
+	return c.httpLogger.Close()
 }
 
 func (c *Client) extraHeadersFor(req *http.Request) http.Header {

--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -78,8 +78,8 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 }
 
 func (c *Client) Close() error {
-	if c.HTTPLogger != nil {
-		return c.HTTPLogger.Close()
+	if c.httpLogger != nil {
+		return c.httpLogger.Close()
 	}
 	return nil
 }

--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -77,6 +77,7 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	return res, c.handleResponse(res)
 }
 
+// Close closes any resources that this client opened.
 func (c *Client) Close() error {
 	if c.httpLogger != nil {
 		return c.httpLogger.Close()

--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -114,19 +114,18 @@ func (c *Client) extraHeaders(u *url.URL) map[string][]string {
 }
 
 func (c *Client) doWithRedirects(cli *http.Client, req *http.Request, via []*http.Request) (*http.Response, error) {
-	c.traceRequest(req)
-	if err := c.prepareRequestBody(req); err != nil {
+	tracedReq, err := c.traceRequest(req)
+	if err != nil {
 		return nil, err
 	}
 
-	start := time.Now()
+	req = annotateReqStart(req)
 	res, err := cli.Do(req)
 	if err != nil {
 		return res, err
 	}
 
-	c.traceResponse(res)
-	c.startResponseStats(res, start)
+	c.traceResponse(tracedReq, res)
 
 	if res.StatusCode != 307 {
 		return res, err

--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -119,7 +119,6 @@ func (c *Client) doWithRedirects(cli *http.Client, req *http.Request, via []*htt
 		return nil, err
 	}
 
-	req = annotateReqStart(req)
 	res, err := cli.Do(req)
 	if err != nil {
 		return res, err
@@ -193,10 +192,11 @@ func (c *Client) httpClient(host string) *http.Client {
 
 	tr := &http.Transport{
 		Proxy: proxyFromClient(c),
-		Dial: (&net.Dialer{
+		DialContext: (&net.Dialer{
 			Timeout:   time.Duration(dialtime) * time.Second,
 			KeepAlive: time.Duration(keepalivetime) * time.Second,
-		}).Dial,
+			DualStack: true,
+		}).DialContext,
 		TLSHandshakeTimeout: time.Duration(tlstime) * time.Second,
 		MaxIdleConnsPerHost: concurrentTransfers,
 	}

--- a/lfsapi/lfsapi.go
+++ b/lfsapi/lfsapi.go
@@ -46,7 +46,7 @@ type Client struct {
 	ntlmSessions map[string]ntlm.ClientSession
 	ntlmMu       sync.Mutex
 
-	HTTPLogger io.WriteCloser
+	httpLogger io.WriteCloser
 	responses  []*http.Response
 	responseMu sync.Mutex
 	transfers  map[*http.Response]*httpTransfer

--- a/lfsapi/lfsapi.go
+++ b/lfsapi/lfsapi.go
@@ -37,7 +37,6 @@ type Client struct {
 
 	Verbose          bool
 	DebuggingVerbose bool
-	LoggingStats     bool
 	VerboseOut       io.Writer
 
 	hostClients map[string]*http.Client
@@ -47,10 +46,10 @@ type Client struct {
 	ntlmMu       sync.Mutex
 
 	httpLogger io.WriteCloser
-	responses  []*http.Response
-	responseMu sync.Mutex
 	transfers  map[*http.Response]*httpTransfer
 	transferMu sync.Mutex
+
+	LoggingStats bool // DEPRECATED
 
 	// only used for per-host ssl certs
 	gitEnv Env
@@ -96,7 +95,6 @@ func NewClient(osEnv Env, gitEnv Env) (*Client, error) {
 		SkipSSLVerify:       !gitEnv.Bool("http.sslverify", true) || osEnv.Bool("GIT_SSL_NO_VERIFY", false),
 		Verbose:             osEnv.Bool("GIT_CURL_VERBOSE", false),
 		DebuggingVerbose:    osEnv.Bool("LFS_DEBUG_HTTP", false),
-		LoggingStats:        osEnv.Bool("GIT_LOG_STATS", false),
 		HTTPSProxy:          httpsProxy,
 		HTTPProxy:           httpProxy,
 		NoProxy:             noProxy,

--- a/lfsapi/lfsapi.go
+++ b/lfsapi/lfsapi.go
@@ -46,8 +46,6 @@ type Client struct {
 	ntlmMu       sync.Mutex
 
 	httpLogger io.WriteCloser
-	transfers  map[*http.Response]*httpTransfer
-	transferMu sync.Mutex
 
 	LoggingStats bool // DEPRECATED
 

--- a/lfsapi/lfsapi.go
+++ b/lfsapi/lfsapi.go
@@ -45,7 +45,7 @@ type Client struct {
 	ntlmSessions map[string]ntlm.ClientSession
 	ntlmMu       sync.Mutex
 
-	httpLogger io.WriteCloser
+	httpLogger *syncLogger
 
 	LoggingStats bool // DEPRECATED
 

--- a/lfsapi/lfsapi.go
+++ b/lfsapi/lfsapi.go
@@ -46,10 +46,10 @@ type Client struct {
 	ntlmSessions map[string]ntlm.ClientSession
 	ntlmMu       sync.Mutex
 
-	transferBuckets  map[string][]*http.Response
-	transferBucketMu sync.Mutex
-	transfers        map[*http.Response]*httpTransfer
-	transferMu       sync.Mutex
+	responses  []*http.Response
+	responseMu sync.Mutex
+	transfers  map[*http.Response]*httpTransfer
+	transferMu sync.Mutex
 
 	// only used for per-host ssl certs
 	gitEnv Env

--- a/lfsapi/lfsapi.go
+++ b/lfsapi/lfsapi.go
@@ -46,6 +46,7 @@ type Client struct {
 	ntlmSessions map[string]ntlm.ClientSession
 	ntlmMu       sync.Mutex
 
+	HTTPLogger io.WriteCloser
 	responses  []*http.Response
 	responseMu sync.Mutex
 	transfers  map[*http.Response]*httpTransfer

--- a/lfsapi/stats.go
+++ b/lfsapi/stats.go
@@ -133,7 +133,7 @@ func (l *syncLogger) LogResponse(req *http.Request, status int, bodySize int64) 
 	if v := req.Context().Value(transferKey); v != nil {
 		t := v.(*httpTransfer)
 		now := time.Now().UnixNano()
-		l.logTransfer(t, "request",
+		l.logTransfer(t, "response",
 			fmt.Sprintf(" status=%d body=%d conntime=%d dnstime=%d tlstime=%d restime=%d time=%d",
 				status,
 				bodySize,

--- a/lfsapi/stats.go
+++ b/lfsapi/stats.go
@@ -18,13 +18,13 @@ type httpTransferStats struct {
 
 type httpTransfer struct {
 	Key           string
-	requestStats  *httpTransferStats
-	responseStats *httpTransferStats
+	RequestStats  httpTransferStats
+	ResponseStats httpTransferStats
 }
 
 type statsContextKey string
 
-const httpStatsKey = statsContextKey("http")
+const statsKeytransferKey = statsContextKey("transfer")
 
 func (c *Client) LogHTTPStats(w io.WriteCloser) {
 	fmt.Fprintf(w, "concurrent=%d time=%d version=%s\n", c.ConcurrentTransfers, time.Now().Unix(), UserAgent)
@@ -41,7 +41,11 @@ func (c *Client) LogStats(out io.Writer) {}
 // LogRequest tells the client to log the request's stats to the http log
 // after the response body has been read.
 func (c *Client) LogRequest(r *http.Request, reqKey string) *http.Request {
-	ctx := context.WithValue(r.Context(), httpStatsKey, reqKey)
+	ctx := context.WithValue(r.Context(), transferKey, httpTransfer{
+		Key:           reqKey,
+		RequestStats:  httpTransferStats{},
+		ResponseStats: httpTransferStats{},
+	})
 	return r.WithContext(ctx)
 }
 
@@ -51,71 +55,48 @@ func (c *Client) LogRequest(r *http.Request, reqKey string) *http.Request {
 func (c *Client) LogResponse(key string, res *http.Response) {}
 
 func (c *Client) startResponseStats(res *http.Response, start time.Time) {
-	if c.httpLogger == nil {
+	v := res.Request.Context().Value(transferKey)
+	if v == nil {
 		return
 	}
 
-	reqHeaderSize := 0
-	resHeaderSize := 0
+	t := v.(httpTransfer)
 
+	t.RequestStats.BodySize = res.Request.ContentLength
 	if dump, err := httputil.DumpRequest(res.Request, false); err == nil {
-		reqHeaderSize = len(dump)
+		t.RequestStats.HeaderSize = len(dump)
 	}
-
-	if dump, err := httputil.DumpResponse(res, false); err == nil {
-		resHeaderSize = len(dump)
-	}
-
-	reqstats := &httpTransferStats{HeaderSize: reqHeaderSize, BodySize: res.Request.ContentLength}
 
 	// Response body size cannot be figured until it is read. Do not rely on a Content-Length
 	// header because it may not exist or be -1 in the case of chunked responses.
-	resstats := &httpTransferStats{HeaderSize: resHeaderSize, Start: start}
-	t := &httpTransfer{requestStats: reqstats, responseStats: resstats}
-	if v := res.Request.Context().Value(httpStatsKey); v != nil {
-		t.Key = v.(string)
-	} else {
-		t.Key = "none"
+	t.ResponseStats.Start = start
+	if dump, err := httputil.DumpResponse(res, false); err == nil {
+		t.ResponseStats.HeaderSize = len(dump)
 	}
-
-	c.transferMu.Lock()
-	if c.transfers == nil {
-		c.transfers = make(map[*http.Response]*httpTransfer)
-	}
-	c.transfers[res] = t
-	c.transferMu.Unlock()
 }
 
 func (c *Client) finishResponseStats(res *http.Response, bodySize int64) {
-	if res == nil || c.httpLogger == nil {
+	v := res.Request.Context().Value(transferKey)
+	if v == nil {
 		return
 	}
 
-	c.transferMu.Lock()
-	defer c.transferMu.Unlock()
-
-	if c.transfers == nil {
-		return
-	}
-
-	if transfer, ok := c.transfers[res]; ok {
-		transfer.responseStats.BodySize = bodySize
-		transfer.responseStats.Stop = time.Now()
-		if c.httpLogger != nil {
-			writeHTTPStats(c.httpLogger, res, transfer)
-		}
-		delete(c.transfers, res)
+	t := v.(httpTransfer)
+	t.ResponseStats.BodySize = bodySize
+	t.ResponseStats.Stop = time.Now()
+	if c.httpLogger != nil {
+		writeHTTPStats(c.httpLogger, res, t)
 	}
 }
 
-func writeHTTPStats(w io.Writer, res *http.Response, t *httpTransfer) {
+func writeHTTPStats(w io.Writer, res *http.Response, t httpTransfer) {
 	fmt.Fprintf(w, "key=%s reqheader=%d reqbody=%d resheader=%d resbody=%d restime=%d status=%d url=%s\n",
 		t.Key,
-		t.requestStats.HeaderSize,
-		t.requestStats.BodySize,
-		t.responseStats.HeaderSize,
-		t.responseStats.BodySize,
-		t.responseStats.Stop.Sub(t.responseStats.Start).Nanoseconds(),
+		t.RequestStats.HeaderSize,
+		t.RequestStats.BodySize,
+		t.ResponseStats.HeaderSize,
+		t.ResponseStats.BodySize,
+		t.ResponseStats.Stop.Sub(t.ResponseStats.Start).Nanoseconds(),
 		res.StatusCode,
 		res.Request.URL,
 	)

--- a/lfsapi/stats.go
+++ b/lfsapi/stats.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/git-lfs/git-lfs/tools"
 )
 
 type httpTransfer struct {
@@ -131,10 +133,10 @@ func (l *syncLogger) LogResponse(req *http.Request, status int, bodySize int64) 
 			fmt.Sprintf(" status=%d body=%d conntime=%d dnstime=%d tlstime=%d time=%d",
 				status,
 				bodySize,
-				(t.ConnEnd-t.ConnStart),
-				(t.DNSEnd-t.DNSStart),
-				(t.TLSEnd-t.TLSStart),
-				(now-t.Start),
+				tools.MaxInt64(t.ConnEnd-t.ConnStart, 0),
+				tools.MaxInt64(t.DNSEnd-t.DNSStart, 0),
+				tools.MaxInt64(t.TLSEnd-t.TLSStart, 0),
+				tools.MaxInt64(now-t.Start, 0),
 			))
 	}
 }

--- a/lfsapi/stats.go
+++ b/lfsapi/stats.go
@@ -51,7 +51,7 @@ func (c *Client) LogRequest(r *http.Request, reqKey string) *http.Request {
 func (c *Client) LogResponse(key string, res *http.Response) {}
 
 func (c *Client) startResponseStats(res *http.Response, start time.Time) {
-	if !c.LoggingStats {
+	if c.httpLogger == nil {
 		return
 	}
 
@@ -87,7 +87,7 @@ func (c *Client) startResponseStats(res *http.Response, start time.Time) {
 }
 
 func (c *Client) finishResponseStats(res *http.Response, bodySize int64) {
-	if !c.LoggingStats || res == nil {
+	if res == nil || c.httpLogger == nil {
 		return
 	}
 

--- a/lfsapi/stats_test.go
+++ b/lfsapi/stats_test.go
@@ -48,6 +48,7 @@ func TestStatsWithKey(t *testing.T) {
 
 	io.Copy(ioutil.Discard, res.Body)
 	res.Body.Close()
+	assert.Nil(t, c.Close())
 
 	assert.Equal(t, 200, res.StatusCode)
 	assert.EqualValues(t, 1, called)
@@ -55,7 +56,7 @@ func TestStatsWithKey(t *testing.T) {
 	stats := strings.TrimSpace(out.String())
 	t.Log(stats)
 	lines := strings.Split(stats, "\n")
-	assert.Equal(t, 2, len(lines))
+	require.Equal(t, 3, len(lines))
 	assert.True(t, strings.Contains(lines[0], "concurrent=5"))
 	expected := []string{
 		"key=stats-test",
@@ -66,6 +67,16 @@ func TestStatsWithKey(t *testing.T) {
 
 	for _, substr := range expected {
 		assert.True(t, strings.Contains(lines[1], substr), "missing: "+substr)
+	}
+
+	expected = []string{
+		"key=stats-test",
+		"event=response",
+		"url=" + srv.URL,
+	}
+
+	for _, substr := range expected {
+		assert.True(t, strings.Contains(lines[2], substr), "missing: "+substr)
 	}
 }
 
@@ -100,6 +111,7 @@ func TestStatsWithoutKey(t *testing.T) {
 	require.Nil(t, err)
 	io.Copy(ioutil.Discard, res.Body)
 	res.Body.Close()
+	assert.Nil(t, c.Close())
 
 	assert.Equal(t, 200, res.StatusCode)
 	assert.EqualValues(t, 1, called)

--- a/lfsapi/stats_test.go
+++ b/lfsapi/stats_test.go
@@ -38,6 +38,7 @@ func TestStatsWithBucket(t *testing.T) {
 	}
 
 	req, err := http.NewRequest("POST", srv.URL, nil)
+	req = c.LogRequest(req, "stats-test")
 	req.Header.Set("Authorization", "Basic ABC")
 	req.Header.Set("Content-Type", "application/json")
 	require.Nil(t, err)
@@ -45,8 +46,6 @@ func TestStatsWithBucket(t *testing.T) {
 
 	res, err := c.Do(req)
 	require.Nil(t, err)
-
-	c.LogResponse("stats-test", res)
 
 	io.Copy(ioutil.Discard, res.Body)
 	res.Body.Close()
@@ -146,6 +145,8 @@ func TestStatsDisabled(t *testing.T) {
 	}
 
 	req, err := http.NewRequest("POST", srv.URL, nil)
+	req = c.LogRequest(req, "stats-test")
+
 	req.Header.Set("Authorization", "Basic ABC")
 	req.Header.Set("Content-Type", "application/json")
 	require.Nil(t, err)
@@ -153,8 +154,6 @@ func TestStatsDisabled(t *testing.T) {
 
 	res, err := c.Do(req)
 	require.Nil(t, err)
-
-	c.LogResponse("stats-test", res)
 
 	io.Copy(ioutil.Discard, res.Body)
 	res.Body.Close()

--- a/lfsapi/stats_test.go
+++ b/lfsapi/stats_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestStatsWithBucket(t *testing.T) {
+func TestStatsWithKey(t *testing.T) {
 	var called uint32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddUint32(&called, 1)
@@ -77,7 +77,7 @@ func TestStatsWithBucket(t *testing.T) {
 	}
 }
 
-func TestStatsWithoutBucket(t *testing.T) {
+func TestStatsWithoutKey(t *testing.T) {
 	var called uint32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddUint32(&called, 1)
@@ -119,7 +119,8 @@ func TestStatsWithoutBucket(t *testing.T) {
 	stats := strings.TrimSpace(out.String())
 	t.Log(stats)
 	assert.True(t, strings.Contains(stats, "concurrent=5"))
-	assert.Equal(t, 1, len(strings.Split(stats, "\n")))
+	assert.True(t, strings.Contains(stats, "key=none"))
+	assert.Equal(t, 2, len(strings.Split(stats, "\n")))
 }
 
 func TestStatsDisabled(t *testing.T) {

--- a/lfsapi/stats_test.go
+++ b/lfsapi/stats_test.go
@@ -32,10 +32,9 @@ func TestStatsWithKey(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := &Client{
-		ConcurrentTransfers: 5,
-		LoggingStats:        true,
-	}
+	out := &bytes.Buffer{}
+	c := &Client{ConcurrentTransfers: 5}
+	c.LogHTTPStats(nopCloser(out))
 
 	req, err := http.NewRequest("POST", srv.URL, nil)
 	req = c.LogRequest(req, "stats-test")
@@ -52,9 +51,6 @@ func TestStatsWithKey(t *testing.T) {
 
 	assert.Equal(t, 200, res.StatusCode)
 	assert.EqualValues(t, 1, called)
-
-	out := &bytes.Buffer{}
-	c.LogStats(out)
 
 	stats := strings.TrimSpace(out.String())
 	t.Log(stats)
@@ -94,10 +90,9 @@ func TestStatsWithoutKey(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := &Client{
-		ConcurrentTransfers: 5,
-		LoggingStats:        true,
-	}
+	out := &bytes.Buffer{}
+	c := &Client{ConcurrentTransfers: 5}
+	c.LogHTTPStats(nopCloser(out))
 
 	req, err := http.NewRequest("POST", srv.URL, nil)
 	req.Header.Set("Authorization", "Basic ABC")
@@ -112,9 +107,6 @@ func TestStatsWithoutKey(t *testing.T) {
 
 	assert.Equal(t, 200, res.StatusCode)
 	assert.EqualValues(t, 1, called)
-
-	out := &bytes.Buffer{}
-	c.LogStats(out)
 
 	stats := strings.TrimSpace(out.String())
 	t.Log(stats)
@@ -140,10 +132,7 @@ func TestStatsDisabled(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := &Client{
-		ConcurrentTransfers: 5,
-		LoggingStats:        false,
-	}
+	c := &Client{ConcurrentTransfers: 5}
 
 	req, err := http.NewRequest("POST", srv.URL, nil)
 	req = c.LogRequest(req, "stats-test")
@@ -165,4 +154,16 @@ func TestStatsDisabled(t *testing.T) {
 	out := &bytes.Buffer{}
 	c.LogStats(out)
 	assert.Equal(t, 0, out.Len())
+}
+
+func nopCloser(w io.Writer) io.WriteCloser {
+	return nopWCloser{w}
+}
+
+type nopWCloser struct {
+	io.Writer
+}
+
+func (w nopWCloser) Close() error {
+	return nil
 }

--- a/lfsapi/stats_test.go
+++ b/lfsapi/stats_test.go
@@ -59,12 +59,8 @@ func TestStatsWithKey(t *testing.T) {
 	assert.True(t, strings.Contains(lines[0], "concurrent=5"))
 	expected := []string{
 		"key=stats-test",
-		"reqheader=",
-		"reqbody=18",
-		"resheader=",
-		"resbody=15",
-		"restime=",
-		"status=200",
+		"event=request",
+		"body=18",
 		"url=" + srv.URL,
 	}
 
@@ -111,8 +107,7 @@ func TestStatsWithoutKey(t *testing.T) {
 	stats := strings.TrimSpace(out.String())
 	t.Log(stats)
 	assert.True(t, strings.Contains(stats, "concurrent=5"))
-	assert.True(t, strings.Contains(stats, "key=none"))
-	assert.Equal(t, 2, len(strings.Split(stats, "\n")))
+	assert.Equal(t, 1, len(strings.Split(stats, "\n")))
 }
 
 func TestStatsDisabled(t *testing.T) {

--- a/lfsapi/verbose.go
+++ b/lfsapi/verbose.go
@@ -59,6 +59,7 @@ func (c *Client) traceResponse(tracedReq *tracedRequest, res *http.Response) {
 	}
 
 	if res == nil {
+		c.httpLogger.LogResponse(res.Request, -1, 0)
 		return
 	}
 

--- a/lfsapi/verbose.go
+++ b/lfsapi/verbose.go
@@ -53,13 +53,13 @@ func (r *tracedRequest) Read(b []byte) (int, error) {
 	return n, err
 }
 
-func (c *Client) traceResponse(tracedReq *tracedRequest, res *http.Response) {
+func (c *Client) traceResponse(req *http.Request, tracedReq *tracedRequest, res *http.Response) {
 	if tracedReq != nil {
-		c.httpLogger.LogRequest(res.Request, tracedReq.BodySize)
+		c.httpLogger.LogRequest(req, tracedReq.BodySize)
 	}
 
 	if res == nil {
-		c.httpLogger.LogResponse(res.Request, -1, 0)
+		c.httpLogger.LogResponse(req, -1, 0)
 		return
 	}
 

--- a/lfsapi/verbose.go
+++ b/lfsapi/verbose.go
@@ -166,7 +166,7 @@ func annotateReqStart(r *http.Request) *http.Request {
 		return r
 	}
 
-	t := v.(httpTransfer)
+	t := v.(*httpTransfer)
 	t.Start = time.Now()
 	return r.WithContext(context.WithValue(ctx, transferKey, t))
 }

--- a/locking/api.go
+++ b/locking/api.go
@@ -50,6 +50,7 @@ func (c *lockClient) Lock(remote string, lockReq *lockRequest) (*lockResponse, *
 		return nil, nil, err
 	}
 
+	req = c.LogRequest(req, "lfs.locks.lock")
 	res, err := c.DoWithAuth(remote, req)
 	if err != nil {
 		return nil, res, err
@@ -90,6 +91,7 @@ func (c *lockClient) Unlock(remote, id string, force bool) (*unlockResponse, *ht
 		return nil, nil, err
 	}
 
+	req = c.LogRequest(req, "lfs.locks.unlock")
 	res, err := c.DoWithAuth(remote, req)
 	if err != nil {
 		return nil, res, err
@@ -173,6 +175,7 @@ func (c *lockClient) Search(remote string, searchReq *lockSearchRequest) (*lockL
 	}
 	req.URL.RawQuery = q.Encode()
 
+	req = c.LogRequest(req, "lfs.locks.search")
 	res, err := c.DoWithAuth(remote, req)
 	if err != nil {
 		return nil, res, err
@@ -230,6 +233,7 @@ func (c *lockClient) SearchVerifiable(remote string, vreq *lockVerifiableRequest
 		return nil, nil, err
 	}
 
+	req = c.LogRequest(req, "lfs.locks.verify")
 	res, err := c.DoWithAuth(remote, req)
 	if err != nil {
 		return nil, res, err

--- a/tools/math.go
+++ b/tools/math.go
@@ -17,3 +17,21 @@ func MaxInt(a, b int) int {
 
 	return b
 }
+
+// MinInt64 returns the smaller of two `int`s, "a", or "b".
+func MinInt64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+
+	return b
+}
+
+// MaxInt64 returns the greater of two `int`s, "a", or "b".
+func MaxInt64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+
+	return b
+}

--- a/tq/api.go
+++ b/tq/api.go
@@ -56,12 +56,12 @@ func (c *tqClient) Batch(remote string, bReq *batchRequest) (*BatchResponse, err
 
 	tracerx.Printf("api: batch %d files", len(bReq.Objects))
 
+	req = c.LogRequest(req, "lfs.batch")
 	res, err := c.DoWithAuth(remote, req)
 	if err != nil {
 		tracerx.Printf("api error: %s", err)
 		return nil, errors.Wrap(err, "batch response")
 	}
-	c.LogResponse("lfs.batch", res)
 
 	if err := lfsapi.DecodeJSON(res, bRes); err != nil {
 		return bRes, errors.Wrap(err, "batch response")

--- a/tq/basic_download.go
+++ b/tq/basic_download.go
@@ -109,6 +109,7 @@ func (a *basicDownloadAdapter) download(t *Transfer, cb ProgressCallback, authOk
 		req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", fromByte, t.Size-1))
 	}
 
+	req = a.apiClient.LogRequest(req, "lfs.data.download")
 	res, err := a.doHTTP(t, req)
 	if err != nil {
 		// Special-case status code 416 () - fall back
@@ -121,7 +122,6 @@ func (a *basicDownloadAdapter) download(t *Transfer, cb ProgressCallback, authOk
 		return errors.NewRetriableError(err)
 	}
 
-	a.apiClient.LogResponse("lfs.data.download", res)
 	defer res.Body.Close()
 
 	// Range request must return 206 & content range to confirm

--- a/tq/basic_upload.go
+++ b/tq/basic_upload.go
@@ -96,6 +96,7 @@ func (a *basicUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb Progres
 
 	req.Body = reader
 
+	req = a.apiClient.LogRequest(req, "lfs.data.upload")
 	res, err := a.doHTTP(t, req)
 	if err != nil {
 		// We're about to return a retriable error, meaning that this
@@ -110,8 +111,6 @@ func (a *basicUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb Progres
 
 		return errors.NewRetriableError(err)
 	}
-
-	a.apiClient.LogResponse("lfs.data.upload", res)
 
 	// A status code of 403 likely means that an authentication token for the
 	// upload has expired. This can be safely retried.

--- a/tq/tus_upload.go
+++ b/tq/tus_upload.go
@@ -134,12 +134,11 @@ func (a *tusUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb ProgressC
 
 	req.Body = reader
 
+	req = a.apiClient.LogRequest(req, "lfs.data.upload")
 	res, err = a.doHTTP(t, req)
 	if err != nil {
 		return errors.NewRetriableError(err)
 	}
-
-	a.apiClient.LogResponse("lfs.data.upload", res)
 
 	// A status code of 403 likely means that an authentication token for the
 	// upload has expired. This can be safely retried.

--- a/tq/verify.go
+++ b/tq/verify.go
@@ -42,6 +42,7 @@ func verifyUpload(c *lfsapi.Client, remote string, t *Transfer) error {
 
 	mv := c.GitEnv().Int(maxVerifiesConfigKey, defaultMaxVerifyAttempts)
 	mv = tools.MaxInt(defaultMaxVerifyAttempts, mv)
+	req = c.LogRequest(req, "lfs.verify")
 
 	for i := 1; i <= mv; i++ {
 		tracerx.Printf("tq: verify %s attempt #%d (max: %d)", t.Oid[:7], i, mv)


### PR DESCRIPTION
This updates the http logging enabled by `GIT_LOG_STATS=1`:

* Updated the format to include more relevant info, including connection, dns, and tls timings. Uninteresting things like header sizes are left out.
* Instead of tracking requests in per-client slices protected by a mutex, the `*httpTransfer` types are passed around in the request context.
* The log is written to in real time, instead of at the end of the command.