### PR TITLE
Update Xenial is to use stretch packages

### DIFF
--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -47,15 +47,15 @@ $distro_name_map = {
     linuxmint/rafaela
     linuxmint/rebecca
     linuxmint/rosa
-    linuxmint/sarah
-    linuxmint/serena
     ubuntu/trusty
     ubuntu/vivid
     ubuntu/wily
-    ubuntu/xenial
   ),
   "debian/9" => %W(
     debian/stretch
+    linuxmint/sarah
+    linuxmint/serena
+    ubuntu/xenial
     ubuntu/yakkety
     ubuntu/zesty
   ),


### PR DESCRIPTION
Apparently I misspoke in #2205

While Mint 18 Sarah and 18.1 Serena are based on Ubuntu Xenial 16.04, it turns out Xenial is actually based on Debian Stretch 9[[1](https://askubuntu.com/a/445496)]. And I use Mint 18...

/cc @git-lfs/core 