### PR TITLE
commands: teach --unit to 'info' subcommand of 'git-lfs-migrate(1)'

### DIFF
--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -209,6 +209,7 @@ func init() {
 	info := NewCommand("info", migrateInfoCommand)
 	info.Flags().IntVar(&migrateInfoTopN, "top", 5, "--top=<n>")
 	info.Flags().StringVar(&migrateInfoAboveFmt, "above", "1mb", "--above=<n>")
+	info.Flags().StringVar(&migrateInfoUnitFmt, "unit", "", "--unit=<unit>")
 
 	RegisterCommand("migrate", nil, func(cmd *cobra.Command) {
 		// Adding flags directly to cmd.Flags() doesn't apply those

--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -44,6 +44,15 @@ The 'info' mode has these additional options:
     Only include the top 'n' entries, ordered by how many total files match the
     given pathspec.
 
+* `--unit=<unit>`
+    Format the number of bytes in each entry as a quantity of the storage unit
+    provided. Valid units include:
+      * b, kib, mib, gib, tib, pib - for IEC storage units
+      * b, kb, mb, gb, tb, pb - for SI storage units
+
+    If a --unit is not specified, the largest unit that can fit the number of
+    counted bytes as a whole number quantity is chosen.
+
 ## INCLUDE AND EXCLUDE
 
 You can configure Git LFS to only migrate tree entries whose pathspec matches

--- a/test/test-migrate-info.sh
+++ b/test/test-migrate-info.sh
@@ -219,3 +219,21 @@ begin_test "migrate info (above threshold, top)"
 )
 end_test
 
+begin_test "migrate info (given unit)"
+(
+  set -e
+
+  setup_multiple_local_branches
+
+  original_head="$(git rev-parse HEAD)"
+
+  diff -u <(git lfs migrate info --above=0b --unit=kb 2>&1) <(cat <<-EOF
+	*.md 	0.1	1/1 files(s)	100%
+	*.txt	0.1	1/1 files(s)	100%
+	EOF)
+
+  migrated_head="$(git rev-parse HEAD)"
+
+  assert_ref_unmoved "HEAD" "$original_head" "$migrated_head"
+)
+end_test

--- a/tools/humanize/humanize.go
+++ b/tools/humanize/humanize.go
@@ -70,6 +70,18 @@ func ParseBytes(str string) (uint64, error) {
 	return 0, errors.Errorf("unknown unit: %q", unit)
 }
 
+// ParseByteUnit returns the number of bytes in a given unit of storage, or an
+// error, if that unit is unrecognized.
+func ParseByteUnit(str string) (uint64, error) {
+	str = strings.TrimSpace(str)
+	str = strings.ToLower(str)
+
+	if u, ok := bytesTable[str]; ok {
+		return u, nil
+	}
+	return 0, errors.Errorf("unknown unit: %q", str)
+}
+
 var sizes = []string{"B", "KB", "MB", "GB", "TB", "PB"}
 
 // FormatBytes outputs the given number of bytes "s" as a human-readable string,

--- a/tools/humanize/humanize.go
+++ b/tools/humanize/humanize.go
@@ -87,20 +87,18 @@ var sizes = []string{"B", "KB", "MB", "GB", "TB", "PB"}
 // FormatBytes outputs the given number of bytes "s" as a human-readable string,
 // rounding to the nearest half within .01.
 func FormatBytes(s uint64) string {
-	if s < 10 {
-		return fmt.Sprintf("%d B", s)
+	var e float64
+	if s == 0 {
+		e = 0
+	} else {
+		e = math.Floor(log(float64(s), 1000))
 	}
 
-	e := math.Floor(log(float64(s), 1000))
+	unit := uint64(math.Pow(1000, e))
 	suffix := sizes[int(e)]
 
-	val := math.Floor(float64(s)/math.Pow(1000, e)*10+.5) / 10
-	f := "%.0f %s"
-	if val < 10 {
-		f = "%.1f %s"
-	}
-
-	return fmt.Sprintf(f, val, suffix)
+	return fmt.Sprintf("%s %s",
+		FormatBytesUnit(s, unit), suffix)
 }
 
 // FormatBytesUnit outputs the given number of bytes "s" as a quantity of the

--- a/tools/humanize/humanize.go
+++ b/tools/humanize/humanize.go
@@ -58,16 +58,16 @@ func ParseBytes(str string) (uint64, error) {
 		return 0, err
 	}
 
-	unit := strings.ToLower(strings.TrimSpace(str[sep:]))
-
-	if m, ok := bytesTable[unit]; ok {
-		f = f * float64(m)
-		if f >= math.MaxUint64 {
-			return 0, errors.New("number of bytes too large")
-		}
-		return uint64(f), nil
+	m, err := ParseByteUnit(str[sep:])
+	if err != nil {
+		return 0, err
 	}
-	return 0, errors.Errorf("unknown unit: %q", unit)
+
+	f = f * float64(m)
+	if f >= math.MaxUint64 {
+		return 0, errors.New("number of bytes too large")
+	}
+	return uint64(f), nil
 }
 
 // ParseByteUnit returns the number of bytes in a given unit of storage, or an

--- a/tools/humanize/humanize.go
+++ b/tools/humanize/humanize.go
@@ -103,6 +103,24 @@ func FormatBytes(s uint64) string {
 	return fmt.Sprintf(f, val, suffix)
 }
 
+// FormatBytesUnit outputs the given number of bytes "s" as a quantity of the
+// given units "u" to the nearest half within .01.
+func FormatBytesUnit(s, u uint64) string {
+	var rounded float64
+	if s < 10 {
+		rounded = float64(s)
+	} else {
+		rounded = math.Floor(float64(s)/float64(u)*10+.5) / 10
+	}
+
+	format := "%.0f"
+	if rounded < 10 && u > 1 {
+		format = "%.1f"
+	}
+
+	return fmt.Sprintf(format, rounded)
+}
+
 // log takes the log base "b" of "n" (\log_b{n})
 func log(n, b float64) float64 {
 	return math.Log(n) / math.Log(b)

--- a/tools/humanize/humanize_test.go
+++ b/tools/humanize/humanize_test.go
@@ -33,6 +33,22 @@ func (c *FormatBytesTestCase) Assert(t *testing.T) {
 	assert.Equal(t, c.Expected, humanize.FormatBytes(c.Given))
 }
 
+type ParseByteUnitTestCase struct {
+	Given    string
+	Expected uint64
+	Err      string
+}
+
+func (c *ParseByteUnitTestCase) Assert(t *testing.T) {
+	got, err := humanize.ParseByteUnit(c.Given)
+	if len(c.Err) == 0 {
+		assert.NoError(t, err, "unexpected error: %s", err)
+		assert.EqualValues(t, c.Expected, got)
+	} else {
+		assert.EqualError(t, err, c.Err)
+	}
+}
+
 func TestParseBytes(t *testing.T) {
 	for desc, c := range map[string]*ParseBytesTestCase{
 		"parse byte":     {"10B", uint64(10 * math.Pow(2, 0)), nil},
@@ -117,6 +133,66 @@ func TestFormatBytes(t *testing.T) {
 		"format gigabytes exact": {uint64(1.3 * math.Pow(10, 9)), "1.3 GB"},
 		"format petabytes exact": {uint64(1.3 * math.Pow(10, 12)), "1.3 TB"},
 		"format terabytes exact": {uint64(1.3 * math.Pow(10, 15)), "1.3 PB"},
+	} {
+		t.Run(desc, c.Assert)
+	}
+}
+
+func TestParseByteUnit(t *testing.T) {
+	for desc, c := range map[string]*ParseByteUnitTestCase{
+		"parse byte":     {"B", uint64(math.Pow(2, 0)), ""},
+		"parse kibibyte": {"KIB", uint64(math.Pow(2, 10)), ""},
+		"parse mebibyte": {"MIB", uint64(math.Pow(2, 20)), ""},
+		"parse gibibyte": {"GIB", uint64(math.Pow(2, 30)), ""},
+		"parse tebibyte": {"TIB", uint64(math.Pow(2, 40)), ""},
+		"parse pebibyte": {"PIB", uint64(math.Pow(2, 50)), ""},
+
+		"parse byte (lowercase)":     {"b", uint64(math.Pow(2, 0)), ""},
+		"parse kibibyte (lowercase)": {"kib", uint64(math.Pow(2, 10)), ""},
+		"parse mebibyte (lowercase)": {"mib", uint64(math.Pow(2, 20)), ""},
+		"parse gibibyte (lowercase)": {"gib", uint64(math.Pow(2, 30)), ""},
+		"parse tebibyte (lowercase)": {"tib", uint64(math.Pow(2, 40)), ""},
+		"parse pebibyte (lowercase)": {"pib", uint64(math.Pow(2, 50)), ""},
+
+		"parse byte (with space)":     {" B", uint64(math.Pow(2, 0)), ""},
+		"parse kibibyte (with space)": {" KIB", uint64(math.Pow(2, 10)), ""},
+		"parse mebibyte (with space)": {" MIB", uint64(math.Pow(2, 20)), ""},
+		"parse gibibyte (with space)": {" GIB", uint64(math.Pow(2, 30)), ""},
+		"parse tebibyte (with space)": {" TIB", uint64(math.Pow(2, 40)), ""},
+		"parse pebibyte (with space)": {" PIB", uint64(math.Pow(2, 50)), ""},
+
+		"parse byte (with space, lowercase)":     {" b", uint64(math.Pow(2, 0)), ""},
+		"parse kibibyte (with space, lowercase)": {" kib", uint64(math.Pow(2, 10)), ""},
+		"parse mebibyte (with space, lowercase)": {" mib", uint64(math.Pow(2, 20)), ""},
+		"parse gibibyte (with space, lowercase)": {" gib", uint64(math.Pow(2, 30)), ""},
+		"parse tebibyte (with space, lowercase)": {" tib", uint64(math.Pow(2, 40)), ""},
+		"parse pebibyte (with space, lowercase)": {" pib", uint64(math.Pow(2, 50)), ""},
+
+		"parse kilobyte": {"KB", uint64(math.Pow(10, 3)), ""},
+		"parse megabyte": {"MB", uint64(math.Pow(10, 6)), ""},
+		"parse gigabyte": {"GB", uint64(math.Pow(10, 9)), ""},
+		"parse terabyte": {"TB", uint64(math.Pow(10, 12)), ""},
+		"parse petabyte": {"PB", uint64(math.Pow(10, 15)), ""},
+
+		"parse kilobyte (lowercase)": {"kb", uint64(math.Pow(10, 3)), ""},
+		"parse megabyte (lowercase)": {"mb", uint64(math.Pow(10, 6)), ""},
+		"parse gigabyte (lowercase)": {"gb", uint64(math.Pow(10, 9)), ""},
+		"parse terabyte (lowercase)": {"tb", uint64(math.Pow(10, 12)), ""},
+		"parse petabyte (lowercase)": {"pb", uint64(math.Pow(10, 15)), ""},
+
+		"parse kilobyte (with space)": {" KB", uint64(math.Pow(10, 3)), ""},
+		"parse megabyte (with space)": {" MB", uint64(math.Pow(10, 6)), ""},
+		"parse gigabyte (with space)": {" GB", uint64(math.Pow(10, 9)), ""},
+		"parse terabyte (with space)": {" TB", uint64(math.Pow(10, 12)), ""},
+		"parse petabyte (with space)": {" PB", uint64(math.Pow(10, 15)), ""},
+
+		"parse kilobyte (with space, lowercase)": {"kb", uint64(math.Pow(10, 3)), ""},
+		"parse megabyte (with space, lowercase)": {"mb", uint64(math.Pow(10, 6)), ""},
+		"parse gigabyte (with space, lowercase)": {"gb", uint64(math.Pow(10, 9)), ""},
+		"parse terabyte (with space, lowercase)": {"tb", uint64(math.Pow(10, 12)), ""},
+		"parse petabyte (with space, lowercase)": {"pb", uint64(math.Pow(10, 15)), ""},
+
+		"parse unknown unit": {"imag", 0, "unknown unit: \"imag\""},
 	} {
 		t.Run(desc, c.Assert)
 	}

--- a/tools/humanize/humanize_test.go
+++ b/tools/humanize/humanize_test.go
@@ -49,6 +49,16 @@ func (c *ParseByteUnitTestCase) Assert(t *testing.T) {
 	}
 }
 
+type FormatBytesUnitTestCase struct {
+	Given    uint64
+	Unit     uint64
+	Expected string
+}
+
+func (c *FormatBytesUnitTestCase) Assert(t *testing.T) {
+	assert.Equal(t, c.Expected, humanize.FormatBytesUnit(c.Given, c.Unit))
+}
+
 func TestParseBytes(t *testing.T) {
 	for desc, c := range map[string]*ParseBytesTestCase{
 		"parse byte":     {"10B", uint64(10 * math.Pow(2, 0)), nil},
@@ -193,6 +203,31 @@ func TestParseByteUnit(t *testing.T) {
 		"parse petabyte (with space, lowercase)": {"pb", uint64(math.Pow(10, 15)), ""},
 
 		"parse unknown unit": {"imag", 0, "unknown unit: \"imag\""},
+	} {
+		t.Run(desc, c.Assert)
+	}
+}
+
+func TestFormatBytesUnit(t *testing.T) {
+	for desc, c := range map[string]*FormatBytesUnitTestCase{
+		"format bytes":     {uint64(1 * math.Pow(10, 0)), humanize.Byte, "1"},
+		"format kilobytes": {uint64(1 * math.Pow(10, 3)), humanize.Byte, "1000"},
+		"format megabytes": {uint64(1 * math.Pow(10, 6)), humanize.Byte, "1000000"},
+		"format gigabytes": {uint64(1 * math.Pow(10, 9)), humanize.Byte, "1000000000"},
+		"format petabytes": {uint64(1 * math.Pow(10, 12)), humanize.Byte, "1000000000000"},
+		"format terabytes": {uint64(1 * math.Pow(10, 15)), humanize.Byte, "1000000000000000"},
+
+		"format kilobytes under": {uint64(1.49 * math.Pow(10, 3)), humanize.Byte, "1490"},
+		"format megabytes under": {uint64(1.49 * math.Pow(10, 6)), humanize.Byte, "1490000"},
+		"format gigabytes under": {uint64(1.49 * math.Pow(10, 9)), humanize.Byte, "1490000000"},
+		"format petabytes under": {uint64(1.49 * math.Pow(10, 12)), humanize.Byte, "1490000000000"},
+		"format terabytes under": {uint64(1.49 * math.Pow(10, 15)), humanize.Byte, "1490000000000000"},
+
+		"format kilobytes over": {uint64(1.51 * math.Pow(10, 3)), humanize.Byte, "1510"},
+		"format megabytes over": {uint64(1.51 * math.Pow(10, 6)), humanize.Byte, "1510000"},
+		"format gigabytes over": {uint64(1.51 * math.Pow(10, 9)), humanize.Byte, "1510000000"},
+		"format petabytes over": {uint64(1.51 * math.Pow(10, 12)), humanize.Byte, "1510000000000"},
+		"format terabytes over": {uint64(1.51 * math.Pow(10, 15)), humanize.Byte, "1510000000000000"},
 	} {
 		t.Run(desc, c.Assert)
 	}


### PR DESCRIPTION
This pull request teaches the `--unit` flag to the 'info' subcommand of `git-lfs-migrate(1)`.

Previously, the behavior of the command was to find the largest storage unit that could represent the number of bytes counted as a whole number. Now, if instead the `--unit` flag is given, that unit is used to format the bytes with at most one decimal place.

Here's a summary of what happened:

- 06fde60 & 40e833d: implement and use `ParseByteUnit` so that we can parse the string `--unit` given.
- cb5baef & 8d09c7e: implement and use `ForamtBytesUnit` so that we can format storage quantities with arbitrary units.
- d1037fc: use the above two utilities to format the bytes accordingly.

Here's a sample from the manpage:

> ```
> * `--unit=<unit>`
>     Format the number of bytes in each entry as a quantity of the storage unit
>     provided. Valid units include:
>       * b, kib, mib, gib, tib, pib - for IEC storage units
>       * b, kb, mb, gb, tb, pb - for SI storage units
> 
>     If a --unit is not specified, the largest unit that can fit the number of
>     counted bytes as a whole number quantity is chosen.
> ```

---

/cc @git-lfs/core 
/cc #2146 