### PR TITLE
git/odb: read packed objects through *git.ObjectScanner

### DIFF
--- a/git/odb/memory_storer.go
+++ b/git/odb/memory_storer.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"os"
 	"sync"
 )
 
@@ -59,7 +60,7 @@ func (ms *memoryStorer) Open(sha []byte) (f io.ReadWriteCloser, err error) {
 
 	key := fmt.Sprintf("%x", sha)
 	if _, ok := ms.fs[key]; !ok {
-		panic(fmt.Sprintf("git/odb: memory storage cannot open %x, doesn't exist", sha))
+		return nil, os.ErrNotExist
 	}
 	return ms.fs[key], nil
 }

--- a/git/odb/memory_storer_test.go
+++ b/git/odb/memory_storer_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -43,18 +44,11 @@ func TestMemoryStorerDoesntOpenMissingEntries(t *testing.T) {
 	hex, err := hex.DecodeString(sha)
 	assert.Nil(t, err)
 
-	defer func() {
-		if err := recover(); err != nil {
-			expeced := fmt.Sprintf("git/odb: memory storage cannot open %x, doesn't exist", hex)
-			assert.Equal(t, expeced, err)
-		} else {
-			t.Fatal("expected panic()")
-		}
-	}()
-
 	ms := newMemoryStorer(nil)
 
-	ms.Open(hex)
+	f, err := ms.Open(hex)
+	assert.Equal(t, os.ErrNotExist, err)
+	assert.Nil(t, f)
 }
 
 func TestMemoryStorerStoresNewEntries(t *testing.T) {

--- a/git/odb/object_db.go
+++ b/git/odb/object_db.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync/atomic"
 
+	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/git"
 )
 
