### PR TITLE
commands/uploader: allow incomplete pushes

### DIFF
--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -326,9 +326,13 @@ func (c *uploadContext) Await() {
 		for name, oid := range corrupt {
 			Print("  (corrupt) %s (%s)", name, oid)
 		}
+
+		if !c.allowMissing {
+			os.Exit(2)
+		}
 	}
 
-	if len(c.tq.Errors()) > 0 {
+	if len(others) > 0 {
 		os.Exit(2)
 	}
 

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -312,7 +312,14 @@ func (c *uploadContext) Await() {
 	}
 
 	if len(missing) > 0 || len(corrupt) > 0 {
-		Print("LFS upload failed:")
+		var action string
+		if c.allowMissing {
+			action = "missing objects"
+		} else {
+			action = "failed"
+		}
+
+		Print("LFS upload %s:", action)
 		for name, oid := range missing {
 			Print("  (missing) %s (%s)", name, oid)
 		}

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -302,6 +302,10 @@ func (c *uploadContext) Await() {
 		}
 	}
 
+	for _, err := range others {
+		FullError(err)
+	}
+
 	if len(missing) > 0 || len(corrupt) > 0 {
 		Print("LFS upload failed:")
 		for name, oid := range missing {
@@ -310,10 +314,6 @@ func (c *uploadContext) Await() {
 		for name, oid := range corrupt {
 			Print("  (corrupt) %s (%s)", name, oid)
 		}
-	}
-
-	for _, err := range others {
-		FullError(err)
 	}
 
 	if len(c.tq.Errors()) > 0 {

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -58,6 +58,10 @@ type uploadContext struct {
 	// locks from theirLocks that were modified in this push
 	unownedLocks []locking.Lock
 
+	// allowMissing specifies whether pushes containing missing/corrupt
+	// pointers should allow pushing Git blobs
+	allowMissing bool
+
 	// tracks errors from gitscanner callbacks
 	scannerErr error
 	errMu      sync.Mutex
@@ -96,6 +100,7 @@ func newUploadContext(remote string, dryRun bool) *uploadContext {
 		ourLocks:       make(map[string]locking.Lock),
 		theirLocks:     make(map[string]locking.Lock),
 		trackedLocksMu: new(sync.Mutex),
+		allowMissing:   cfg.Git.Bool("lfs.allowincompletepush", false),
 	}
 
 	ctx.meter = buildProgressMeter(ctx.DryRun)

--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -128,6 +128,13 @@ be scoped inside the configuration for a remote.
   not an integer, is less than one, or is not given, a default value of three
   will be used instead.
 
+### Push settings
+
+* `lfs.allowincompletepush`
+
+  When pushing, allow objects to be missing from the local cache without halting
+  a Git push.
+
 ### Fetch settings
 
 * `lfs.fetchinclude`
@@ -141,7 +148,6 @@ be scoped inside the configuration for a remote.
   When fetching, do not download objects which match any item on this
   comma-separated list of paths/filenames. Wildcard matching is as per
   git-ignore(1). See git-lfs-fetch(1) for examples.
-
 
 * `lfs.fetchrecentrefsdays`
 

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -200,36 +200,6 @@ begin_test "pre-push with missing pointer not on server"
 )
 end_test
 
-begin_test "pre-push with missing object (lfs.allowincompletepush)"
-(
-  set -e
-
-  reponame="$(basename "$0" ".sh")-missing-pointer-allow-incomplete"
-  setup_remote_repo "$reponame"
-  clone_repo "$reponame" "$reponame"
-
-  oid="7aa7a5359173d05b63cfd682e3c38487f3cb4f7f1d60659fe59fab1505977d4c"
-
-  echo "$(pointer "$oid" 4)" > new.dat
-  git add new.dat
-  git commit -m "add new pointer"
-
-  git config "lfs.allowincompletepush" "true"
-
-  echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
-    git lfs pre-push origin "$GITSERVER/$reponame" 2>&1 |
-    tee push.log
-
-  if [ "0" -ne "${PIPESTATUS[1]}" ]; then
-    echo >&2 "fatal: expected 'git lfs pre-push origin $GITSERVER/$reponame' to succeed"
-    exit 1
-  fi
-
-  grep "LFS upload missing objects" push.log
-  grep "  (missing) new.dat ($oid)" push.log
-)
-end_test
-
 begin_test "pre-push with missing pointer which is on server"
 (
   # should permit push if files missing locally but are on server, shouldn't

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -241,6 +241,54 @@ begin_test "pre-push with missing pointer which is on server"
 )
 end_test
 
+begin_test "pre-push with missing and present pointers"
+(
+  set -e
+
+  reponame="pre-push-missing-and-present"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  present="present"
+  present_oid="$(calc_oid "$present")"
+  printf "$present" > present.dat
+
+  missing="missing"
+  missing_oid="$(calc_oid "$missing")"
+  printf "$missing" > missing.dat
+
+  git add present.dat missing.dat
+  git commit -m "add present.dat and missing.dat"
+
+  # :fire: the "missing" object
+  missing_oid_part_1="$(echo "$missing_oid" | cut -b 1-2)"
+  missing_oid_part_2="$(echo "$missing_oid" | cut -b 3-4)"
+  missing_oid_path=".git/lfs/objects/$missing_oid_part_1/$missing_oid_part_2/$missing_oid"
+  rm "$missing_oid_path"
+
+  git config "lfs.allowincompletepush" "true"
+
+  echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
+    git lfs pre-push origin "$GITSERVER/$reponame" 2>&1 |
+    tee push.log
+
+  if [ "0" -ne "${PIPESTATUS[1]}" ]; then
+    echo >&2 "fatal: expected \`git lfs pre-push origin $GITSERVER/$reponame\` to succeed..."
+    exit 1
+  fi
+
+  grep "LFS upload missing objects" push.log
+  grep "  (missing) missing.dat ($missing_oid)" push.log
+
+  assert_server_object "$reponame" "$present_oid"
+  refute_server_object "$reponame" "$missing_oid"
+)
+end_test
+
 begin_test "pre-push multiple branches"
 (
   set -e

--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -610,4 +610,48 @@ begin_test "push with deprecated _links"
 
   assert_server_object "$reponame" "$contents_oid"
 )
+
+begin_test "push with missing objects (lfs.allowincompletepush)"
+(
+  set -e
+
+  reponame="push-with-missing-objects"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  present="present"
+  present_oid="$(calc_oid "$present")"
+  printf "$present" > present.dat
+
+  missing="missing"
+  missing_oid="$(calc_oid "$missing")"
+  printf "$missing" > missing.dat
+
+  git add missing.dat present.dat
+  git commit -m "add objects"
+
+  # :fire: the "missing" object
+  missing_oid_part_1="$(echo "$missing_oid" | cut -b 1-2)"
+  missing_oid_part_2="$(echo "$missing_oid" | cut -b 3-4)"
+  missing_oid_path=".git/lfs/objects/$missing_oid_part_1/$missing_oid_part_2/$missing_oid"
+  rm "$missing_oid_path"
+
+  git config "lfs.allowincompletepush" "true"
+
+  git push origin master 2>&1 | tee push.log
+  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected \`git push origin master\` to succeed ..."
+    exit 1
+  fi
+
+  grep "LFS upload missing objects" push.log
+  grep "  (missing) missing.dat ($missing_oid)" push.log
+
+  assert_server_object "$reponame" "$present_oid"
+  refute_server_object "$reponame" "$missing_oid"
+)
 end_test


### PR DESCRIPTION
This pull request allows the uploader to push ranges with incomplete or missing/corrupt LFS objects as given by the `lfs.allowincompletepush` configuration value.

Closes: #2063.

---

/cc @git-lfs/core @allaryin https://github.com/git-lfs/git-lfs/issues/2193 https://github.com/git-lfs/git-lfs/issues/2063