### PR TITLE
git/odb: ensure that object directory exists before moving into it

### DIFF
--- a/git/odb/file_storer.go
+++ b/git/odb/file_storer.go
@@ -47,10 +47,10 @@ func (fs *fileStorer) Store(sha []byte, r io.Reader) (n int64, err error) {
 	}
 
 	n, err = io.Copy(tmp, r)
-	if err != nil {
+	if err = tmp.Close(); err != nil {
 		return n, err
 	}
-	if err = tmp.Close(); err != nil {
+	if err != nil {
 		return n, err
 	}
 

--- a/git/odb/file_storer.go
+++ b/git/odb/file_storer.go
@@ -57,14 +57,11 @@ func (fs *fileStorer) Store(sha []byte, r io.Reader) (n int64, err error) {
 	path := fs.path(sha)
 	dir := filepath.Dir(path)
 
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		// Since .git/objects partitions objects based on the first two
-		// characters of their ASCII-encoded SHA1 object ID, ensure that
-		// the directory exists before copying a file into it.
-		err = os.MkdirAll(dir, 0755)
-		if err != nil {
-			return n, err
-		}
+	// Since .git/objects partitions objects based on the first two
+	// characters of their ASCII-encoded SHA1 object ID, ensure that
+	// the directory exists before copying a file into it.
+	if err = os.MkdirAll(dir, 0755); err != nil {
+		return n, err
 	}
 
 	if _, err := os.Stat(path); os.IsExist(err) {

--- a/git/odb/file_storer.go
+++ b/git/odb/file_storer.go
@@ -50,6 +50,9 @@ func (fs *fileStorer) Store(sha []byte, r io.Reader) (n int64, err error) {
 	if err != nil {
 		return n, err
 	}
+	if err = tmp.Close(); err != nil {
+		return n, err
+	}
 
 	path := fs.path(sha)
 
@@ -61,9 +64,6 @@ func (fs *fileStorer) Store(sha []byte, r io.Reader) (n int64, err error) {
 		return n, err
 	}
 
-	if err = tmp.Close(); err != nil {
-		return n, err
-	}
 	return n, nil
 }
 

--- a/git/odb/file_storer.go
+++ b/git/odb/file_storer.go
@@ -55,6 +55,17 @@ func (fs *fileStorer) Store(sha []byte, r io.Reader) (n int64, err error) {
 	}
 
 	path := fs.path(sha)
+	dir := filepath.Dir(path)
+
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		// Since .git/objects partitions objects based on the first two
+		// characters of their ASCII-encoded SHA1 object ID, ensure that
+		// the directory exists before copying a file into it.
+		err = os.MkdirAll(dir, 0755)
+		if err != nil {
+			return n, err
+		}
+	}
 
 	if _, err := os.Stat(path); os.IsExist(err) {
 		return n, errors.Errorf("git/odb: file storer cannot copy into file %q, which already exists", path)


### PR DESCRIPTION
This pull request fixes an issue in the `git/odb` package that caused a panic when new objects are written to directories that don't have a prefix that has been created.

This is due to how Git partitions objects in the `.git/objects` directory. For instance:

```
~/g/git-lfs (master) $ tree .git/objects | head
.git/objects
├── 00
│   └── 21dd014660145da7cb00c2477359b82cf98dd3
├── 01
│   ├── 091f55ffa8b31575f351e1ede0549cea86058d
```

For an object with the OID `0021dd014660145da7cb00c2477359b82cf98dd3`, Git first places that in a directory called `00`, and then takes the remaining 38 ASCII-encoded hex SHA1 characters as the filename for that object.

Prior to this pull request, if the `git/odb` package tried to write an object that began with a two character combination that did _not_ yet exist in the `.git/objects` directory, it would panic after trying to rename a file as a child node of a directory that didn't exist. https://github.com/git-lfs/git-lfs/commit/0db751e7f8384749d83fd0e6930c4c19912f51c0 addresses this by first `stat()`-ing the directory that will contain the file and running an `os.MkdirAll()` if the error returned from `os.Stat` matches `os.IsNotExist()`.

While in here, I also updated the file storer code to close the temporary buffer earlier, to increase the readability of that code in: e731785.

This is required work for the migrate command (see discussion: #2146).

---

/cc @git-lfs/core 