### PR TITLE
Retry on timeout or temporary errors

### DIFF
--- a/errors/types.go
+++ b/errors/types.go
@@ -2,6 +2,7 @@ package errors
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/pkg/errors"
 )
@@ -133,6 +134,9 @@ func IsRetriableError(err error) bool {
 		RetriableError() bool
 	}); ok {
 		return e.RetriableError()
+	}
+	if cause, ok := Cause(err).(*url.Error); ok {
+		return cause.Temporary() || cause.Timeout()
 	}
 	if parent := parentOf(err); parent != nil {
 		return IsRetriableError(parent)

--- a/errors/types_test.go
+++ b/errors/types_test.go
@@ -1,0 +1,46 @@
+package errors_test
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/git-lfs/git-lfs/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+type TemporaryError struct {
+}
+
+func (e TemporaryError) Error() string {
+	return ""
+}
+
+func (e TemporaryError) Temporary() bool {
+	return true
+}
+
+type TimeoutError struct {
+}
+
+func (e TimeoutError) Error() string {
+	return ""
+}
+
+func (e TimeoutError) Timeout() bool {
+	return true
+}
+
+func TestCanRetryOnTemporaryError(t *testing.T) {
+	err := &url.Error{Err: TemporaryError{}}
+	assert.True(t, errors.IsRetriableError(err))
+}
+
+func TestCanRetryOnTimeoutError(t *testing.T) {
+	err := &url.Error{Err: TimeoutError{}}
+	assert.True(t, errors.IsRetriableError(err))
+}
+
+func TestCannotRetryOnGenericUrlError(t *testing.T) {
+	err := &url.Error{Err: errors.New("")}
+	assert.False(t, errors.IsRetriableError(err))
+}

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -1,7 +1,6 @@
 package tq
 
 import (
-	"net/url"
 	"os"
 	"sort"
 	"sync"
@@ -634,12 +633,7 @@ func (q *TransferQueue) run() {
 
 // canRetry returns whether or not the given error "err" is retriable.
 func (q *TransferQueue) canRetry(err error) bool {
-	switch cause := errors.Cause(err).(type) {
-	case *url.Error:
-		return cause.Temporary() || cause.Timeout()
-	default:
-		return errors.IsRetriableError(err)
-	}
+	return errors.IsRetriableError(err)
 }
 
 // canRetryObject returns whether the given error is retriable for the object

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -1,6 +1,7 @@
 package tq
 
 import (
+	"net/url"
 	"os"
 	"sort"
 	"sync"
@@ -633,7 +634,12 @@ func (q *TransferQueue) run() {
 
 // canRetry returns whether or not the given error "err" is retriable.
 func (q *TransferQueue) canRetry(err error) bool {
-	return errors.IsRetriableError(err)
+	switch cause := errors.Cause(err).(type) {
+	case *url.Error:
+		return cause.Temporary() || cause.Timeout()
+	default:
+		return errors.IsRetriableError(err)
+	}
 }
 
 // canRetryObject returns whether the given error is retriable for the object


### PR DESCRIPTION
git-lfs could fail randomly on "i/o timeout" error. This is especially
annoying with very long running transfers. This change recognises
Timeout or Temporary errors and retries them.

---

Tested by doing git lfs smudge on a file in lfs repository, where `lfs.url=http://localhost:9000` and  `nc -v -l 9000` was listening locally.

Without the fix git-lfs client aborted instantly, with the fix it retried.
