### PR TITLE
Backport #2227 for v2.1.x: tq/basic_download: guard against nil HTTP response

### DIFF
--- a/tq/basic_download.go
+++ b/tq/basic_download.go
@@ -113,7 +113,7 @@ func (a *basicDownloadAdapter) download(t *Transfer, cb ProgressCallback, authOk
 	res, err := a.doHTTP(t, req)
 	if err != nil {
 		// Special-case status code 416 () - fall back
-		if fromByte > 0 && dlFile != nil && res.StatusCode == 416 {
+		if fromByte > 0 && dlFile != nil && (res != nil && res.StatusCode == 416) {
 			tracerx.Printf("xfer: server rejected resume download request for %q from byte %d; re-downloading from start", t.Oid, fromByte)
 			dlFile.Close()
 			os.Remove(dlFile.Name())


### PR DESCRIPTION
This backports #2227.