### PR TITLE
release: backport Debian 9-related changes

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -46,6 +46,11 @@ override_dh_strip:
 	# strip disabled as golang upstream doesn't support it and it makes go
 	# crash. See https://launchpad.net/bugs/1200255.
 
+override_dh_golang:
+	# The dh_golang is used to add the Built-using field to the deb.  This is only for reference.
+	# As of https://anonscm.debian.org/cgit/collab-maint/dh-golang.git/commit/script/dh_golang?id=7c3fbec6ea92294477fa8910264fe9bd823f21c3
+	# dh_golang errors out because the go compiler used was not installed via a package.  Therefore the step is skipped
+
 override_dh_auto_install:
 	mkdir -p debian/git-lfs/usr/bin
 	cp $(BUILD_DIR)/bin/git-lfs debian/git-lfs/usr/bin/

--- a/docker/run_dockers.bsh
+++ b/docker/run_dockers.bsh
@@ -54,7 +54,7 @@ while [[ $# > 0 ]]; do
 done
 
 if [[ ${#IMAGES[@]} == 0 ]]; then
-  IMAGES=(centos_6 centos_7 debian_7 debian_8)
+  IMAGES=(centos_6 centos_7 debian_7 debian_8 debian_9)
 fi
 
 mkdir -p "${PACKAGE_DIR}"

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -44,14 +44,20 @@ $distro_name_map = {
   ),
   "debian/8" => %w(
     debian/jessie
-    linuxmint/sarah
-    linuxmint/rebecca
     linuxmint/rafaela
+    linuxmint/rebecca
     linuxmint/rosa
+    linuxmint/sarah
+    linuxmint/serena
     ubuntu/trusty
     ubuntu/vivid
     ubuntu/wily
     ubuntu/xenial
+  ),
+  "debian/9" => %W(
+    debian/stretch
+    ubuntu/yakkety
+    ubuntu/zesty
   ),
 }
 

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -97,6 +97,7 @@ package_files.each do |full_path|
   os, distro = case full_path
   when /debian\/7/ then ["Debian 7", "debian/wheezy"]
   when /debian\/8/ then ["Debian 8", "debian/jessie"]
+  when /debian\/9/ then ["Debian 9", "debian/stretch"]
   when /centos\/5/ then ["RPM RHEL 5/CentOS 5", "el/5"]
   when /centos\/6/ then ["RPM RHEL 6/CentOS 6", "el/6"]
   when /centos\/7/ then ["RPM RHEL 7/CentOS 7", "el/7"]

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -47,15 +47,15 @@ $distro_name_map = {
     linuxmint/rafaela
     linuxmint/rebecca
     linuxmint/rosa
-    linuxmint/sarah
-    linuxmint/serena
     ubuntu/trusty
     ubuntu/vivid
     ubuntu/wily
-    ubuntu/xenial
   ),
   "debian/9" => %W(
     debian/stretch
+    linuxmint/sarah
+    linuxmint/serena
+    ubuntu/xenial
     ubuntu/yakkety
     ubuntu/zesty
   ),


### PR DESCRIPTION
This pull request is a manual backporting of the 4 pull requests involved in supporting building/releasing on Debian 9:

- https://github.com/git-lfs/git-lfs/pull/2203 (@ssgelm): fix building on Debian 9
- https://github.com/git-lfs/git-lfs/pull/2205 (@ttaylorr): publish Debian 9 packages
- https://github.com/git-lfs/git-lfs/pull/2211 (@ttaylorr): add Debian 9 to release notes
- https://github.com/git-lfs/git-lfs/pull/2212 (@andyneff): fix broken publishing rules

---

/cc @git-lfs/core 