### PR TITLE
git/{odb,githistory}: close blob appropriately

### DIFF
--- a/git/odb/object_db.go
+++ b/git/odb/object_db.go
@@ -237,6 +237,12 @@ func (o *ObjectDatabase) open(sha []byte) (*ObjectReader, error) {
 
 // decode decodes an object given by the sha "sha []byte" into the given object
 // "into", or returns an error if one was encountered.
+//
+// Ordinarily, it closes the object's underlying io.ReadCloser (if it implements
+// the `io.Closer` interface), but skips this if the "into" Object is of type
+// BlobObjectType. Blob's don't exhaust the buffer completely (they instead
+// maintain a handle on the blob's contents via an io.LimitedReader) and
+// therefore cannot be closed until signaled explicitly by git/odb.Blob.Close().
 func (o *ObjectDatabase) decode(sha []byte, into Object) error {
 	r, err := o.open(sha)
 	if err != nil {
@@ -254,8 +260,10 @@ func (o *ObjectDatabase) decode(sha []byte, into Object) error {
 		return err
 	}
 
-	if err = r.Close(); err != nil {
-		return err
+	if into.Type() != BlobObjectType {
+		if err = r.Close(); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/git/odb/object_db.go
+++ b/git/odb/object_db.go
@@ -265,10 +265,8 @@ func (o *ObjectDatabase) decode(sha []byte, into Object) error {
 		return err
 	}
 
-	if into.Type() != BlobObjectType {
-		if err = r.Close(); err != nil {
-			return err
-		}
+	if into.Type() == BlobObjectType {
+		return nil
 	}
-	return nil
+	return r.Close()
 }

--- a/git/odb/object_db.go
+++ b/git/odb/object_db.go
@@ -106,6 +106,11 @@ func (o *ObjectDatabase) WriteBlob(b *Blob) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if err = b.Close(); err != nil {
+		return nil, err
+	}
+
 	return sha, nil
 }
 


### PR DESCRIPTION
This pull request fixes two instances where we closed the underlying file descriptor feeding the `*git/odb.Blob` type incorrectly.

1. 1d5ef4c: when decoding a loose object, the `git/odb` package expected (prior to 1d5ef4c) the implementing `Object` type to exhaust the `io.Reader` feeding it, so that it could safely call `Close()`. This is the case in `*git/odb.Tree`'s `*git/odb.Commit`'s, where the `io.Reader` is drained completely in order to decode the object.

In `*git/odb.Blob`'s, however, the reader is _not_ drained completely, as the blob may be too large to fit in memory. Instead, a `*bufio.Reader` is used to buffer the file contents, and the `Close()` is delayed. If the Blob's `Size` is less than 4096 (the amount buffered by default in the `*bufio.Reader`), this problem does not occur. If the file size is greater than 4096, then the `*bufio.Reader` will exhaust its own buffer before then polling the underlying `*os.File`, which is closed, and therefore does not allow `Read()`'s.

To solve this, delay closing the blob until `*git/odb.Blob.Close()` is called.

2. 9ec9686 & 8631e3e: A natural point to close the blob being modified is after `*git/odb.ObjectDatabase.WriteBlob()` has been called. This change is implemented in 9ec9686, which takes affect on the rewritten blobs. If, however, the `BlobFn` given to the `*git/githistory.Rewriter` returns the _same_ Blob as both "rewritten" and "original", then the file will have already been closed (the two are using the same underlying `*os.File`), and therefore a `os.ErrInvalid` will be returned. To solve this, only close the original blob if it is _different_ than the rewritten blob. (8631e3e).

This is required work for the `git-lfs-migrate(1)` command (see discussion: #2146).

---

/cc @git-lfs/core 