### PR TITLE
git/odb: introduce 'NewBlobFromBytes'

### DIFF
--- a/git/odb/blob.go
+++ b/git/odb/blob.go
@@ -1,6 +1,9 @@
 package odb
 
-import "io"
+import (
+	"bytes"
+	"io"
+)
 
 // Blob represents a Git object of type "blob".
 type Blob struct {
@@ -14,6 +17,14 @@ type Blob struct {
 	// the Blob.  In particular, this will close a file, if the Blob is
 	// being read from a file on disk.
 	closeFn func() error
+}
+
+// NewBlobFromBytes returns a new *Blob that yields the data given.
+func NewBlobFromBytes(contents []byte) *Blob {
+	return &Blob{
+		Contents: bytes.NewReader(contents),
+		Size:     int64(len(contents)),
+	}
 }
 
 // Type implements Object.ObjectType by returning the correct object type for

--- a/git/odb/blob_test.go
+++ b/git/odb/blob_test.go
@@ -15,6 +15,19 @@ func TestBlobReturnsCorrectObjectType(t *testing.T) {
 	assert.Equal(t, BlobObjectType, new(Blob).Type())
 }
 
+func TestBlobFromString(t *testing.T) {
+	given := []byte("example")
+	glen := len(given)
+
+	b := NewBlobFromBytes(given)
+
+	assert.EqualValues(t, glen, b.Size)
+
+	contents, err := ioutil.ReadAll(b.Contents)
+	assert.NoError(t, err)
+	assert.Equal(t, given, contents)
+}
+
 func TestBlobEncoding(t *testing.T) {
 	const contents = "Hello, world!\n"
 


### PR DESCRIPTION
This pull request introduces a new `*git/odb.Blob` constructor that returns a blob whose contents is equal to the give `[]byte`.

---

/cc @git-lfs/core  
/ref #2146 