### PR TITLE
commands/clone: support shorthand --verbose '-v' flag

### DIFF
--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -145,7 +145,7 @@ func init() {
 		cmd.Flags().StringVarP(&cloneFlags.Config, "config", "c", "", "See 'git clone --help'")
 		cmd.Flags().BoolVarP(&cloneFlags.SingleBranch, "single-branch", "", false, "See 'git clone --help'")
 		cmd.Flags().BoolVarP(&cloneFlags.NoSingleBranch, "no-single-branch", "", false, "See 'git clone --help'")
-		cmd.Flags().BoolVarP(&cloneFlags.Verbose, "verbose", "", false, "See 'git clone --help'")
+		cmd.Flags().BoolVarP(&cloneFlags.Verbose, "verbose", "v", false, "See 'git clone --help'")
 		cmd.Flags().BoolVarP(&cloneFlags.Ipv4, "ipv4", "", false, "See 'git clone --help'")
 		cmd.Flags().BoolVarP(&cloneFlags.Ipv6, "ipv6", "", false, "See 'git clone --help'")
 

--- a/test/test-clone.sh
+++ b/test/test-clone.sh
@@ -281,11 +281,11 @@ begin_test "clone with flags"
   # specific test for --bare
   git lfs clone --bare "$GITSERVER/$reponame" "$newclonedir"
   [ -d "$newclonedir/objects" ]
+  rm -rf "$newclonedir"
 
   # short flags
   git lfs clone -l -v -n -s -b branch2 "$GITSERVER/$reponame" "$newclonedir"
   rm -rf "$newclonedir"
-
 )
 end_test
 


### PR DESCRIPTION
This pull request closes https://github.com/git-lfs/git-lfs/issues/2249 by adding the shorthand `-v` flag to be the equivelant of `--verbose` when calling `git lfs clone`.

This more closely matches the behavior of the builtin `git-clone(1)`:

> ```
> --verbose, -v
>    Run verbosely. Does not affect the reporting of progress status to the standard error stream.
> ```

While looking through the man pages for `git-clone(1)`, I double checked to make sure that none of the other wrapped clone flags that we provide were missing shorthand, single `-` flags.

Closes https://github.com/git-lfs/git-lfs/issues/2249.

---

/cc @git-lfs/core 