### PR TITLE
Backport #2241 for v2.1.x: sanitize ssh options parsed from ssh:// url

### DIFF
--- a/test/cmd/lfs-ssh-echo.go
+++ b/test/cmd/lfs-ssh-echo.go
@@ -19,14 +19,29 @@ type sshResponse struct {
 
 func main() {
 	// expect args:
-	//   ssh-echo -p PORT git@127.0.0.1 git-lfs-authenticate REPO OPERATION
-	if len(os.Args) != 5 {
+	//   lfs-ssh-echo -p PORT -- git@127.0.0.1 git-lfs-authenticate REPO OPERATION
+	if len(os.Args) != 6 {
 		fmt.Fprintf(os.Stderr, "got %d args: %v", len(os.Args), os.Args)
 		os.Exit(1)
 	}
 
+	if os.Args[1] != "-p" {
+		fmt.Fprintf(os.Stderr, "$1 expected \"-p\", got %q", os.Args[1])
+		os.Exit(1)
+	}
+
+	if os.Args[3] != "--" {
+		fmt.Fprintf(os.Stderr, "$3 expected \"--\", got %q", os.Args[3])
+		os.Exit(1)
+	}
+
+	if os.Args[4] != "git@127.0.0.1" {
+		fmt.Fprintf(os.Stderr, "$4 expected \"git@127.0.0.1\", got %q", os.Args[4])
+		os.Exit(1)
+	}
+
 	// just "git-lfs-authenticate REPO OPERATION"
-	authLine := strings.Split(os.Args[4], " ")
+	authLine := strings.Split(os.Args[5], " ")
 	if len(authLine) < 13 {
 		fmt.Fprintf(os.Stderr, "bad git-lfs-authenticate line: %s\nargs: %v", authLine, os.Args)
 	}

--- a/test/cmd/lfs-ssh-proxy-test.go
+++ b/test/cmd/lfs-ssh-proxy-test.go
@@ -1,0 +1,9 @@
+// +build testtools
+
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("SSH PROXY TEST called")
+}

--- a/test/test-env.sh
+++ b/test/test-env.sh
@@ -673,7 +673,7 @@ begin_test "env with multiple ssh remotes"
   SSH=git@git-server.com:user/repo.git
 Endpoint (other)=https://other-git-server.com/user/repo.git/info/lfs (auth=none)
   SSH=git@other-git-server.com:user/repo.git
-GIT_SSH=ssh-echo'
+GIT_SSH=lfs-ssh-echo'
 
   contains_same_elements "$expected" "$(git lfs env | grep -e "Endpoint" -e "SSH=")"
 )

--- a/test/test-ssh.sh
+++ b/test/test-ssh.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+. "test/testlib.sh"
+
+begin_test "ssh with proxy command in lfs.url"
+(
+  set -e
+
+  reponame="batch-ssh-proxy"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  sshurl="${GITSERVER/http:\/\//ssh://-oProxyCommand=ssh-proxy-test/}/$reponame"
+  echo $sshurl
+  git config lfs.url "$sshurl"
+
+  contents="test"
+  oid="$(calc_oid "$contents")"
+  git lfs track "*.dat"
+  printf "$contents" > test.dat
+  git add .gitattributes test.dat
+  git commit -m "initial commit"
+
+  git push origin master 2>&1 | tee push.log
+  if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: push succeeded"
+    exit 1
+  fi
+
+  grep "got 4 args" push.log
+  grep "lfs-ssh-echo -- -oProxyCommand" push.log
+)
+end_test

--- a/test/testenv.sh
+++ b/test/testenv.sh
@@ -120,7 +120,7 @@ TESTHOME="$REMOTEDIR/home"
 
 GIT_CONFIG_NOSYSTEM=1
 GIT_TERMINAL_PROMPT=0
-GIT_SSH=ssh-echo
+GIT_SSH=lfs-ssh-echo
 APPVEYOR_REPO_COMMIT_MESSAGE="test: env test should look for GIT_SSH too"
 
 export CREDSDIR


### PR DESCRIPTION
This backports #2241.