### PR TITLE
git/githistory: introduce `*refUpdater` to update references

### DIFF
--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -70,6 +70,8 @@ func rewriteOptions(args []string, opts *githistory.RewriteOptions) (*githistory
 		Include: include,
 		Exclude: exclude,
 
+		UpdateRefs: opts.UpdateRefs,
+
 		BlobFn:         opts.BlobFn,
 		TreeCallbackFn: opts.TreeCallbackFn,
 	}, nil

--- a/git/githistory/fixtures_test.go
+++ b/git/githistory/fixtures_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -127,6 +128,20 @@ func AssertCommitTree(t *testing.T, db *odb.ObjectDatabase, sha, tree string) {
 	}
 
 	assert.Equal(t, decoded, commit.TreeID, "git/odb: expected tree ID: %s (got: %x)", tree, commit.TreeID)
+}
+
+// AssertRef asserts that a given refname points at the expected commit.
+func AssertRef(t *testing.T, db *odb.ObjectDatabase, ref string, expected []byte) {
+	root, ok := db.Root()
+	assert.True(t, ok, "git/odb: expected *odb.ObjectDatabase to have Root()")
+
+	cmd := exec.Command("git", "rev-parse", ref)
+	cmd.Dir = root
+	out, err := cmd.Output()
+
+	assert.Nil(t, err)
+
+	assert.Equal(t, hex.EncodeToString(expected), strings.TrimSpace(string(out)))
 }
 
 // HexDecode decodes the given ASCII hex-encoded string into []byte's, or fails

--- a/git/githistory/ref_updater.go
+++ b/git/githistory/ref_updater.go
@@ -1,0 +1,59 @@
+package githistory
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/git-lfs/git-lfs/errors"
+	"github.com/git-lfs/git-lfs/git"
+	"github.com/git-lfs/git-lfs/git/githistory/log"
+)
+
+// refUpdater is a type responsible for moving references from one point in the
+// Git object graph to another.
+type refUpdater struct {
+	// CacheFn is a function that returns the SHA1 transformation from an
+	// original hash to a new one. It specifies a "bool" return value
+	// signaling whether or not that given "old" SHA1 was migrated.
+	CacheFn func(old []byte) ([]byte, bool)
+	// Logger logs the progress of reference updating.
+	Logger *log.Logger
+	// Refs is a set of *git.Ref's to migrate.
+	Refs []*git.Ref
+	// Root is the given directory on disk in which the repository is
+	// located.
+	Root string
+}
+
+// UpdateRefs performs the reference update(s) from existing locations (see:
+// Refs) to their respective new locations in the graph (see CacheFn).
+//
+// It creates reflog entries as well as stderr log entries as it progresses
+// through the reference updates.
+//
+// It returns any error encountered, or nil if the reference update(s) was/were
+// successful.
+func (r *refUpdater) UpdateRefs() error {
+	list := r.Logger.List("migrate: Updating refs")
+	defer list.Complete()
+
+	for _, ref := range r.Refs {
+		sha1, err := hex.DecodeString(ref.Sha)
+		if err != nil {
+			return errors.Wrapf(err, "could not decode: %q", ref.Sha)
+		}
+
+		to, ok := r.CacheFn(sha1)
+		if !ok {
+			continue
+		}
+
+		if err := git.UpdateRefIn(r.Root, ref, to, ""); err != nil {
+			return err
+		}
+
+		list.Entry(fmt.Sprintf("%s\t%s -> %x", ref, ref.Sha, to))
+	}
+
+	return nil
+}

