### PR TITLE
Bugfix: cannot push to scp style URL

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -251,15 +251,8 @@ func ValidateRemote(remote string) error {
 
 // ValidateRemoteURL checks that a string is a valid Git remote URL
 func ValidateRemoteURL(remote string) error {
-	u, err := url.Parse(remote)
-	if err != nil {
-		return err
-	}
-
-	switch u.Scheme {
-	case "ssh", "http", "https", "git":
-		return nil
-	case "":
+	u, _ := url.Parse(remote)
+	if u == nil || u.Scheme == "" {
 		// This is either an invalid remote name (maybe the user made a typo
 		// when selecting a named remote) or a bare SSH URL like
 		// "x@y.com:path/to/resource.git". Guess that this is a URL in the latter
@@ -267,8 +260,14 @@ func ValidateRemoteURL(remote string) error {
 		// does not.
 		if strings.Contains(remote, ":") {
 			return nil
+		} else {
+			return fmt.Errorf("Invalid remote name: %q", remote)
 		}
-		return fmt.Errorf("Invalid remote name: %q", remote)
+	}
+
+	switch u.Scheme {
+	case "ssh", "http", "https", "git":
+		return nil
 	default:
 		return fmt.Errorf("Invalid remote url protocol %q in %q", u.Scheme, remote)
 	}

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -531,3 +531,14 @@ func TestGetFilesChanges(t *testing.T) {
 	assert.Equal(t, expected1to2, changes)
 
 }
+
+func TestValidateRemoteURL(t *testing.T) {
+	assert.Nil(t, ValidateRemoteURL("https://github.com/git-lfs/git-lfs"))
+	assert.Nil(t, ValidateRemoteURL("http://github.com/git-lfs/git-lfs"))
+	assert.Nil(t, ValidateRemoteURL("git://github.com/git-lfs/git-lfs"))
+	assert.Nil(t, ValidateRemoteURL("ssh://git@github.com/git-lfs/git-lfs"))
+	assert.Nil(t, ValidateRemoteURL("ssh://git@github.com:22/git-lfs/git-lfs"))
+	assert.Nil(t, ValidateRemoteURL("git@github.com:git-lfs/git-lfs"))
+	assert.Nil(t, ValidateRemoteURL("git@server:/absolute/path.git"))
+	assert.NotNil(t, ValidateRemoteURL("ftp://git@github.com/git-lfs/git-lfs"))
+}


### PR DESCRIPTION
When push to a scp style url, like:

    git push git@github.com:git-lfs/git-lfs.git HEAD

Git-lfs will complain about bad url.  This is because golang 1.8 has
changed the implement of `url.Parse` method.  It will fail with a nil
pointer and an error if the remote url is a scp style URL.

Make a golang compatible test, I.E. check null pointer, then check u.Scheme.

Signed-off-by: Jiang Xin <xin.jiang@huawei.com>