### PR TITLE
filepathfilter: teach AllowsPattern()

### DIFF
--- a/filepathfilter/filepathfilter.go
+++ b/filepathfilter/filepathfilter.go
@@ -148,6 +148,12 @@ func (p *pathPrefixPattern) Match(name string) bool {
 	return matched
 }
 
+// String returns a string representation of the underlying pattern for which
+// this *pathPrefixPattern is matching.
+func (p *pathPrefixPattern) String() string {
+	return p.rawPattern
+}
+
 type pathPattern struct {
 	rawPattern string
 	prefix     string

--- a/filepathfilter/filepathfilter.go
+++ b/filepathfilter/filepathfilter.go
@@ -223,6 +223,12 @@ func (p *doubleWildcardPattern) Match(name string) bool {
 	return matched || p.wildcardRE.MatchString(name)
 }
 
+// String returns a string representation of the underlying pattern for which
+// this *doubleWildcardPattern is matching.
+func (p *doubleWildcardPattern) String() string {
+	return p.rawPattern
+}
+
 type noOpMatcher struct {
 }
 

--- a/filepathfilter/filepathfilter.go
+++ b/filepathfilter/filepathfilter.go
@@ -236,6 +236,10 @@ func (n noOpMatcher) Match(name string) bool {
 	return true
 }
 
+func (n noOpMatcher) String() string {
+	return ""
+}
+
 var localDirSet = map[string]struct{}{
 	".":   struct{}{},
 	"./":  struct{}{},

--- a/filepathfilter/filepathfilter.go
+++ b/filepathfilter/filepathfilter.go
@@ -204,6 +204,12 @@ func (p *pathlessWildcardPattern) Match(name string) bool {
 	return matched || p.wildcardRE.MatchString(filepath.Base(name))
 }
 
+// String returns a string representation of the underlying pattern for which
+// this *pathlessWildcardPattern is matching.
+func (p *pathlessWildcardPattern) String() string {
+	return p.rawPattern
+}
+
 type doubleWildcardPattern struct {
 	rawPattern string
 	wildcardRE *regexp.Regexp

--- a/filepathfilter/filepathfilter.go
+++ b/filepathfilter/filepathfilter.go
@@ -179,6 +179,12 @@ func (p *simpleExtPattern) Match(name string) bool {
 	return strings.HasSuffix(name, p.ext)
 }
 
+// String returns a string representation of the underlying pattern for which
+// this *simpleExtPattern is matching.
+func (p *simpleExtPattern) String() string {
+	return fmt.Sprintf("*%s", p.ext)
+}
+
 type pathlessWildcardPattern struct {
 	rawPattern string
 	wildcardRE *regexp.Regexp

--- a/filepathfilter/filepathfilter.go
+++ b/filepathfilter/filepathfilter.go
@@ -165,6 +165,12 @@ func (p *pathPattern) Match(name string) bool {
 	return matched
 }
 
+// String returns a string representation of the underlying pattern for which
+// this *pathPattern is matching.
+func (p *pathPattern) String() string {
+	return p.rawPattern
+}
+
 type simpleExtPattern struct {
 	ext string
 }

--- a/filepathfilter/filepathfilter.go
+++ b/filepathfilter/filepathfilter.go
@@ -9,6 +9,9 @@ import (
 
 type Pattern interface {
 	Match(filename string) bool
+	// String returns a string representation (see: regular expressions) of
+	// the underlying pattern used to match filenames against this Pattern.
+	String() string
 }
 
 type Filter struct {

--- a/filepathfilter/filepathfilter_test.go
+++ b/filepathfilter/filepathfilter_test.go
@@ -105,66 +105,78 @@ func patternMatch(pattern, filename string) bool {
 }
 
 type filterTest struct {
-	expectedResult bool
-	includes       []string
-	excludes       []string
+	expectedResult  bool
+	expectedPattern string
+	includes        []string
+	excludes        []string
 }
 
 func TestFilterAllows(t *testing.T) {
 	cases := []filterTest{
 		// Null case
-		filterTest{true, nil, nil},
+		filterTest{true, "", nil, nil},
 		// Inclusion
-		filterTest{true, []string{"*.dat"}, nil},
-		filterTest{true, []string{"file*.dat"}, nil},
-		filterTest{true, []string{"file*"}, nil},
-		filterTest{true, []string{"*name.dat"}, nil},
-		filterTest{false, []string{"/*.dat"}, nil},
-		filterTest{false, []string{"otherfolder/*.dat"}, nil},
-		filterTest{false, []string{"*.nam"}, nil},
-		filterTest{true, []string{"test/filename.dat"}, nil},
-		filterTest{true, []string{"test/filename.dat"}, nil},
-		filterTest{false, []string{"blank", "something", "foo"}, nil},
-		filterTest{false, []string{"test/notfilename.dat"}, nil},
-		filterTest{true, []string{"test"}, nil},
-		filterTest{true, []string{"test/*"}, nil},
-		filterTest{false, []string{"nottest"}, nil},
-		filterTest{false, []string{"nottest/*"}, nil},
-		filterTest{true, []string{"test/fil*"}, nil},
-		filterTest{false, []string{"test/g*"}, nil},
-		filterTest{true, []string{"tes*/*"}, nil},
-		filterTest{true, []string{"[Tt]est/[Ff]ilename.dat"}, nil},
+		filterTest{true, "*.dat", []string{"*.dat"}, nil},
+		filterTest{true, "file*.dat", []string{"file*.dat"}, nil},
+		filterTest{true, "file*", []string{"file*"}, nil},
+		filterTest{true, "*name.dat", []string{"*name.dat"}, nil},
+		filterTest{false, "", []string{"/*.dat"}, nil},
+		filterTest{false, "", []string{"otherfolder/*.dat"}, nil},
+		filterTest{false, "", []string{"*.nam"}, nil},
+		filterTest{true, "test/filename.dat", []string{"test/filename.dat"}, nil},
+		filterTest{true, "test/filename.dat", []string{"test/filename.dat"}, nil},
+		filterTest{false, "", []string{"blank", "something", "foo"}, nil},
+		filterTest{false, "", []string{"test/notfilename.dat"}, nil},
+		filterTest{true, "test", []string{"test"}, nil},
+		filterTest{true, "test/*", []string{"test/*"}, nil},
+		filterTest{false, "", []string{"nottest"}, nil},
+		filterTest{false, "", []string{"nottest/*"}, nil},
+		filterTest{true, "test/fil*", []string{"test/fil*"}, nil},
+		filterTest{false, "", []string{"test/g*"}, nil},
+		filterTest{true, "tes*/*", []string{"tes*/*"}, nil},
+		filterTest{true, "[Tt]est/[Ff]ilename.dat", []string{"[Tt]est/[Ff]ilename.dat"}, nil},
 		// Exclusion
-		filterTest{false, nil, []string{"*.dat"}},
-		filterTest{false, nil, []string{"file*.dat"}},
-		filterTest{false, nil, []string{"file*"}},
-		filterTest{false, nil, []string{"*name.dat"}},
-		filterTest{true, nil, []string{"/*.dat"}},
-		filterTest{true, nil, []string{"otherfolder/*.dat"}},
-		filterTest{false, nil, []string{"test/filename.dat"}},
-		filterTest{false, nil, []string{"blank", "something", "test/filename.dat", "foo"}},
-		filterTest{true, nil, []string{"blank", "something", "foo"}},
-		filterTest{true, nil, []string{"test/notfilename.dat"}},
-		filterTest{false, nil, []string{"test"}},
-		filterTest{false, nil, []string{"test/*"}},
-		filterTest{true, nil, []string{"nottest"}},
-		filterTest{true, nil, []string{"nottest/*"}},
-		filterTest{false, nil, []string{"test/fil*"}},
-		filterTest{true, nil, []string{"test/g*"}},
-		filterTest{false, nil, []string{"tes*/*"}},
-		filterTest{false, nil, []string{"[Tt]est/[Ff]ilename.dat"}},
+		filterTest{false, "*.dat", nil, []string{"*.dat"}},
+		filterTest{false, "file*.dat", nil, []string{"file*.dat"}},
+		filterTest{false, "file*", nil, []string{"file*"}},
+		filterTest{false, "*name.dat", nil, []string{"*name.dat"}},
+		filterTest{true, "", nil, []string{"/*.dat"}},
+		filterTest{true, "", nil, []string{"otherfolder/*.dat"}},
+		filterTest{false, "test/filename.dat", nil, []string{"test/filename.dat"}},
+		filterTest{false, "test/filename.dat", nil, []string{"blank", "something", "test/filename.dat", "foo"}},
+		filterTest{true, "", nil, []string{"blank", "something", "foo"}},
+		filterTest{true, "", nil, []string{"test/notfilename.dat"}},
+		filterTest{false, "test", nil, []string{"test"}},
+		filterTest{false, "test/*", nil, []string{"test/*"}},
+		filterTest{true, "", nil, []string{"nottest"}},
+		filterTest{true, "", nil, []string{"nottest/*"}},
+		filterTest{false, "test/fil*", nil, []string{"test/fil*"}},
+		filterTest{true, "", nil, []string{"test/g*"}},
+		filterTest{false, "tes*/*", nil, []string{"tes*/*"}},
+		filterTest{false, "[Tt]est/[Ff]ilename.dat", nil, []string{"[Tt]est/[Ff]ilename.dat"}},
 
-		// Both
-		filterTest{true, []string{"test/filename.dat"}, []string{"test/notfilename.dat"}},
-		filterTest{false, []string{"test"}, []string{"test/filename.dat"}},
-		filterTest{true, []string{"test/*"}, []string{"test/notfile*"}},
-		filterTest{false, []string{"test/*"}, []string{"test/file*"}},
-		filterTest{false, []string{"another/*", "test/*"}, []string{"test/notfilename.dat", "test/filename.dat"}},
+		// // Both
+		filterTest{true, "test/filename.dat", []string{"test/filename.dat"}, []string{"test/notfilename.dat"}},
+		filterTest{false, "test/filename.dat", []string{"test"}, []string{"test/filename.dat"}},
+		filterTest{true, "test/*", []string{"test/*"}, []string{"test/notfile*"}},
+		filterTest{false, "test/file*", []string{"test/*"}, []string{"test/file*"}},
+		filterTest{false, "test/filename.dat", []string{"another/*", "test/*"}, []string{"test/notfilename.dat", "test/filename.dat"}},
 	}
 
 	for _, c := range cases {
-		result := New(c.includes, c.excludes).Allows("test/filename.dat")
-		assert.Equal(t, c.expectedResult, result, "includes: %v excludes: %v", c.includes, c.excludes)
+		filter := New(c.includes, c.excludes)
+
+		r1 := filter.Allows("test/filename.dat")
+		pattern, r2 := filter.AllowsPattern("test/filename.dat")
+
+		assert.Equal(t, r1, r2,
+			"filepathfilter: expected Allows() and AllowsPattern() to return identical result")
+
+		assert.Equal(t, c.expectedResult, r2, "includes: %v excludes: %v", c.includes, c.excludes)
+		assert.Equal(t, c.expectedPattern, pattern,
+			"filepathfilter: expected pattern match of: %q, got: %q",
+			c.expectedPattern, pattern)
+
 		if runtime.GOOS == "windows" {
 			// also test with \ path separators, tolerate mixed separators
 			for i, inc := range c.includes {
@@ -173,7 +185,19 @@ func TestFilterAllows(t *testing.T) {
 			for i, ex := range c.excludes {
 				c.excludes[i] = strings.Replace(ex, "/", "\\", -1)
 			}
-			assert.Equal(t, c.expectedResult, New(c.includes, c.excludes).Allows("test/filename.dat"), c)
+
+			filter = New(c.includes, c.excludes)
+
+			r1 = filter.Allows("test/filename.dat")
+			pattern, r2 = filter.AllowsPattern("test/filename.dat")
+
+			assert.Equal(t, r1, r2,
+				"filepathfilter: expected Allows() and AllowsPattern() to return identical result")
+
+			assert.Equal(t, c.expectedResult, r1, c)
+			assert.Equal(t, c.expectedPattern, pattern,
+				"filepathfilter: expected pattern match of: %q, got: %q",
+				c.expectedPattern, pattern)
 		}
 	}
 }

--- a/filepathfilter/filepathfilter_test.go
+++ b/filepathfilter/filepathfilter_test.go
@@ -164,7 +164,9 @@ func TestFilterAllows(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c.expectedPattern = strings.Replace(c.expectedPattern, "/", "\\", -1)
+		if runtime.GOOS == "windows" {
+			c.expectedPattern = strings.Replace(c.expectedPattern, "/", "\\", -1)
+		}
 
 		filter := New(c.includes, c.excludes)
 

--- a/filepathfilter/filepathfilter_test.go
+++ b/filepathfilter/filepathfilter_test.go
@@ -164,6 +164,8 @@ func TestFilterAllows(t *testing.T) {
 	}
 
 	for _, c := range cases {
+		c.expectedPattern = filepath.Clean(c.expectedPattern)
+
 		filter := New(c.includes, c.excludes)
 
 		r1 := filter.Allows("test/filename.dat")
@@ -190,7 +192,6 @@ func TestFilterAllows(t *testing.T) {
 
 			r1 = filter.Allows("test/filename.dat")
 			pattern, r2 = filter.AllowsPattern("test/filename.dat")
-			pattern = strings.Replace(pattern, "/", "\\", -1)
 
 			assert.Equal(t, r1, r2,
 				"filepathfilter: expected Allows() and AllowsPattern() to return identical result")

--- a/filepathfilter/filepathfilter_test.go
+++ b/filepathfilter/filepathfilter_test.go
@@ -164,7 +164,7 @@ func TestFilterAllows(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c.expectedPattern = filepath.Clean(c.expectedPattern)
+		c.expectedPattern = strings.Replace(c.expectedPattern, "/", "\\", -1)
 
 		filter := New(c.includes, c.excludes)
 

--- a/filepathfilter/filepathfilter_test.go
+++ b/filepathfilter/filepathfilter_test.go
@@ -190,6 +190,7 @@ func TestFilterAllows(t *testing.T) {
 
 			r1 = filter.Allows("test/filename.dat")
 			pattern, r2 = filter.AllowsPattern("test/filename.dat")
+			pattern = strings.Replace(pattern, "/", "\\", -1)
 
 			assert.Equal(t, r1, r2,
 				"filepathfilter: expected Allows() and AllowsPattern() to return identical result")


### PR DESCRIPTION
This pull request teaches a new function to the `filepathfilter.Filter` type: `AllowsPattern()`. `AllowsPattern()` has the same semantics as `Allows()`, but also returns the pattern that caused the given filename to be accepted or rejected.

The `git-lfs-migrate(1)` 'import' subcommand needs to modify `.gitattributes` with the pattern(s) that matched a given filename, i.e.: if we cleaned `a.dat` and `*.dat` was given as a pattern, make sure we add `*.dat` to the `.gitattributes`, not `a.dat`.

I'm not totally sold on the name `AllowsPattern()`: @technoweenie do you have ideas here?

---

/cc @git-lfs/core 
/refs #2146 