### PR TITLE
git: teach AllRefs()

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -1083,12 +1083,7 @@ func RemoteRefs(remoteName string) ([]*Ref, error) {
 // AllRefs returns a slice of all references in a Git repository in the current
 // working directory, or an error if those references could not be loaded.
 func AllRefs() ([]*Ref, error) {
-	wd, err := os.Getwd()
-	if err != nil {
-		return nil, err
-	}
-
-	return AllRefsIn(wd)
+	return AllRefsIn("")
 }
 
 // AllRefs returns a slice of all references in a Git repository located in a

--- a/git/git.go
+++ b/git/git.go
@@ -1080,11 +1080,24 @@ func RemoteRefs(remoteName string) ([]*Ref, error) {
 	return ret, cmd.Wait()
 }
 
-// AllRefs returns a slice of all references in a Git repository, or an error if
-// those references could not be loaded.
+// AllRefs returns a slice of all references in a Git repository in the current
+// working directory, or an error if those references could not be loaded.
 func AllRefs() ([]*Ref, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+
+	return AllRefsIn(wd)
+}
+
+// AllRefs returns a slice of all references in a Git repository located in a
+// the given working directory "wd", or an error if those references could not
+// be loaded.
+func AllRefsIn(wd string) ([]*Ref, error) {
 	cmd := subprocess.ExecCommand("git",
 		"for-each-ref", "--format=%(objectname)%00%(refname)")
+	cmd.Dir = wd
 
 	outp, err := cmd.StdoutPipe()
 	if err != nil {

--- a/git/git.go
+++ b/git/git.go
@@ -1084,7 +1084,7 @@ func RemoteRefs(remoteName string) ([]*Ref, error) {
 // those references could not be loaded.
 func AllRefs() ([]*Ref, error) {
 	cmd := subprocess.ExecCommand("git",
-		"for-each-ref", "--format='%(objectname)%00%(refname)'")
+		"for-each-ref", "--format=%(objectname)%00%(refname)")
 
 	outp, err := cmd.StdoutPipe()
 	if err != nil {


### PR DESCRIPTION
This pull request teaches a new function to the `git` package, `AllRefs()` which returns a listing of all references in a repository.

This is required for the `import` subcommand of `git-lfs-migrate(1)` which needs a listing of all references in order to move references from the old graph onto the migrated one. Ideally this could come from `git-rev-list(1)` (which we already run to generate a listing of commits to migrate), but tricking the output to be machine readable is difficult to do without switching to `git-log`, which doesn't have great machine-readable output either.

---

/cc @git-lfs/core 
/cc #2146