### PR TITLE
commands: invert *odb.ObjectDatabase argument to migrate()

### DIFF
--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -20,15 +20,10 @@ var (
 	migrateExcludeRefs []string
 )
 
-// migrate takes the given command and arguments, as well as a BlobRewriteFn to
-// apply, and performs a migration.
-func migrate(cmd *cobra.Command, args []string, fn githistory.BlobRewriteFn) {
+// migrate takes the given command and arguments, *odb.ObjectDatabase, as well
+// as a BlobRewriteFn to apply, and performs a migration.
+func migrate(cmd *cobra.Command, args []string, db *odb.ObjectDatabase, fn githistory.BlobRewriteFn) {
 	requireInRepo()
-
-	db, err := getObjectDatabase()
-	if err != nil {
-		ExitWithError(err)
-	}
 
 	opts, err := rewriteOptions(args, fn)
 	if err != nil {

--- a/commands/command_migrate_info.go
+++ b/commands/command_migrate_info.go
@@ -30,6 +30,11 @@ var (
 )
 
 func migrateInfoCommand(cmd *cobra.Command, args []string) {
+	db, err := getObjectDatabase()
+	if err != nil {
+		ExitWithError(err)
+	}
+
 	exts := make(map[string]*MigrateInfoEntry)
 
 	above, err := humanize.ParseBytes(migrateInfoAboveFmt)
@@ -39,7 +44,7 @@ func migrateInfoCommand(cmd *cobra.Command, args []string) {
 
 	migrateInfoAbove = above
 
-	migrate(cmd, args, func(path string, b *odb.Blob) (*odb.Blob, error) {
+	migrate(cmd, args, db, func(path string, b *odb.Blob) (*odb.Blob, error) {
 		ext := fmt.Sprintf("*%s", filepath.Ext(path))
 
 		if len(ext) > 1 {


### PR DESCRIPTION
This pull request inverts the argument order for the `*git/odb.ObjectDatabase` argument so that it can be passed into the `migrate()` function.

This is required so that we can add arbitrary blobs to the object database, such that they are valid tree entries (for instance, adding/modifying a tree's `.gitattributes`).

---

/cc @git-lfs/core 
/refs #2146 