### PR TITLE
commands: fix logged error not interpolating format qualifiers

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -354,10 +354,10 @@ func logPanicToWriter(w io.Writer, loggedError error, le string) {
 	w.Write(ErrorBuffer.Bytes())
 	fmt.Fprint(w, le)
 
-	fmt.Fprint(w, "%+v"+le, loggedError)
+	fmt.Fprintf(w, "%+v"+le, loggedError)
 
 	for key, val := range errors.Context(err) {
-		fmt.Fprint(w, "%s=%v"+le, key, val)
+		fmt.Fprintf(w, "%s=%v"+le, key, val)
 	}
 
 	fmt.Fprint(w, le+"ENV:"+le)


### PR DESCRIPTION
This pull request fixes an error I noticed in our `LoggedError` and `logPanic` functions that format variables like `"%+v"` weren't being formatted correctly when viewing the output of `git lfs logs last`.

This problem was introduced in https://github.com/git-lfs/git-lfs/pull/2178.

---

/cc @git-lfs/core 