### PR TITLE
git/githistory: teach Filter() to access filepathfilter used

### DIFF
--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -389,6 +389,12 @@ func (r *Rewriter) scannerOpts() *git.ScanRefsOptions {
 	return opts
 }
 
+// Filter returns the filter used by this *Rewriter to filter subtrees, blobs
+// (see above).
+func (r *Rewriter) Filter() *filepathfilter.Filter {
+	return r.filter
+}
+
 // cacheEntry caches then given "from" entry so that it is always rewritten as
 // a *TreeEntry equivalent to "to".
 func (r *Rewriter) cacheEntry(from, to *odb.TreeEntry) *odb.TreeEntry {

--- a/git/githistory/rewriter_test.go
+++ b/git/githistory/rewriter_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -297,6 +298,17 @@ func TestHistoryRewriterUseOriginalParentsForPartialMigration(t *testing.T) {
 
 	assert.NoError(t, err)
 	AssertCommitParent(t, db, hex.EncodeToString(tip), expectedParent)
+}
+
+func TestHistoryRewriterReturnsFilter(t *testing.T) {
+	f := filepathfilter.New([]string{"a"}, []string{"b"})
+	r := NewRewriter(nil, WithFilter(f))
+
+	expected := reflect.ValueOf(f).Elem().Addr().Pointer()
+	got := reflect.ValueOf(r.Filter()).Elem().Addr().Pointer()
+
+	assert.Equal(t, expected, got,
+		"git/githistory: expected Rewriter.Filter() to return same *filepathfilter.Filter instance")
 }
 
 func root(path string) string {


### PR DESCRIPTION
This pull request teaches the `git/githistory.Rewriter` type to return a copy of the filepath filter it's using, or nil.

This is required by the 'import' subcommand of the `git-lfs-migrate(1)` which needs to do filepath pattern matching in order to determine which entries to add to the repository's `.gitattributes` file. Instead of constructing the filepathfilter twice, we use `Filter()` to return a reference.

---

/cc @git-lfs/core 
/refs #2146 