### PR TITLE
remove quotes from git config syntax

### DIFF
--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -138,7 +138,7 @@ func verifyLocks(remote string) (ours, theirs []locking.Lock, st verifyState) {
 				}
 			} else {
 				Print("Remote %q does not support the LFS locking API. Consider disabling it with:", remote)
-				Print("  $ git config 'lfs.%s.locksverify' false", endpoint.Url)
+				Print("  $ git config lfs.%s.locksverify false", endpoint.Url)
 				if state == verifyStateEnabled {
 					ExitWithError(err)
 				}
@@ -146,7 +146,7 @@ func verifyLocks(remote string) (ours, theirs []locking.Lock, st verifyState) {
 		}
 	} else if state == verifyStateUnknown {
 		Print("Locking support detected on remote %q. Consider enabling it with:", remote)
-		Print("  $ git config 'lfs.%s.locksverify' true", endpoint.Url)
+		Print("  $ git config lfs.%s.locksverify true", endpoint.Url)
 	}
 
 	return ours, theirs, state

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -667,7 +667,7 @@ begin_test "pre-push locks verify 5xx with verification enabled"
 
   git push origin master 2>&1 | tee push.log
   grep "\"origin\" does not support the LFS locking API" push.log
-  grep "git config 'lfs.$endpoint.locksverify' false" push.log
+  grep "git config lfs.$endpoint.locksverify false" push.log
 
   refute_server_object "$reponame" "$contents_oid"
 )
@@ -851,7 +851,7 @@ begin_test "pre-push locks verify 200"
   git push origin master 2>&1 | tee push.log
 
   grep "Locking support detected on remote \"origin\"." push.log
-  grep "git config 'lfs.$endpoint.locksverify' true" push.log
+  grep "git config lfs.$endpoint.locksverify true" push.log
   assert_server_object "$reponame" "$contents_oid"
 )
 end_test


### PR DESCRIPTION
The quoted syntax doesn't work on Windows. Probably a bash vs Windows cmd thing.

/cc https://github.com/git-lfs/git-lfs/issues/2204#issuecomment-299907812