### PR TITLE
commands/clone: add new flags since Git 2.9

### DIFF
--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -150,6 +150,7 @@ func init() {
 		cmd.Flags().BoolVarP(&cloneFlags.Ipv4, "ipv4", "", false, "See 'git clone --help'")
 		cmd.Flags().BoolVarP(&cloneFlags.Ipv6, "ipv6", "", false, "See 'git clone --help'")
 		cmd.Flags().StringVarP(&cloneFlags.ShallowSince, "shallow-since", "", "", "See 'git clone --help'")
+		cmd.Flags().StringVarP(&cloneFlags.ShallowExclude, "shallow-exclude", "", "", "See 'git clone --help'")
 
 		cmd.Flags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")
 		cmd.Flags().StringVarP(&excludeArg, "exclude", "X", "", "Exclude a list of paths")

--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -137,6 +137,7 @@ func init() {
 		cmd.Flags().StringVarP(&cloneFlags.Branch, "branch", "b", "", "See 'git clone --help'")
 		cmd.Flags().StringVarP(&cloneFlags.Upload, "upload-pack", "u", "", "See 'git clone --help'")
 		cmd.Flags().StringVarP(&cloneFlags.Reference, "reference", "", "", "See 'git clone --help'")
+		cmd.Flags().StringVarP(&cloneFlags.ReferenceIfAble, "reference-if-able", "", "", "See 'git clone --help'")
 		cmd.Flags().BoolVarP(&cloneFlags.Dissociate, "dissociate", "", false, "See 'git clone --help'")
 		cmd.Flags().StringVarP(&cloneFlags.SeparateGit, "separate-git-dir", "", "", "See 'git clone --help'")
 		cmd.Flags().StringVarP(&cloneFlags.Depth, "depth", "", "", "See 'git clone --help'")

--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -149,6 +149,7 @@ func init() {
 		cmd.Flags().BoolVarP(&cloneFlags.Verbose, "verbose", "", false, "See 'git clone --help'")
 		cmd.Flags().BoolVarP(&cloneFlags.Ipv4, "ipv4", "", false, "See 'git clone --help'")
 		cmd.Flags().BoolVarP(&cloneFlags.Ipv6, "ipv6", "", false, "See 'git clone --help'")
+		cmd.Flags().StringVarP(&cloneFlags.ShallowSince, "shallow-since", "", "", "See 'git clone --help'")
 
 		cmd.Flags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")
 		cmd.Flags().StringVarP(&excludeArg, "exclude", "X", "", "Exclude a list of paths")

--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -153,6 +153,7 @@ func init() {
 		cmd.Flags().StringVarP(&cloneFlags.ShallowExclude, "shallow-exclude", "", "", "See 'git clone --help'")
 		cmd.Flags().BoolVarP(&cloneFlags.ShallowSubmodules, "shallow-submodules", "", false, "See 'git clone --help'")
 		cmd.Flags().BoolVarP(&cloneFlags.NoShallowSubmodules, "no-shallow-submodules", "", false, "See 'git clone --help'")
+		cmd.Flags().Int64VarP(&cloneFlags.Jobs, "jobs", "j", 1, "See 'git clone --help'")
 
 		cmd.Flags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")
 		cmd.Flags().StringVarP(&excludeArg, "exclude", "X", "", "Exclude a list of paths")

--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -151,6 +151,7 @@ func init() {
 		cmd.Flags().BoolVarP(&cloneFlags.Ipv6, "ipv6", "", false, "See 'git clone --help'")
 		cmd.Flags().StringVarP(&cloneFlags.ShallowSince, "shallow-since", "", "", "See 'git clone --help'")
 		cmd.Flags().StringVarP(&cloneFlags.ShallowExclude, "shallow-exclude", "", "", "See 'git clone --help'")
+		cmd.Flags().BoolVarP(&cloneFlags.ShallowSubmodules, "shallow-submodules", "", false, "See 'git clone --help'")
 
 		cmd.Flags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")
 		cmd.Flags().StringVarP(&excludeArg, "exclude", "X", "", "Exclude a list of paths")

--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -152,6 +152,7 @@ func init() {
 		cmd.Flags().StringVarP(&cloneFlags.ShallowSince, "shallow-since", "", "", "See 'git clone --help'")
 		cmd.Flags().StringVarP(&cloneFlags.ShallowExclude, "shallow-exclude", "", "", "See 'git clone --help'")
 		cmd.Flags().BoolVarP(&cloneFlags.ShallowSubmodules, "shallow-submodules", "", false, "See 'git clone --help'")
+		cmd.Flags().BoolVarP(&cloneFlags.NoShallowSubmodules, "no-shallow-submodules", "", false, "See 'git clone --help'")
 
 		cmd.Flags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")
 		cmd.Flags().StringVarP(&excludeArg, "exclude", "X", "", "Exclude a list of paths")

--- a/git/git.go
+++ b/git/git.go
@@ -804,6 +804,8 @@ type CloneFlags struct {
 	ShallowSince string
 	// --shallow-since <date>
 	ShallowExclude string
+	// --shallow-submodules
+	ShallowSubmodules bool
 }
 
 // CloneWithoutFilters clones a git repo but without the smudge filter enabled
@@ -911,6 +913,9 @@ func CloneWithoutFilters(flags CloneFlags, args []string) error {
 	}
 	if len(flags.ShallowExclude) > 0 {
 		cmdargs = append(cmdargs, "--shallow-exclude", flags.ShallowExclude)
+	}
+	if flags.ShallowSubmodules {
+		cmdargs = append(cmdargs, "--shallow-submodules")
 	}
 
 	// Now args

--- a/git/git.go
+++ b/git/git.go
@@ -806,6 +806,8 @@ type CloneFlags struct {
 	ShallowExclude string
 	// --shallow-submodules
 	ShallowSubmodules bool
+	// --no-shallow-submodules
+	NoShallowSubmodules bool
 }
 
 // CloneWithoutFilters clones a git repo but without the smudge filter enabled
@@ -916,6 +918,9 @@ func CloneWithoutFilters(flags CloneFlags, args []string) error {
 	}
 	if flags.ShallowSubmodules {
 		cmdargs = append(cmdargs, "--shallow-submodules")
+	}
+	if flags.NoShallowSubmodules {
+		cmdargs = append(cmdargs, "--no-shallow-submodules")
 	}
 
 	// Now args

--- a/git/git.go
+++ b/git/git.go
@@ -776,6 +776,8 @@ type CloneFlags struct {
 	Upload string
 	// --reference <repository>
 	Reference string
+	// --reference-if-able <repository>
+	ReferenceIfAble string
 	// --dissociate
 	Dissociate bool
 	// --separate-git-dir <git dir>
@@ -878,6 +880,9 @@ func CloneWithoutFilters(flags CloneFlags, args []string) error {
 	}
 	if len(flags.Reference) > 0 {
 		cmdargs = append(cmdargs, "--reference", flags.Reference)
+	}
+	if len(flags.ReferenceIfAble) > 0 {
+		cmdargs = append(cmdargs, "--reference-if-able", flags.ReferenceIfAble)
 	}
 	if len(flags.SeparateGit) > 0 {
 		cmdargs = append(cmdargs, "--separate-git-dir", flags.SeparateGit)

--- a/git/git.go
+++ b/git/git.go
@@ -800,6 +800,8 @@ type CloneFlags struct {
 	Ipv4 bool
 	// --ipv6
 	Ipv6 bool
+	// --shallow-since <date>
+	ShallowSince string
 }
 
 // CloneWithoutFilters clones a git repo but without the smudge filter enabled
@@ -901,6 +903,9 @@ func CloneWithoutFilters(flags CloneFlags, args []string) error {
 	}
 	if flags.Verbose {
 		cmdargs = append(cmdargs, "--verbose")
+	}
+	if len(flags.ShallowSince) > 0 {
+		cmdargs = append(cmdargs, "--shallow-since", flags.ShallowSince)
 	}
 
 	// Now args

--- a/git/git.go
+++ b/git/git.go
@@ -808,6 +808,8 @@ type CloneFlags struct {
 	ShallowSubmodules bool
 	// --no-shallow-submodules
 	NoShallowSubmodules bool
+	// jobs <n>
+	Jobs int64
 }
 
 // CloneWithoutFilters clones a git repo but without the smudge filter enabled
@@ -921,6 +923,9 @@ func CloneWithoutFilters(flags CloneFlags, args []string) error {
 	}
 	if flags.NoShallowSubmodules {
 		cmdargs = append(cmdargs, "--no-shallow-submodules")
+	}
+	if flags.Jobs > -1 {
+		cmdargs = append(cmdargs, "--jobs", strconv.FormatInt(flags.Jobs, 10))
 	}
 
 	// Now args

--- a/git/git.go
+++ b/git/git.go
@@ -802,6 +802,8 @@ type CloneFlags struct {
 	Ipv6 bool
 	// --shallow-since <date>
 	ShallowSince string
+	// --shallow-since <date>
+	ShallowExclude string
 }
 
 // CloneWithoutFilters clones a git repo but without the smudge filter enabled
@@ -906,6 +908,9 @@ func CloneWithoutFilters(flags CloneFlags, args []string) error {
 	}
 	if len(flags.ShallowSince) > 0 {
 		cmdargs = append(cmdargs, "--shallow-since", flags.ShallowSince)
+	}
+	if len(flags.ShallowExclude) > 0 {
+		cmdargs = append(cmdargs, "--shallow-exclude", flags.ShallowExclude)
 	}
 
 	// Now args


### PR DESCRIPTION
This pull request updates our wrapped clone command to include new flags added since Git 2.9, namely:

<details>
<summary><code>--reference[-if-able] <repository></code></summary>
<pre>
--reference[-if-able] <repository>
    If the reference repository is on the local machine, automatically setup
    .git/objects/info/alternates to obtain objects from the reference repository. Using an already
    existing repository as an alternate will require fewer objects to be copied from the repository
    being cloned, reducing network and local storage costs. When using the --reference-if-able, a
    non existing directory is skipped with a warning instead of aborting the clone.

    NOTE: see the NOTE for the --shared option, and also the --dissociate option.
</pre>
</details>

<details>
<summary><code>--shallow-since<=date></code></summary>
<pre>
--shallow-since=<date>
    Create a shallow clone with a history after the specified time.
</pre>
</details>

<details>
<summary><code>--shallow-exclude=<revision></code></summary>
<pre>
--shallow-exclude=<revision>
    Create a shallow clone with a history, excluding commits reachable from a specified remote
    branch or tag. This option can be specified multiple times.
</pre>
</details>

<details>
<summary><code>-[no-]shallow-submodules</code></summary>
<pre>
-[no-]shallow-submodules
   All submodules which are cloned will be shallow with a depth of 1.
</pre>
</details>

<details>
<summary><code>-j <n>, --jobs <n></code></summary>
<pre>
-j <n>, --jobs <n>
    The number of submodules fetched at the same time. Defaults to the submodule.fetchJobs option.
</pre>
</details>

</br>

Closes https://github.com/git-lfs/git-lfs/issues/2250.

---

/cc @git-lfs/core 