### PR TITLE
Backport #2237 for v2.1.x: Make pull return non-zero error code when some downloads failed

### DIFF
--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -103,7 +103,9 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 	}
 
 	if !success {
-		Exit("Warning: errors occurred")
+		c := getAPIClient()
+		e := c.Endpoints.Endpoint("download", cfg.CurrentRemote)
+		Exit("error: failed to push some objects to '%s'", e.Url)
 	}
 }
 

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -104,8 +104,16 @@ func pull(remote string, filter *filepathfilter.Filter) {
 
 	singleCheckout.Close()
 
+	success := true
 	for _, err := range q.Errors() {
+		success = false
 		FullError(err)
+	}
+
+	if !success {
+		c := getAPIClient()
+		e := c.Endpoints.Endpoint("download", remote)
+		Exit("error: failed to push some objects to '%s'", e.Url)
 	}
 }
 

--- a/test/test-pull.sh
+++ b/test/test-pull.sh
@@ -10,7 +10,6 @@ begin_test "pull"
   setup_remote_repo "$reponame"
 
   clone_repo "$reponame" clone
-
   clone_repo "$reponame" repo
 
   git lfs track "*.dat" 2>&1 | tee track.log
@@ -136,6 +135,32 @@ begin_test "pull with raw remote url"
   assert_local_object "$contents_oid" 1
   [ "0" = "$(grep -c "$contents_oid" a.dat)" ]
   [ "a" = "$(cat a.dat)" ]
+)
+end_test
+
+begin_test "pull: with missing object"
+(
+  set -e
+
+  # this clone is setup in the first test in this file
+  cd clone
+  rm -rf .git/lfs/objects
+
+  contents_oid=$(calc_oid "a")
+  reponame="$(basename "$0" ".sh")"
+  delete_server_object "$reponame" "$contents_oid"
+  refute_server_object "$reponame" "$contents_oid"
+
+  # should return non-zero, but should also download all the other valid files too
+  git lfs pull 2>&1 | tee pull.log
+  pull_exit="${PIPESTATUS[0]}"
+  [ "$pull_exit" != "0" ]
+
+  grep "$contents_oid" pull.log
+
+  contents2_oid=$(calc_oid "A")
+  assert_local_object "$contents2_oid" 1
+  refute_local_object "$contents_oid"
 )
 end_test
 


### PR DESCRIPTION
This backports #2237.