### PR TITLE
git/githistory: make path include absolute root

### DIFF
--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -3,6 +3,7 @@ package githistory
 import (
 	"encoding/hex"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sync"
 
@@ -42,9 +43,10 @@ type RewriteOptions struct {
 	// BlobFn specifies a function to rewrite blobs.
 	//
 	// It is called once per unique, unchanged path. That is to say, if
-	// a/foo and a/bar contain identical contents, the BlobFn will be called
-	// twice: once for a/foo and once for a/bar, but no more on each blob
-	// for subsequent revisions, so long as each entry remains unchanged.
+	// /a/foo and /a/bar contain identical contents, the BlobFn will be
+	// called twice: once for /a/foo and once for /a/bar, but no more on
+	// each blob for subsequent revisions, so long as each entry remains
+	// unchanged.
 	BlobFn BlobRewriteFn
 }
 
@@ -57,8 +59,8 @@ type RewriteOptions struct {
 //
 // The path argument is given to be an absolute path to the tree entry being
 // rewritten, where the repository root is the root of the path given. For
-// instance, a file "b.txt" in directory "dir" would be given as "dir/b.txt",
-// where as a file "a.txt" in the root would be given as "a.txt".
+// instance, a file "b.txt" in directory "dir" would be given as "/dir/b.txt",
+// where as a file "a.txt" in the root would be given as "/a.txt".
 //
 // As above, the path separators are OS specific, and equivalent to the result
 // of filepath.Join(...) or os.PathSeparator.
@@ -115,7 +117,7 @@ func (r *Rewriter) Rewrite(opt *RewriteOptions) ([]byte, error) {
 		}
 
 		// Rewrite the tree given at that commit.
-		rewrittenTree, err := r.rewriteTree(original.TreeID, "", opt.BlobFn)
+		rewrittenTree, err := r.rewriteTree(original.TreeID, string(os.PathSeparator), opt.BlobFn)
 		if err != nil {
 			return nil, err
 		}

--- a/git/githistory/rewriter_test.go
+++ b/git/githistory/rewriter_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"io"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -136,8 +137,8 @@ func TestRewriterDoesntVisitUnchangedSubtrees(t *testing.T) {
 
 	assert.Nil(t, err)
 
-	assert.Equal(t, 2, seen["a.txt"])
-	assert.Equal(t, 1, seen[filepath.Join("subdir", "b.txt")])
+	assert.Equal(t, 2, seen[root("a.txt")])
+	assert.Equal(t, 1, seen[root(filepath.Join("subdir", "b.txt"))])
 }
 
 func TestRewriterVisitsUniqueEntriesWithIdenticalContents(t *testing.T) {
@@ -146,7 +147,7 @@ func TestRewriterVisitsUniqueEntriesWithIdenticalContents(t *testing.T) {
 
 	tip, err := r.Rewrite(&RewriteOptions{Left: "master",
 		BlobFn: func(path string, b *odb.Blob) (*odb.Blob, error) {
-			if path == "b.txt" {
+			if path == root("b.txt") {
 				return b, nil
 			}
 
@@ -193,6 +194,13 @@ func TestRewriterIgnoresPathsThatDontMatchFilter(t *testing.T) {
 	})
 
 	assert.Nil(t, err)
-	assert.Equal(t, 1, seen["a.txt"])
-	assert.Equal(t, 0, seen["subdir/b.txt"])
+	assert.Equal(t, 1, seen[root("a.txt")])
+	assert.Equal(t, 0, seen[root(filepath.Join("subdir", "b.txt"))])
+}
+
+func root(path string) string {
+	if !strings.HasPrefix(path, string(os.PathSeparator)) {
+		path = string(os.PathSeparator) + path
+	}
+	return path
 }


### PR DESCRIPTION
This pull request improves the path qualification for the `BlobCallbackFn` when using the `*git/githistory.Rewriter` to be `"/"` instead of `""` for the root tree in a repository.

This is done in order to improve the path for the next PR in this series, which includes a `TreeCallbackFn`. Instead of recognizing an empty string `""` as the root tree, it will now be the OS's path separator (`os.PathSeparator`).

---

/cc @git-lfs/core 