### PR TITLE
build: publish Debian 9-compat packages

### DIFF
--- a/docker/run_dockers.bsh
+++ b/docker/run_dockers.bsh
@@ -54,7 +54,7 @@ while [[ $# > 0 ]]; do
 done
 
 if [[ ${#IMAGES[@]} == 0 ]]; then
-  IMAGES=(centos_6 centos_7 debian_7 debian_8)
+  IMAGES=(centos_6 centos_7 debian_7 debian_8 debian_9)
 fi
 
 mkdir -p "${PACKAGE_DIR}"

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -44,10 +44,11 @@ $distro_name_map = {
   ),
   "debian/8" => %w(
     debian/jessie
-    linuxmint/sarah
-    linuxmint/rebecca
     linuxmint/rafaela
+    linuxmint/rebecca
     linuxmint/rosa
+    linuxmint/sarah
+    linuxmint/serena
     ubuntu/trusty
     ubuntu/vivid
     ubuntu/wily
@@ -55,8 +56,6 @@ $distro_name_map = {
   ),
   "debian/9" => %W(
     debian/stretch
-    linuxmint/sarah
-    linuxmint/serena
     ubuntu/yakkety
     ubuntu/zesty
   ),

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -53,6 +53,13 @@ $distro_name_map = {
     ubuntu/wily
     ubuntu/xenial
   ),
+  "debian/9" => %W(
+    debian/stretch
+    linuxmint/sarah
+    linuxmint/serena
+    ubuntu/yakkety
+    ubuntu/zesty
+  ),
 }
 
 # caches distro id lookups


### PR DESCRIPTION
This pull request expands on #2203 to include Debian 9 in the build matrix, and distribute packages to Linux distributions built on/with Debian 9.

---

/cc @git-lfs/core 