### PR TITLE
git: teach Checkout()

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -995,6 +995,29 @@ func CloneWithoutFilters(flags CloneFlags, args []string) error {
 	return nil
 }
 
+// Checkout performs an invocation of `git-checkout(1)` applying the given
+// treeish, paths, and force option, if given.
+//
+// If any error was encountered, it will be returned immediately. Otherwise, the
+// checkout has occurred successfully.
+func Checkout(treeish string, paths []string, force bool) error {
+	args := []string{"checkout"}
+	if force {
+		args = append(args, "--force")
+	}
+
+	if len(treeish) > 0 {
+		args = append(args, treeish)
+	}
+
+	if len(paths) > 0 {
+		args = append(args, append([]string{"--"}, paths...)...)
+	}
+
+	_, err := subprocess.SimpleExec("git", args...)
+	return err
+}
+
 // CachedRemoteRefs returns the list of branches & tags for a remote which are
 // currently cached locally. No remote request is made to verify them.
 func CachedRemoteRefs(remoteName string) ([]*Ref, error) {


### PR DESCRIPTION
This pull request teaches the `git` package how to execute a `git-checkout(1)` command via a new helper, `git.Checkout()`.

Although `git-checkout(1)` accepts a wide range of arguments and flags, this pull request starts with the most essential options for the work required by the `migrate` command (see discussion: #2146).

While working on the migrate command, the issue is that as changes get propagated into the `HEAD` ref, the working copy does not get checked out, which causes the file to show as modified. This will allow the migrate command to force a manual checkout after updating a ref (using `git.UpdateRef`) and will leave the repository in a clean state.

---

/cc @git-lfs/core 