### PR TITLE
Fix tools.TranslateCygwinPath() on MSYS

### DIFF
--- a/tools/cygwin_windows.go
+++ b/tools/cygwin_windows.go
@@ -43,7 +43,7 @@ func isCygwin() bool {
 		return false
 	}
 
-	if bytes.Contains(out, []byte("CYGWIN")) {
+	if bytes.Contains(out, []byte("CYGWIN")) || bytes.Contains(out, []byte("MSYS")) {
 		cygwinState = cygwinStateEnabled
 	} else {
 		cygwinState = cygwinStateDisabled


### PR DESCRIPTION
Git LFS commands like `git lfs track` hang forever on MSYS2 setup on Windows because of `git --git-dir` returning cygwin path which `ioutil.ReadFile()` can't handle.

This is related to #865 issue which is fixed by #1820. Although the fix in #1820 does not work under MSYS2 as `uname` there returns `MSYS_NT-10.0` (and the code only checks for `CYGWIN`).

So this fix just adds check for `MSYS` string inside of `tools.isCygwin()`.