### PR TITLE
git: teach opt.{Reverse,WorkingDir} to RevListScanner

### DIFF
--- a/git/rev_list_scanner.go
+++ b/git/rev_list_scanner.go
@@ -95,6 +95,9 @@ type ScanRefsOptions struct {
 	// git-rev-list(1). If this is an empty string, (has len(WorkingDir) ==
 	// 0), it is equivalent to running in os.Getwd().
 	WorkingDir string
+	// Reverse specifies whether or not to give the revisions in reverse
+	// order.
+	Reverse bool
 
 	// SkippedRefs provides a list of refs to ignore.
 	SkippedRefs []string
@@ -226,6 +229,10 @@ func revListArgs(l, r string, opt *ScanRefsOptions) (io.Reader, []string, error)
 	args := []string{"rev-list"}
 	if !opt.CommitsOnly {
 		args = append(args, "--objects")
+	}
+
+	if opt.Reverse {
+		args = append(args, "--reverse")
 	}
 
 	if orderFlag, ok := opt.Order.Flag(); ok {

--- a/git/rev_list_scanner.go
+++ b/git/rev_list_scanner.go
@@ -91,6 +91,10 @@ type ScanRefsOptions struct {
 	// return only commits, or all objects in range by performing a
 	// traversal of the graph. By default, false: show all objects.
 	CommitsOnly bool
+	// WorkingDir specifies the working directory in which to run
+	// git-rev-list(1). If this is an empty string, (has len(WorkingDir) ==
+	// 0), it is equivalent to running in os.Getwd().
+	WorkingDir string
 
 	// SkippedRefs provides a list of refs to ignore.
 	SkippedRefs []string
@@ -167,6 +171,9 @@ func NewRevListScanner(left, right string, opt *ScanRefsOptions) (*RevListScanne
 	}
 
 	cmd := exec.Command("git", args...)
+	if len(opt.WorkingDir) > 0 {
+		cmd.Dir = opt.WorkingDir
+	}
 
 	cmd.Stdin = stdin
 	stdout, err := cmd.StdoutPipe()

--- a/git/rev_list_scanner_test.go
+++ b/git/rev_list_scanner_test.go
@@ -135,6 +135,13 @@ func TestRevListArgs(t *testing.T) {
 			},
 			ExpectedArgs: []string{"rev-list", "--do-walk", "left", "right", "--"},
 		},
+		"scan reverse": {
+			Left: "left", Right: "right", Opt: &ScanRefsOptions{
+				Mode:    ScanRefsMode,
+				Reverse: true,
+			},
+			ExpectedArgs: []string{"rev-list", "--objects", "--reverse", "--do-walk", "left", "right", "--"},
+		},
 	} {
 		t.Run(desc, c.Assert)
 	}


### PR DESCRIPTION
This pull request teaches two minor options to the `*git.RevListScanner`: `WorkingDir` and `Reverse`.

- `WorkingDir`: this option is given to provide a working dir not equal to `os.Getwd()`, in case we're operating on a Git repository that isn't in the current working directory. This isn't the case for `git lfs migrate` usage, but when testing using bare `.git` fixtures, this is required instead of stubbing out `git-rev-list(1)`.
- `Reverse`: this option is one I missed in #2263, and is needed for the `migrate` command (see discussion: #2146). In order to rewrite commits, we must see parents before children when visiting a repository's history in topological ordering. By default `--topo-order` gives us _children_ first, but we want _parents_ first. `--reverse` does that via the `Reverse` option. Since this is a `bool`, the zero-value doesn't change the default behavior of this command.

These two are both required for the migrate command.

---

/cc @git-lfs/core 