### PR TITLE
git/odb: don't rewrite objects that already exist

### DIFF
--- a/git/odb/memory_storer.go
+++ b/git/odb/memory_storer.go
@@ -43,9 +43,6 @@ func (ms *memoryStorer) Store(sha []byte, r io.Reader) (n int64, err error) {
 	defer ms.mu.Unlock()
 
 	key := fmt.Sprintf("%x", sha)
-	if _, ok := ms.fs[key]; ok {
-		panic(fmt.Sprintf("git/odb: memory storage create %x, already exists", sha))
-	}
 
 	ms.fs[key] = &bufCloser{new(bytes.Buffer)}
 	return io.Copy(ms.fs[key], r)

--- a/git/odb/memory_storer_test.go
+++ b/git/odb/memory_storer_test.go
@@ -3,7 +3,6 @@ package odb
 import (
 	"bytes"
 	"encoding/hex"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -71,7 +70,7 @@ func TestMemoryStorerStoresNewEntries(t *testing.T) {
 	assert.Equal(t, "hello", string(contents))
 }
 
-func TestMemoryStorerStoresNewEntriesExclusively(t *testing.T) {
+func TestMemoryStorerStoresExistingEntries(t *testing.T) {
 	hex, err := hex.DecodeString("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 	assert.Nil(t, err)
 
@@ -83,14 +82,7 @@ func TestMemoryStorerStoresNewEntriesExclusively(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(ms.fs))
 
-	defer func() {
-		expected := fmt.Sprintf("git/odb: memory storage create %x, already exists", hex)
-		if err := recover(); err != nil {
-			assert.Equal(t, expected, err)
-		} else {
-			t.Fatal("expected panic()")
-		}
-	}()
-
-	ms.Store(hex, new(bytes.Buffer))
+	n, err := ms.Store(hex, new(bytes.Buffer))
+	assert.Nil(t, err)
+	assert.EqualValues(t, 0, n)
 }


### PR DESCRIPTION
This pull request fixes some behavior where objects that already exist would cause the `*MemoryStorer` and `*FileStorer` to `panic()` and return an error, respectively.

Except in the case of SHA1 collisions, these calls should be an effective no-op.

Required work for the `git-lfs-migrate(1)` command (see discussion: #2146), and to unblock the work ongoing in #2300.

---

/cc @git-lfs/core 