### PR TITLE
commands: typo fix for fetch errors messages

### DIFF
--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -105,7 +105,7 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 	if !success {
 		c := getAPIClient()
 		e := c.Endpoints.Endpoint("download", cfg.CurrentRemote)
-		Exit("error: failed to push some objects to '%s'", e.Url)
+		Exit("error: failed to fetch some objects from '%s'", e.Url)
 	}
 }
 

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -113,7 +113,7 @@ func pull(remote string, filter *filepathfilter.Filter) {
 	if !success {
 		c := getAPIClient()
 		e := c.Endpoints.Endpoint("download", remote)
-		Exit("error: failed to push some objects to '%s'", e.Url)
+		Exit("error: failed to fetch some objects from '%s'", e.Url)
 	}
 }
 


### PR DESCRIPTION
the are some strange messages when we fetching objects (not pushing they).
fixed this misunderstanding