### PR TITLE
git/rev_list_scanner: teach CommitsOnly option

### DIFF
--- a/git/rev_list_scanner.go
+++ b/git/rev_list_scanner.go
@@ -87,6 +87,10 @@ type ScanRefsOptions struct {
 	// output of `git-rev-list(1)`. For more information, see the above
 	// documentation on the RevListOrder type.
 	Order RevListOrder
+	// CommitsOnly specifies whether or not the *RevListScanner should
+	// return only commits, or all objects in range by performing a
+	// traversal of the graph. By default, false: show all objects.
+	CommitsOnly bool
 
 	// SkippedRefs provides a list of refs to ignore.
 	SkippedRefs []string
@@ -212,7 +216,10 @@ func NewRevListScanner(left, right string, opt *ScanRefsOptions) (*RevListScanne
 // occurred.
 func revListArgs(l, r string, opt *ScanRefsOptions) (io.Reader, []string, error) {
 	var stdin io.Reader
-	args := []string{"rev-list", "--objects"}
+	args := []string{"rev-list"}
+	if !opt.CommitsOnly {
+		args = append(args, "--objects")
+	}
 
 	if orderFlag, ok := opt.Order.Flag(); ok {
 		args = append(args, orderFlag)

--- a/git/rev_list_scanner_test.go
+++ b/git/rev_list_scanner_test.go
@@ -128,6 +128,13 @@ func TestRevListArgs(t *testing.T) {
 			},
 			ExpectedArgs: []string{"rev-list", "--objects", "--topo-order", "--do-walk", "left", "right", "--"},
 		},
+		"scan commits only": {
+			Left: "left", Right: "right", Opt: &ScanRefsOptions{
+				Mode:        ScanRefsMode,
+				CommitsOnly: true,
+			},
+			ExpectedArgs: []string{"rev-list", "--do-walk", "left", "right", "--"},
+		},
 	} {
 		t.Run(desc, c.Assert)
 	}


### PR DESCRIPTION
This pull request teaches the `*git.RevListScanner` the ability to not traverse the object graph if asking for `CommitsOnly`.

This is needed for the `migrate` command (see: #2146 for discussion), which requires a topologically ordered list of just commits, not objects.

Since the default value of `bool` is `false`, this imposes no behavior changes on existing code.

---

/cc @git-lfs/core 