### PR TITLE
git,lfs: make *git.RevListScanner take Include, Exclude []string

### DIFF
--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -35,10 +35,12 @@ type Rewriter struct {
 
 // RewriteOptions is an options type given to the Rewrite() function.
 type RewriteOptions struct {
-	// Left is the starting commit.
-	Left string
-	// Right is the ending commit.
-	Right string
+	// Include is the list of refs of which commits reachable by that ref
+	// will be included.
+	Include []string
+	// Exclude is the list of refs of which commits reachable by that ref
+	// will be excluded.
+	Exclude []string
 
 	// BlobFn specifies a function to rewrite blobs.
 	//
@@ -144,7 +146,7 @@ func NewRewriter(db *odb.ObjectDatabase, opts ...rewriterOption) *Rewriter {
 func (r *Rewriter) Rewrite(opt *RewriteOptions) ([]byte, error) {
 	// First, construct a scanner to iterate through the range of commits to
 	// rewrite.
-	scanner, err := git.NewRevListScanner(opt.Left, opt.Right, r.scannerOpts())
+	scanner, err := git.NewRevListScanner(opt.Include, opt.Exclude, r.scannerOpts())
 	if err != nil {
 		return nil, err
 	}

--- a/git/githistory/rewriter_test.go
+++ b/git/githistory/rewriter_test.go
@@ -19,7 +19,7 @@ func TestRewriterRewritesHistory(t *testing.T) {
 	db := DatabaseFromFixture(t, "linear-history.git")
 	r := NewRewriter(db)
 
-	tip, err := r.Rewrite(&RewriteOptions{Left: "master",
+	tip, err := r.Rewrite(&RewriteOptions{Include: []string{"refs/heads/master"},
 		BlobFn: func(path string, b *odb.Blob) (*odb.Blob, error) {
 			contents, err := ioutil.ReadAll(b.Contents)
 			if err != nil {
@@ -80,7 +80,7 @@ func TestRewriterRewritesOctopusMerges(t *testing.T) {
 	db := DatabaseFromFixture(t, "octopus-merge.git")
 	r := NewRewriter(db)
 
-	tip, err := r.Rewrite(&RewriteOptions{Left: "master",
+	tip, err := r.Rewrite(&RewriteOptions{Include: []string{"refs/heads/master"},
 		BlobFn: func(path string, b *odb.Blob) (*odb.Blob, error) {
 			return &odb.Blob{
 				Contents: io.MultiReader(b.Contents, strings.NewReader("_new")),
@@ -127,7 +127,7 @@ func TestRewriterDoesntVisitUnchangedSubtrees(t *testing.T) {
 
 	seen := make(map[string]int)
 
-	_, err := r.Rewrite(&RewriteOptions{Left: "master",
+	_, err := r.Rewrite(&RewriteOptions{Include: []string{"refs/heads/master"},
 		BlobFn: func(path string, b *odb.Blob) (*odb.Blob, error) {
 			seen[path] = seen[path] + 1
 
@@ -145,7 +145,7 @@ func TestRewriterVisitsUniqueEntriesWithIdenticalContents(t *testing.T) {
 	db := DatabaseFromFixture(t, "identical-blobs.git")
 	r := NewRewriter(db)
 
-	tip, err := r.Rewrite(&RewriteOptions{Left: "master",
+	tip, err := r.Rewrite(&RewriteOptions{Include: []string{"refs/heads/master"},
 		BlobFn: func(path string, b *odb.Blob) (*odb.Blob, error) {
 			if path == root("b.txt") {
 				return b, nil
@@ -185,7 +185,7 @@ func TestRewriterIgnoresPathsThatDontMatchFilter(t *testing.T) {
 
 	seen := make(map[string]int)
 
-	_, err := r.Rewrite(&RewriteOptions{Left: "master",
+	_, err := r.Rewrite(&RewriteOptions{Include: []string{"refs/heads/master"},
 		BlobFn: func(path string, b *odb.Blob) (*odb.Blob, error) {
 			seen[path] = seen[path] + 1
 
@@ -208,7 +208,7 @@ func TestRewriterAllowsAdditionalTreeEntries(t *testing.T) {
 	})
 	assert.Nil(t, err)
 
-	tip, err := r.Rewrite(&RewriteOptions{Left: "master",
+	tip, err := r.Rewrite(&RewriteOptions{Include: []string{"refs/heads/master"},
 		BlobFn: func(path string, b *odb.Blob) (*odb.Blob, error) {
 			return b, nil
 		},

--- a/lfs/gitscanner_refs.go
+++ b/lfs/gitscanner_refs.go
@@ -41,7 +41,7 @@ func scanRefsToChan(scanner *GitScanner, pointerCb GitScannerFoundPointer, refLe
 		panic("no scan ref options")
 	}
 
-	revs, err := revListShas(refLeft, refRight, opt)
+	revs, err := revListShas([]string{refLeft, refRight}, nil, opt)
 	if err != nil {
 		return err
 	}
@@ -89,8 +89,8 @@ func scanRefsToChan(scanner *GitScanner, pointerCb GitScannerFoundPointer, refLe
 // revListShas uses git rev-list to return the list of object sha1s
 // for the given ref. If all is true, ref is ignored. It returns a
 // channel from which sha1 strings can be read.
-func revListShas(refLeft, refRight string, opt *ScanRefsOptions) (*StringChannelWrapper, error) {
-	scanner, err := git.NewRevListScanner(refLeft, refRight, &git.ScanRefsOptions{
+func revListShas(include, exclude []string, opt *ScanRefsOptions) (*StringChannelWrapper, error) {
+	scanner, err := git.NewRevListScanner(include, exclude, &git.ScanRefsOptions{
 		Mode:             git.ScanningMode(opt.ScanMode),
 		Remote:           opt.RemoteName,
 		SkipDeletedBlobs: opt.SkipDeletedBlobs,


### PR DESCRIPTION
This pull request makes the signature(s) of `*git.RevListScanner` mirror more closely the behavior described by `git-rev-list(1)`:

> ```
> GIT-REV-LIST(1)                   Git Manual                   GIT-REV-LIST(1)
>
> NAME
>        git-rev-list - Lists commit objects in reverse chronological order
>
> SYNOPSIS
>        git rev-list [ --max-count=<number> ]
>                     # ...
>                     <commit>... [ -- <paths>... ]
> ```

Where instead of including `left` and `right` commitish's (indicating that rev-list will scan between those two boundaries), this pull request changes that behavior to `Include, Exclude []string`. Each entry in each slice represents a reference to include, or exclude, respectively.

In other words, from the documentation:

```go
// NewRevListScanner instantiates a new RevListScanner instance scanning all
// revisions reachable by refs contained in "include" and not reachable by any
// refs included in "excluded", using the *ScanRefsOptions "opt" configuration.
//
// ...
func NewRevListScanner(include, excluded []string, opt *ScanRefsOptions) (*RevListScanner, error) { ... }
```

This is required work for the `git-lfs-migrate(1)` command (see discussion: #2146).

---

/cc @git-lfs/core 