### PR TITLE
commands/help: print helptext to stdout for consistency with Git

### DIFF
--- a/commands/run.go
+++ b/commands/run.go
@@ -102,9 +102,9 @@ func usageCommand(cmd *cobra.Command) error {
 
 func printHelp(commandName string) {
 	if txt, ok := ManPages[commandName]; ok {
-		fmt.Fprintf(os.Stderr, "%s\n", strings.TrimSpace(txt))
+		fmt.Fprintf(os.Stdout, "%s\n", strings.TrimSpace(txt))
 	} else {
-		fmt.Fprintf(os.Stderr, "Sorry, no usage text found for %q\n", commandName)
+		fmt.Fprintf(os.Stdout, "Sorry, no usage text found for %q\n", commandName)
 	}
 }
 


### PR DESCRIPTION
This pull request resolves https://github.com/git-lfs/git-lfs/issues/2207 by printing command help text/manpages to `os.Stdout` instead of `os.Stderr` for consistency with the behavior of Git.

For instance:

```
~/g/git-lfs (help-to-stdout) $ git help 2>/dev/null
usage: git [--version] [--help] [-C <path>] [-c name=value]
           [--exec-path[=<path>]] [--html-path] [--man-path] [--info-path]
           [-p | --paginate | --no-pager] [--no-replace-objects] [--bare]
           [--git-dir=<path>] [--work-tree=<path>] [--namespace=<name>]
           <command> [<args>]
```  

and before:

```
~/g/git-lfs (master) $ git lfs help 2>/dev/null
```

after:

```
~/g/git-lfs (help-to-stdout) $ git lfs help 2>/dev/null
git lfs <command> [<args>]

# ...
```

Closes: https://github.com/git-lfs/git-lfs/issues/2207

---

/cc @git-lfs/core @lyosha https://github.com/git-lfs/git-lfs/issues/2207