--- a/git/githistory/ref_updater_test.go
+++ b/git/githistory/ref_updater_test.go
@@ -1,0 +1,60 @@
+package githistory
+
+import (
+	"testing"
+
+	"github.com/git-lfs/git-lfs/git"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRefUpdaterMovesRefs(t *testing.T) {
+	db := DatabaseFromFixture(t, "linear-history-with-tags.git")
+	root, _ := db.Root()
+
+	updater := &refUpdater{
+		CacheFn: func(old []byte) ([]byte, bool) {
+			return HexDecode(t, "d941e4756add6b06f5bee766fcf669f55419f13f"), true
+		},
+		Refs: []*git.Ref{
+			{
+				Name: "middle",
+				Sha:  "228afe30855933151f7a88e70d9d88314fd2f191",
+				Type: git.RefTypeLocalTag,
+			},
+		},
+		Root: root,
+	}
+
+	err := updater.UpdateRefs()
+
+	assert.NoError(t, err)
+
+	AssertRef(t, db,
+		"refs/tags/middle", HexDecode(t, "d941e4756add6b06f5bee766fcf669f55419f13f"))
+}
+
+func TestRefUpdaterIgnoresUnovedRefs(t *testing.T) {
+	db := DatabaseFromFixture(t, "linear-history-with-tags.git")
+	root, _ := db.Root()
+
+	updater := &refUpdater{
+		CacheFn: func(old []byte) ([]byte, bool) {
+			return nil, false
+		},
+		Refs: []*git.Ref{
+			{
+				Name: "middle",
+				Sha:  "228afe30855933151f7a88e70d9d88314fd2f191",
+				Type: git.RefTypeLocalTag,
+			},
+		},
+		Root: root,
+	}
+
+	err := updater.UpdateRefs()
+
+	assert.NoError(t, err)
+
+	AssertRef(t, db,
+		"refs/tags/middle", HexDecode(t, "228afe30855933151f7a88e70d9d88314fd2f191"))
+}

--- a/git/githistory/ref_updater_test.go
+++ b/git/githistory/ref_updater_test.go
@@ -11,6 +11,9 @@ func TestRefUpdaterMovesRefs(t *testing.T) {
 	db := DatabaseFromFixture(t, "linear-history-with-tags.git")
 	root, _ := db.Root()
 
+	AssertRef(t, db,
+		"refs/tags/middle", HexDecode(t, "228afe30855933151f7a88e70d9d88314fd2f191"))
+
 	updater := &refUpdater{
 		CacheFn: func(old []byte) ([]byte, bool) {
 			return HexDecode(t, "d941e4756add6b06f5bee766fcf669f55419f13f"), true
@@ -36,6 +39,9 @@ func TestRefUpdaterMovesRefs(t *testing.T) {
 func TestRefUpdaterIgnoresUnovedRefs(t *testing.T) {
 	db := DatabaseFromFixture(t, "linear-history-with-tags.git")
 	root, _ := db.Root()
+
+	AssertRef(t, db,
+		"refs/tags/middle", HexDecode(t, "228afe30855933151f7a88e70d9d88314fd2f191"))
 
 	updater := &refUpdater{
 		CacheFn: func(old []byte) ([]byte, bool) {

--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -366,6 +366,15 @@ func (r *Rewriter) commitsToMigrate(opt *RewriteOptions) ([][]byte, error) {
 	return commits, nil
 }
 
+// refsToMigrate returns a list of references to migrate, or an error if loading
+// those references failed.
+func (r *Rewriter) refsToMigrate() ([]*git.Ref, error) {
+	if root, ok := r.db.Root(); ok {
+		return git.AllRefsIn(root)
+	}
+	return git.AllRefs()
+}
+
 // scannerOpts returns a *git.ScanRefsOptions instance to be given to the
 // *git.RevListScanner.
 //

--- a/git/githistory/rewriter_test.go
+++ b/git/githistory/rewriter_test.go
@@ -303,6 +303,9 @@ func TestHistoryRewriterUpdatesRefs(t *testing.T) {
 	db := DatabaseFromFixture(t, "linear-history.git")
 	r := NewRewriter(db)
 
+	AssertRef(t, db,
+		"refs/heads/master", HexDecode(t, "e669b63f829bfb0b91fc52a5bcea53dd7977a0ee"))
+
 	tip, err := r.Rewrite(&RewriteOptions{
 		Include: []string{"refs/heads/master"},
 


### PR DESCRIPTION
This pull request introduces a new type and option: `*refUpdater` and `UpdateRefs bool`, respectively.

In normal migrations up to this point ('info', so far) no commits are re-written, therefore no references need to be moved. However, 'import' (and 'export') migration will rewrite commits, and therefore the references in the original graph must be moved to their corresponding locations in the new graph.

The `*refUpdater` performs this transition. Given:

- `Refs []*git.Ref`: A set of references to move (currently all references in the repository, see #2338 for discussion), and
- `CacheFn func(old []byte) ([]byte, bool)`: A function to return the migrated location of a given commit SHA1, or nil if the SHA1 was unmoved.

the `*refUpdater` iterates through all `Refs` given, and updates each reference if the SHA1 that reference is pointing to has moved. If the reference has moved, the `*RefUpdater` will create a reflog entry, as well as log to the `*git/githistory/log.Logger` instance (if one was given).

A few notes:

- `CacheFn` is given from the `*HistoryRewriter`, since copying the map would be expensive `(20*2*N(commits))`, and using the existing map allows us to maintain the `*sync.Mutex` locking guarantees.
- `Refs` is given to be all references in a repository, since displaying which refs point at a given commit in the output of `git-rev-list(1)` is difficult without using `git-log(1)`, which isn't machine-readable. Git would be doing the same operation in the background (if `--format="%D"` is given to `git-rev-list(1)`), so the performance cost is that of spawning a new subprocess.

##

/cc @git-lfs/core 
/cc #2146 