### PR TITLE
git/odb: fix parsing commits with special keyword prefixes

### DIFF
--- a/git/odb/commit.go
+++ b/git/odb/commit.go
@@ -104,13 +104,11 @@ func (c *Commit) Decode(from io.Reader, size int64) (n int, err error) {
 			continue
 		}
 
-		fields := strings.Fields(text)
-		if len(fields) > 0 {
+		if fields := strings.Fields(text); len(fields) > 0 && !finishedHeaders {
 			switch fields[0] {
 			case "tree":
 				id, err := hex.DecodeString(fields[1])
 				if err != nil {
-					panic(1)
 					return n, err
 				}
 				c.TreeID = id
@@ -125,15 +123,13 @@ func (c *Commit) Decode(from io.Reader, size int64) (n int, err error) {
 			case "committer":
 				c.Committer = strings.Join(fields[1:], " ")
 			default:
-				if finishedHeaders {
-					messageParts = append(messageParts, s.Text())
-				} else {
-					c.ExtraHeaders = append(c.ExtraHeaders, &ExtraHeader{
-						K: fields[0],
-						V: strings.Join(fields[1:], " "),
-					})
-				}
+				c.ExtraHeaders = append(c.ExtraHeaders, &ExtraHeader{
+					K: fields[0],
+					V: strings.Join(fields[1:], " "),
+				})
 			}
+		} else {
+			messageParts = append(messageParts, s.Text())
 		}
 	}
 

--- a/git/odb/commit_test.go
+++ b/git/odb/commit_test.go
@@ -83,6 +83,33 @@ func TestCommitDecoding(t *testing.T) {
 	assert.Equal(t, "initial commit", commit.Message)
 }
 
+func TestCommitDecodingWithMessageKeywordPrefix(t *testing.T) {
+	author := &Signature{Name: "John Doe", Email: "john@example.com", When: time.Now()}
+	committer := &Signature{Name: "Jane Doe", Email: "jane@example.com", When: time.Now()}
+
+	treeId := []byte("aaaaaaaaaaaaaaaaaaaa")
+	treeIdAscii := hex.EncodeToString(treeId)
+
+	from := new(bytes.Buffer)
+	fmt.Fprintf(from, "author %s\n", author)
+	fmt.Fprintf(from, "committer %s\n", committer)
+	fmt.Fprintf(from, "tree %s\n", hex.EncodeToString(treeId))
+	fmt.Fprintf(from, "\ntree <- initial commit\n")
+
+	flen := from.Len()
+
+	commit := new(Commit)
+	n, err := commit.Decode(from, int64(flen))
+
+	assert.NoError(t, err)
+	assert.Equal(t, flen, n)
+
+	assert.Equal(t, author.String(), commit.Author)
+	assert.Equal(t, committer.String(), commit.Committer)
+	assert.Equal(t, treeIdAscii, hex.EncodeToString(commit.TreeID))
+	assert.Equal(t, "tree <- initial commit", commit.Message)
+}
+
 func assertLine(t *testing.T, buf *bytes.Buffer, wanted string, args ...interface{}) {
 	got, err := buf.ReadString('\n')
 


### PR DESCRIPTION
This pull request fixes a bug caused by parsing commits with a message that begins with either `tree` or `parent`.

The issue is that we still allow `tree` or `parent` as the first field to indicate a commit header, so we try and parse the remaining substring as ASCII-encoded hex. In the overwhelming majority of cases, this is possible, and therefore causes a panic.

For instance, the test added in this pull request fails before 7fa88dc:

```
=== RUN   TestCommitDecodingWithMessageKeywordPrefix
--- FAIL: TestCommitDecodingWithMessageKeywordPrefix (0.00s)
        Error Trace:    commit_test.go:104
        Error:          Received unexpected error "encoding/hex: invalid byte: U+003C '<'"

        Error Trace:    commit_test.go:110
        Error:          Not equal: "tree <- initial commit" (expected)
                                != "" (actual)
```

This is required work for the `git-lfs-migrate(1)` command (see: #2146).

---

/cc @git-lfs/core 