### PR TITLE
git/odb: use io.ReadFull instead of *bufio.Reader.Read

### DIFF
--- a/git/odb/tree.go
+++ b/git/odb/tree.go
@@ -50,7 +50,7 @@ func (t *Tree) Decode(from io.Reader, size int64) (n int, err error) {
 		fname = strings.TrimSuffix(fname, "\x00")
 
 		var sha [20]byte
-		if _, err = buf.Read(sha[:]); err != nil {
+		if _, err = io.ReadFull(buf, sha[:]); err != nil {
 			return n, err
 		}
 		n += 20

--- a/git/odb/tree_test.go
+++ b/git/odb/tree_test.go
@@ -11,30 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTreeDecodingShaBoundary(t *testing.T) {
-	var from bytes.Buffer
-
-	fmt.Fprintf(&from, "%s %s\x00%s",
-		strconv.FormatInt(int64(0100644), 8),
-		"a.dat", []byte("aaaaaaaaaaaaaaaaaaaa"))
-
-	flen := from.Len()
-
-	tree := new(Tree)
-	n, err := tree.Decode(bufio.NewReaderSize(&from, flen-2), int64(flen))
-
-	assert.Nil(t, err)
-	assert.Equal(t, flen, n)
-
-	require.Len(t, tree.Entries, 1)
-	assert.Equal(t, &TreeEntry{
-		Name:     "a.dat",
-		Type:     BlobObjectType,
-		Oid:      []byte("aaaaaaaaaaaaaaaaaaaa"),
-		Filemode: 0100644,
-	}, tree.Entries[0])
-}
-
 func TestTreeReturnsCorrectObjectType(t *testing.T) {
 	assert.Equal(t, TreeObjectType, new(Tree).Type())
 }
@@ -124,6 +100,30 @@ func TestTreeDecoding(t *testing.T) {
 		Oid:      []byte("dddddddddddddddddddd"),
 		Filemode: 0160000,
 	}, tree.Entries[3])
+}
+
+func TestTreeDecodingShaBoundary(t *testing.T) {
+	var from bytes.Buffer
+
+	fmt.Fprintf(&from, "%s %s\x00%s",
+		strconv.FormatInt(int64(0100644), 8),
+		"a.dat", []byte("aaaaaaaaaaaaaaaaaaaa"))
+
+	flen := from.Len()
+
+	tree := new(Tree)
+	n, err := tree.Decode(bufio.NewReaderSize(&from, flen-2), int64(flen))
+
+	assert.Nil(t, err)
+	assert.Equal(t, flen, n)
+
+	require.Len(t, tree.Entries, 1)
+	assert.Equal(t, &TreeEntry{
+		Name:     "a.dat",
+		Type:     BlobObjectType,
+		Oid:      []byte("aaaaaaaaaaaaaaaaaaaa"),
+		Filemode: 0100644,
+	}, tree.Entries[0])
 }
 
 func assertTreeEntry(t *testing.T, buf *bytes.Buffer,


### PR DESCRIPTION
This pull request fixes a bug when reading loose trees longer than 4096 bytes.

The issue is caused by reading a tree entry whose SHA lies across a multiple of 4096 bytes (the buffer size of `*bufio.Reader`. When reading, we do the following:

```go
var sha [20]byte
if _, err := buf.Read(sha[:]); err != nil {
        // ...
}

// ...
```

The issue lies in the fact that `*bufio.Reader.Read()` will make _at most_ one call to the underling `io.Reader.Read()`<sup>[[1](https://golang.org/pkg/bufio/#Reader.Read)]</sup>:

> Read reads data into p. It returns the number of bytes read into p. The bytes are taken from at most one Read on the underlying Reader, hence n may be less than len(p). At EOF, the count will be zero and err will be io.EOF.

If the buffer is exhausted part of the way through reading a SHA, it will stop, and return `0`'s for the remaining bytes. Since we don't check `n`, this behavior goes unnoticed, and causes us to be `20-n` bytes behind the desired reader position in the tree when we make subsequent reads, resulting in corrupted filenames, modes, etc.

To solve this, use `io.ReadFull`, which will make as many calls as needed to `io.Reader.Read()`<sup>[[2](https://golang.org/pkg/io/#ReadFull)]</sup>:

> ReadFull reads exactly len(buf) bytes from r into buf. It returns the number of bytes copied and an error if fewer bytes were read. The error is EOF only if no bytes were read. If an EOF happens after reading some but not all the bytes, ReadFull returns ErrUnexpectedEOF. On return, n == len(buf) if and only if err == nil.

Since this is the only spot that we read into a byte slice directly in `git/odb`, this is a complete fix for the entire package.

This is required work for the `git-lfs-migrate(1)` subcommand (see discussion: #2146).

---

/cc @git-lfs/core  