### PR TITLE
all: build on Go 1.8.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # http://docs.travis-ci.com/user/languages/go/
 language: go
 
-go: 1.8.1
+go: 1.8.3
 
 os:
   - linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ clone_folder: $(GOPATH)\src\github.com\git-lfs\git-lfs
 
 install:
   - rd C:\Go /s /q
-  - cinst golang --version 1.8.1 -y
+  - cinst golang --version 1.8.3 -y
   - cinst InnoSetup -y
   - refreshenv
   - ps: |


### PR DESCRIPTION
This pull request upgrades our CI services to build using Go 1.8.3, which was released today on the golang-announce mailing list [[source]](https://groups.google.com/forum/#!topic/golang-announce/q8Ddz0ZgAQw).

Similar to our discussion in https://github.com/git-lfs/git-lfs/issues/2141, I would like to stay on the latest version of Go to minimize the change between versions if we ever were affected by a security vulnerability and needed to upgrade.

Here's a breakdown of our different CI services and how they're affected:

- CircleCI: uses Homebrew to install Go, so it's always on the latest of what's offered on `homebrew-core`. That repo was updated today in https://github.com/Homebrew/homebrew-core/pull/13905.
- TravisCI: uses the `.travis.yml`, which was updated in this pull request via fc7f6a1.
- AppVeyor: which uses Chocolatey (via `cinst`) to install Go v1.8.3. 1.8.3 isn't on Chocolatey yet, so we can either take an approach similar to 4acff49aea7253413a4382f8d7507324eadb1c59, or wait. I don't think we have a release scheduled anytime soon, so I'm fine to let this sit for until Chocolatey gets updated and then merge. @sschuberth: I'd be curious to hear your thoughts on this and defer to your judgement.

The corresponding build-dockers PR is here: https://github.com/git-lfs/build-dockers/pull/17.

---

/cc @git-lfs/core 