### PR TITLE
git/odb: rewind temporary buffer before saving to disk

### DIFF
--- a/git/odb/object_db.go
+++ b/git/odb/object_db.go
@@ -128,6 +128,9 @@ func (d *ObjectDatabase) encodeBuffer(object Object, buf io.ReadWriter) (sha []b
 		return nil, 0, err
 	}
 
+	if _, err := tmp.Seek(0, io.SeekStart); err != nil {
+		return nil, 0, err
+	}
 	return d.save(to.Sha(), tmp)
 }
 


### PR DESCRIPTION
This pull requests fixes an issue where no data would be copied to disk when writing loose objects from the `*git.ObjectDatabase` type.

Here's a brief overview of what was going on: In order to create a "full" Git object, you need:

1. The object type
2. The object's encoded contents
3. The length of the encoded contents (zlib inflated)

In order to determine the third item, we write a temporary buffer containing the encoded contents. Once this is done, we then take the length and the object type, write a header, and then rename the object into place in your `.git/objects` directory.

To do this, however, we were using an `*os.File`, since we may encounter large blobs which exceed the available RAM on a computer running `git-lfs-migrate(1)`. The problem is that since `*os.File` implements `io.Seeker`, we were writing and advancing the seek index, so that when we copied the file into place, we were copying from the end (no remaining data), and not from the beginning. This pull request fixes that by first rewinding to the start of the temporary file.

This pull request is required work for the `git-lfs-migrate(1)` command (see discussion: #2146).

---

/cc @git-lfs/core 