### PR TITLE
commands: add logging to git-lfs-migrate-info(1)

### DIFF
--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -202,7 +203,8 @@ func getHistoryRewriter(cmd *cobra.Command, db *odb.ObjectDatabase) *githistory.
 	include, exclude := getIncludeExcludeArgs(cmd)
 	filter := buildFilepathFilter(cfg, include, exclude)
 
-	return githistory.NewRewriter(db, githistory.WithFilter(filter))
+	return githistory.NewRewriter(db,
+		githistory.WithFilter(filter), githistory.WithLogger(os.Stderr))
 }
 
 func init() {

--- a/git/githistory/log/log.go
+++ b/git/githistory/log/log.go
@@ -114,9 +114,10 @@ func (l *Logger) consume() {
 		}
 	}()
 
+	defer close(l.tasks)
+
 	pending := make([]Task, 0)
 
-L:
 	for {
 		// If there is a pending task, "peek" it off of the set of
 		// pending tasks.
@@ -132,7 +133,7 @@ L:
 			if !ok {
 				// If the queue is closed, no more new tasks may
 				// be added.
-				break L
+				return
 			}
 
 			// Otherwise, add a new task to the set of tasks to
@@ -148,7 +149,7 @@ L:
 				if !ok {
 					// If the queue is closed, no more tasks
 					// may be added.
-					break L
+					return
 				}
 				// Otherwise, add the next task to the set of
 				// pending, active tasks.
@@ -160,8 +161,6 @@ L:
 			}
 		}
 	}
-
-	close(l.tasks)
 }
 
 // logTask logs the set of updates from a given task to the sink, then logs a

