### PR TITLE
Fix debian 9 (stretch) builds

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -46,6 +46,11 @@ override_dh_strip:
 	# strip disabled as golang upstream doesn't support it and it makes go
 	# crash. See https://launchpad.net/bugs/1200255.
 
+override_dh_golang:
+	# The dh_golang is used to add the Built-using field to the deb.  This is only for reference.
+	# As of https://anonscm.debian.org/cgit/collab-maint/dh-golang.git/commit/script/dh_golang?id=7c3fbec6ea92294477fa8910264fe9bd823f21c3
+	# dh_golang errors out because the go compiler used was not installed via a package.  Therefore the step is skipped
+
 override_dh_auto_install:
 	mkdir -p debian/git-lfs/usr/bin
 	cp $(BUILD_DIR)/bin/git-lfs debian/git-lfs/usr/bin/


### PR DESCRIPTION
Sorry for the delay on this - I've had it on my todo list for months but hadn't gotten around to it.

The fix was to skip the `dh_golang` step which is used to add the `Built-using` field to the resulting deb.  The field is only used to track the version of go used to build a package so omitting it shouldn't be a problem.  In the commit at https://anonscm.debian.org/cgit/collab-maint/dh-golang.git/commit/script/dh_golang?id=7c3fbec6ea92294477fa8910264fe9bd823f21c3 the dh-golang maintainers changed the logic used to determine the version of go used to check the installed package.  This fails because git-lfs gets built using a manually installed version of go.

This fixes #1472.