### PR TITLE
support lfs.<url>.* values where url does not include .git

### DIFF
--- a/config/url_config_test.go
+++ b/config/url_config_test.go
@@ -8,26 +8,38 @@ import (
 
 func TestURLConfig(t *testing.T) {
 	u := NewURLConfig(EnvironmentOf(MapFetcher(map[string][]string{
-		"http.key":                         []string{"root", "root-2"},
-		"http.https://host.com.key":        []string{"host", "host-2"},
-		"http.https://user@host.com/a.key": []string{"user-a", "user-b"},
-		"http.https://user@host.com.key":   []string{"user", "user-2"},
-		"http.https://host.com/a.key":      []string{"host-a", "host-b"},
-		"http.https://host.com:8080.key":   []string{"port", "port-2"},
+		"http.key":                           []string{"root", "root-2"},
+		"http.https://host.com.key":          []string{"host", "host-2"},
+		"http.https://user@host.com/a.key":   []string{"user-a", "user-b"},
+		"http.https://user@host.com.key":     []string{"user", "user-2"},
+		"http.https://host.com/a.key":        []string{"host-a", "host-b"},
+		"http.https://host.com:8080.key":     []string{"port", "port-2"},
+		"http.https://host.com/repo.git.key": []string{".git"},
+		"http.https://host.com/repo.key":     []string{"no .git"},
+		"http.https://host.com/repo2.key":    []string{"no .git"},
 	})))
 
 	getOne := map[string]string{
-		"https://root.com/a/b/c":           "root-2",
-		"https://host.com/":                "host-2",
-		"https://host.com/a/b/c":           "host-b",
-		"https://user:pass@host.com/a/b/c": "user-b",
-		"https://user:pass@host.com/z/b/c": "user-2",
-		"https://host.com:8080/a":          "port-2",
+		"https://root.com/a/b/c":                      "root-2",
+		"https://host.com/":                           "host-2",
+		"https://host.com/a/b/c":                      "host-b",
+		"https://user:pass@host.com/a/b/c":            "user-b",
+		"https://user:pass@host.com/z/b/c":            "user-2",
+		"https://host.com:8080/a":                     "port-2",
+		"https://host.com/repo.git/info/lfs":          ".git",
+		"https://host.com/repo.git/info":              ".git",
+		"https://host.com/repo.git":                   ".git",
+		"https://host.com/repo":                       "no .git",
+		"https://host.com/repo2.git/info/lfs/foo/bar": "no .git",
+		"https://host.com/repo2.git/info/lfs":         "no .git",
+		"https://host.com/repo2.git/info":             "host-2", // doesn't match /.git/info/lfs\Z/
+		"https://host.com/repo2.git":                  "host-2", // ditto
+		"https://host.com/repo2":                      "no .git",
 	}
 
 	for rawurl, expected := range getOne {
 		value, _ := u.Get("http", rawurl, "key")
-		assert.Equal(t, expected, value, rawurl)
+		assert.Equal(t, expected, value, "get one: "+rawurl)
 	}
 
 	getAll := map[string][]string{
@@ -41,6 +53,6 @@ func TestURLConfig(t *testing.T) {
 
 	for rawurl, expected := range getAll {
 		values := u.GetAll("http", rawurl, "key")
-		assert.Equal(t, expected, values, rawurl)
+		assert.Equal(t, expected, values, "get all: "+rawurl)
 	}
 }


### PR DESCRIPTION
LFS 2.1.0 added the ability to specify some `lfs.*` and `http.*` values with a URL. You can set `lfs.*.access` based on the Endpoint URL:

```sh
$ git lfs env
git-lfs/2.2.0-pre (GitHub; darwin amd64; go 1.8.1; git 68340281)
git version 2.11.0

Endpoint=https://github.com/git-lfs/git-lfs.git/info/lfs (auth=none)

# enables basic auth for this repo
$ git config lfs.https://github.com/git-lfs/git-lfs.git/info/lfs.access basic
```

Most Git hosts don't require the `.git` extension, so you'd _think_ you could use that url in the config:

```sh
$ git remote get-url origin
https://github.com/git-lfs/git-lfs

$ git config lfs.https://github.com/git-lfs/git-lfs.access basic

$ git lfs env
git-lfs/2.2.0-pre (GitHub; darwin amd64; go 1.8.1; git 68340281)
git version 2.11.0

Endpoint=https://github.com/git-lfs/git-lfs.git/info/lfs (auth=none)
```

It fails here because it's checking the following git config keys:

* `lfs.https://github.com/git-lfs/git-lfs.git/info/lfs.access`
* `lfs.https://github.com/git-lfs/git-lfs.git/info.access`
* `lfs.https://github.com/git-lfs/git-lfs.git.access`
* `lfs.https://github.com/git-lfs.access`

It totally skips `https://github.com/git-lfs/git-lfs`! 

This PR adds an extra check if the url has `.git/info/lfs` in it.


* `lfs.https://github.com/git-lfs/git-lfs.git/info/lfs.access`
* `lfs.https://github.com/git-lfs/git-lfs.git/info.access`
* `lfs.https://github.com/git-lfs/git-lfs.git.access`
* `lfs.https://github.com/git-lfs/git-lfs.access`
* `lfs.https://github.com/git-lfs.access`

/cc https://github.com/git-lfs/git-lfs/issues/2190