### PR TITLE
commands/uploader: don't verify locks if verification is disabled

### DIFF
--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -122,6 +122,9 @@ func newUploadContext(remote string, dryRun bool) *uploadContext {
 func verifyLocks(remote string) (ours, theirs []locking.Lock, st verifyState) {
 	endpoint := getAPIClient().Endpoints.Endpoint("upload", remote)
 	state := getVerifyStateFor(endpoint)
+	if state == verifyStateDisabled {
+		return
+	}
 
 	lockClient := newLockClient(remote)
 


### PR DESCRIPTION
This pull request disables the locks verification check if `lfs.<url>.locksverify` is set to a false-y value, as per discussion in https://github.com/git-lfs/git-lfs/issues/2269.

For servers that send a 401 instead of a 403 for invalid credentials against the locks verification endpoint, this can cause an infinite loop when requesting locks verification. Prior to this pull request, disabling locks verification would _still_ make the request, causing an infinite loop in the credential helper.

Closes: https://github.com/git-lfs/git-lfs/issues/2269.

---

/cc @git-lfs/core 
/cc https://github.com/git-lfs/git-lfs/issues/2269