### PR TITLE
packagecloud: add Debian 9 entry to formatted list

### DIFF
--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -97,6 +97,7 @@ package_files.each do |full_path|
   os, distro = case full_path
   when /debian\/7/ then ["Debian 7", "debian/wheezy"]
   when /debian\/8/ then ["Debian 8", "debian/jessie"]
+  when /debian\/9/ then ["Debian 9", "debian/stretch"]
   when /centos\/5/ then ["RPM RHEL 5/CentOS 5", "el/5"]
   when /centos\/6/ then ["RPM RHEL 6/CentOS 6", "el/6"]
   when /centos\/7/ then ["RPM RHEL 7/CentOS 7", "el/7"]


### PR DESCRIPTION
This pull request adds a "Debian 9" entry to the list we generate at the end of running `script/packagecloud.rb`. I noticed that I missed this from #2205.

---

/cc @git-lfs/core 