### PR TITLE
git: allow custom `--<t>-order` in RevListScanner

### DIFF
--- a/git/rev_list_scanner.go
+++ b/git/rev_list_scanner.go
@@ -43,6 +43,9 @@ const (
 	// AuthorDateRevListOrder gives the revisions such that no parents are
 	// shown before children, and otherwise in author date timestamp order.
 	AuthorDateRevListOrder
+	// TopoRevListOrder gives the revisions such that they appear in
+	// topological order.
+	TopoRevListOrder
 )
 
 // ScanRefsOptions is an "options" type that is used to configure a scan
@@ -194,6 +197,8 @@ func revListArgs(l, r string, opt *ScanRefsOptions) (io.Reader, []string, error)
 		args = append(args, "--date-order")
 	case AuthorDateRevListOrder:
 		args = append(args, "--author-date-order")
+	case TopoRevListOrder:
+		args = append(args, "--topo-order")
 	}
 
 	switch opt.Mode {

--- a/git/rev_list_scanner.go
+++ b/git/rev_list_scanner.go
@@ -28,6 +28,17 @@ const (
 	ScanLeftToRemoteMode
 )
 
+// RevListOrder is a constant type that allows for variation in the ordering of
+// revisions given by the *RevListScanner below.
+type RevListOrder int
+
+const (
+	// DefaultRevListOrder is the zero-value for this type and yields the
+	// results as given by git-rev-list(1) without any `--<t>-order`
+	// argument given. By default: reverse chronological order.
+	DefaultRevListOrder RevListOrder = iota
+)
+
 // ScanRefsOptions is an "options" type that is used to configure a scan
 // operation on the `*git.RevListScanner` instance when given to the function
 // `NewRevListScanner()`.
@@ -41,6 +52,10 @@ type ScanRefsOptions struct {
 	// ancestry (revealing potentially deleted (unreferenced) blobs, trees,
 	// or commits.
 	SkipDeletedBlobs bool
+	// Order specifies the order in which revisions are yielded from the
+	// output of `git-rev-list(1)`. For more information, see the above
+	// documentation on the RevListOrder type.
+	Order RevListOrder
 
 	// SkippedRefs provides a list of refs to ignore.
 	SkippedRefs []string

--- a/git/rev_list_scanner.go
+++ b/git/rev_list_scanner.go
@@ -37,6 +37,9 @@ const (
 	// results as given by git-rev-list(1) without any `--<t>-order`
 	// argument given. By default: reverse chronological order.
 	DefaultRevListOrder RevListOrder = iota
+	// DateRevListOrder gives the revisions such that no parents are shown
+	// before children, and otherwise in commit timestamp order.
+	DateRevListOrder
 )
 
 // ScanRefsOptions is an "options" type that is used to configure a scan
@@ -182,6 +185,11 @@ func NewRevListScanner(left, right string, opt *ScanRefsOptions) (*RevListScanne
 func revListArgs(l, r string, opt *ScanRefsOptions) (io.Reader, []string, error) {
 	var stdin io.Reader
 	args := []string{"rev-list", "--objects"}
+
+	switch opt.Order {
+	case DateRevListOrder:
+		args = append(args, "--date-order")
+	}
 
 	switch opt.Mode {
 	case ScanRefsMode:

--- a/git/rev_list_scanner.go
+++ b/git/rev_list_scanner.go
@@ -40,6 +40,9 @@ const (
 	// DateRevListOrder gives the revisions such that no parents are shown
 	// before children, and otherwise in commit timestamp order.
 	DateRevListOrder
+	// AuthorDateRevListOrder gives the revisions such that no parents are
+	// shown before children, and otherwise in author date timestamp order.
+	AuthorDateRevListOrder
 )
 
 // ScanRefsOptions is an "options" type that is used to configure a scan
@@ -189,6 +192,8 @@ func revListArgs(l, r string, opt *ScanRefsOptions) (io.Reader, []string, error)
 	switch opt.Order {
 	case DateRevListOrder:
 		args = append(args, "--date-order")
+	case AuthorDateRevListOrder:
+		args = append(args, "--author-date-order")
 	}
 
 	switch opt.Mode {

--- a/git/rev_list_scanner_test.go
+++ b/git/rev_list_scanner_test.go
@@ -121,6 +121,13 @@ func TestRevListArgs(t *testing.T) {
 			},
 			ExpectedArgs: []string{"rev-list", "--objects", "--author-date-order", "--do-walk", "left", "right", "--"},
 		},
+		"scan topo order": {
+			Left: "left", Right: "right", Opt: &ScanRefsOptions{
+				Mode:  ScanRefsMode,
+				Order: TopoRevListOrder,
+			},
+			ExpectedArgs: []string{"rev-list", "--objects", "--topo-order", "--do-walk", "left", "right", "--"},
+		},
 	} {
 		t.Run(desc, c.Assert)
 	}

--- a/git/rev_list_scanner_test.go
+++ b/git/rev_list_scanner_test.go
@@ -114,6 +114,13 @@ func TestRevListArgs(t *testing.T) {
 			},
 			ExpectedArgs: []string{"rev-list", "--objects", "--date-order", "--do-walk", "left", "right", "--"},
 		},
+		"scan author date order": {
+			Left: "left", Right: "right", Opt: &ScanRefsOptions{
+				Mode:  ScanRefsMode,
+				Order: AuthorDateRevListOrder,
+			},
+			ExpectedArgs: []string{"rev-list", "--objects", "--author-date-order", "--do-walk", "left", "right", "--"},
+		},
 	} {
 		t.Run(desc, c.Assert)
 	}

--- a/git/rev_list_scanner_test.go
+++ b/git/rev_list_scanner_test.go
@@ -107,6 +107,13 @@ func TestRevListArgs(t *testing.T) {
 			},
 			ExpectedErr: "unknown scan type: -1",
 		},
+		"scan date order": {
+			Left: "left", Right: "right", Opt: &ScanRefsOptions{
+				Mode:  ScanRefsMode,
+				Order: DateRevListOrder,
+			},
+			ExpectedArgs: []string{"rev-list", "--objects", "--date-order", "--do-walk", "left", "right", "--"},
+		},
 	} {
 		t.Run(desc, c.Assert)
 	}


### PR DESCRIPTION
This pull request expands the `RevListOptions` type to include an `Order` field, and teaches the `RevListScanner` type how to add flags to `git-rev-list(1)` accordingly.

We require a `--topo-order`-sorted list of commits in order to create a parallel DAG efficiently when performing a migrate (see: #2146 for discussion), so this pull request is required for that.

When I first implemented this, I instead added a `TopoOrder bool` field to the `RevListOptions` type, but felt that this approach was too fragile in case we need to add support for other orderings. Git allows for `--date-order`, `--author-date-order`, and `--topo-order` (in addition to its default with none of these flags given), so I added a constant type to represent this and have support for all four. Since the zero-values of the `RevListOrder` type is `DefaultRevListOrder` (which is purposefully ignored), none of the existing code requires any change to keep its behavior.

---

/cc @git-lfs/core 