@@ -51,7 +52,7 @@ func FromFilesystem(root string) (*ObjectDatabase, error) {
 // If Close() has already been called, this function will panic().
 func (o *ObjectDatabase) Close() error {
 	if !atomic.CompareAndSwapUint32(&o.closed, 0, 1) {
-		panic("git/odb: *ObjectDatabase already closed")
+		return errors.New("git/odb: *ObjectDatabase already closed")
 	}
 
 	if err := o.objectScanner.Close(); err != nil {
@@ -197,7 +198,7 @@ func (o *ObjectDatabase) open(sha []byte) (*ObjectReader, error) {
 		// load its contents from the *git.ObjectScanner by leveraging
 		// `git-cat-file --batch`.
 		if atomic.LoadUint32(&o.closed) == 1 {
-			panic("git/odb: cannot use closed *git.ObjectScanner")
+			return nil, errors.New("git/odb: cannot use closed *git.ObjectScanner")
 		}
 
 		if !o.objectScanner.Scan(hex.EncodeToString(sha)) {

--- a/git/odb/object_db.go
+++ b/git/odb/object_db.go
@@ -142,15 +142,21 @@ func (o *ObjectDatabase) save(sha []byte, buf io.Reader) ([]byte, int64, error) 
 	return sha, n, err
 }
 
+// open gives an `*ObjectReader` for the given loose object keyed by the given
+// "sha" []byte, or an error.
+func (o *ObjectDatabase) open(sha []byte) (*ObjectReader, error) {
+	f, err := o.s.Open(sha)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewObjectReadCloser(f)
+}
+
 // decode decodes an object given by the sha "sha []byte" into the given object
 // "into", or returns an error if one was encountered.
 func (o *ObjectDatabase) decode(sha []byte, into Object) error {
-	f, err := o.s.Open(sha)
-	if err != nil {
-		return err
-	}
-
-	r, err := NewObjectReadCloser(f)
+	r, err := o.open(sha)
 	if err != nil {
 		return err
 	}

--- a/git/odb/object_db.go
+++ b/git/odb/object_db.go
@@ -49,7 +49,7 @@ func FromFilesystem(root string) (*ObjectDatabase, error) {
 // `*git.ObjectScanner instance), and returning any errors encountered in
 // closing them.
 //
-// If Close() has already been called, this function will panic().
+// If Close() has already been called, this function will return an error.
 func (o *ObjectDatabase) Close() error {
 	if !atomic.CompareAndSwapUint32(&o.closed, 0, 1) {
 		return errors.New("git/odb: *ObjectDatabase already closed")

--- a/git/odb/object_db_test.go
+++ b/git/odb/object_db_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/git-lfs/git-lfs/git"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -166,6 +167,44 @@ func TestWriteCommit(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, expected, hex.EncodeToString(sha))
 	assert.NotNil(t, fs.fs[hex.EncodeToString(sha)])
+}
+
+func TestReadingAMissingObject(t *testing.T) {
+	sha, _ := hex.DecodeString("af5626b4a114abcb82d63db7c8082c3c4756e51b")
+	out := strings.NewReader(fmt.Sprintf("%x blob 14\nHello, world!\n", sha))
+
+	db := &ObjectDatabase{
+		s:             newMemoryStorer(nil),
+		objectScanner: git.NewObjectScannerFrom(out),
+	}
+
+	blob, err := db.Blob(sha)
+
+	assert.Nil(t, err)
+	assert.EqualValues(t, 14, blob.Size)
+
+	contents, err := ioutil.ReadAll(blob.Contents)
+	assert.Nil(t, err)
+	assert.Equal(t, "Hello, world!\n", string(contents))
+}
+
+func TestReadingAMissingObjectAfterClose(t *testing.T) {
+	sha, _ := hex.DecodeString("af5626b4a114abcb82d63db7c8082c3c4756e51b")
+
+	db := &ObjectDatabase{
+		s:      newMemoryStorer(nil),
+		closed: 1,
+	}
+
+	defer func() {
+		if err := recover(); err != nil {
+			assert.Equal(t, "git/odb: cannot use closed *git.ObjectScanner", err)
+		} else {
+			t.Fatal("git/odb: expected panic() ...")
+		}
+	}()
+
+	db.Blob(sha)
 }
 
 func TestClosingAnObjectDatabaseMoreThanOnce(t *testing.T) {

--- a/git/odb/object_db_test.go
+++ b/git/odb/object_db_test.go
@@ -196,29 +196,15 @@ func TestReadingAMissingObjectAfterClose(t *testing.T) {
 		closed: 1,
 	}
 
-	defer func() {
-		if err := recover(); err != nil {
-			assert.Equal(t, "git/odb: cannot use closed *git.ObjectScanner", err)
-		} else {
-			t.Fatal("git/odb: expected panic() ...")
-		}
-	}()
-
-	db.Blob(sha)
+	blob, err := db.Blob(sha)
+	assert.EqualError(t, err, "git/odb: cannot use closed *git.ObjectScanner")
+	assert.Nil(t, blob)
 }
 
 func TestClosingAnObjectDatabaseMoreThanOnce(t *testing.T) {
-	defer func() {
-		if err := recover(); err != nil {
-			assert.Equal(t, "git/odb: *ObjectDatabase already closed", err)
-		} else {
-			t.Fatal("git/odb: expected panic() ...")
-		}
-	}()
-
 	db, err := FromFilesystem("/tmp")
 	assert.Nil(t, err)
 
-	db.Close()
-	db.Close() // <- panic()
+	assert.Nil(t, db.Close())
+	assert.EqualError(t, db.Close(), "git/odb: *ObjectDatabase already closed")
 }

--- a/git/odb/object_db_test.go
+++ b/git/odb/object_db_test.go
@@ -167,3 +167,19 @@ func TestWriteCommit(t *testing.T) {
 	assert.Equal(t, expected, hex.EncodeToString(sha))
 	assert.NotNil(t, fs.fs[hex.EncodeToString(sha)])
 }
+
+func TestClosingAnObjectDatabaseMoreThanOnce(t *testing.T) {
+	defer func() {
+		if err := recover(); err != nil {
+			assert.Equal(t, "git/odb: *ObjectDatabase already closed", err)
+		} else {
+			t.Fatal("git/odb: expected panic() ...")
+		}
+	}()
+
+	db, err := FromFilesystem("/tmp")
+	assert.Nil(t, err)
+
+	db.Close()
+	db.Close() // <- panic()
+}

--- a/git/odb/object_reader.go
+++ b/git/odb/object_reader.go
@@ -45,7 +45,14 @@ func NewObjectReader(r io.Reader) (*ObjectReader, error) {
 	return NewObjectReadCloser(ioutil.NopCloser(r))
 }
 
-// NewReader takes a given io.Reader that yields zlib-compressed data, and
+// NewObjectReader takes a given io.Reader that yields uncompressed data and
+// returns an *ObjectReader wrapping it, or an error if one occurred during
+// construction time.
+func NewUncompressedObjectReader(r io.Reader) (*ObjectReader, error) {
+	return NewUncompressedObjectReadCloser(ioutil.NopCloser(r))
+}
+
+// NewObjectReadCloser takes a given io.Reader that yields zlib-compressed data, and
 // returns an *ObjectReader wrapping it, or an error if one occurred during
 // construction time.
 //
@@ -68,6 +75,19 @@ func NewObjectReadCloser(r io.ReadCloser) (*ObjectReader, error) {
 			}
 			return nil
 		},
+	}, nil
+}
+
+// NewUncompressObjectReadCloser takes a given io.Reader that yields
+// uncompressed data, and returns an *ObjectReader wrapping it, or an error if
+// one occurred during construction time.
+//
+// It also calls the Close() function given by the implementation "r" of the
+// type io.Closer.
+func NewUncompressedObjectReadCloser(r io.ReadCloser) (*ObjectReader, error) {
+	return &ObjectReader{
+		r:       bufio.NewReader(r),
+		closeFn: r.Close,
 	}, nil
 }
 


### PR DESCRIPTION
This pull request teaches the `*git/odb.ObjectDatabase` type to read "missing," or (more accurately) packed objects from the Git object database.

When an object becomes packed by Git (before a push, after a `git-pack-objects(1)`, or `git-gc(1)`) they are no longer accessible inside of `.git/objects/xx/yyyy`. Instead, they are delta compressed and stored inside of `.git/objects/pack/pack-nnn.pack` (and the corresponding `.git/objects/pack/pack-nnn.idx`).

Since the `git/odb` package doesn't currently know how to read packed objects, this pull request teaches it to fallback to the `*git.ObjectScanner` (which internally uses `git-cat-file(1) --batch` to "unpack" the objects before streaming their contents back to `git/odb`.

Here's a quick breakdown of what happened:

- 70818eb: Introduce an `open()` function which will be the home for reassembling the object from `git-cat-file` output.
- e8b24aa: Since `git-cat-file(1) --batch` yields objects without zlib compression applied, a new set of "uncompressed" `*git/odb.ObjectReader`'s are introduced to support reading uncompressed data. This is done to avoid recompressing the data just to immediately decompress it. 
- 4ac2ece: Prepare to test this new behavior by returning an error which satisfies `os.IsNotExist`.
- aaf8a45: Store and provide utilities to `Close()` a `*git.ObjectScanner` on the `*git/odb.ObjectDatabase`.
- 39d387a: Fallback to the `*git.ObjectScanner` when objects are missing by reassembling their object contents.

Some other thoughts to keep in mind after merging: Increasing the number of code paths for reading an object is intentional for two reasons.

I'm primarily concerned about the speed of reading large blobs through a pipe on Windows, which I think is kept faster by opening a file descriptor instead of a pipe.

The second is that I'd eventually like to teach the migrator how to parallelize history recreation. Right now, the cost of parallelization scales linearly with the number of parallel "workers" as a function of the cost of open file descriptors. If we moved the primary object reading path to go through `git-cat-file(1)`, we'd have to run multiple invocations of the command in order to read multiple objects at once. In addition to more pipe throughput (which is already slower), we also have to pay the cost as a linear function of the overhead caused by spawning a new process. 

---

/cc @git-lfs/core 