### PR TITLE
git/githistory/log: implement ListTask type

### DIFF
--- a/git/githistory/log/list_task.go
+++ b/git/githistory/log/list_task.go
@@ -32,9 +32,9 @@ func (l *ListTask) Complete() {
 	close(l.ch)
 }
 
-// Durable implements the Task.Durable function and ensures that all log updates
-// are printed to the sink.
-func (l *ListTask) Durable() bool { return true }
+// Throttled implements the Task.Throttled function and ensures that all log
+// updates are printed to the sink.
+func (l *ListTask) Throttled() bool { return false }
 
 // Updates implements the Task.Updates function and returns a channel of updates
 // to log to the sink.

--- a/git/githistory/log/list_task.go
+++ b/git/githistory/log/list_task.go
@@ -32,9 +32,8 @@ func (l *ListTask) Complete() {
 	close(l.ch)
 }
 
-// Durable implements the DurableTask.Durable function (and therefore the
-// DurableTask interface) and ensures that all log updates are printed to the
-// sink.
+// Durable implements the Task.Durable function and ensures that all log updates
+// are printed to the sink.
 func (l *ListTask) Durable() bool { return true }
 
 // Updates implements the Task.Updates function and returns a channel of updates

--- a/git/githistory/log/list_task.go
+++ b/git/githistory/log/list_task.go
@@ -1,0 +1,42 @@
+package log
+
+import "fmt"
+
+// ListTask is a Task implementation that logs all updates in a list where each
+// entry is line-delimited.
+//
+// For example:
+//   entry #1
+//   entry #2
+//   msg: ..., done
+type ListTask struct {
+	msg string
+	ch  chan string
+}
+
+// NewListTask instantiates a new *ListTask instance with the given message.
+func NewListTask(msg string) *ListTask {
+	return &ListTask{
+		msg: msg,
+		ch:  make(chan string, 1),
+	}
+}
+
+// Entry logs a line-delimited task entry.
+func (l *ListTask) Entry(update string) {
+	l.ch <- fmt.Sprintf("%s\n", update)
+}
+
+func (l *ListTask) Complete() {
+	l.ch <- fmt.Sprintf("%s: ...", l.msg)
+	close(l.ch)
+}
+
+// Durable implements the DurableTask.Durable function (and therefore the
+// DurableTask interface) and ensures that all log updates are printed to the
+// sink.
+func (l *ListTask) Durable() bool { return true }
+
+// Updates implements the Task.Updates function and returns a channel of updates
+// to log to the sink.
+func (l *ListTask) Updates() <-chan string { return l.ch }

--- a/git/githistory/log/list_task_test.go
+++ b/git/githistory/log/list_task_test.go
@@ -1,0 +1,52 @@
+package log
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListTaskCallsDoneWhenComplete(t *testing.T) {
+	task := NewListTask("example")
+	task.Complete()
+
+	select {
+	case update, ok := <-task.Updates():
+		assert.Equal(t, "example: ...", update)
+		assert.True(t, ok,
+			"git/githistory/log: expected Updates() to remain open")
+	default:
+		t.Fatal("git/githistory/log: expected update from *ListTask")
+	}
+
+	select {
+	case update, ok := <-task.Updates():
+		assert.False(t, ok,
+			"git/githistory.log: unexpected *ListTask.Update(): %s", update)
+	default:
+		t.Fatal("git/githistory/log: expected *ListTask.Updates() to be closed")
+	}
+}
+
+func TestListTaskWritesEntries(t *testing.T) {
+	task := NewListTask("example")
+	task.Entry("1")
+
+	select {
+	case update, ok := <-task.Updates():
+		assert.True(t, ok,
+			"git/githistory/log: expected ListTask.Updates() to remain open")
+		assert.Equal(t, "1\n", update)
+	default:
+		t.Fatal("git/githistory/log: expected task.Updates() to have an update")
+	}
+}
+
+func TestListTaskIsDurable(t *testing.T) {
+	task := NewListTask("example")
+
+	durable := task.Durable()
+
+	assert.True(t, durable,
+		"git/githistory/log: expected *ListTask to be Durable()")
+}

--- a/git/githistory/log/list_task_test.go
+++ b/git/githistory/log/list_task_test.go
@@ -42,11 +42,11 @@ func TestListTaskWritesEntries(t *testing.T) {
 	}
 }
 
-func TestListTaskIsDurable(t *testing.T) {
+func TestListTaskIsNotThrottled(t *testing.T) {
 	task := NewListTask("example")
 
-	durable := task.Durable()
+	throttled := task.Throttled()
 
-	assert.True(t, durable,
-		"git/githistory/log: expected *ListTask to be Durable()")
+	assert.False(t, throttled,
+		"git/githistory/log: expected *ListTask to be Throttle()-d")
 }

--- a/git/githistory/log/log.go
+++ b/git/githistory/log/log.go
@@ -94,6 +94,14 @@ func (l *Logger) Percentage(msg string, total uint64) *PercentageTask {
 	return t
 }
 
+// List creates and enqueues a new *ListTask.
+func (l *Logger) List(msg string) *ListTask {
+	t := NewListTask(msg)
+	l.enqueue(t)
+
+	return t
+}
+
 // enqueue enqueues the given Tasks "ts".
 func (l *Logger) enqueue(ts ...Task) {
 	if l == nil {


### PR DESCRIPTION
This pull request provides a new `Task` implementation, `ListTask`, which is used to log line-delimited lists of data using the `git/githistory/log.Logger` type.

This is required work for the `import` subcommand of `git-lfs-migrate(1)` which will print out one line for each ref updated by the migrator.

--- 

/cc @git-lfs/core 
/refs #2146 #2329 #2334 