### PR TITLE
git/githistory/log: teach Durable() to Task

### DIFF
--- a/git/githistory/log/log.go
+++ b/git/githistory/log/log.go
@@ -185,7 +185,7 @@ func (l *Logger) consume() {
 func (l *Logger) logTask(task Task) {
 	defer l.wg.Done()
 
-	logAll := task.Durable()
+	logAll := !task.Throttled()
 	var last time.Time
 
 	var msg string

--- a/git/githistory/log/log.go
+++ b/git/githistory/log/log.go
@@ -175,8 +175,20 @@ func (l *Logger) consume() {
 
 // logTask logs the set of updates from a given task to the sink, then logs a
 // "done" message, and then marks the task as done.
+//
+// By default, the *Logger throttles log entry updates to once per the duration
+// of time specified by `l.throttle time.Duration`.
+//
+// If the duration if 0, or the task is "durable" (by implementing
+// github.com/git-lfs/git-lfs/git/githistory/log#DurableTask), then all entries
+// will be logged.
 func (l *Logger) logTask(task Task) {
 	defer l.wg.Done()
+
+	var logAll bool
+	if durable, ok := task.(DurableTask); ok {
+		logAll = durable.Durable()
+	}
 
 	var last time.Time
 
@@ -184,7 +196,7 @@ func (l *Logger) logTask(task Task) {
 	for msg = range task.Updates() {
 		now := time.Now()
 
-		if l.throttle == 0 || now.After(last.Add(l.throttle)) {
+		if logAll || l.throttle == 0 || now.After(last.Add(l.throttle)) {
 			l.logLine(msg)
 			last = now
 		}

--- a/git/githistory/log/log.go
+++ b/git/githistory/log/log.go
@@ -185,11 +185,7 @@ func (l *Logger) consume() {
 func (l *Logger) logTask(task Task) {
 	defer l.wg.Done()
 
-	var logAll bool
-	if durable, ok := task.(DurableTask); ok {
-		logAll = durable.Durable()
-	}
-
+	logAll := task.Durable()
 	var last time.Time
 
 	var msg string

--- a/git/githistory/log/log_test.go
+++ b/git/githistory/log/log_test.go
@@ -13,13 +13,13 @@ type ChanTask chan string
 
 func (e ChanTask) Updates() <-chan string { return e }
 
-func (e ChanTask) Durable() Bool { return false }
+func (e ChanTask) Throttled() bool { return true }
 
-type DurableChanTask chan string
+type UnthrottledChanTask chan string
 
-func (e DurableChanTask) Updates() <-chan string { return e }
+func (e UnthrottledChanTask) Updates() <-chan string { return e }
 
-func (e DurableChanTask) Durable() bool { return true }
+func (e UnthrottledChanTask) Throttled() bool { return false }
 
 func TestLoggerLogsTasks(t *testing.T) {
 	var buf bytes.Buffer
@@ -163,7 +163,7 @@ func TestLoggerLogsAllDurableUpdates(t *testing.T) {
 		close(t1)      // t = 0+3ε ms, throttle is closed
 	}()
 
-	l.enqueue(DurableChanTask(t1))
+	l.enqueue(UnthrottledChanTask(t1))
 	l.Close()
 
 	assert.Equal(t, strings.Join([]string{

--- a/git/githistory/log/log_test.go
+++ b/git/githistory/log/log_test.go
@@ -13,6 +13,12 @@ type ChanTask chan string
 
 func (e ChanTask) Updates() <-chan string { return e }
 
+type DurableChanTask chan string
+
+func (e DurableChanTask) Updates() <-chan string { return e }
+
+func (e DurableChanTask) Durable() bool { return true }
+
 func TestLoggerLogsTasks(t *testing.T) {
 	var buf bytes.Buffer
 
@@ -137,6 +143,30 @@ func TestLoggerThrottlesLastWrite(t *testing.T) {
 
 	assert.Equal(t, strings.Join([]string{
 		"first\r",
+		"second, done\n",
+	}, ""), buf.String())
+}
+
+func TestLoggerLogsAllDurableUpdates(t *testing.T) {
+	var buf bytes.Buffer
+
+	l := NewLogger(&buf)
+	l.widthFn = func() int { return 0 }
+	l.throttle = 15 * time.Minute
+
+	t1 := make(chan string)
+	go func() {
+		t1 <- "first"  // t = 0+ε  ms, throttle is open
+		t1 <- "second" // t = 0+2ε ms, throttle is closed
+		close(t1)      // t = 0+3ε ms, throttle is closed
+	}()
+
+	l.enqueue(DurableChanTask(t1))
+	l.Close()
+
+	assert.Equal(t, strings.Join([]string{
+		"first\r",
+		"second\r",
 		"second, done\n",
 	}, ""), buf.String())
 }

--- a/git/githistory/log/log_test.go
+++ b/git/githistory/log/log_test.go
@@ -13,6 +13,8 @@ type ChanTask chan string
 
 func (e ChanTask) Updates() <-chan string { return e }
 
+func (e ChanTask) Durable() Bool { return false }
+
 type DurableChanTask chan string
 
 func (e DurableChanTask) Updates() <-chan string { return e }

--- a/git/githistory/log/percentage_task.go
+++ b/git/githistory/log/percentage_task.go
@@ -65,6 +65,6 @@ func (c *PercentageTask) Updates() <-chan string {
 	return c.ch
 }
 
-// Durable implements Task.Durable and returns false, indicating that this task
-// is not durable.
-func (c *PercentageTask) Durable() bool { return false }
+// Throttled implements Task.Throttled and returns true, indicating that this
+// task is throttled.
+func (c *PercentageTask) Throttled() bool { return true }

--- a/git/githistory/log/percentage_task.go
+++ b/git/githistory/log/percentage_task.go
@@ -64,3 +64,7 @@ func (c *PercentageTask) Count(n uint64) (new uint64) {
 func (c *PercentageTask) Updates() <-chan string {
 	return c.ch
 }
+
+// Durable implements Task.Durable and returns false, indicating that this task
+// is not durable.
+func (c *PercentageTask) Durable() bool { return false }

--- a/git/githistory/log/percentage_task_test.go
+++ b/git/githistory/log/percentage_task_test.go
@@ -37,3 +37,12 @@ func TestPercentageTaskCallsDoneWhenComplete(t *testing.T) {
 		t.Fatalf("expected channel to be closed")
 	}
 }
+
+func TestPercentageTaskIsThrottled(t *testing.T) {
+	task := NewPercentageTask("example", 10)
+
+	throttled := task.Throttled()
+
+	assert.True(t, throttled,
+		"git/githistory/log: expected *PercentageTask to be Throttle()-d")
+}

--- a/git/githistory/log/task.go
+++ b/git/githistory/log/task.go
@@ -7,3 +7,15 @@ type Task interface {
 	// complete.
 	Updates() <-chan string
 }
+
+// DurableTask is a Task sub-interface which ensures that all activity is
+// logged by disabling throttling behavior in the logger.
+type DurableTask interface {
+	Task
+
+	// Durable returns whether or not this task should be treated as
+	// Durable.
+	//
+	// It is expected to return the same value for a given Task instance.
+	Durable() bool
+}

--- a/git/githistory/log/task.go
+++ b/git/githistory/log/task.go
@@ -6,12 +6,6 @@ type Task interface {
 	// of the Task when an update is present. It is closed when the task is
 	// complete.
 	Updates() <-chan string
-}
-
-// DurableTask is a Task sub-interface which ensures that all activity is
-// logged by disabling throttling behavior in the logger.
-type DurableTask interface {
-	Task
 
 	// Durable returns whether or not this task should be treated as
 	// Durable.

--- a/git/githistory/log/task.go
+++ b/git/githistory/log/task.go
@@ -7,9 +7,9 @@ type Task interface {
 	// complete.
 	Updates() <-chan string
 
-	// Durable returns whether or not this task should be treated as
-	// Durable.
+	// Throttled returns whether or not updates from this task should be
+	// limited when being printed to a sink via *log.Logger.
 	//
 	// It is expected to return the same value for a given Task instance.
-	Durable() bool
+	Throttled() bool
 }

--- a/git/githistory/log/waiting_task.go
+++ b/git/githistory/log/waiting_task.go
@@ -27,3 +27,7 @@ func (w *WaitingTask) Complete() {
 func (w *WaitingTask) Updates() <-chan string {
 	return w.ch
 }
+
+// Durable implements Task.Durable and returns false, indicating that this task
+// is not durable.
+func (w *WaitingTask) Durable() bool { return false }

--- a/git/githistory/log/waiting_task.go
+++ b/git/githistory/log/waiting_task.go
@@ -28,6 +28,6 @@ func (w *WaitingTask) Updates() <-chan string {
 	return w.ch
 }
 
-// Durable implements Task.Durable and returns false, indicating that this task
-// is not durable.
-func (w *WaitingTask) Durable() bool { return false }
+// Throttled implements Task.Throttled and returns true, indicating that this
+// task is Throttled.
+func (w *WaitingTask) Throttled() bool { return true }

--- a/git/githistory/log/waiting_task_test.go
+++ b/git/githistory/log/waiting_task_test.go
@@ -51,3 +51,12 @@ func TestWaitingTaskPanicsWithMultipleDoneCalls(t *testing.T) {
 
 	task.Complete()
 }
+
+func TestWaitingTaskIsThrottled(t *testing.T) {
+	task := NewWaitingTask("example")
+
+	throttled := task.Throttled()
+
+	assert.True(t, throttled,
+		"git/githistory/log: expected *WaitingTask to be Throttle()-d")
+}


### PR DESCRIPTION
This pull request teaches a new `Task` type to the `github.com/git-lfs/git-lfs/git/githistory/log` package: `DurableTask`.

A `DurableTask` ensures that all log `<-Update()` reads are logged to the `sink io.Writer`, regardless of throttling conditions. This required for multi-line log updates (like output from `git-ref-update(1)`) where all log lines are important.

---

/cc @git-lfs/core 
/refs #2146 #2329 