### PR TITLE
commands: invert (& clean up) `migrate()` arguments

### DIFF
--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -23,7 +23,7 @@ var (
 
 // migrate takes the given command and arguments, *odb.ObjectDatabase, as well
 // as a BlobRewriteFn to apply, and performs a migration.
-func migrate(cmd *cobra.Command, args []string, db *odb.ObjectDatabase, fn githistory.BlobRewriteFn) {
+func migrate(cmd *cobra.Command, args []string, r *githistory.Rewriter, fn githistory.BlobRewriteFn) {
 	requireInRepo()
 
 	opts, err := rewriteOptions(args, fn)
@@ -31,7 +31,7 @@ func migrate(cmd *cobra.Command, args []string, db *odb.ObjectDatabase, fn githi
 		ExitWithError(err)
 	}
 
-	_, err = getHistoryRewriter(cmd, db).Rewrite(opts)
+	_, err = r.Rewrite(opts)
 	if err != nil {
 		ExitWithError(err)
 	}

--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -23,10 +23,10 @@ var (
 
 // migrate takes the given command and arguments, *odb.ObjectDatabase, as well
 // as a BlobRewriteFn to apply, and performs a migration.
-func migrate(args []string, r *githistory.Rewriter, fn githistory.BlobRewriteFn) {
+func migrate(args []string, r *githistory.Rewriter, opts *githistory.RewriteOptions) {
 	requireInRepo()
 
-	opts, err := rewriteOptions(args, fn)
+	opts, err := rewriteOptions(args, opts)
 	if err != nil {
 		ExitWithError(err)
 	}
@@ -49,18 +49,18 @@ func getObjectDatabase() (*odb.ObjectDatabase, error) {
 
 // rewriteOptions returns *githistory.RewriteOptions able to be passed to a
 // *githistory.Rewriter that reflect the current arguments and flags passed to
-// an invocation of git-lfs-migrate(1).?
+// an invocation of git-lfs-migrate(1).
 //
-// Repository references are included and excluded based on the following rules:
+// It is merged with the given "opts". In other words, an identical "opts" is
+// returned, where the Include and Exclude fields have been filled based on the
+// following rules:
 //
 // The included and excluded references are determined based on the output of
 // includeExcludeRefs (see below for documentation and detail).
 //
-// The given "fn" githistory.BlobRewriteFn is passed as the BlobFn.
-//
 // If any of the above could not be determined without error, that error will be
 // returned immediately.
-func rewriteOptions(args []string, fn githistory.BlobRewriteFn) (*githistory.RewriteOptions, error) {
+func rewriteOptions(args []string, opts *githistory.RewriteOptions) (*githistory.RewriteOptions, error) {
 	include, exclude, err := includeExcludeRefs(args)
 	if err != nil {
 		return nil, err
@@ -70,7 +70,10 @@ func rewriteOptions(args []string, fn githistory.BlobRewriteFn) (*githistory.Rew
 		Include: include,
 		Exclude: exclude,
 
-		BlobFn: fn,
+		UpdateRefs: opts.UpdateRefs,
+
+		BlobFn:         opts.BlobFn,
+		TreeCallbackFn: opts.TreeCallbackFn,
 	}, nil
 }
 

--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -70,8 +70,6 @@ func rewriteOptions(args []string, opts *githistory.RewriteOptions) (*githistory
 		Include: include,
 		Exclude: exclude,
 
-		UpdateRefs: opts.UpdateRefs,
-
 		BlobFn:         opts.BlobFn,
 		TreeCallbackFn: opts.TreeCallbackFn,
 	}, nil

--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -23,7 +23,7 @@ var (
 
 // migrate takes the given command and arguments, *odb.ObjectDatabase, as well
 // as a BlobRewriteFn to apply, and performs a migration.
-func migrate(cmd *cobra.Command, args []string, r *githistory.Rewriter, fn githistory.BlobRewriteFn) {
+func migrate(args []string, r *githistory.Rewriter, fn githistory.BlobRewriteFn) {
 	requireInRepo()
 
 	opts, err := rewriteOptions(args, fn)

--- a/commands/command_migrate_info.go
+++ b/commands/command_migrate_info.go
@@ -42,6 +42,7 @@ func migrateInfoCommand(cmd *cobra.Command, args []string) {
 	if err != nil {
 		ExitWithError(err)
 	}
+	rewriter := getHistoryRewriter(cmd, db)
 
 	exts := make(map[string]*MigrateInfoEntry)
 
@@ -61,7 +62,7 @@ func migrateInfoCommand(cmd *cobra.Command, args []string) {
 
 	migrateInfoAbove = above
 
-	migrate(cmd, args, db, func(path string, b *odb.Blob) (*odb.Blob, error) {
+	migrate(cmd, args, rewriter, func(path string, b *odb.Blob) (*odb.Blob, error) {
 		ext := fmt.Sprintf("*%s", filepath.Ext(path))
 
 		if len(ext) > 1 {

--- a/commands/command_migrate_info.go
+++ b/commands/command_migrate_info.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/git-lfs/git-lfs/errors"
+	"github.com/git-lfs/git-lfs/git/githistory"
 	"github.com/git-lfs/git-lfs/git/odb"
 	"github.com/git-lfs/git-lfs/tools"
 	"github.com/git-lfs/git-lfs/tools/humanize"
@@ -62,27 +63,29 @@ func migrateInfoCommand(cmd *cobra.Command, args []string) {
 
 	migrateInfoAbove = above
 
-	migrate(args, rewriter, func(path string, b *odb.Blob) (*odb.Blob, error) {
-		ext := fmt.Sprintf("*%s", filepath.Ext(path))
+	migrate(args, rewriter, &githistory.RewriteOptions{
+		BlobFn: func(path string, b *odb.Blob) (*odb.Blob, error) {
+			ext := fmt.Sprintf("*%s", filepath.Ext(path))
 
-		if len(ext) > 1 {
-			entry := exts[ext]
-			if entry == nil {
-				entry = &MigrateInfoEntry{Qualifier: ext}
+			if len(ext) > 1 {
+				entry := exts[ext]
+				if entry == nil {
+					entry = &MigrateInfoEntry{Qualifier: ext}
+				}
+
+				entry.Total++
+				entry.BytesTotal += b.Size
+
+				if b.Size > int64(migrateInfoAbove) {
+					entry.TotalAbove++
+					entry.BytesAbove += b.Size
+				}
+
+				exts[ext] = entry
 			}
 
-			entry.Total++
-			entry.BytesTotal += b.Size
-
-			if b.Size > int64(migrateInfoAbove) {
-				entry.TotalAbove++
-				entry.BytesAbove += b.Size
-			}
-
-			exts[ext] = entry
-		}
-
-		return b, nil
+			return b, nil
+		},
 	})
 
 	entries := EntriesBySize(MapToEntries(exts))

--- a/commands/command_migrate_info.go
+++ b/commands/command_migrate_info.go
@@ -62,7 +62,7 @@ func migrateInfoCommand(cmd *cobra.Command, args []string) {
 
 	migrateInfoAbove = above
 
-	migrate(cmd, args, rewriter, func(path string, b *odb.Blob) (*odb.Blob, error) {
+	migrate(args, rewriter, func(path string, b *odb.Blob) (*odb.Blob, error) {
 		ext := fmt.Sprintf("*%s", filepath.Ext(path))
 
 		if len(ext) > 1 {


### PR DESCRIPTION
This pull request cleans up and makes more flexible the conventions for calling `migrate()` from inside the `commands` package. Here's what happened:

1. 186d916: invert `*githistory.Rewriter` so that callers can have a handle on the `Rewriter`'s `Filter()` function (see: https://github.com/git-lfs/git-lfs/pull/2347)
2. 0dde5c8: realize that `cmd` is no longer used, remove that.
3. 7f22ed9: pass in `*githistory.RewriteOptions` so that callers can control the `UpdateRefs` property (`false` in the 'info' command, `true` in the 'import' command)

---

/cc @git-lfs/core 
/refs #2146  