### PR TITLE
commands: add git-lfs-migrate(1) 'info' subcommand

### DIFF
--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -20,6 +20,27 @@ var (
 	migrateExcludeRefs []string
 )
 
+// migrate takes the given command and arguments, as well as a BlobRewriteFn to
+// apply, and performs a migration.
+func migrate(cmd *cobra.Command, args []string, fn githistory.BlobRewriteFn) {
+	requireInRepo()
+
+	db, err := getObjectDatabase()
+	if err != nil {
+		ExitWithError(err)
+	}
+
+	opts, err := rewriteOptions(args, fn)
+	if err != nil {
+		ExitWithError(err)
+	}
+
+	_, err = getHistoryRewriter(cmd, db).Rewrite(opts)
+	if err != nil {
+		ExitWithError(err)
+	}
+}
+
 // getObjectDatabase creates a *git.ObjectDatabase from the filesystem pointed
 // at the .git directory of the currently checked-out repository.
 func getObjectDatabase() (*odb.ObjectDatabase, error) {

--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -175,6 +175,15 @@ func currentRefToMigrate() (*git.Ref, error) {
 	return current, nil
 }
 
+// getHistoryRewriter returns a history rewriter that includes the filepath
+// filter given by the --include and --exclude arguments.
+func getHistoryRewriter(cmd *cobra.Command, db *odb.ObjectDatabase) *githistory.Rewriter {
+	include, exclude := getIncludeExcludeArgs(cmd)
+	filter := buildFilepathFilter(cfg, include, exclude)
+
+	return githistory.NewRewriter(db, githistory.WithFilter(filter))
+}
+
 func init() {
 	RegisterCommand("migrate", nil, func(cmd *cobra.Command) {
 		// Adding flags directly to cmd.Flags() doesn't apply those

--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"path/filepath"
+	"strings"
 
 	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/git"
@@ -26,6 +27,23 @@ func getObjectDatabase() (*odb.ObjectDatabase, error) {
 		return nil, errors.Wrap(err, "cannot open root")
 	}
 	return odb.FromFilesystem(filepath.Join(dir, "objects"))
+}
+
+// formatRefName returns the fully-qualified name for the given Git reference
+// "ref".
+func formatRefName(ref *git.Ref, remote string) string {
+	var name []string
+
+	switch ref.Type {
+	case git.RefTypeRemoteBranch:
+		name = []string{"refs", "remotes", remote, ref.Name}
+	case git.RefTypeRemoteTag:
+		name = []string{"refs", "tags", ref.Name}
+	default:
+		return ref.Name
+	}
+	return strings.Join(name, "/")
+
 }
 
 // currentRefToMigrate returns the fully-qualified name of the currently

--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -29,6 +29,31 @@ func getObjectDatabase() (*odb.ObjectDatabase, error) {
 	return odb.FromFilesystem(filepath.Join(dir, "objects"))
 }
 
+// getRemoteRefs returns a fully qualified set of references belonging to all
+// remotes known by the currently checked-out repository, or an error if those
+// references could not be determined.
+func getRemoteRefs() ([]string, error) {
+	var refs []string
+
+	remotes, err := git.RemoteList()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, remote := range remotes {
+		refsForRemote, err := git.RemoteRefs(remote)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, ref := range refsForRemote {
+			refs = append(refs, formatRefName(ref, remote))
+		}
+	}
+
+	return refs, nil
+}
+
 // formatRefName returns the fully-qualified name for the given Git reference
 // "ref".
 func formatRefName(ref *git.Ref, remote string) string {

--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -206,6 +206,9 @@ func getHistoryRewriter(cmd *cobra.Command, db *odb.ObjectDatabase) *githistory.
 }
 
 func init() {
+	info := NewCommand("info", migrateInfoCommand)
+	info.Flags().IntVar(&migrateInfoTopN, "top", 5, "--top=<n>")
+
 	RegisterCommand("migrate", nil, func(cmd *cobra.Command) {
 		// Adding flags directly to cmd.Flags() doesn't apply those
 		// flags to any subcommands of the root. Therefore, loop through
@@ -216,7 +219,7 @@ func init() {
 		// `git-lfs-migrate(1)` command as a subcommand (child).
 
 		for _, subcommand := range []*cobra.Command{
-			MigrateInfoCommand,
+			info,
 		} {
 			subcommand.Flags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")
 			subcommand.Flags().StringVarP(&excludeArg, "exclude", "X", "", "Exclude a list of paths")

--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -1,6 +1,10 @@
 package commands
 
 import (
+	"path/filepath"
+
+	"github.com/git-lfs/git-lfs/git"
+	"github.com/git-lfs/git-lfs/git/odb"
 	"github.com/spf13/cobra"
 )
 
@@ -12,6 +16,16 @@ var (
 	// in the migration.
 	migrateExcludeRefs []string
 )
+
+// getObjectDatabase creates a *git.ObjectDatabase from the filesystem pointed
+// at the .git directory of the currently checked-out repository.
+func getObjectDatabase() (*odb.ObjectDatabase, error) {
+	dir, err := git.GitDir()
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot open root")
+	}
+	return odb.FromFilesystem(filepath.Join(dir, "objects"))
+}
 
 func init() {
 	RegisterCommand("migrate", nil, func(cmd *cobra.Command) {

--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -208,7 +208,7 @@ func getHistoryRewriter(cmd *cobra.Command, db *odb.ObjectDatabase) *githistory.
 func init() {
 	info := NewCommand("info", migrateInfoCommand)
 	info.Flags().IntVar(&migrateInfoTopN, "top", 5, "--top=<n>")
-	info.Flags().StringVar(&migrateInfoAboveFmt, "above", "0 B", "--above=<n>")
+	info.Flags().StringVar(&migrateInfoAboveFmt, "above", "1mb", "--above=<n>")
 
 	RegisterCommand("migrate", nil, func(cmd *cobra.Command) {
 		// Adding flags directly to cmd.Flags() doesn't apply those

--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -208,6 +208,7 @@ func getHistoryRewriter(cmd *cobra.Command, db *odb.ObjectDatabase) *githistory.
 func init() {
 	info := NewCommand("info", migrateInfoCommand)
 	info.Flags().IntVar(&migrateInfoTopN, "top", 5, "--top=<n>")
+	info.Flags().StringVar(&migrateInfoAboveFmt, "above", "0 B", "--above=<n>")
 
 	RegisterCommand("migrate", nil, func(cmd *cobra.Command) {
 		// Adding flags directly to cmd.Flags() doesn't apply those

--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -1,0 +1,12 @@
+package commands
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func migrateCommand(cmd *cobra.Command, args []string) {
+}
+
+func init() {
+	RegisterCommand("migrate", migrateCommand, nil)
+}

--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -4,9 +4,33 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func migrateCommand(cmd *cobra.Command, args []string) {
-}
+var (
+	// migrateIncludeRefs is a set of Git references to explicitly include
+	// in the migration.
+	migrateIncludeRefs []string
+	// migrateExcludeRefs is a set of Git references to explicitly exclude
+	// in the migration.
+	migrateExcludeRefs []string
+)
 
 func init() {
-	RegisterCommand("migrate", migrateCommand, nil)
+	RegisterCommand("migrate", nil, func(cmd *cobra.Command) {
+		// Adding flags directly to cmd.Flags() doesn't apply those
+		// flags to any subcommands of the root. Therefore, loop through
+		// each subcommand specifically, and include common arguments to
+		// each.
+		//
+		// Once done, link each orphaned command to the
+		// `git-lfs-migrate(1)` command as a subcommand (child).
+
+		for _, subcommand := range []*cobra.Command{} {
+			subcommand.Flags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")
+			subcommand.Flags().StringVarP(&excludeArg, "exclude", "X", "", "Exclude a list of paths")
+
+			subcommand.Flags().StringSliceVar(&migrateIncludeRefs, "include-ref", nil, "An explicit list of refs to include")
+			subcommand.Flags().StringSliceVar(&migrateExcludeRefs, "exclude-ref", nil, "An explicit list of refs to exclude")
+
+			cmd.AddCommand(subcommand)
+		}
+	})
 }

--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -215,7 +215,9 @@ func init() {
 		// Once done, link each orphaned command to the
 		// `git-lfs-migrate(1)` command as a subcommand (child).
 
-		for _, subcommand := range []*cobra.Command{} {
+		for _, subcommand := range []*cobra.Command{
+			MigrateInfoCommand,
+		} {
 			subcommand.Flags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")
 			subcommand.Flags().StringVarP(&excludeArg, "exclude", "X", "", "Exclude a list of paths")
 

--- a/commands/command_migrate_info.go
+++ b/commands/command_migrate_info.go
@@ -36,7 +36,7 @@ func migrateInfoCommand(cmd *cobra.Command, args []string) {
 	entries := EntriesBySize(MapToEntries(exts))
 	sort.Sort(sort.Reverse(entries))
 
-	migrateInfoTopN = tools.ClampInt(migrateInfoTopN, 0, len(entries))
+	migrateInfoTopN = tools.ClampInt(migrateInfoTopN, len(entries), 0)
 
 	entries = entries[:tools.MaxInt(0, migrateInfoTopN)]
 

--- a/commands/command_migrate_info.go
+++ b/commands/command_migrate_info.go
@@ -56,7 +56,6 @@ func migrateInfoCommand(cmd *cobra.Command, args []string) {
 				entry.BytesAbove += b.Size
 			}
 
-			// TODO(@ttaylorr): needed?
 			exts[ext] = entry
 		}
 

--- a/commands/command_migrate_info.go
+++ b/commands/command_migrate_info.go
@@ -1,0 +1,117 @@
+package commands
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/git-lfs/git-lfs/git/odb"
+	"github.com/git-lfs/git-lfs/tools"
+	"github.com/spf13/cobra"
+)
+
+var MigrateInfoCommand = NewCommand("info", migrateInfoCommand)
+
+var (
+	// migrateInfoTopN is a flag given to the git-lfs-migrate(1) subcommand
+	// 'info' which specifies how many info entries to show by default.
+	migrateInfoTopN int
+)
+
+func migrateInfoCommand(cmd *cobra.Command, args []string) {
+	exts := make(map[string]int64)
+
+	migrate(cmd, args, func(path string, b *odb.Blob) (*odb.Blob, error) {
+		ext := fmt.Sprintf("*%s", filepath.Ext(path))
+		if len(ext) > 1 {
+			exts[ext] = exts[ext] + b.Size
+		}
+
+		return b, nil
+	})
+
+	entries := EntriesBySize(MapToEntries(exts))
+	sort.Sort(sort.Reverse(entries))
+
+	migrateInfoTopN = tools.ClampInt(migrateInfoTopN, 0, len(entries))
+
+	entries = entries[:tools.MaxInt(0, migrateInfoTopN)]
+
+	entries.Print(os.Stderr)
+}
+
+// MigrateInfoEntry represents a tuple of filetype to total size taken by that
+// file type.
+type MigrateInfoEntry struct {
+	// Qualifier is the filepath's extension.
+	Qualifier string
+	// Size is the total size in bytes taken by that filepath's extension.
+	Size int64
+}
+
+// MapToEntries creates a set of `*MigrateInfoEntry`'s for a given map of
+// filepath extensions to file size in bytes.
+func MapToEntries(exts map[string]int64) []*MigrateInfoEntry {
+	entries := make([]*MigrateInfoEntry, 0, len(exts))
+	for qualifier, size := range exts {
+		entries = append(entries, &MigrateInfoEntry{
+			Qualifier: qualifier,
+			Size:      size,
+		})
+	}
+
+	return entries
+}
+
+// EntriesBySize is an implementation of sort.Interface that sorts a set of
+// `*MigrateInfoEntry`'s
+type EntriesBySize []*MigrateInfoEntry
+
+// Len returns the total length of the set of `*MigrateInfoEntry`'s.
+func (e EntriesBySize) Len() int { return len(e) }
+
+// Less returns the whether or not the MigrateInfoEntry given at `i` takes up
+// less total size than the MigrateInfoEntry given at `j`.
+func (e EntriesBySize) Less(i, j int) bool { return e[i].Size < e[j].Size }
+
+// Swap swaps the entries given at i, j.
+func (e EntriesBySize) Swap(i, j int) { e[i], e[j] = e[j], e[i] }
+
+// LongestQualifier returns the string length of the longest qualifier in the
+// set.
+func (e EntriesBySize) LongestQualifier() int {
+	var longest int
+	for _, entry := range e {
+		longest = tools.MaxInt(longest, len(entry.Qualifier))
+	}
+
+	return longest
+}
+
+// Print formats the `*MigrateInfoEntry`'s in the set and prints them to the
+// given io.Writer, "to", returning "n" the number of bytes written, and any
+// error, if one occurred.
+func (e EntriesBySize) Print(to io.Writer) (int, error) {
+	output := make([]string, 0, len(e))
+
+	longest := e.LongestQualifier()
+
+	for _, entry := range e {
+		offset := longest - len(entry.Qualifier)
+		padding := strings.Repeat(" ", tools.MaxInt(0, offset))
+		bytes := humanizeBytes(entry.Size)
+
+		line := fmt.Sprintf("%s%s %s", entry.Qualifier, padding, bytes)
+
+		output = append(output, line)
+	}
+
+	return fmt.Fprintln(to, strings.Join(output, "\n"))
+}
+
+func init() {
+	MigrateInfoCommand.Flags().IntVar(&migrateInfoTopN, "top", 5, "--top=<n>")
+}

--- a/commands/command_migrate_info.go
+++ b/commands/command_migrate_info.go
@@ -69,7 +69,7 @@ func migrateInfoCommand(cmd *cobra.Command, args []string) {
 
 	entries = entries[:tools.MaxInt(0, migrateInfoTopN)]
 
-	entries.Print(os.Stderr)
+	entries.Print(os.Stdout)
 }
 
 // MigrateInfoEntry represents a tuple of filetype to bytes and entry count

--- a/commands/command_migrate_info.go
+++ b/commands/command_migrate_info.go
@@ -118,32 +118,27 @@ func (e EntriesBySize) Swap(i, j int) { e[i], e[j] = e[j], e[i] }
 // error, if one occurred.
 func (e EntriesBySize) Print(to io.Writer) (int, error) {
 	extensions := make([]string, 0, len(e))
-	for _, entry := range e {
-		extensions = append(extensions, entry.Qualifier)
-	}
-	extensions = tools.Ljust(extensions)
-
 	files := make([]string, 0, len(e))
+	percentages := make([]string, 0, len(e))
+
 	for _, entry := range e {
 		bytes := humanize.FormatBytes(uint64(entry.BytesAbove))
 		above := entry.TotalAbove
 		total := entry.Total
+		percentAbove := 100 * (float64(above) / float64(total))
 
 		file := fmt.Sprintf("%s, %d/%d files(s)",
 			bytes, above, total)
 
-		files = append(files, file)
-	}
-	files = tools.Rjust(files)
-
-	percentages := make([]string, 0, len(e))
-	for _, entry := range e {
-		percentAbove := 100 * (float64(entry.TotalAbove) / float64(entry.Total))
-
 		percentage := fmt.Sprintf("%.0f%%", percentAbove)
 
+		extensions = append(extensions, entry.Qualifier)
+		files = append(files, file)
 		percentages = append(percentages, percentage)
 	}
+
+	extensions = tools.Ljust(extensions)
+	files = tools.Rjust(files)
 	percentages = tools.Rjust(percentages)
 
 	output := make([]string, 0, len(e))

--- a/commands/command_migrate_info.go
+++ b/commands/command_migrate_info.go
@@ -118,36 +118,39 @@ func (e EntriesBySize) Swap(i, j int) { e[i], e[j] = e[j], e[i] }
 // error, if one occurred.
 func (e EntriesBySize) Print(to io.Writer) (int, error) {
 	extensions := make([]string, 0, len(e))
+	sizes := make([]string, 0, len(e))
 	stats := make([]string, 0, len(e))
 	percentages := make([]string, 0, len(e))
 
 	for _, entry := range e {
-		bytes := humanize.FormatBytes(uint64(entry.BytesAbove))
 		above := entry.TotalAbove
 		total := entry.Total
 		percentAbove := 100 * (float64(above) / float64(total))
 
-		stat := fmt.Sprintf("%s, %d/%d files(s)",
-			bytes, above, total)
+		stat := fmt.Sprintf("%d/%d files(s)",
+			above, total)
 
 		percentage := fmt.Sprintf("%.0f%%", percentAbove)
 
 		extensions = append(extensions, entry.Qualifier)
+		sizes = append(sizes, humanize.FormatBytes(uint64(entry.BytesAbove)))
 		stats = append(stats, stat)
 		percentages = append(percentages, percentage)
 	}
 
 	extensions = tools.Ljust(extensions)
+	sizes = tools.Ljust(sizes)
 	stats = tools.Rjust(stats)
 	percentages = tools.Rjust(percentages)
 
 	output := make([]string, 0, len(e))
 	for i := 0; i < len(e); i++ {
 		extension := extensions[i]
+		size := sizes[i]
 		stat := stats[i]
 		percentage := percentages[i]
 
-		line := strings.Join([]string{extension, stat, percentage}, "\t")
+		line := strings.Join([]string{extension, size, stat, percentage}, "\t")
 
 		output = append(output, line)
 	}

--- a/commands/command_migrate_info.go
+++ b/commands/command_migrate_info.go
@@ -8,8 +8,10 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/git/odb"
 	"github.com/git-lfs/git-lfs/tools"
+	"github.com/git-lfs/git-lfs/tools/humanize"
 	"github.com/spf13/cobra"
 )
 
@@ -17,15 +19,45 @@ var (
 	// migrateInfoTopN is a flag given to the git-lfs-migrate(1) subcommand
 	// 'info' which specifies how many info entries to show by default.
 	migrateInfoTopN int
+
+	// migrateInfoAboveFmt is a flag given to the git-lfs-migrate(1)
+	// subcommand 'info' specifying a human-readable string threshold of
+	// filesize before entries are counted.
+	migrateInfoAboveFmt string
+	// migrateInfoAbove is the number of bytes parsed from the above
+	// migrateInfoAboveFmt flag.
+	migrateInfoAbove uint64
 )
 
 func migrateInfoCommand(cmd *cobra.Command, args []string) {
-	exts := make(map[string]int64)
+	exts := make(map[string]*MigrateInfoEntry)
+
+	above, err := humanize.ParseBytes(migrateInfoAboveFmt)
+	if err != nil {
+		ExitWithError(errors.Wrap(err, "cannot parse --above=<n>"))
+	}
+
+	migrateInfoAbove = above
 
 	migrate(cmd, args, func(path string, b *odb.Blob) (*odb.Blob, error) {
 		ext := fmt.Sprintf("*%s", filepath.Ext(path))
+
 		if len(ext) > 1 {
-			exts[ext] = exts[ext] + b.Size
+			entry := exts[ext]
+			if entry == nil {
+				entry = &MigrateInfoEntry{Qualifier: ext}
+			}
+
+			entry.Total++
+			entry.BytesTotal += b.Size
+
+			if b.Size > int64(migrateInfoAbove) {
+				entry.TotalAbove++
+				entry.BytesAbove += b.Size
+			}
+
+			// TODO(@ttaylorr): needed?
+			exts[ext] = entry
 		}
 
 		return b, nil
@@ -46,19 +78,19 @@ func migrateInfoCommand(cmd *cobra.Command, args []string) {
 type MigrateInfoEntry struct {
 	// Qualifier is the filepath's extension.
 	Qualifier string
-	// Size is the total size in bytes taken by that filepath's extension.
-	Size int64
+
+	BytesAbove int64
+	TotalAbove int64
+	BytesTotal int64
+	Total      int64
 }
 
 // MapToEntries creates a set of `*MigrateInfoEntry`'s for a given map of
 // filepath extensions to file size in bytes.
-func MapToEntries(exts map[string]int64) []*MigrateInfoEntry {
+func MapToEntries(exts map[string]*MigrateInfoEntry) []*MigrateInfoEntry {
 	entries := make([]*MigrateInfoEntry, 0, len(exts))
-	for qualifier, size := range exts {
-		entries = append(entries, &MigrateInfoEntry{
-			Qualifier: qualifier,
-			Size:      size,
-		})
+	for _, entry := range exts {
+		entries = append(entries, entry)
 	}
 
 	return entries
@@ -73,39 +105,57 @@ func (e EntriesBySize) Len() int { return len(e) }
 
 // Less returns the whether or not the MigrateInfoEntry given at `i` takes up
 // less total size than the MigrateInfoEntry given at `j`.
-func (e EntriesBySize) Less(i, j int) bool { return e[i].Size < e[j].Size }
+func (e EntriesBySize) Less(i, j int) bool { return e[i].BytesAbove < e[j].BytesAbove }
 
 // Swap swaps the entries given at i, j.
 func (e EntriesBySize) Swap(i, j int) { e[i], e[j] = e[j], e[i] }
-
-// LongestQualifier returns the string length of the longest qualifier in the
-// set.
-func (e EntriesBySize) LongestQualifier() int {
-	var longest int
-	for _, entry := range e {
-		longest = tools.MaxInt(longest, len(entry.Qualifier))
-	}
-
-	return longest
-}
 
 // Print formats the `*MigrateInfoEntry`'s in the set and prints them to the
 // given io.Writer, "to", returning "n" the number of bytes written, and any
 // error, if one occurred.
 func (e EntriesBySize) Print(to io.Writer) (int, error) {
-	output := make([]string, 0, len(e))
-
-	longest := e.LongestQualifier()
-
+	extensions := make([]string, 0, len(e))
 	for _, entry := range e {
-		offset := longest - len(entry.Qualifier)
-		padding := strings.Repeat(" ", tools.MaxInt(0, offset))
-		bytes := humanizeBytes(entry.Size)
+		extensions = append(extensions, entry.Qualifier)
+	}
+	extensions = tools.Ljust(extensions)
 
-		line := fmt.Sprintf("%s%s %s", entry.Qualifier, padding, bytes)
+	files := make([]string, 0, len(e))
+	for _, entry := range e {
+		bytes := humanize.FormatBytes(uint64(entry.BytesAbove))
+		above := entry.TotalAbove
+		total := entry.Total
+
+		file := fmt.Sprintf("%s, %d/%d files(s)",
+			bytes, above, total)
+
+		files = append(files, file)
+	}
+	files = tools.Rjust(files)
+
+	percentages := make([]string, 0, len(e))
+	for _, entry := range e {
+		percentAbove := 100 * (float64(entry.TotalAbove) / float64(entry.Total))
+
+		percentage := fmt.Sprintf("%.0f%%", percentAbove)
+
+		percentages = append(percentages, percentage)
+	}
+	percentages = tools.Rjust(percentages)
+
+	output := make([]string, 0, len(e))
+	for i := 0; i < len(e); i++ {
+		extension := extensions[i]
+		fileCount := files[i]
+		percentage := percentages[i]
+
+		line := strings.Join([]string{extension, fileCount, percentage}, "\t")
 
 		output = append(output, line)
 	}
+
+	header := fmt.Sprintf("Files above %s:", humanize.FormatBytes(migrateInfoAbove))
+	output = append([]string{header}, output...)
 
 	return fmt.Fprintln(to, strings.Join(output, "\n"))
 }

--- a/commands/command_migrate_info.go
+++ b/commands/command_migrate_info.go
@@ -13,8 +13,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var MigrateInfoCommand = NewCommand("info", migrateInfoCommand)
-
 var (
 	// migrateInfoTopN is a flag given to the git-lfs-migrate(1) subcommand
 	// 'info' which specifies how many info entries to show by default.
@@ -110,8 +108,4 @@ func (e EntriesBySize) Print(to io.Writer) (int, error) {
 	}
 
 	return fmt.Fprintln(to, strings.Join(output, "\n"))
-}
-
-func init() {
-	MigrateInfoCommand.Flags().IntVar(&migrateInfoTopN, "top", 5, "--top=<n>")
 }

--- a/commands/command_migrate_info.go
+++ b/commands/command_migrate_info.go
@@ -118,7 +118,7 @@ func (e EntriesBySize) Swap(i, j int) { e[i], e[j] = e[j], e[i] }
 // error, if one occurred.
 func (e EntriesBySize) Print(to io.Writer) (int, error) {
 	extensions := make([]string, 0, len(e))
-	files := make([]string, 0, len(e))
+	stats := make([]string, 0, len(e))
 	percentages := make([]string, 0, len(e))
 
 	for _, entry := range e {
@@ -127,27 +127,27 @@ func (e EntriesBySize) Print(to io.Writer) (int, error) {
 		total := entry.Total
 		percentAbove := 100 * (float64(above) / float64(total))
 
-		file := fmt.Sprintf("%s, %d/%d files(s)",
+		stat := fmt.Sprintf("%s, %d/%d files(s)",
 			bytes, above, total)
 
 		percentage := fmt.Sprintf("%.0f%%", percentAbove)
 
 		extensions = append(extensions, entry.Qualifier)
-		files = append(files, file)
+		stats = append(stats, stat)
 		percentages = append(percentages, percentage)
 	}
 
 	extensions = tools.Ljust(extensions)
-	files = tools.Rjust(files)
+	stats = tools.Rjust(stats)
 	percentages = tools.Rjust(percentages)
 
 	output := make([]string, 0, len(e))
 	for i := 0; i < len(e); i++ {
 		extension := extensions[i]
-		fileCount := files[i]
+		stat := stats[i]
 		percentage := percentages[i]
 
-		line := strings.Join([]string{extension, fileCount, percentage}, "\t")
+		line := strings.Join([]string{extension, stat, percentage}, "\t")
 
 		output = append(output, line)
 	}

--- a/commands/command_migrate_info.go
+++ b/commands/command_migrate_info.go
@@ -72,16 +72,20 @@ func migrateInfoCommand(cmd *cobra.Command, args []string) {
 	entries.Print(os.Stderr)
 }
 
-// MigrateInfoEntry represents a tuple of filetype to total size taken by that
-// file type.
+// MigrateInfoEntry represents a tuple of filetype to bytes and entry count
+// above and below a threshold.
 type MigrateInfoEntry struct {
 	// Qualifier is the filepath's extension.
 	Qualifier string
 
+	// BytesAbove is total size of all files above a given threshold.
 	BytesAbove int64
+	// TotalAbove is the count of all files above a given size threshold.
 	TotalAbove int64
+	// BytesTotal is the number of bytes of all files
 	BytesTotal int64
-	Total      int64
+	// Total is the count of all files.
+	Total int64
 }
 
 // MapToEntries creates a set of `*MigrateInfoEntry`'s for a given map of

--- a/commands/command_migrate_info.go
+++ b/commands/command_migrate_info.go
@@ -155,8 +155,5 @@ func (e EntriesBySize) Print(to io.Writer) (int, error) {
 		output = append(output, line)
 	}
 
-	header := fmt.Sprintf("Files above %s:", humanize.FormatBytes(migrateInfoAbove))
-	output = append([]string{header}, output...)
-
 	return fmt.Fprintln(to, strings.Join(output, "\n"))
 }

--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -7,10 +7,6 @@ git-lfs-migrate(1) - Migrate history to or from git-lfs
 
 ## MODES
 
-* `import`
-    Import existing history from Git into Git LFS by converting large objects to
-    pointer files, and creating entries in .git/lfs/objects.
-
 * `info`
     Perform no migration, instead show information about repository size.
 

--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -26,7 +26,7 @@ git-lfs-migrate(1) - Migrate history to or from git-lfs
 
 * [branch ...]:
     Migrate only the set of branches listed. If not given, `git-lfs-migrate(1)`
-    will the currently checked out branch.
+    will migrate the currently checked out branch.
 
     If any of `--include-ref` or `--exclude-ref` are given, the checked out
     branch will not be appended, but branches given explicitly will be appended.

--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -8,7 +8,7 @@ git-lfs-migrate(1) - Migrate history to or from git-lfs
 ## MODES
 
 * `info`
-    Perform no migration, instead show information about repository size.
+    Show information about repository size.
 
 ## OPTIONS
 

--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -3,11 +3,11 @@ git-lfs-migrate(1) - Migrate history to or from git-lfs
 
 ## SYNOPSIS
 
-`git lfs migrate` <type> [options] [--] [branch ...]
+`git lfs migrate` <mode> [options] [--] [branch ...]
 
 ## DESCRIPTION
 
-## TYPES
+## MODES
 
 * `import`
     Import existing history from Git into Git LFS by converting large objects to

--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -26,7 +26,7 @@ git-lfs-migrate(1) - Migrate history to or from git-lfs
 
 * [branch ...]:
     Migrate only the set of branches listed. If not given, `git-lfs-migrate(1)`
-    will migrate the entire repository.
+    will the currently checked out branch.
 
 ## INCLUDE AND EXCLUDE
 

--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -18,9 +18,18 @@ git-lfs-migrate(1) - Migrate history to or from git-lfs
 * `-X` <paths> `--exclude=`<paths>:
     See [INCLUDE AND EXCLUDE].
 
+* `--include-ref`=<refname>:
+    See [INCLUDE AND EXCLUDE (REFS)].
+
+* `--exclude-ref`=<refname>:
+    See [INCLUDE AND EXCLUDE (REFS)].
+
 * [branch ...]:
     Migrate only the set of branches listed. If not given, `git-lfs-migrate(1)`
     will the currently checked out branch.
+
+    If any of `--include-ref` or `--exclude-ref` are given, the checked out
+    branch will not be appended, but branches given explicitly will be appended.
 
 ## INCLUDE AND EXCLUDE
 
@@ -30,6 +39,33 @@ time or to only migrate part of your repo.
 
 Pattern matching is done as given to be functionally equivalent to pattern
 matching as in .gitattributes.
+
+## INCLUDE AND EXCLUDE (REFS)
+
+You can configure Git LFS to only migrate commits reachable by references
+include by `--include-ref` and not reachable by `--exclude-ref`.
+
+        D---E---F
+       /         \
+  A---B------C    refs/heads/my-feature
+   \          \
+    \          refs/heads/master
+     \
+      refs/remotes/origin/master
+
+In the above configuration, the following commits are reachable by each ref:
+
+refs/heads/master:         C, B, A
+refs/heads/my-feature:     F, E, D, B, A
+refs/remote/origin/master: A
+
+The following configuration:
+
+  --include-ref=refs/heads/my-feature
+  --include-ref=refs/heads/master
+  --exclude-ref=refs/remotes/origin/master
+
+Would, therefore, include commits: F, E, D, C, B, but exclude commit A.
 
 ## SEE ALSO
 

--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -5,8 +5,6 @@ git-lfs-migrate(1) - Migrate history to or from git-lfs
 
 `git lfs migrate` <mode> [options] [--] [branch ...]
 
-## DESCRIPTION
-
 ## MODES
 
 * `import`

--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -13,10 +13,6 @@ git-lfs-migrate(1) - Migrate history to or from git-lfs
     Import existing history from Git into Git LFS by converting large objects to
     pointer files, and creating entries in .git/lfs/objects.
 
-* `export`
-    Export existing history from Git LFS into Git by converting pointer files to
-    large objects, and creating entries in .git/objects.
-
 * `info`
     Perform no migration, instead show information about repository size.
 

--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -31,6 +31,19 @@ git-lfs-migrate(1) - Migrate history to or from git-lfs
     If any of `--include-ref` or `--exclude-ref` are given, the checked out
     branch will not be appended, but branches given explicitly will be appended.
 
+### INFO
+
+The 'info' mode has these additional options:
+
+* `--above=<size>`
+    Only count files whose individual filesize is above the given size. 'size'
+    may be specified as a number of bytes, or a number followed by a storage
+    unit, e.g., "1b", "20 MB", "3 TiB", etc.
+
+* `--top=<n>`
+    Only include the top 'n' entries, ordered by how many total files match the
+    given pathspec.
+
 ## INCLUDE AND EXCLUDE
 
 You can configure Git LFS to only migrate tree entries whose pathspec matches

--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -1,0 +1,46 @@
+git-lfs-migrate(1) - Migrate history to or from git-lfs
+=======================================================
+
+## SYNOPSIS
+
+`git lfs migrate` <type> [options] [--] [branch ...]
+
+## DESCRIPTION
+
+## TYPES
+
+* `import`
+    Import existing history from Git into Git LFS by converting large objects to
+    pointer files, and creating entries in .git/lfs/objects.
+
+* `export`
+    Export existing history from Git LFS into Git by converting pointer files to
+    large objects, and creating entries in .git/objects.
+
+* `info`
+    Perform no migration, instead show information about repository size.
+
+## OPTIONS
+
+* `-I` <paths> `--include=`<paths>:
+    See [INCLUDE AND EXCLUDE].
+
+* `-X` <paths> `--exclude=`<paths>:
+    See [INCLUDE AND EXCLUDE].
+
+* [branch ...]:
+    Migrate only the set of branches listed. If not given, `git-lfs-migrate(1)`
+    will migrate the entire repository.
+
+## INCLUDE AND EXCLUDE
+
+You can configure Git LFS to only migrate tree entries whose pathspec matches
+the include glob and does not match the exclude glob, to reduce total migration
+time or to only migrate part of your repo.
+
+Pattern matching is done as given to be functionally equivalent to pattern
+matching as in .gitattributes.
+
+## SEE ALSO
+
+Part of the git-lfs(1) suite.

--- a/test/test-migrate-fixtures.sh
+++ b/test/test-migrate-fixtures.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+
+# assert_ref_unmoved ensures that the previous and current SHA1 of a given ref
+# is equal by string comparison:
+#
+#   assert_ref_unmoved "HEAD" "$previous_sha" "$current_sha"
+#
+# If the two are unequal (the ref has moved), a message is printed to stderr and
+# the program exits.
+assert_ref_unmoved() {
+  local name="$1"
+  local prev_sha="$2"
+  local current_sha="$3"
+
+  if [ "$prev_sha" != "$current_sha" ]; then
+    echo >&2 "$name should not have moved (from: $prev_sha, to: $current_sha)"
+    exit 1
+  fi
+}
+
+# setup_single_remote_branch creates a repository as follows:
+#
+#     B
+#    / \
+#   A   refs/heads/my-feature
+#    \
+#     refs/heads/master
+#
+# - Commit 'A' has 120, 140 bytes of data in a.txt, and a.md, respectively.
+#
+# - Commit 'B' has 30 bytes of data in a.txt, and includes commit 'A' as a
+#   parent.
+setup_multiple_local_branches() {
+  set -e
+
+  reponame="migrate-info-multiple-local-branches"
+
+  remove_and_create_local_repo "$reponame"
+
+  base64 < /dev/urandom | head -c 120 > a.txt
+  base64 < /dev/urandom | head -c 140 > a.md
+
+  git add a.txt a.md
+  git commit -m "initial commit"
+
+  git checkout -b my-feature
+
+  base64 < /dev/urandom | head -c 30 > a.md
+
+  git add a.md
+  git commit -m "add an additional 30 bytes to a.md"
+
+  git checkout master
+}
+
+# setup_single_remote_branch creates a repository as follows:
+#
+#   A---B
+#    \   \
+#     \   refs/heads/master
+#      \
+#       refs/remotes/origin/master
+#
+# - Commit 'A' has 120, 140 bytes of data in a.txt, and a.md, respectively. It
+#   is the latest commit pushed to the remote 'origin'.
+#
+# - Commit 'B' has 30, 50 bytes of data in a.txt, and a.md, respectively.
+setup_single_remote_branch() {
+  set -e
+
+  reponame="migrate-info-single-remote-branch"
+
+  remove_and_create_remote_repo "$reponame"
+
+  base64 < /dev/urandom | head -c 120 > a.txt
+  base64 < /dev/urandom | head -c 140 > a.md
+
+  git add a.txt a.md
+  git commit -m "initial commit"
+
+  git push origin master
+
+  base64 < /dev/urandom | head -c 30 > a.txt
+  base64 < /dev/urandom | head -c 50 > a.md
+
+  git add a.md a.txt
+  git commit -m "add an additional 30, 50 bytes to a.{txt,md}"
+}
+
+# setup_multiple_remote_branches creates a repository as follows:
+#
+#         C
+#        / \
+#   A---B   refs/heads/my-feature
+#    \   \
+#     \   refs/heads/master
+#      \
+#       refs/remotes/origin/master
+#
+# - Commit 'A' has 10, 11 bytes of data in a.txt, and a.md, respectively. It is
+#   the latest commit pushed to the remote 'origin'.
+#
+# - Commit 'B' has 20, 21 bytes of data in a.txt, and a.md, respectively.
+#
+# - Commit 'C' has 30, 31 bytes of data in a.txt, and a.md, respectively. It is
+#   the latest commit on refs/heads/my-feature.
+setup_multiple_remote_branches() {
+  set -e
+
+  reponame="migrate-info-exclude-remote-refs-given-branch"
+
+  remove_and_create_remote_repo "$reponame"
+
+  base64 < /dev/urandom | head -c 10 > a.txt
+  base64 < /dev/urandom | head -c 11 > a.md
+  git add a.txt a.md
+  git commit -m "add 10, 11 bytes, a.{txt,md}"
+
+  git push origin master
+
+  base64 < /dev/urandom | head -c 20 > a.txt
+  base64 < /dev/urandom | head -c 21 > a.md
+  git add a.txt a.md
+  git commit -m "add 20, 21 bytes, a.{txt,md}"
+
+  git checkout -b my-feature
+
+  base64 < /dev/urandom | head -c 30 > a.txt
+  base64 < /dev/urandom | head -c 31 > a.md
+  git add a.txt a.md
+  git commit -m "add 30, 31 bytes, a.{txt,md}"
+
+  git checkout master
+}
+
+# remove_and_create_local_repo removes, creates, and checks out a local
+# repository given by a particular name:
+#
+#   remove_and_create_local_repo "$reponame"
+remove_and_create_local_repo() {
+  local reponame="$1"
+
+  rm -rf "$reponame" || true
+
+  git init "$reponame"
+  cd "$reponame"
+}
+
+# remove_and_create_remote_repo removes, creates, and checks out a remote
+# repository both locally and on the gitserver, given by a particular name:
+#
+#   remove_and_create_remote_repo "$reponame"
+remove_and_create_remote_repo() {
+  local reponame="$1"
+
+  rm -rf "$reponame" "$REMOTEDIR/$reponame.git" || true
+
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+}

--- a/test/test-migrate-info.sh
+++ b/test/test-migrate-info.sh
@@ -12,8 +12,9 @@ begin_test "migrate info (default branch)"
   original_head="$(git rev-parse HEAD)"
 
   diff -u <(git lfs migrate info 2>&1) <(cat <<-EOF
-	*.md  140 B
-	*.txt 120 B
+	Files above 0 B:
+	*.md 	140 B, 1/1 files(s)	100%
+	*.txt	120 B, 1/1 files(s)	100%
 	EOF)
 
   migrated_head="$(git rev-parse HEAD)"
@@ -32,8 +33,9 @@ begin_test "migrate info (given branch)"
   original_feature="$(git rev-parse refs/heads/my-feature)"
 
   diff -u <(git lfs migrate info my-feature 2>&1) <(cat <<-EOF
-	*.md  170 B
-	*.txt 120 B
+	Files above 0 B:
+	*.md 	170 B, 2/2 files(s)	100%
+	*.txt	120 B, 1/1 files(s)	100%
 	EOF)
 
   migrated_master="$(git rev-parse refs/heads/master)"
@@ -53,7 +55,8 @@ begin_test "migrate info (default branch with filter)"
   original_head="$(git rev-parse HEAD)"
 
   diff -u <(git lfs migrate info --include "*.md" 2>&1) <(cat <<-EOF
-	*.md 140 B
+	Files above 0 B:
+	*.md	140 B, 1/1 files(s)	100%
 	EOF)
 
   migrated_head="$(git rev-parse HEAD)"
@@ -72,7 +75,8 @@ begin_test "migrate info (given branch with filter)"
   original_feature="$(git rev-parse refs/heads/my-feature)"
 
   diff -u <(git lfs migrate info --include "*.md" my-feature 2>&1) <(cat <<-EOF
-	*.md 170 B
+	Files above 0 B:
+	*.md	170 B, 2/2 files(s)	100%
 	EOF)
 
   migrated_master="$(git rev-parse refs/heads/master)"
@@ -95,8 +99,9 @@ begin_test "migrate info (default branch, exclude remote refs)"
   original_master="$(git rev-parse refs/heads/master)"
 
   diff -u <(git lfs migrate info 2>&1) <(cat <<-EOF
-	*.md  50 B
-	*.txt 30 B
+	Files above 0 B:
+	*.md 	50 B, 1/1 files(s)	100%
+	*.txt	30 B, 1/1 files(s)	100%
 	EOF)
 
   migrated_remote="$(git rev-parse refs/remotes/origin/master)"
@@ -118,8 +123,9 @@ begin_test "migrate info (given branch, exclude remote refs)"
   original_feature="$(git rev-parse refs/heads/my-feature)"
 
   diff -u <(git lfs migrate info my-feature 2>&1) <(cat <<-EOF
-	*.md  52 B
-	*.txt 50 B
+	Files above 0 B:
+	*.md 	52 B, 2/2 files(s)	100%
+	*.txt	50 B, 2/2 files(s)	100%
 	EOF)
 
   migrated_remote="$(git rev-parse refs/remotes/origin/master)"
@@ -144,8 +150,9 @@ begin_test "migrate info (include/exclude ref)"
   diff -u <(git lfs migrate info \
     --include-ref=refs/heads/my-feature \
     --exclude-ref=refs/heads/master 2>&1) <(cat <<-EOF
-	*.md  31 B
-	*.txt 30 B
+	Files above 0 B:
+	*.md 	31 B, 1/1 files(s)	100%
+	*.txt	30 B, 1/1 files(s)	100%
 	EOF)
 
   migrated_master="$(git rev-parse refs/heads/master)"
@@ -169,7 +176,8 @@ begin_test "migrate info (include/exclude ref with filter)"
     --include="*.txt" \
     --include-ref=refs/heads/my-feature \
     --exclude-ref=refs/heads/master 2>&1) <(cat <<-EOF
-	*.txt 30 B
+	Files above 0 B:
+	*.txt	30 B, 1/1 files(s)	100%
 	EOF)
 
   migrated_master="$(git rev-parse refs/heads/master)"
@@ -179,3 +187,43 @@ begin_test "migrate info (include/exclude ref with filter)"
   assert_ref_unmoved "refs/heads/my-feature" "$original_feature" "$migrated_feature"
 )
 end_test
+
+begin_test "migrate info (above threshold)"
+(
+  set -e
+
+  setup_multiple_local_branches
+
+  original_head="$(git rev-parse HEAD)"
+
+  diff -u <(git lfs migrate info --above=130B 2>&1) <(cat <<-EOF
+	Files above 130 B:
+	*.md 	140 B, 1/1 files(s)	100%
+	*.txt	  0 B, 0/1 files(s)	  0%
+	EOF)
+
+  migrated_head="$(git rev-parse HEAD)"
+
+  assert_ref_unmoved "HEAD" "$original_head" "$migrated_head"
+)
+end_test
+
+begin_test "migrate info (above threshold, top)"
+(
+  set -e
+
+  setup_multiple_local_branches
+
+  original_head="$(git rev-parse HEAD)"
+
+  diff -u <(git lfs migrate info --above=130B --top=1 2>&1) <(cat <<-EOF
+	Files above 130 B:
+	*.md	140 B, 1/1 files(s)	100%
+	EOF)
+
+  migrated_head="$(git rev-parse HEAD)"
+
+  assert_ref_unmoved "HEAD" "$original_head" "$migrated_head"
+)
+end_test
+

--- a/test/test-migrate-info.sh
+++ b/test/test-migrate-info.sh
@@ -12,7 +12,6 @@ begin_test "migrate info (default branch)"
   original_head="$(git rev-parse HEAD)"
 
   diff -u <(git lfs migrate info 2>&1) <(cat <<-EOF
-	Files above 0 B:
 	*.md 	140 B	1/1 files(s)	100%
 	*.txt	120 B	1/1 files(s)	100%
 	EOF)
@@ -33,7 +32,6 @@ begin_test "migrate info (given branch)"
   original_feature="$(git rev-parse refs/heads/my-feature)"
 
   diff -u <(git lfs migrate info my-feature 2>&1) <(cat <<-EOF
-	Files above 0 B:
 	*.md 	170 B	2/2 files(s)	100%
 	*.txt	120 B	1/1 files(s)	100%
 	EOF)
@@ -55,7 +53,6 @@ begin_test "migrate info (default branch with filter)"
   original_head="$(git rev-parse HEAD)"
 
   diff -u <(git lfs migrate info --include "*.md" 2>&1) <(cat <<-EOF
-	Files above 0 B:
 	*.md	140 B	1/1 files(s)	100%
 	EOF)
 
@@ -75,7 +72,6 @@ begin_test "migrate info (given branch with filter)"
   original_feature="$(git rev-parse refs/heads/my-feature)"
 
   diff -u <(git lfs migrate info --include "*.md" my-feature 2>&1) <(cat <<-EOF
-	Files above 0 B:
 	*.md	170 B	2/2 files(s)	100%
 	EOF)
 
@@ -99,7 +95,6 @@ begin_test "migrate info (default branch, exclude remote refs)"
   original_master="$(git rev-parse refs/heads/master)"
 
   diff -u <(git lfs migrate info 2>&1) <(cat <<-EOF
-	Files above 0 B:
 	*.md 	50 B	1/1 files(s)	100%
 	*.txt	30 B	1/1 files(s)	100%
 	EOF)
@@ -123,7 +118,6 @@ begin_test "migrate info (given branch, exclude remote refs)"
   original_feature="$(git rev-parse refs/heads/my-feature)"
 
   diff -u <(git lfs migrate info my-feature 2>&1) <(cat <<-EOF
-	Files above 0 B:
 	*.md 	52 B	2/2 files(s)	100%
 	*.txt	50 B	2/2 files(s)	100%
 	EOF)
@@ -150,7 +144,6 @@ begin_test "migrate info (include/exclude ref)"
   diff -u <(git lfs migrate info \
     --include-ref=refs/heads/my-feature \
     --exclude-ref=refs/heads/master 2>&1) <(cat <<-EOF
-	Files above 0 B:
 	*.md 	31 B	1/1 files(s)	100%
 	*.txt	30 B	1/1 files(s)	100%
 	EOF)
@@ -176,7 +169,6 @@ begin_test "migrate info (include/exclude ref with filter)"
     --include="*.txt" \
     --include-ref=refs/heads/my-feature \
     --exclude-ref=refs/heads/master 2>&1) <(cat <<-EOF
-	Files above 0 B:
 	*.txt	30 B	1/1 files(s)	100%
 	EOF)
 
@@ -197,7 +189,6 @@ begin_test "migrate info (above threshold)"
   original_head="$(git rev-parse HEAD)"
 
   diff -u <(git lfs migrate info --above=130B 2>&1) <(cat <<-EOF
-	Files above 130 B:
 	*.md 	140 B	1/1 files(s)	100%
 	*.txt	0 B  	0/1 files(s)	  0%
 	EOF)
@@ -217,7 +208,6 @@ begin_test "migrate info (above threshold, top)"
   original_head="$(git rev-parse HEAD)"
 
   diff -u <(git lfs migrate info --above=130B --top=1 2>&1) <(cat <<-EOF
-	Files above 130 B:
 	*.md	140 B	1/1 files(s)	100%
 	EOF)
 

--- a/test/test-migrate-info.sh
+++ b/test/test-migrate-info.sh
@@ -13,8 +13,8 @@ begin_test "migrate info (default branch)"
 
   diff -u <(git lfs migrate info 2>&1) <(cat <<-EOF
 	Files above 0 B:
-	*.md 	140 B, 1/1 files(s)	100%
-	*.txt	120 B, 1/1 files(s)	100%
+	*.md 	140 B	1/1 files(s)	100%
+	*.txt	120 B	1/1 files(s)	100%
 	EOF)
 
   migrated_head="$(git rev-parse HEAD)"
@@ -34,8 +34,8 @@ begin_test "migrate info (given branch)"
 
   diff -u <(git lfs migrate info my-feature 2>&1) <(cat <<-EOF
 	Files above 0 B:
-	*.md 	170 B, 2/2 files(s)	100%
-	*.txt	120 B, 1/1 files(s)	100%
+	*.md 	170 B	2/2 files(s)	100%
+	*.txt	120 B	1/1 files(s)	100%
 	EOF)
 
   migrated_master="$(git rev-parse refs/heads/master)"
@@ -56,7 +56,7 @@ begin_test "migrate info (default branch with filter)"
 
   diff -u <(git lfs migrate info --include "*.md" 2>&1) <(cat <<-EOF
 	Files above 0 B:
-	*.md	140 B, 1/1 files(s)	100%
+	*.md	140 B	1/1 files(s)	100%
 	EOF)
 
   migrated_head="$(git rev-parse HEAD)"
@@ -76,7 +76,7 @@ begin_test "migrate info (given branch with filter)"
 
   diff -u <(git lfs migrate info --include "*.md" my-feature 2>&1) <(cat <<-EOF
 	Files above 0 B:
-	*.md	170 B, 2/2 files(s)	100%
+	*.md	170 B	2/2 files(s)	100%
 	EOF)
 
   migrated_master="$(git rev-parse refs/heads/master)"
@@ -100,8 +100,8 @@ begin_test "migrate info (default branch, exclude remote refs)"
 
   diff -u <(git lfs migrate info 2>&1) <(cat <<-EOF
 	Files above 0 B:
-	*.md 	50 B, 1/1 files(s)	100%
-	*.txt	30 B, 1/1 files(s)	100%
+	*.md 	50 B	1/1 files(s)	100%
+	*.txt	30 B	1/1 files(s)	100%
 	EOF)
 
   migrated_remote="$(git rev-parse refs/remotes/origin/master)"
@@ -124,8 +124,8 @@ begin_test "migrate info (given branch, exclude remote refs)"
 
   diff -u <(git lfs migrate info my-feature 2>&1) <(cat <<-EOF
 	Files above 0 B:
-	*.md 	52 B, 2/2 files(s)	100%
-	*.txt	50 B, 2/2 files(s)	100%
+	*.md 	52 B	2/2 files(s)	100%
+	*.txt	50 B	2/2 files(s)	100%
 	EOF)
 
   migrated_remote="$(git rev-parse refs/remotes/origin/master)"
@@ -151,8 +151,8 @@ begin_test "migrate info (include/exclude ref)"
     --include-ref=refs/heads/my-feature \
     --exclude-ref=refs/heads/master 2>&1) <(cat <<-EOF
 	Files above 0 B:
-	*.md 	31 B, 1/1 files(s)	100%
-	*.txt	30 B, 1/1 files(s)	100%
+	*.md 	31 B	1/1 files(s)	100%
+	*.txt	30 B	1/1 files(s)	100%
 	EOF)
 
   migrated_master="$(git rev-parse refs/heads/master)"
@@ -177,7 +177,7 @@ begin_test "migrate info (include/exclude ref with filter)"
     --include-ref=refs/heads/my-feature \
     --exclude-ref=refs/heads/master 2>&1) <(cat <<-EOF
 	Files above 0 B:
-	*.txt	30 B, 1/1 files(s)	100%
+	*.txt	30 B	1/1 files(s)	100%
 	EOF)
 
   migrated_master="$(git rev-parse refs/heads/master)"
@@ -198,8 +198,8 @@ begin_test "migrate info (above threshold)"
 
   diff -u <(git lfs migrate info --above=130B 2>&1) <(cat <<-EOF
 	Files above 130 B:
-	*.md 	140 B, 1/1 files(s)	100%
-	*.txt	  0 B, 0/1 files(s)	  0%
+	*.md 	140 B	1/1 files(s)	100%
+	*.txt	0 B  	0/1 files(s)	  0%
 	EOF)
 
   migrated_head="$(git rev-parse HEAD)"
@@ -218,7 +218,7 @@ begin_test "migrate info (above threshold, top)"
 
   diff -u <(git lfs migrate info --above=130B --top=1 2>&1) <(cat <<-EOF
 	Files above 130 B:
-	*.md	140 B, 1/1 files(s)	100%
+	*.md	140 B	1/1 files(s)	100%
 	EOF)
 
   migrated_head="$(git rev-parse HEAD)"

--- a/test/test-migrate-info.sh
+++ b/test/test-migrate-info.sh
@@ -11,7 +11,7 @@ begin_test "migrate info (default branch)"
 
   original_head="$(git rev-parse HEAD)"
 
-  diff -u <(git lfs migrate info 2>&1) <(cat <<-EOF
+  diff -u <(git lfs migrate info --above=0b 2>&1) <(cat <<-EOF
 	*.md 	140 B	1/1 files(s)	100%
 	*.txt	120 B	1/1 files(s)	100%
 	EOF)
@@ -31,7 +31,7 @@ begin_test "migrate info (given branch)"
   original_master="$(git rev-parse refs/heads/master)"
   original_feature="$(git rev-parse refs/heads/my-feature)"
 
-  diff -u <(git lfs migrate info my-feature 2>&1) <(cat <<-EOF
+  diff -u <(git lfs migrate info --above=0b my-feature 2>&1) <(cat <<-EOF
 	*.md 	170 B	2/2 files(s)	100%
 	*.txt	120 B	1/1 files(s)	100%
 	EOF)
@@ -52,7 +52,7 @@ begin_test "migrate info (default branch with filter)"
 
   original_head="$(git rev-parse HEAD)"
 
-  diff -u <(git lfs migrate info --include "*.md" 2>&1) <(cat <<-EOF
+  diff -u <(git lfs migrate info --above=0b --include "*.md" 2>&1) <(cat <<-EOF
 	*.md	140 B	1/1 files(s)	100%
 	EOF)
 
@@ -71,7 +71,7 @@ begin_test "migrate info (given branch with filter)"
   original_master="$(git rev-parse refs/heads/master)"
   original_feature="$(git rev-parse refs/heads/my-feature)"
 
-  diff -u <(git lfs migrate info --include "*.md" my-feature 2>&1) <(cat <<-EOF
+  diff -u <(git lfs migrate info --above=0b --include "*.md" my-feature 2>&1) <(cat <<-EOF
 	*.md	170 B	2/2 files(s)	100%
 	EOF)
 
@@ -94,7 +94,7 @@ begin_test "migrate info (default branch, exclude remote refs)"
   original_remote="$(git rev-parse refs/remotes/origin/master)"
   original_master="$(git rev-parse refs/heads/master)"
 
-  diff -u <(git lfs migrate info 2>&1) <(cat <<-EOF
+  diff -u <(git lfs migrate info --above=0b 2>&1) <(cat <<-EOF
 	*.md 	50 B	1/1 files(s)	100%
 	*.txt	30 B	1/1 files(s)	100%
 	EOF)
@@ -117,7 +117,7 @@ begin_test "migrate info (given branch, exclude remote refs)"
   original_master="$(git rev-parse refs/heads/master)"
   original_feature="$(git rev-parse refs/heads/my-feature)"
 
-  diff -u <(git lfs migrate info my-feature 2>&1) <(cat <<-EOF
+  diff -u <(git lfs migrate info --above=0b my-feature 2>&1) <(cat <<-EOF
 	*.md 	52 B	2/2 files(s)	100%
 	*.txt	50 B	2/2 files(s)	100%
 	EOF)
@@ -142,6 +142,7 @@ begin_test "migrate info (include/exclude ref)"
   original_feature="$(git rev-parse refs/heads/my-feature)"
 
   diff -u <(git lfs migrate info \
+    --above=0b \
     --include-ref=refs/heads/my-feature \
     --exclude-ref=refs/heads/master 2>&1) <(cat <<-EOF
 	*.md 	31 B	1/1 files(s)	100%
@@ -166,6 +167,7 @@ begin_test "migrate info (include/exclude ref with filter)"
   original_feature="$(git rev-parse refs/heads/my-feature)"
 
   diff -u <(git lfs migrate info \
+    --above=0b \
     --include="*.txt" \
     --include-ref=refs/heads/my-feature \
     --exclude-ref=refs/heads/master 2>&1) <(cat <<-EOF

--- a/test/test-migrate-info.sh
+++ b/test/test-migrate-info.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+
+. "test/test-migrate-fixtures.sh"
+. "test/testlib.sh"
+
+begin_test "migrate info (default branch)"
+(
+  set -e
+
+  setup_multiple_local_branches
+
+  original_head="$(git rev-parse HEAD)"
+
+  diff -u <(git lfs migrate info 2>&1) <(cat <<-EOF
+	*.md  140 B
+	*.txt 120 B
+	EOF)
+
+  migrated_head="$(git rev-parse HEAD)"
+
+  assert_ref_unmoved "HEAD" "$original_head" "$migrated_head"
+)
+end_test
+
+begin_test "migrate info (given branch)"
+(
+  set -e
+
+  setup_multiple_local_branches
+
+  original_master="$(git rev-parse refs/heads/master)"
+  original_feature="$(git rev-parse refs/heads/my-feature)"
+
+  diff -u <(git lfs migrate info my-feature 2>&1) <(cat <<-EOF
+	*.md  170 B
+	*.txt 120 B
+	EOF)
+
+  migrated_master="$(git rev-parse refs/heads/master)"
+  migrated_feature="$(git rev-parse refs/heads/my-feature)"
+
+  assert_ref_unmoved "refs/heads/master" "$original_master" "$migrated_master"
+  assert_ref_unmoved "refs/heads/my-feature" "$original_feature" "$migrated_feature"
+)
+end_test
+
+begin_test "migrate info (default branch with filter)"
+(
+  set -e
+
+  setup_multiple_local_branches
+
+  original_head="$(git rev-parse HEAD)"
+
+  diff -u <(git lfs migrate info --include "*.md" 2>&1) <(cat <<-EOF
+	*.md 140 B
+	EOF)
+
+  migrated_head="$(git rev-parse HEAD)"
+
+  assert_ref_unmoved "refs/heads/master" "$original_head" "$migrated_head"
+)
+end_test
+
+begin_test "migrate info (given branch with filter)"
+(
+  set -e
+
+  setup_multiple_local_branches
+
+  original_master="$(git rev-parse refs/heads/master)"
+  original_feature="$(git rev-parse refs/heads/my-feature)"
+
+  diff -u <(git lfs migrate info --include "*.md" my-feature 2>&1) <(cat <<-EOF
+	*.md 170 B
+	EOF)
+
+  migrated_master="$(git rev-parse refs/heads/master)"
+  migrated_feature="$(git rev-parse refs/heads/my-feature)"
+
+  assert_ref_unmoved "refs/heads/master" "$original_master" "$migrated_master"
+  assert_ref_unmoved "refs/heads/my-feature" "$original_feature" "$migrated_feature"
+)
+end_test
+
+begin_test "migrate info (default branch, exclude remote refs)"
+(
+  set -e
+
+  setup_single_remote_branch
+
+  git show-ref
+
+  original_remote="$(git rev-parse refs/remotes/origin/master)"
+  original_master="$(git rev-parse refs/heads/master)"
+
+  diff -u <(git lfs migrate info 2>&1) <(cat <<-EOF
+	*.md  50 B
+	*.txt 30 B
+	EOF)
+
+  migrated_remote="$(git rev-parse refs/remotes/origin/master)"
+  migrated_master="$(git rev-parse refs/heads/master)"
+
+  assert_ref_unmoved "refs/heads/master" "$original_master" "$migrated_master"
+  assert_ref_unmoved "refs/remotes/origin/master" "$original_remote" "$migrated_remote"
+)
+end_test
+
+begin_test "migrate info (given branch, exclude remote refs)"
+(
+  set -e
+
+  setup_multiple_remote_branches
+
+  original_remote="$(git rev-parse refs/remotes/origin/master)"
+  original_master="$(git rev-parse refs/heads/master)"
+  original_feature="$(git rev-parse refs/heads/my-feature)"
+
+  diff -u <(git lfs migrate info my-feature 2>&1) <(cat <<-EOF
+	*.md  52 B
+	*.txt 50 B
+	EOF)
+
+  migrated_remote="$(git rev-parse refs/remotes/origin/master)"
+  migrated_master="$(git rev-parse refs/heads/master)"
+  migrated_feature="$(git rev-parse refs/heads/my-feature)"
+
+  assert_ref_unmoved "refs/remotes/origin/master" "$original_remote" "$migrated_remote"
+  assert_ref_unmoved "refs/heads/master" "$original_master" "$migrated_master"
+  assert_ref_unmoved "refs/heads/my-feature" "$original_feature" "$migrated_feature"
+)
+end_test
+
+begin_test "migrate info (include/exclude ref)"
+(
+  set -e
+
+  setup_multiple_remote_branches
+
+  original_master="$(git rev-parse refs/heads/master)"
+  original_feature="$(git rev-parse refs/heads/my-feature)"
+
+  diff -u <(git lfs migrate info \
+    --include-ref=refs/heads/my-feature \
+    --exclude-ref=refs/heads/master 2>&1) <(cat <<-EOF
+	*.md  31 B
+	*.txt 30 B
+	EOF)
+
+  migrated_master="$(git rev-parse refs/heads/master)"
+  migrated_feature="$(git rev-parse refs/heads/my-feature)"
+
+  assert_ref_unmoved "refs/heads/master" "$original_master" "$migrated_master"
+  assert_ref_unmoved "refs/heads/my-feature" "$original_feature" "$migrated_feature"
+)
+end_test
+
+begin_test "migrate info (include/exclude ref with filter)"
+(
+  set -e
+
+  setup_multiple_remote_branches
+
+  original_master="$(git rev-parse refs/heads/master)"
+  original_feature="$(git rev-parse refs/heads/my-feature)"
+
+  diff -u <(git lfs migrate info \
+    --include="*.txt" \
+    --include-ref=refs/heads/my-feature \
+    --exclude-ref=refs/heads/master 2>&1) <(cat <<-EOF
+	*.txt 30 B
+	EOF)
+
+  migrated_master="$(git rev-parse refs/heads/master)"
+  migrated_feature="$(git rev-parse refs/heads/my-feature)"
+
+  assert_ref_unmoved "refs/heads/master" "$original_master" "$migrated_master"
+  assert_ref_unmoved "refs/heads/my-feature" "$original_feature" "$migrated_feature"
+)
+end_test

--- a/tools/math.go
+++ b/tools/math.go
@@ -18,6 +18,11 @@ func MaxInt(a, b int) int {
 	return b
 }
 
+// ClampInt returns the integer "n" bounded between "min" and "max".
+func ClampInt(n, min, max int) int {
+	return MinInt(min, MaxInt(max, n))
+}
+
 // MinInt64 returns the smaller of two `int`s, "a", or "b".
 func MinInt64(a, b int64) int64 {
 	if a < b {

--- a/tools/math_test.go
+++ b/tools/math_test.go
@@ -13,3 +13,15 @@ func MinIntPicksTheSmallerInt(t *testing.T) {
 func MaxIntPicksTheBiggertInt(t *testing.T) {
 	assert.Equal(t, 1, MaxInt(-1, 1))
 }
+
+func ClampDiscardsIntsLowerThanMin(t *testing.T) {
+	assert.Equal(t, 0, ClampInt(-1, 0, 1))
+}
+
+func ClampDiscardsIntsGreaterThanMax(t *testing.T) {
+	assert.Equal(t, 1, ClampInt(2, 0, 1))
+}
+
+func ClampAcceptsIntsWithinBounds(t *testing.T) {
+	assert.Equal(t, 1, ClampInt(1, 0, 2))
+}

--- a/tools/str_tools.go
+++ b/tools/str_tools.go
@@ -1,6 +1,9 @@
 package tools
 
-import "regexp"
+import (
+	"regexp"
+	"strings"
+)
 
 var (
 	// quoteFieldRe greedily matches between matching pairs of '', "", or
@@ -43,6 +46,24 @@ func QuotedFields(s string) []string {
 	return out
 }
 
+// Rjust returns a copied string slice where each element is right justified to
+// match the width of the longest element in the set.
+func Rjust(strs []string) []string {
+	llen := len(Longest(strs))
+
+	dup := make([]string, len(strs), cap(strs))
+	copy(dup, strs)
+
+	for i, str := range strs {
+		width := MaxInt(0, llen-len(str))
+		padding := strings.Repeat(" ", width)
+
+		dup[i] = padding + str
+	}
+
+	return dup
+}
+
 // Longest returns the longest element in the string slice in O(n) time and O(1)
 // space. If strs is empty or nil, an empty string will be returned.
 func Longest(strs []string) string {
@@ -52,7 +73,7 @@ func Longest(strs []string) string {
 
 	var longest string
 	var llen int
-	for _, str := range longest {
+	for _, str := range strs {
 		if len(str) >= llen {
 			longest = str
 			llen = len(longest)

--- a/tools/str_tools.go
+++ b/tools/str_tools.go
@@ -42,3 +42,22 @@ func QuotedFields(s string) []string {
 
 	return out
 }
+
+// Longest returns the longest element in the string slice in O(n) time and O(1)
+// space. If strs is empty or nil, an empty string will be returned.
+func Longest(strs []string) string {
+	if len(strs) == 0 {
+		return ""
+	}
+
+	var longest string
+	var llen int
+	for _, str := range longest {
+		if len(str) >= llen {
+			longest = str
+			llen = len(longest)
+		}
+	}
+
+	return longest
+}

--- a/tools/str_tools.go
+++ b/tools/str_tools.go
@@ -46,6 +46,24 @@ func QuotedFields(s string) []string {
 	return out
 }
 
+// Ljust returns a copied string slice where each element is left justified to
+// match the width of the longest element in the set.
+func Ljust(strs []string) []string {
+	llen := len(Longest(strs))
+
+	dup := make([]string, len(strs), cap(strs))
+	copy(dup, strs)
+
+	for i, str := range strs {
+		width := MaxInt(0, llen-len(str))
+		padding := strings.Repeat(" ", width)
+
+		dup[i] = str + padding
+	}
+
+	return dup
+}
+
 // Rjust returns a copied string slice where each element is right justified to
 // match the width of the longest element in the set.
 func Rjust(strs []string) []string {

--- a/tools/str_tools_test.go
+++ b/tools/str_tools_test.go
@@ -82,3 +82,18 @@ func TestLongestReturnsLongestString(t *testing.T) {
 func TestLongestReturnsLastStringGivenSameLength(t *testing.T) {
 	assert.Equal(t, "baz", []string{"foo", "bar", "baz"})
 }
+
+func TestRjustRightJustifiesString(t *testing.T) {
+	unjust := []string{
+		"short",
+		"longer",
+		"longest",
+	}
+	expected := []string{
+		"  short",
+		" longer",
+		"longest",
+	}
+
+	assert.Equal(t, expected, Rjust(unjust))
+}

--- a/tools/str_tools_test.go
+++ b/tools/str_tools_test.go
@@ -76,11 +76,11 @@ func TestLongestReturnsEmptyStringGivenEmptySet(t *testing.T) {
 }
 
 func TestLongestReturnsLongestString(t *testing.T) {
-	assert.Equal(t, "longest", []string{"short", "longer", "longest"})
+	assert.Equal(t, "longest", Longest([]string{"short", "longer", "longest"}))
 }
 
 func TestLongestReturnsLastStringGivenSameLength(t *testing.T) {
-	assert.Equal(t, "baz", []string{"foo", "bar", "baz"})
+	assert.Equal(t, "baz", Longest([]string{"foo", "bar", "baz"}))
 }
 
 func TestRjustRightJustifiesString(t *testing.T) {

--- a/tools/str_tools_test.go
+++ b/tools/str_tools_test.go
@@ -97,3 +97,18 @@ func TestRjustRightJustifiesString(t *testing.T) {
 
 	assert.Equal(t, expected, Rjust(unjust))
 }
+
+func TestLjustLeftJustifiesString(t *testing.T) {
+	unjust := []string{
+		"short",
+		"longer",
+		"longest",
+	}
+	expected := []string{
+		"short  ",
+		"longer ",
+		"longest",
+	}
+
+	assert.Equal(t, expected, Ljust(unjust))
+}

--- a/tools/str_tools_test.go
+++ b/tools/str_tools_test.go
@@ -70,3 +70,15 @@ func TestQuotedFields(t *testing.T) {
 		c.Assert(t)
 	}
 }
+
+func TestLongestReturnsEmptyStringGivenEmptySet(t *testing.T) {
+	assert.Equal(t, "", Longest(nil))
+}
+
+func TestLongestReturnsLongestString(t *testing.T) {
+	assert.Equal(t, "longest", []string{"short", "longer", "longest"})
+}
+
+func TestLongestReturnsLastStringGivenSameLength(t *testing.T) {
+	assert.Equal(t, "baz", []string{"foo", "bar", "baz"})
+}


### PR DESCRIPTION
This pull request adds documentation and an implementation for the 'info' subcommand of the `git-lfs-migrate(1)` suite.

The 'info' subcommand is designed to gather statistics regarding the size of data stored in Git per filepath extension. The output of the command looks as follows:

```
~/g/git-lfs (migrate-subcommand-info) $ git-lfs migrate info \
  --include-ref=refs/heads/migrate-subcommand-info \
  --exclude-ref=refs/heads/master \
  --top=3
*.go 2.0 MB
*.sh 325.3 KB
*.md 225.6 KB
``` 

The following arguments are permitted:

- `--include-ref`: a set of references of which commits reachable by those refs are included in the traversal.
- `--exclude-ref`: a set of references of which commits reachable by those refs are excluded in the traversal.
- `--include`: a filepath filter include set
- `--exclude`: a filepath filter exclude set
- `<branch ...>`: an optional set of branches to include, defaulting to the currently checked out branch, or those references given in `--{include,exclude}-ref`.

Here's a summary of the changes:

- fd837f4...11b8d1f: document and specify command arguments in the man pages
- b47255d: add scaffolding for subcommands to `git-lfs-migrate(1)`.
- 58fda2d...1a67cec: helper functions necessary to complete a migration.
- d2c6b0c: teach `tools.ClampInt`.
- 1612c44: add test fixtures for the `info` subcommand
- af3871b: implement and test the `info` subcommand

---

This is the first command to be implemented as described in the `git-lfs-migrate(1)` proposal issue: (see discussion: #2146).

---

/cc @git-lfs/core 