### PR TITLE
tq/basic_download: guard against nil HTTP response

### DIFF
--- a/tq/basic_download.go
+++ b/tq/basic_download.go
@@ -113,7 +113,7 @@ func (a *basicDownloadAdapter) download(t *Transfer, cb ProgressCallback, authOk
 	res, err := a.doHTTP(t, req)
 	if err != nil {
 		// Special-case status code 416 () - fall back
-		if fromByte > 0 && dlFile != nil && res.StatusCode == 416 {
+		if fromByte > 0 && dlFile != nil && (res != nil && res.StatusCode == 416) {
 			tracerx.Printf("xfer: server rejected resume download request for %q from byte %d; re-downloading from start", t.Oid, fromByte)
 			dlFile.Close()
 			os.Remove(dlFile.Name())


### PR DESCRIPTION
This pull request fixes a potential nil-pointer dereference as described in https://github.com/git-lfs/git-lfs/issues/2222.

The issue is that when the `basic_download` adapter tries to issue a "resume download" request to the server and there was an error sending or receiving that request, the client tries to clean up the resources that it held _if_ the response code is 416.

However, this check occurs in an `if err != nil { ... }` block, meaning that the `*http.Request`, `req` can be nil. To solve this, first guard that `res != nil && ...` to prevent a nil-pointer dereference.

My additional concern when I wrote this was that other transfer adapters were affected. I checked all of our transfer adapters, and found that the only time that `req` is ever referenced inside an `if err != nil { ... }` after an `a.doHTTP()` call is in `tq/basic_download.go`, so this is safe. `a.doHTTP()` will never return `(nil, nil)`. One _or_ the other can be `nil`, but not both.

Closes: https://github.com/git-lfs/git-lfs/issues/2222.

---

/cc @git-lfs/core