### PR TITLE
Minor cleanups in help index

### DIFF
--- a/docs/man/git-lfs.1.ronn
+++ b/docs/man/git-lfs.1.ronn
@@ -32,11 +32,11 @@ commands and low level ("plumbing") commands.
 * git-lfs-env(1):
     Display the Git LFS environment.
 * git-lfs-checkout(1):
-    Populate working copy with real content from Git LFS files
+    Populate working copy with real content from Git LFS files.
 * git lfs clone:
-    Efficiently clone a Git LFS-enabled repository
+    Efficiently clone a Git LFS-enabled repository.
 * git-lfs-fetch(1):
-    Download git LFS files from a remote
+    Download git LFS files from a remote.
 * git-lfs-fsck(1):
     Check GIT LFS files for consistency.
 * git-lfs-install(1):
@@ -44,13 +44,13 @@ commands and low level ("plumbing") commands.
 * git-lfs-lock(1):
     Set a file as "locked" on the Git LFS server.
 * git-lfs-locks(1):
-    List currently locked files from the Git LFS server.
+    List currently "locked" files from the Git LFS server.
 * git-lfs-logs(1):
     Show errors from the git-lfs command.
 * git-lfs-ls-files(1):
     Show information about Git LFS files in the index and working tree.
 * git-lfs-pull(1):
-    Fetch LFS changes from the remote & checkout any required working tree files
+    Fetch LFS changes from the remote & checkout any required working tree files.
 * git-lfs-push(1):
     Push queued large files to the Git LFS endpoint.
 * git-lfs-status(1):


### PR DESCRIPTION
- Add missing trailing periods

- Add quotes around "locked" for consistency
