### PR TITLE
git/odb: teach *ObjectDatabase.Root() to return filesystem root

### DIFF
--- a/git/odb/file_storer.go
+++ b/git/odb/file_storer.go
@@ -75,6 +75,11 @@ func (fs *fileStorer) Store(sha []byte, r io.Reader) (n int64, err error) {
 	return n, nil
 }
 
+// Root gives the absolute (fully-qualified) path to the file storer on disk.
+func (fs *fileStorer) Root() string {
+	return fs.root
+}
+
 // open opens a given file.
 func (fs *fileStorer) open(path string, flag int) (*os.File, error) {
 	return os.OpenFile(path, flag, 0)

--- a/git/odb/object_db.go
+++ b/git/odb/object_db.go
@@ -129,6 +129,22 @@ func (o *ObjectDatabase) WriteCommit(c *Commit) ([]byte, error) {
 	return sha, nil
 }
 
+// Root returns the filesystem root that this *ObjectDatabase works within, if
+// backed by a fileStorer (constructed by FromFilesystem). If so, it returns
+// the fully-qualified path on a disk and a value of true.
+//
+// Otherwise, it returns empty-string and a value of false.
+func (o *ObjectDatabase) Root() (string, bool) {
+	type rooter interface {
+		Root() string
+	}
+
+	if root, ok := o.s.(rooter); ok {
+		return root.Root(), true
+	}
+	return "", false
+}
+
 // encode encodes and saves an object to the storage backend and uses an
 // in-memory buffer to calculate the object's encoded body.
 func (d *ObjectDatabase) encode(object Object) (sha []byte, n int64, err error) {

--- a/git/odb/object_db_test.go
+++ b/git/odb/object_db_test.go
@@ -208,3 +208,19 @@ func TestClosingAnObjectDatabaseMoreThanOnce(t *testing.T) {
 	assert.Nil(t, db.Close())
 	assert.EqualError(t, db.Close(), "git/odb: *ObjectDatabase already closed")
 }
+
+func TestObjectDatabaseRootWithRoot(t *testing.T) {
+	db, err := FromFilesystem("/foo/bar/baz")
+	assert.Nil(t, err)
+
+	root, ok := db.Root()
+	assert.Equal(t, "/foo/bar/baz", root)
+	assert.True(t, ok)
+}
+
+func TestObjectDatabaseRootWithoutRoot(t *testing.T) {
+	root, ok := new(ObjectDatabase).Root()
+
+	assert.Equal(t, "", root)
+	assert.False(t, ok)
+}


### PR DESCRIPTION
This pull request teaches the `*git/odb.ObjectDatabase()` to return the `Root()` path on disk (fully-qualified) that it is operating in. It depends on 23173cf from https://github.com/git-lfs/git-lfs/pull/2286.

This is required work for testing a new type I'm working on `*git/odb.HistoryRewriter`, which requires that the `*git.RevListOperator` (used by the `*HistoryRewriter` to determine which commits to rewrite) work in a directory outside of `os.Getwd()`. This is a result of using bare repositories as fixture data on disk in a different path than the current working directory.

In pursuit of the `git-lfs-migrate(1)` command (see discussion: #2146).

From the documentation:

> ```go
> // Root returns the filesystem root that this *ObjectDatabase works within, if
> // backed by a fileStorer (constructed by FromFilesystem). If so, it returns
> // the fully-qualified path on a disk and a value of true.
> //
> // Otherwise, it returns empty-string and a value of false.
> ```

---

/cc @git-lfs/core 