### PR TITLE
[WIP] lfsapi/ssh: refactor `sshGetExeAndArgs`

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -111,7 +111,7 @@ func initConfig(c *Configuration) {
 //
 // Otherwise, the field will be set to the value of calling the
 // appropriately-typed method on the specified environment.
-func (c *Configuration) Unmarshal(v interface{}) error {
+func Unmarshal(git, os Enviornment, v interface{}) error {
 	into := reflect.ValueOf(v)
 	if into.Kind() != reflect.Ptr {
 		return fmt.Errorf("lfs/config: unable to parse non-pointer type of %T", v)
@@ -151,6 +151,10 @@ func (c *Configuration) Unmarshal(v interface{}) error {
 	}
 
 	return nil
+}
+
+func (c *Configuration) Unmarshal(v interface{}) error {
+	return Unmarshal(c.Git, c.Os, v)
 }
 
 var (

--- a/lfsapi/lfsapi.go
+++ b/lfsapi/lfsapi.go
@@ -74,7 +74,7 @@ func NewClient(osEnv Env, gitEnv Env) (*Client, error) {
 	var creds CredentialHelper = &commandCredentialHelper{
 		SkipPrompt: !osEnv.Bool("GIT_TERMINAL_PROMPT", true),
 	}
-	var sshResolver SSHResolver = &sshAuthClient{os: osEnv}
+	var sshResolver SSHResolver = &sshAuthClient{os: osEnv, git: gitEnv}
 
 	if gitEnv.Bool("lfs.cachecredentials", false) {
 		creds = withCredentialCache(creds)

--- a/lfsapi/ssh.go
+++ b/lfsapi/ssh.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/git-lfs/git-lfs/config"
 	"github.com/git-lfs/git-lfs/tools"
 	"github.com/rubyist/tracerx"
 )
@@ -68,7 +69,7 @@ func (r *sshAuthResponse) IsExpiredWithin(d time.Duration) (time.Time, bool) {
 }
 
 type sshAuthClient struct {
-	os Env
+	os, git Env
 }
 
 func (c *sshAuthClient) Resolve(e Endpoint, method string) (sshAuthResponse, error) {
@@ -112,6 +113,66 @@ func sshGetLFSExeAndArgs(osEnv Env, e Endpoint, method string) (string, []string
 	exe, args := sshGetExeAndArgs(osEnv, e)
 	return exe, append(args,
 		fmt.Sprintf("git-lfs-authenticate %s %s", e.SshPath, operation))
+}
+
+type sshVariant uint
+
+type sshConfig struct {
+	cmd     string `os:"GIT_SSH_COMMAND" os:"GIT_SSH" git:"core.sshCommand"`
+	variant string `git:"ssh.variant"`
+}
+
+func (c *sshConfig) Command() []string {
+	if len(c.cmd) == 0 {
+		return []string{"ssh"}
+	}
+	return tools.QuotedFields(c.cmd)
+}
+
+func (c *sshConfig) Exe() string {
+	return c.Command()[0]
+}
+
+func (c *sshConfig) Args() []string {
+	return c.Command()[1:]
+}
+
+func (c *sshConfig) Variant() (plink, tortoise bool) {
+	variant := c.variant
+	if len(variant) == 0 {
+		variant = filepath.Base(c.Command()[0])
+		variant = strings.TrimSuffix(variant, filepath.Ext(variant))
+	}
+
+	return strings.EqualFold(variant, "plink"),
+		strings.EqualFold(variant, "tortoiseplink")
+}
+
+func sshGetExeAndArgs2(git, os Env, e Endpoint) (exe string, baseargs []string) {
+	var sc sshConfig
+	if err := config.Unmarshal(git, os, &sc); err != nil {
+		panic(err.Error())
+	}
+
+	args := s.Args()
+	plink, tortoise := sc.Variant()
+
+	if tortoise {
+		// TortoisePlink requires the -batch argument to behave like ssh/plink
+		args = append(args, "-batch")
+	}
+
+	if len(e.SshPort) > 0 {
+		if isPlink || isTortoise {
+			args = append(args, "-P")
+		} else {
+			args = append(args, "-p")
+		}
+		args = append(args, e.SshPort)
+	}
+	args = append(args, e.SshUserAndPort)
+
+	return sc.Exe(), args
 }
 
 // Return the executable name for ssh on this machine and the base args


### PR DESCRIPTION
This pull request begins refactoring the `sshGetExeAndArgs` function in the `lfsapi` package in order to:

1. Evaluate `GIT_SSH_COMMAND` in a shell, and...
2. Respect the ordering of `core.sshCommand`.

It is currently a work in progress and based off of https://github.com/git-lfs/git-lfs/pull/2216. An inter-diff is available here: https://github.com/git-lfs/git-lfs/compare/config-multi-env...ssh-command-args.

---