### PR TITLE
git: teach UpdateRef, UpdateRefReason

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -38,6 +38,30 @@ const (
 	RefBeforeFirstCommit = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 )
 
+// Prefix returns the given RefType's prefix, "refs/heads", "ref/remotes",
+// etc. It returns an additional value of either true/false, whether or not this
+// given ref type has a prefix.
+//
+// If the RefType is unrecognized, Prefix() will panic.
+func (t RefType) Prefix() (string, bool) {
+	switch t {
+	case RefTypeLocalBranch:
+		return "refs/heads", true
+	case RefTypeRemoteBranch:
+		return "refs/remotes", true
+	case RefTypeLocalTag:
+		return "refs/tags", true
+	case RefTypeRemoteTag:
+		return "refs/remotes/tags", true
+	case RefTypeHEAD:
+		return "", false
+	case RefTypeOther:
+		return "", false
+	default:
+		panic(fmt.Sprintf("git: unknown RefType %d", t))
+	}
+}
+
 // A git reference (branch, tag etc)
 type Ref struct {
 	Name string

--- a/git/git.go
+++ b/git/git.go
@@ -254,15 +254,10 @@ func LocalRefs() ([]*Ref, error) {
 	return refs, cmd.Wait()
 }
 
-// UpdateRef moves the given ref to a new sha, and returns an error if any were
-// encountered.
-func UpdateRef(ref *Ref, to []byte) error {
-	return UpdateRefReason(ref, to, "")
-}
-
 // UpdateRef moves the given ref to a new sha with a given reason (and creates a
-// reflog entry). It returns an error if any were encountered.
-func UpdateRefReason(ref *Ref, to []byte, reason string) error {
+// reflog entry, if a "reason" was provided). It returns an error if any were
+// encountered.
+func UpdateRef(ref *Ref, to []byte, reason string) error {
 	var refspec string
 	if prefix, ok := ref.Type.Prefix(); ok {
 		refspec = fmt.Sprintf("%s/%s", prefix, ref.Name)

--- a/git/git.go
+++ b/git/git.go
@@ -5,6 +5,7 @@ package git
 import (
 	"bufio"
 	"bytes"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -251,6 +252,31 @@ func LocalRefs() ([]*Ref, error) {
 	}
 
 	return refs, cmd.Wait()
+}
+
+// UpdateRef moves the given ref to a new sha, and returns an error if any were
+// encountered.
+func UpdateRef(ref *Ref, to []byte) error {
+	return UpdateRefReason(ref, to, "")
+}
+
+// UpdateRef moves the given ref to a new sha with a given reason (and creates a
+// reflog entry). It returns an error if any were encountered.
+func UpdateRefReason(ref *Ref, to []byte, reason string) error {
+	var refspec string
+	if prefix, ok := ref.Type.Prefix(); ok {
+		refspec = fmt.Sprintf("%s/%s", prefix, ref.Name)
+	} else {
+		refspec = ref.Name
+	}
+
+	args := []string{"update-ref", refspec, hex.EncodeToString(to)}
+	if len(reason) > 0 {
+		args = append(args, "-m", reason)
+	}
+
+	_, err := subprocess.SimpleExec("git", args...)
+	return err
 }
 
 // ValidateRemote checks that a named remote is valid for use

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -542,3 +542,35 @@ func TestValidateRemoteURL(t *testing.T) {
 	assert.Nil(t, ValidateRemoteURL("git@server:/absolute/path.git"))
 	assert.NotNil(t, ValidateRemoteURL("ftp://git@github.com/git-lfs/git-lfs"))
 }
+
+func TestRefTypeKnownPrefixes(t *testing.T) {
+	for typ, expected := range map[RefType]struct {
+		Prefix string
+		Ok     bool
+	}{
+		RefTypeLocalBranch:  {"refs/heads", true},
+		RefTypeRemoteBranch: {"refs/remotes", true},
+		RefTypeLocalTag:     {"refs/tags", true},
+		RefTypeRemoteTag:    {"refs/remotes/tags", true},
+		RefTypeHEAD:         {"", false},
+		RefTypeOther:        {"", false},
+	} {
+		prefix, ok := typ.Prefix()
+
+		assert.Equal(t, expected.Prefix, prefix)
+		assert.Equal(t, expected.Ok, ok)
+	}
+}
+
+func TestRefTypeUnknownPrefix(t *testing.T) {
+	defer func() {
+		if err := recover(); err != nil {
+			assert.Equal(t, "git: unknown RefType -1", err)
+		} else {
+			t.Fatal("git: expected panic() from RefType.Prefix()")
+		}
+	}()
+
+	unknown := RefType(-1)
+	unknown.Prefix()
+}


### PR DESCRIPTION
This pull request implements both `git.UpdateRef` and `git.UpdateRefReason` to perform an execution of `git-update-ref(1)`.

This is required work to update changes out to the ref tips for the migrate command (see discussion: #2146).

---

/cc @git-lfs/core 