### PR TITLE
git/odb: teach SubtreeOrder to sort tree entries

### DIFF
--- a/git/odb/tree.go
+++ b/git/odb/tree.go
@@ -163,6 +163,10 @@ func (s SubtreeOrder) Less(i, j int) bool {
 // This is done because '/' sorts ahead of '\0', and is compatible with the
 // tree order in upstream Git.
 func (s SubtreeOrder) Name(i int) string {
+	if i < 0 || i >= len(s) {
+		return ""
+	}
+
 	entry := s[i]
 
 	if entry.Type() == TreeObjectType {

--- a/git/odb/tree.go
+++ b/git/odb/tree.go
@@ -168,6 +168,9 @@ func (s SubtreeOrder) Name(i int) string {
 	}
 
 	entry := s[i]
+	if entry == nil {
+		return ""
+	}
 
 	if entry.Type() == TreeObjectType {
 		return entry.Name + "/"

--- a/git/odb/tree_test.go
+++ b/git/odb/tree_test.go
@@ -186,6 +186,12 @@ func TestSubtreeOrder(t *testing.T) {
 	assert.Equal(t, "a=b", entries[4].Name)
 }
 
+func TestSubtreeOrderReturnsEmptyForOutOfBounds(t *testing.T) {
+	o := SubtreeOrder([]*TreeEntry{{Name: "a"}})
+
+	assert.Equal(t, "", o.Name(len(o)+1))
+}
+
 func assertTreeEntry(t *testing.T, buf *bytes.Buffer,
 	name string, oid []byte, mode int32) {
 

--- a/git/odb/tree_test.go
+++ b/git/odb/tree_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"sort"
 	"strconv"
 	"testing"
 
@@ -155,6 +156,34 @@ func TestTreeEntryTypeResolutionUnknown(t *testing.T) {
 	}()
 
 	e.Type()
+}
+
+func TestSubtreeOrder(t *testing.T) {
+	// The below list (e1, e2, ..., e5) is entered in subtree order: that
+	// is, lexicographically byte-ordered as if blobs end in a '\0', and
+	// sub-trees end in a '/'.
+	//
+	// See:
+	//   http://public-inbox.org/git/7vac6jfzem.fsf@assigned-by-dhcp.cox.net
+	e1 := &TreeEntry{Filemode: 100644, Name: "a-"}
+	e2 := &TreeEntry{Filemode: 100644, Name: "a-b"}
+	e3 := &TreeEntry{Filemode: 040000, Name: "a"}
+	e4 := &TreeEntry{Filemode: 100644, Name: "a="}
+	e5 := &TreeEntry{Filemode: 100644, Name: "a=b"}
+
+	// Create a set of entries in the wrong order:
+	entries := []*TreeEntry{e3, e4, e1, e5, e2}
+
+	sort.Sort(SubtreeOrder(entries))
+
+	// Assert that they are in the correct order after sorting in sub-tree
+	// order:
+	require.Len(t, entries, 5)
+	assert.Equal(t, "a-", entries[0].Name)
+	assert.Equal(t, "a-b", entries[1].Name)
+	assert.Equal(t, "a", entries[2].Name)
+	assert.Equal(t, "a=", entries[3].Name)
+	assert.Equal(t, "a=b", entries[4].Name)
 }
 
 func assertTreeEntry(t *testing.T, buf *bytes.Buffer,

--- a/git/odb/tree_test.go
+++ b/git/odb/tree_test.go
@@ -192,6 +192,12 @@ func TestSubtreeOrderReturnsEmptyForOutOfBounds(t *testing.T) {
 	assert.Equal(t, "", o.Name(len(o)+1))
 }
 
+func TestSubtreeOrderReturnsEmptyForNilElements(t *testing.T) {
+	o := SubtreeOrder([]*TreeEntry{nil})
+
+	assert.Equal(t, "", o.Name(0))
+}
+
 func assertTreeEntry(t *testing.T, buf *bytes.Buffer,
 	name string, oid []byte, mode int32) {
 

--- a/git/odb/tree_test.go
+++ b/git/odb/tree_test.go
@@ -165,11 +165,11 @@ func TestSubtreeOrder(t *testing.T) {
 	//
 	// See:
 	//   http://public-inbox.org/git/7vac6jfzem.fsf@assigned-by-dhcp.cox.net
-	e1 := &TreeEntry{Filemode: 100644, Name: "a-"}
-	e2 := &TreeEntry{Filemode: 100644, Name: "a-b"}
+	e1 := &TreeEntry{Filemode: 0100644, Name: "a-"}
+	e2 := &TreeEntry{Filemode: 0100644, Name: "a-b"}
 	e3 := &TreeEntry{Filemode: 040000, Name: "a"}
-	e4 := &TreeEntry{Filemode: 100644, Name: "a="}
-	e5 := &TreeEntry{Filemode: 100644, Name: "a=b"}
+	e4 := &TreeEntry{Filemode: 0100644, Name: "a="}
+	e5 := &TreeEntry{Filemode: 0100644, Name: "a=b"}
 
 	// Create a set of entries in the wrong order:
 	entries := []*TreeEntry{e3, e4, e1, e5, e2}


### PR DESCRIPTION
This pull request provides an implementation of `sort.Interface` that sorts `[]*TreeEntry`'s in subtree order, required to write valid trees to the object database.

Right now, there are no call sites in Git LFS that modify (append/delete/re-order) the set of `Entries` on the `*git/odb.Tree` instance.

However, the 'import' subcommand of the `git-lfs-migrate(1)` suite will conditionally append a `.gitattributes` tree entry into the root tree. In doing so, we may potentially create an out of order tree, which causes Git to behave in undefined ways. (I found this out during some testing today where Git would persistently mark a file as modified even though it wasn't. `git-fsck(1)` gave further details).

The following pull request will introduce an `Append(entries ...*TreeEntry)` method to append arbitrary tree entries. This has the potential to create out-of-order tree entries. To mitigate this, introduce a way to sort that will be called after appending new tree entries to guarantee that we always write valid (sub-)trees.

---

/cc @git-lfs/core 
/cc #2146  