### PR TITLE
git/{githistory,odb}: make Type() a function of *TreeEntry

### DIFF
--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -271,7 +271,7 @@ func (r *Rewriter) rewriteTree(sha []byte, path string, fn BlobRewriteFn, tfn Tr
 
 		var oid []byte
 
-		switch entry.Type {
+		switch entry.Type() {
 		case odb.BlobObjectType:
 			oid, err = r.rewriteBlob(entry.Oid, path, fn)
 		case odb.TreeObjectType:
@@ -287,7 +287,6 @@ func (r *Rewriter) rewriteTree(sha []byte, path string, fn BlobRewriteFn, tfn Tr
 		entries = append(entries, r.cacheEntry(entry, &odb.TreeEntry{
 			Filemode: entry.Filemode,
 			Name:     entry.Name,
-			Type:     entry.Type,
 			Oid:      oid,
 		}))
 	}

--- a/git/odb/object_db_test.go
+++ b/git/odb/object_db_test.go
@@ -68,7 +68,6 @@ func TestDecodeTree(t *testing.T) {
 	require.Equal(t, 1, len(tree.Entries))
 	assert.Equal(t, &TreeEntry{
 		Name:     "hello.txt",
-		Type:     BlobObjectType,
 		Oid:      hexBlobSha,
 		Filemode: 0100644,
 	}, tree.Entries[0])
@@ -130,7 +129,6 @@ func TestWriteTree(t *testing.T) {
 	sha, err := odb.WriteTree(&Tree{Entries: []*TreeEntry{
 		{
 			Name:     "hello.txt",
-			Type:     BlobObjectType,
 			Oid:      hexBlobSha,
 			Filemode: 0100644,
 		},


### PR DESCRIPTION
This pull request removes the `Type git/odb.ObjectType` member field from `*git/odb.TreeEntry` and replaces it with `git/odb.TreeEntry.Type() git/odb.ObjectType`.

This is done because the type is not a top-level property of the `*TreeEntry` type. `Type()` is a property inferred from the value of `Filemode`. Type can be determined by examining the bits underneath `syscall.S_IFMT` by `entry.Filemode & syscall.S_IFMT`.

This is dependent work for the following pull request, which introduces an implementation of `sort.Interface` that sorts `[]*TreeEntry`'s in subtree order. [source](https://github.com/git/git/blob/v2.13.0/fsck.c#L492-L525)

To avoid relying on an optional property, we move `Type` into a function so we can call that function instead.

---

/cc @git-lfs/core 
/cc #2146   