--- a/git/githistory/log/log.go
+++ b/git/githistory/log/log.go
@@ -184,7 +184,7 @@ func (l *Logger) logTask(task Task) {
 	for msg = range task.Updates() {
 		now := time.Now()
 
-		if now.After(last.Add(l.throttle)) {
+		if l.throttle == 0 || now.After(last.Add(l.throttle)) {
 			l.logLine(msg)
 			last = now
 		}

--- a/git/githistory/log/log.go
+++ b/git/githistory/log/log.go
@@ -88,11 +88,11 @@ func (l *Logger) Percentage(msg string, total uint64) *PercentageTask {
 func (l *Logger) enqueue(ts ...Task) {
 	if l == nil {
 		for _, t := range ts {
-			go func() {
+			go func(t Task) {
 				for range <-t.Updates() {
 					// Discard all updates.
 				}
-			}()
+			}(t)
 		}
 		return
 	}

--- a/git/githistory/log/log.go
+++ b/git/githistory/log/log.go
@@ -59,6 +59,10 @@ func NewLogger(sink io.Writer) *Logger {
 // Close closes the queue and does not allow new Tasks to be `enqueue()`'d. It
 // waits until the currently running Task has completed.
 func (l *Logger) Close() {
+	if l == nil {
+		return
+	}
+
 	close(l.queue)
 
 	l.wg.Wait()

--- a/git/githistory/log/log.go
+++ b/git/githistory/log/log.go
@@ -1,0 +1,193 @@
+package log
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"strings"
+	"sync"
+
+	"github.com/git-lfs/git-lfs/tools"
+	"github.com/olekukonko/ts"
+)
+
+// Logger logs a series of tasks to an io.Writer, processing each task in order
+// until completion .
+type Logger struct {
+	// sink is the writer to write to.
+	sink io.Writer
+
+	// widthFn is a function that returns the width of the terminal that
+	// this logger is running within.
+	widthFn func() int
+
+	// queue is the incoming, unbuffered queue of tasks to enqueue.
+	queue chan Task
+	// tasks is the set of tasks to process.
+	tasks chan Task
+	// wg is a WaitGroup that is incremented when new tasks are enqueued,
+	// and decremented when tasks finish.
+	wg *sync.WaitGroup
+}
+
+// NewLogger retuns a new *Logger instance that logs to "sink" and uses the
+// current terminal width as the width of the line.
+func NewLogger(sink io.Writer) *Logger {
+	if sink == nil {
+		sink = ioutil.Discard
+	}
+
+	l := &Logger{
+		sink: sink,
+		widthFn: func() int {
+			size, err := ts.GetSize()
+			if err != nil {
+				return 80
+			}
+			return size.Col()
+		},
+		queue: make(chan Task),
+		tasks: make(chan Task),
+		wg:    new(sync.WaitGroup),
+	}
+
+	go l.consume()
+
+	return l
+}
+
+// Close closes the queue and does not allow new Tasks to be `enqueue()`'d. It
+// waits until the currently running Task has completed.
+func (l *Logger) Close() {
+	close(l.queue)
+
+	l.wg.Wait()
+}
+
+// Waitier creates and enqueues a new *WaitingTask.
+func (l *Logger) Waiter(msg string) *WaitingTask {
+	t := NewWaitingTask(msg)
+	l.enqueue(t)
+
+	return t
+}
+
+// Percentage creates and enqueues a new *PercentageTask.
+func (l *Logger) Percentage(msg string, total uint64) *PercentageTask {
+	t := NewPercentageTask(msg, total)
+	l.enqueue(t)
+
+	return t
+}
+
+// enqueue enqueues the given Tasks "ts".
+func (l *Logger) enqueue(ts ...Task) {
+	if l == nil {
+		for _, t := range ts {
+			go func() {
+				for range <-t.Updates() {
+					// Discard all updates.
+				}
+			}()
+		}
+		return
+	}
+
+	l.wg.Add(len(ts))
+	for _, t := range ts {
+		l.queue <- t
+	}
+}
+
+// consume creates a pseudo-infinte buffer between the incoming set of tasks and
+// the queue of tasks to work on.
+func (l *Logger) consume() {
+	go func() {
+		// Process the single next task in sequence until completion,
+		// then consume the next task.
+		for task := range l.tasks {
+			l.logTask(task)
+		}
+	}()
+
+	pending := make([]Task, 0)
+
+L:
+	for {
+		// If there is a pending task, "peek" it off of the set of
+		// pending tasks.
+		var next Task
+		if len(pending) > 0 {
+			next = pending[0]
+		}
+
+		if next == nil {
+			// If there was no pending task, wait for either a)
+			// l.queue to close, or b) a new task to be submitted.
+			task, ok := <-l.queue
+			if !ok {
+				// If the queue is closed, no more new tasks may
+				// be added.
+				break L
+			}
+
+			// Otherwise, add a new task to the set of tasks to
+			// process immediately, since there is no current
+			// buffer.
+			l.tasks <- task
+		} else {
+			// If there is a pending task, wait for either a) a
+			// write to process the task to become non-blocking, or
+			// b) a new task to enter the queue.
+			select {
+			case task, ok := <-l.queue:
+				if !ok {
+					// If the queue is closed, no more tasks
+					// may be added.
+					break L
+				}
+				// Otherwise, add the next task to the set of
+				// pending, active tasks.
+				pending = append(pending, task)
+			case l.tasks <- next:
+				// Or "pop" the peeked task off of the pending
+				// set.
+				pending = pending[1:]
+			}
+		}
+	}
+
+	close(l.tasks)
+}
+
+// logTask logs the set of updates from a given task to the sink, then logs a
+// "done" message, and then marks the task as done.
+func (l *Logger) logTask(task Task) {
+	defer l.wg.Done()
+
+	var last string
+	for last = range task.Updates() {
+		l.logLine(last)
+	}
+
+	l.log(fmt.Sprintf("%s, done\n", last))
+}
+
+// logLine writes a complete line and moves the cursor to the beginning of the
+// line.
+//
+// It returns the number of bytes "n" written to the sink and the error "err",
+// if one was encountered.
+func (l *Logger) logLine(str string) (n int, err error) {
+	padding := strings.Repeat(" ", tools.MaxInt(0, l.widthFn()-len(str)))
+
+	return l.log(str + padding + "\r")
+}
+
+// log writes a string verbatim to the sink.
+//
+// It returns the number of bytes "n" written to the sink and the error "err",
+// if one was encountered.
+func (l *Logger) log(str string) (n int, err error) {
+	return fmt.Fprint(l.sink, str)
+}

--- a/git/githistory/log/log_test.go
+++ b/git/githistory/log/log_test.go
@@ -95,17 +95,17 @@ func TestLoggerThrottlesWrites(t *testing.T) {
 
 	t1 := make(chan string)
 	go func() {
-		t1 <- "first"                    // t = 0    ms, throttle was open
-		time.Sleep(3 * time.Millisecond) // t = 3    ms, throttle is closed
-		t1 <- "second"                   // t = 3+ε  ms, throttle is closed
-		time.Sleep(3 * time.Millisecond) // t = 6    ms, throttle is open
-		t1 <- "third"                    // t = 6+ε  ms, throttle was open
-		close(t1)                        // t = 6+2ε ms, throttle is closed
+		t1 <- "first"                     // t = 0     ms, throttle was open
+		time.Sleep(10 * time.Millisecond) // t = 10    ms, throttle is closed
+		t1 <- "second"                    // t = 10+ε  ms, throttle is closed
+		time.Sleep(10 * time.Millisecond) // t = 20    ms, throttle is open
+		t1 <- "third"                     // t = 20+ε  ms, throttle was open
+		close(t1)                         // t = 20+2ε ms, throttle is closed
 	}()
 
 	l := NewLogger(&buf)
 	l.widthFn = func() int { return 0 }
-	l.throttle = 5 * time.Millisecond
+	l.throttle = 15 * time.Millisecond
 
 	l.enqueue(ChanTask(t1))
 	l.Close()
@@ -122,15 +122,15 @@ func TestLoggerThrottlesLastWrite(t *testing.T) {
 
 	t1 := make(chan string)
 	go func() {
-		t1 <- "first"                    // t = 0    ms, throttle was open
-		time.Sleep(3 * time.Millisecond) // t = 3    ms, throttle is closed
-		t1 <- "second"                   // t = 3+ε  ms, throttle is closed
-		close(t1)                        // t = 3+2ε ms, throttle is closed
+		t1 <- "first"                     // t = 0     ms, throttle was open
+		time.Sleep(10 * time.Millisecond) // t = 10    ms, throttle is closed
+		t1 <- "second"                    // t = 10+ε  ms, throttle is closed
+		close(t1)                         // t = 10+2ε ms, throttle is closed
 	}()
 
 	l := NewLogger(&buf)
 	l.widthFn = func() int { return 0 }
-	l.throttle = 5 * time.Millisecond
+	l.throttle = 15 * time.Millisecond
 
 	l.enqueue(ChanTask(t1))
 	l.Close()

--- a/git/githistory/log/log_test.go
+++ b/git/githistory/log/log_test.go
@@ -1,0 +1,62 @@
+package log
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type ChanTask chan string
+
+func (e ChanTask) Updates() <-chan string { return e }
+
+func TestLoggerLogsTasks(t *testing.T) {
+	var buf bytes.Buffer
+
+	task := make(chan string)
+	go func() {
+		task <- "first"
+		task <- "second"
+		close(task)
+	}()
+
+	l := NewLogger(&buf)
+	l.widthFn = func() int { return 0 }
+	l.enqueue(ChanTask(task))
+	l.Close()
+
+	assert.Equal(t, "first\rsecond\rsecond, done\n", buf.String())
+}
+
+func TestLoggerLogsMultipleTasksInOrder(t *testing.T) {
+	var buf bytes.Buffer
+
+	t1 := make(chan string)
+	go func() {
+		t1 <- "first"
+		t1 <- "second"
+		close(t1)
+	}()
+	t2 := make(chan string)
+	go func() {
+		t2 <- "third"
+		t2 <- "fourth"
+		close(t2)
+	}()
+
+	l := NewLogger(&buf)
+	l.widthFn = func() int { return 0 }
+	l.enqueue(ChanTask(t1), ChanTask(t2))
+	l.Close()
+
+	assert.Equal(t, strings.Join([]string{
+		"first\r",
+		"second\r",
+		"second, done\n",
+		"third\r",
+		"fourth\r",
+		"fourth, done\n",
+	}, ""), buf.String())
+}

--- a/git/githistory/log/percentage_task.go
+++ b/git/githistory/log/percentage_task.go
@@ -44,7 +44,12 @@ func (c *PercentageTask) Count(n uint64) (new uint64) {
 	msg := fmt.Sprintf("%s: %3.f%% (%d/%d)",
 		c.msg, percentage, new, c.total)
 
-	c.ch <- msg
+	select {
+	case c.ch <- msg:
+	default:
+		// Use a non-blocking write, since it's unimportant that callers
+		// receive all updates.
+	}
 
 	if new >= c.total {
 		close(c.ch)

--- a/git/githistory/log/percentage_task.go
+++ b/git/githistory/log/percentage_task.go
@@ -1,0 +1,61 @@
+package log
+
+import (
+	"fmt"
+	"sync/atomic"
+)
+
+// PercentageTask is a task that is performed against a known number of
+// elements.
+type PercentageTask struct {
+	// msg is the task message.
+	msg string
+	// n is the number of elements whose work has been completed. It is
+	// managed sync/atomic.
+	n uint64
+	// total is the total number of elements to execute work upon.
+	total uint64
+	// ch is a channel which is written to when the task state changes and
+	// is closed when the task is completed.
+	ch chan string
+}
+
+func NewPercentageTask(msg string, total uint64) *PercentageTask {
+	p := &PercentageTask{
+		msg:   msg,
+		total: total,
+		ch:    make(chan string, 1),
+	}
+	p.Count(0)
+
+	return p
+}
+
+// Count indicates that work has been completed against "n" number of elements,
+// marking the task as complete if the total "n" given to all invocations of
+// this method is equal to total.
+//
+// Count returns the new total number of (atomically managed) elements that have
+// been completed.
+func (c *PercentageTask) Count(n uint64) (new uint64) {
+	new = atomic.AddUint64(&c.n, n)
+
+	percentage := 100 * float64(new) / float64(c.total)
+	msg := fmt.Sprintf("%s: %3.f%% (%d/%d)",
+		c.msg, percentage, new, c.total)
+
+	c.ch <- msg
+
+	if new >= c.total {
+		close(c.ch)
+	}
+
+	return new
+}
+
+// Updates implements Task.Updates and returns a channel which is written to
+// when the state of this task changes, and closed when the task is completed.
+// has been completed.
+func (c *PercentageTask) Updates() <-chan string {
+	return c.ch
+}

--- a/git/githistory/log/percentage_task_test.go
+++ b/git/githistory/log/percentage_task_test.go
@@ -1,0 +1,39 @@
+package log
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPercentageTaskCalculuatesPercentages(t *testing.T) {
+	task := NewPercentageTask("example", 10)
+
+	assert.Equal(t, "example:   0% (0/10)", <-task.Updates())
+
+	n := task.Count(3)
+	assert.EqualValues(t, 3, n)
+
+	assert.Equal(t, "example:  30% (3/10)", <-task.Updates())
+}
+
+func TestPercentageTaskCallsDoneWhenComplete(t *testing.T) {
+	task := NewPercentageTask("example", 10)
+
+	select {
+	case v, ok := <-task.Updates():
+		if ok {
+			assert.Equal(t, "example:   0% (0/10)", v)
+		} else {
+			t.Fatal("expected channel to be open")
+		}
+	default:
+	}
+
+	assert.EqualValues(t, 10, task.Count(10))
+	assert.Equal(t, "example: 100% (10/10)", <-task.Updates())
+
+	if _, ok := <-task.Updates(); ok {
+		t.Fatalf("expected channel to be closed")
+	}
+}

--- a/git/githistory/log/task.go
+++ b/git/githistory/log/task.go
@@ -1,0 +1,9 @@
+package log
+
+// Task is an interface which encapsulates an activity which can be logged.
+type Task interface {
+	// Updates returns a channel which is written to with the current state
+	// of the Task when an update is present. It is closed when the task is
+	// complete.
+	Updates() <-chan string
+}

--- a/git/githistory/log/waiting_task.go
+++ b/git/githistory/log/waiting_task.go
@@ -1,0 +1,29 @@
+package log
+
+import "fmt"
+
+// WaitingTask represents a task for which the total number of items to do work
+// is on is unknown.
+type WaitingTask struct {
+	// ch is used to transmit task updates.
+	ch chan string
+}
+
+// NewWaitingTask returns a new *WaitingTask.
+func NewWaitingTask(msg string) *WaitingTask {
+	ch := make(chan string, 1)
+	ch <- fmt.Sprintf("%s: ...", msg)
+
+	return &WaitingTask{ch: ch}
+}
+
+// Complete marks the task as completed.
+func (w *WaitingTask) Complete() {
+	close(w.ch)
+}
+
+// Done implements Task.Done and returns a channel which is closed when
+// Complete() is called.
+func (w *WaitingTask) Updates() <-chan string {
+	return w.ch
+}

--- a/git/githistory/log/waiting_task_test.go
+++ b/git/githistory/log/waiting_task_test.go
@@ -1,0 +1,53 @@
+package log
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWaitingTaskDisplaysWaitingStatus(t *testing.T) {
+	task := NewWaitingTask("example")
+
+	assert.Equal(t, "example: ...", <-task.Updates())
+}
+
+func TestWaitingTaskCallsDoneWhenComplete(t *testing.T) {
+	task := NewWaitingTask("example")
+
+	select {
+	case v, ok := <-task.Updates():
+		if ok {
+			assert.Equal(t, "example: ...", v)
+		} else {
+			t.Fatal("expected channel to be open")
+		}
+	default:
+	}
+
+	task.Complete()
+
+	if _, ok := <-task.Updates(); ok {
+		t.Fatalf("expected channel to be closed")
+	}
+}
+
+func TestWaitingTaskPanicsWithMultipleDoneCalls(t *testing.T) {
+	task := NewWaitingTask("example")
+
+	task.Complete()
+
+	defer func() {
+		if err := recover(); err == nil {
+			t.Fatal("githistory/log: expected panic()")
+		} else {
+			if s, ok := err.(error); ok {
+				assert.Equal(t, "close of closed channel", s.Error())
+			} else {
+				t.Fatal("githistory/log: expected panic() to implement error")
+			}
+		}
+	}()
+
+	task.Complete()
+}

--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -332,6 +332,8 @@ func (r *Rewriter) rewriteBlob(from []byte, path string, fn BlobRewriteFn) ([]by
 //
 // If any error was encountered, it will be returned.
 func (r *Rewriter) commitsToMigrate(opt *RewriteOptions) ([][]byte, error) {
+	waiter := r.l.Waiter("migrate: Sorting commits")
+
 	scanner, err := git.NewRevListScanner(
 		opt.Include, opt.Exclude, r.scannerOpts())
 	if err != nil {
@@ -340,6 +342,10 @@ func (r *Rewriter) commitsToMigrate(opt *RewriteOptions) ([][]byte, error) {
 
 	var commits [][]byte
 	for scanner.Scan() {
+		if len(commits) == 0 {
+			waiter.Complete()
+		}
+
 		commits = append(commits, scanner.OID())
 	}
 

--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -3,12 +3,14 @@ package githistory
 import (
 	"encoding/hex"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sync"
 
 	"github.com/git-lfs/git-lfs/filepathfilter"
 	"github.com/git-lfs/git-lfs/git"
+	"github.com/git-lfs/git-lfs/git/githistory/log"
 	"github.com/git-lfs/git-lfs/git/odb"
 )
 
@@ -31,6 +33,8 @@ type Rewriter struct {
 	// db is the *ObjectDatabase from which blobs, commits, and trees are
 	// loaded from.
 	db *odb.ObjectDatabase
+	// l is the *log.Logger to which updates are written.
+	l *log.Logger
 }
 
 // RewriteOptions is an options type given to the Rewrite() function.
@@ -114,6 +118,14 @@ var (
 	WithFilter = func(filter *filepathfilter.Filter) rewriterOption {
 		return func(r *Rewriter) {
 			r.filter = filter
+		}
+	}
+
+	// WithLogger logs updates caused by the *git/githistory.Rewriter to the
+	// given io.Writer "sink".
+	WithLogger = func(sink io.Writer) rewriterOption {
+		return func(r *Rewriter) {
+			r.l = log.NewLogger(sink)
 		}
 	}
 

--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -162,6 +162,8 @@ func (r *Rewriter) Rewrite(opt *RewriteOptions) ([]byte, error) {
 		return nil, err
 	}
 
+	p := r.l.Percentage("migrate: Rewriting commits", uint64(len(commits)))
+
 	// Keep track of the last commit that we rewrote. Callers often want
 	// this so that they can perform a git-update-ref(1).
 	var tip []byte
@@ -224,9 +226,15 @@ func (r *Rewriter) Rewrite(opt *RewriteOptions) ([]byte, error) {
 		// commit.
 		r.cacheCommit(oid, rewrittenCommit)
 
+		// Increment the percentage displayed in the terminal.
+		p.Count(1)
+
 		// Move the tip forward.
 		tip = rewrittenCommit
 	}
+
+	r.l.Close()
+
 	return tip, err
 }
 

--- a/test/test-migrate-info.sh
+++ b/test/test-migrate-info.sh
@@ -11,7 +11,7 @@ begin_test "migrate info (default branch)"
 
   original_head="$(git rev-parse HEAD)"
 
-  diff -u <(git lfs migrate info --above=0b 2>&1) <(cat <<-EOF
+  diff -u <(git lfs migrate info --above=0b 2>&1 | tail -n 2) <(cat <<-EOF
 	*.md 	140 B	1/1 files(s)	100%
 	*.txt	120 B	1/1 files(s)	100%
 	EOF)
@@ -31,7 +31,7 @@ begin_test "migrate info (given branch)"
   original_master="$(git rev-parse refs/heads/master)"
   original_feature="$(git rev-parse refs/heads/my-feature)"
 
-  diff -u <(git lfs migrate info --above=0b my-feature 2>&1) <(cat <<-EOF
+  diff -u <(git lfs migrate info --above=0b my-feature 2>&1 | tail -n 2) <(cat <<-EOF
 	*.md 	170 B	2/2 files(s)	100%
 	*.txt	120 B	1/1 files(s)	100%
 	EOF)
@@ -52,7 +52,7 @@ begin_test "migrate info (default branch with filter)"
 
   original_head="$(git rev-parse HEAD)"
 
-  diff -u <(git lfs migrate info --above=0b --include "*.md" 2>&1) <(cat <<-EOF
+  diff -u <(git lfs migrate info --above=0b --include "*.md" 2>&1 | tail -n 1) <(cat <<-EOF
 	*.md	140 B	1/1 files(s)	100%
 	EOF)
 
@@ -71,7 +71,7 @@ begin_test "migrate info (given branch with filter)"
   original_master="$(git rev-parse refs/heads/master)"
   original_feature="$(git rev-parse refs/heads/my-feature)"
 
-  diff -u <(git lfs migrate info --above=0b --include "*.md" my-feature 2>&1) <(cat <<-EOF
+  diff -u <(git lfs migrate info --above=0b --include "*.md" my-feature 2>&1 | tail -n 1) <(cat <<-EOF
 	*.md	170 B	2/2 files(s)	100%
 	EOF)
 
@@ -94,7 +94,7 @@ begin_test "migrate info (default branch, exclude remote refs)"
   original_remote="$(git rev-parse refs/remotes/origin/master)"
   original_master="$(git rev-parse refs/heads/master)"
 
-  diff -u <(git lfs migrate info --above=0b 2>&1) <(cat <<-EOF
+  diff -u <(git lfs migrate info --above=0b 2>&1 | tail -n 2) <(cat <<-EOF
 	*.md 	50 B	1/1 files(s)	100%
 	*.txt	30 B	1/1 files(s)	100%
 	EOF)
@@ -117,7 +117,7 @@ begin_test "migrate info (given branch, exclude remote refs)"
   original_master="$(git rev-parse refs/heads/master)"
   original_feature="$(git rev-parse refs/heads/my-feature)"
 
-  diff -u <(git lfs migrate info --above=0b my-feature 2>&1) <(cat <<-EOF
+  diff -u <(git lfs migrate info --above=0b my-feature 2>&1 | tail -n 2) <(cat <<-EOF
 	*.md 	52 B	2/2 files(s)	100%
 	*.txt	50 B	2/2 files(s)	100%
 	EOF)
@@ -144,7 +144,7 @@ begin_test "migrate info (include/exclude ref)"
   diff -u <(git lfs migrate info \
     --above=0b \
     --include-ref=refs/heads/my-feature \
-    --exclude-ref=refs/heads/master 2>&1) <(cat <<-EOF
+    --exclude-ref=refs/heads/master 2>&1 | tail -n 2) <(cat <<-EOF
 	*.md 	31 B	1/1 files(s)	100%
 	*.txt	30 B	1/1 files(s)	100%
 	EOF)
@@ -170,7 +170,7 @@ begin_test "migrate info (include/exclude ref with filter)"
     --above=0b \
     --include="*.txt" \
     --include-ref=refs/heads/my-feature \
-    --exclude-ref=refs/heads/master 2>&1) <(cat <<-EOF
+    --exclude-ref=refs/heads/master 2>&1 | tail -n 1) <(cat <<-EOF
 	*.txt	30 B	1/1 files(s)	100%
 	EOF)
 
@@ -190,7 +190,7 @@ begin_test "migrate info (above threshold)"
 
   original_head="$(git rev-parse HEAD)"
 
-  diff -u <(git lfs migrate info --above=130B 2>&1) <(cat <<-EOF
+  diff -u <(git lfs migrate info --above=130B 2>&1 | tail -n 2) <(cat <<-EOF
 	*.md 	140 B	1/1 files(s)	100%
 	*.txt	0 B  	0/1 files(s)	  0%
 	EOF)
@@ -209,7 +209,7 @@ begin_test "migrate info (above threshold, top)"
 
   original_head="$(git rev-parse HEAD)"
 
-  diff -u <(git lfs migrate info --above=130B --top=1 2>&1) <(cat <<-EOF
+  diff -u <(git lfs migrate info --above=130B --top=1 2>&1 | tail -n 1) <(cat <<-EOF
 	*.md	140 B	1/1 files(s)	100%
 	EOF)
 
@@ -218,4 +218,3 @@ begin_test "migrate info (above threshold, top)"
   assert_ref_unmoved "HEAD" "$original_head" "$migrated_head"
 )
 end_test
-


### PR DESCRIPTION
This pull request introduces a new package, `github.com/git-lfs/git-lfs/git/githistory/log` for Git-style progress based logging, like this:

![](https://user-images.githubusercontent.com/443245/27157106-4df5e11a-511d-11e7-88c9-9e192ec47202.gif)

This pull request is based off the `migrate-subcommand-info` branch, since I wanted to use the `info(1)` subcommand to test out the logger in a real-world setting. Once #2313 is merged, I'll change the base of this pull request to `master`.

The API works as follows: given a `*log.Logger` with a `sink io.Writer`, ask for one of two types of logging tasks:

- `*WaitingTask` (via `(*log.Logger) Waiter()`): a task for which the upper bound of items to process is not known. Logged as `message: ...` and `message: ..., done`. 
- `*PercentageTask` (via `(*log.Logger) Percentage()`): a task for which the upper bound of items is known. Logged as `message:   1% (1/100)` and `message: 100% (100/100), done`.

When a new task is created (via either `Waiter()` or `Percentage()`) that task is queued by the logger and becomes the primary task being logged. Only one task may be logged at a time, though new tasks can be created before the existing task is completed. This, together, creates the two axioms of `*log.Logger`:

1. Only one task may be logged at once, and that task is logged until completion.
2. "Infinite" tasks may be created before the current task is finished logging, creating a pseudo-infinite channel buffer.

The finer details of how this works are described in the `consume()` logger function.

One other note: this was originally designed as a utility for the `githistory` package, but I think that it could have other uses throughout LFS. I'd like to eventually consider what making this a top-level `github.com/git-lfs/git-lfs/log` package could look like.

---

/cc @git-lfs/core 
/ref #2146, #2313 