### PR TITLE
version: bump to 2.2.0-pre

### DIFF
--- a/config/version.go
+++ b/config/version.go
@@ -12,7 +12,7 @@ var (
 )
 
 const (
-	Version = "2.1.0"
+	Version = "2.2.0-pre"
 )
 
 func init() {

--- a/rpm/SPECS/git-lfs.spec
+++ b/rpm/SPECS/git-lfs.spec
@@ -1,5 +1,5 @@
 Name:           git-lfs
-Version:        2.1.0
+Version:        2.2.0-pre
 Release:        1%{?dist}
 Summary:        Git extension for versioning large files
 

--- a/versioninfo.json
+++ b/versioninfo.json
@@ -13,6 +13,6 @@
 		"FileDescription": "Git LFS",
 		"LegalCopyright": "GitHub, Inc. and Git LFS contributors",
 		"ProductName": "Git Large File Storage (LFS)",
-		"ProductVersion": "2.1.0"
+		"ProductVersion": "2.2.0-pre"
 	}
 }


### PR DESCRIPTION
This pull request bumps the version identifier to be `Git LFS v2.2.0-pre` in all places that we can.

Since we [released v2.1.0](https://github.com/git-lfs/git-lfs/releases/tag/v2.1.0), the next major version on master will be 2.2.0.

---

/cc @git-lfs/core 