### PR TITLE
commands: add git-lfs-migrate(1) 'import' subcommand

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   global:
     - GIT_LFS_TEST_DIR="$HOME/git-lfs-tests"
     - GIT_SOURCE_REPO="https://github.com/git/git.git"
-    - GIT_EARLIEST_SUPPORTED_VERSION="v1.8.5"
+    - GIT_EARLIEST_SUPPORTED_VERSION="v1.9.0"
     - GIT_LATEST_SOURCE_BRANCH="master"
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   global:
     - GIT_LFS_TEST_DIR="$HOME/git-lfs-tests"
     - GIT_SOURCE_REPO="https://github.com/git/git.git"
-    - GIT_EARLIEST_SUPPORTED_VERSION="v1.9.0"
+    - GIT_EARLIEST_SUPPORTED_VERSION="v2.0.0
     - GIT_LATEST_SOURCE_BRANCH="master"
 
 matrix:

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   environment:
     GIT_LFS_TEST_DIR: $HOME/git-lfs-tests
     GIT_SOURCE_REPO: https://github.com/git/git.git
-    GIT_EARLIEST_SUPPORTED_VERSION: v1.8.5
+    GIT_EARLIEST_SUPPORTED_VERSION: v1.9.0
     GIT_LATEST_SOURCE_BRANCH: master
     XCODE_SCHEME: test
     XCODE_WORKSPACE: test

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   environment:
     GIT_LFS_TEST_DIR: $HOME/git-lfs-tests
     GIT_SOURCE_REPO: https://github.com/git/git.git
-    GIT_EARLIEST_SUPPORTED_VERSION: v1.9.0
+    GIT_EARLIEST_SUPPORTED_VERSION: v2.0.0
     GIT_LATEST_SOURCE_BRANCH: master
     XCODE_SCHEME: test
     XCODE_WORKSPACE: test

--- a/commands/command_filter_process.go
+++ b/commands/command_filter_process.go
@@ -59,7 +59,7 @@ func filterCommand(cmd *cobra.Command, args []string) {
 		switch req.Header["command"] {
 		case "clean":
 			w = git.NewPktlineWriter(os.Stdout, cleanFilterBufferCapacity)
-			err = clean(w, req.Payload, req.Header["pathname"])
+			err = clean(w, req.Payload, req.Header["pathname"], -1)
 		case "smudge":
 			w = git.NewPktlineWriter(os.Stdout, smudgeFilterBufferCapacity)
 			err = smudge(w, req.Payload, req.Header["pathname"], skip, filter)

--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -211,6 +211,8 @@ func init() {
 	info.Flags().StringVar(&migrateInfoAboveFmt, "above", "1mb", "--above=<n>")
 	info.Flags().StringVar(&migrateInfoUnitFmt, "unit", "", "--unit=<unit>")
 
+	importCmd := NewCommand("import", migrateImportCommand)
+
 	RegisterCommand("migrate", nil, func(cmd *cobra.Command) {
 		// Adding flags directly to cmd.Flags() doesn't apply those
 		// flags to any subcommands of the root. Therefore, loop through
@@ -221,7 +223,7 @@ func init() {
 		// `git-lfs-migrate(1)` command as a subcommand (child).
 
 		for _, subcommand := range []*cobra.Command{
-			info,
+			importCmd, info,
 		} {
 			subcommand.Flags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")
 			subcommand.Flags().StringVarP(&excludeArg, "exclude", "X", "", "Exclude a list of paths")

--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -29,6 +29,10 @@ func migrateImportCommand(cmd *cobra.Command, args []string) {
 
 	migrate(args, rewriter, &githistory.RewriteOptions{
 		BlobFn: func(path string, b *odb.Blob) (*odb.Blob, error) {
+			if filepath.Base(path) == ".gitattributes" {
+				return b, nil
+			}
+
 			var buf bytes.Buffer
 
 			if err := clean(&buf, b.Contents, path, b.Size); err != nil {
@@ -115,7 +119,7 @@ func trackedFromFilter(filter *filepathfilter.Filter) *tools.OrderedSet {
 var (
 	// attrsCache maintains a cache from the hex-encoded SHA1 of a
 	// .gitattributes blob to the set of patterns parsed from that blob.
-	attrsCache map[string]*tools.OrderedSet
+	attrsCache = make(map[string]*tools.OrderedSet)
 )
 
 // trackedFromAttrs returns an ordered line-delimited set of the contents of a

--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -50,15 +50,16 @@ func migrateImportCommand(cmd *cobra.Command, args []string) {
 				return t, nil
 			}
 
-			if tracked.Cardinality() == 0 {
+			ours := tracked
+			if ours.Cardinality() == 0 {
 				// If there were no explicitly tracked
 				// --include, --exclude filters, assume that the
 				// include set is the wildcard filepath
 				// extensions of files tracked.
-				tracked = exts
+				ours = exts
 			}
 
-			attrs, err := trackedFromAttrs(db, t)
+			theirs, err := trackedFromAttrs(db, t)
 			if err != nil {
 				return nil, err
 			}
@@ -72,7 +73,7 @@ func migrateImportCommand(cmd *cobra.Command, args []string) {
 			// is present and has a diff between commits in the
 			// range of commits to migrate, those changes are
 			// preserved.
-			blob, err := trackedToBlob(db, attrs.Clone().Union(tracked))
+			blob, err := trackedToBlob(db, theirs.Clone().Union(ours))
 			if err != nil {
 				return nil, err
 			}

--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -35,7 +35,7 @@ func migrateImportCommand(cmd *cobra.Command, args []string) {
 				return nil, err
 			}
 
-			if ext := filepath.Ext(path); len(ext) > 1 {
+			if ext := filepath.Ext(path); len(ext) > 0 {
 				exts.Add(fmt.Sprintf("*%s filter=lfs diff=lfs merge=lfs -text", ext))
 			}
 

--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -1,0 +1,7 @@
+package commands
+
+import "github.com/spf13/cobra"
+
+func migrateImportCommand(cmd *cobra.Command, args []string) {
+
+}

--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -1,7 +1,181 @@
 package commands
 
-import "github.com/spf13/cobra"
+import (
+	"bufio"
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/git-lfs/git-lfs/filepathfilter"
+	"github.com/git-lfs/git-lfs/git"
+	"github.com/git-lfs/git-lfs/git/githistory"
+	"github.com/git-lfs/git-lfs/git/odb"
+	"github.com/git-lfs/git-lfs/tools"
+	"github.com/spf13/cobra"
+)
 
 func migrateImportCommand(cmd *cobra.Command, args []string) {
+	db, err := getObjectDatabase()
+	if err != nil {
+		ExitWithError(err)
+	}
+	rewriter := getHistoryRewriter(cmd, db)
 
+	tracked := trackedFromFilter(rewriter.Filter())
+	exts := tools.NewOrderedSet()
+
+	migrate(args, rewriter, &githistory.RewriteOptions{
+		BlobFn: func(path string, b *odb.Blob) (*odb.Blob, error) {
+			var buf bytes.Buffer
+
+			if err := clean(&buf, b.Contents, path, b.Size); err != nil {
+				return nil, err
+			}
+
+			if ext := filepath.Ext(path); len(ext) > 1 {
+				exts.Add(fmt.Sprintf("*%s filter=lfs diff=lfs merge=lfs -text", ext))
+			}
+
+			return &odb.Blob{
+				Contents: &buf, Size: int64(buf.Len()),
+			}, nil
+		},
+
+		TreeCallbackFn: func(path string, t *odb.Tree) (*odb.Tree, error) {
+			if path != string(os.PathSeparator) {
+				// Ignore non-root trees.
+				return t, nil
+			}
+
+			if tracked.Cardinality() == 0 {
+				// If there were no explicitly tracked
+				// --include, --exclude filters, assume that the
+				// include set is the wildcard filepath
+				// extensions of files tracked.
+				tracked = exts
+			}
+
+			attrs, err := trackedFromAttrs(db, t)
+			if err != nil {
+				return nil, err
+			}
+
+			// Create a blob of the attributes that are optionally
+			// present in the "t" tree's .gitattributes blob, and
+			// union in the patterns that we've tracked.
+			//
+			// Perform this Union() operation each time we visit a
+			// root tree such that if the underlying .gitattributes
+			// is present and has a diff between commits in the
+			// range of commits to migrate, those changes are
+			// preserved.
+			blob, err := trackedToBlob(db, attrs.Clone().Union(tracked))
+			if err != nil {
+				return nil, err
+			}
+
+			// Finally, return a copy of the tree "t" that has the
+			// new .gitattributes file included/replaced.
+			return t.Merge(&odb.TreeEntry{
+				Name:     ".gitattributes",
+				Filemode: 0100644,
+				Oid:      blob,
+			}), nil
+		},
+
+		UpdateRefs: true,
+	})
+
+	if err := git.Checkout("", nil, true); err != nil {
+		ExitWithError(err)
+	}
+}
+
+// trackedFromFilter returns an ordered set of strings where each entry is a
+// line in the .gitattributes file. It adds/removes the fiter/diff/merge=lfs
+// attributes based on patterns included/excldued in the given filter.
+func trackedFromFilter(filter *filepathfilter.Filter) *tools.OrderedSet {
+	tracked := tools.NewOrderedSet()
+
+	for _, include := range filter.Include() {
+		tracked.Add(fmt.Sprintf("%s filter=lfs diff=lfs merge=lfs -text", include))
+	}
+
+	for _, exclude := range filter.Exclude() {
+		tracked.Add(fmt.Sprintf("%s text -filter -merge -diff", exclude))
+	}
+
+	return tracked
+}
+
+var (
+	// attrsCache maintains a cache from the hex-encoded SHA1 of a
+	// .gitattributes blob to the set of patterns parsed from that blob.
+	attrsCache map[string]*tools.OrderedSet
+)
+
+// trackedFromAttrs returns an ordered line-delimited set of the contents of a
+// .gitattributes blob in a given tree "t".
+//
+// It returns an empty set if no attributes file could be found, or an error if
+// it could not otherwise be opened.
+func trackedFromAttrs(db *odb.ObjectDatabase, t *odb.Tree) (*tools.OrderedSet, error) {
+	var oid []byte
+
+	for _, e := range t.Entries {
+		if strings.ToLower(e.Name) == ".gitattributes" && e.Type() == odb.BlobObjectType {
+			oid = e.Oid
+			break
+		}
+	}
+
+	if oid == nil {
+		// TODO(@ttaylorr): make (*tools.OrderedSet)(nil) a valid
+		// receiver for non-mutative methods.
+		return tools.NewOrderedSet(), nil
+	}
+
+	sha1 := hex.EncodeToString(oid)
+
+	if s, ok := attrsCache[sha1]; ok {
+		return s, nil
+	}
+
+	blob, err := db.Blob(oid)
+	if err != nil {
+		return nil, err
+	}
+
+	attrs := tools.NewOrderedSet()
+
+	scanner := bufio.NewScanner(blob.Contents)
+	for scanner.Scan() {
+		attrs.Add(scanner.Text())
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	attrsCache[sha1] = attrs
+
+	return attrsCache[sha1], nil
+}
+
+// trackedToBlob writes and returns the OID of a .gitattributes blob based on
+// the patterns given in the ordered set of patterns, "patterns".
+func trackedToBlob(db *odb.ObjectDatabase, patterns *tools.OrderedSet) ([]byte, error) {
+	var attrs bytes.Buffer
+
+	for pattern := range patterns.Iter() {
+		fmt.Fprintf(&attrs, "%s\n", pattern)
+	}
+
+	return db.WriteBlob(&odb.Blob{
+		Contents: &attrs,
+		Size:     int64(attrs.Len()),
+	})
 }

--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -31,6 +31,18 @@ git-lfs-migrate(1) - Migrate history to or from git-lfs
     If any of `--include-ref` or `--exclude-ref` are given, the checked out
     branch will not be appended, but branches given explicitly will be appended.
 
+### IMPORT
+
+The 'import' mode migrates large objects present in the Git history to pointer
+files tracked and stored with Git LFS.
+
+If `--include` or `--exclude` (`-I`, `-X`, respectively) are given, the
+.gitattributes will be modified to include any new filepath patterns as given by
+those flags.
+
+If neither of those flags are given, the gitattributes will be incrementally
+modified to include new filepath extensions as they are rewritten in history.
+
 ### INFO
 
 The 'info' mode has these additional options:

--- a/filepathfilter/filepathfilter.go
+++ b/filepathfilter/filepathfilter.go
@@ -27,6 +27,25 @@ func New(include, exclude []string) *Filter {
 	return NewFromPatterns(convertToPatterns(include), convertToPatterns(exclude))
 }
 
+// Include returns the result of calling String() on each Pattern in the
+// include set of this *Filter.
+func (f *Filter) Include() []string { return patternsToStrings(f.include...) }
+
+// Exclude returns the result of calling String() on each Pattern in the
+// exclude set of this *Filter.
+func (f *Filter) Exclude() []string { return patternsToStrings(f.exclude...) }
+
+// patternsToStrings maps the given set of Pattern's to a string slice by
+// calling String() on each pattern.
+func patternsToStrings(ps ...Pattern) []string {
+	s := make([]string, 0, len(ps))
+	for _, p := range ps {
+		s = append(s, p.String())
+	}
+
+	return s
+}
+
 func (f *Filter) Allows(filename string) bool {
 	_, allowed := f.AllowsPattern(filename)
 	return allowed

--- a/filepathfilter/filepathfilter_test.go
+++ b/filepathfilter/filepathfilter_test.go
@@ -205,3 +205,15 @@ func TestFilterAllows(t *testing.T) {
 		}
 	}
 }
+
+func TestFilterReportsIncludePatterns(t *testing.T) {
+	filter := New([]string{"*.foo", "*.bar"}, nil)
+
+	assert.Equal(t, []string{"*.foo", "*.bar"}, filter.Include())
+}
+
+func TestFilterReportsExcludePatterns(t *testing.T) {
+	filter := New(nil, []string{"*.baz", "*.quux"})
+
+	assert.Equal(t, []string{"*.baz", "*.quux"}, filter.Exclude())
+}

--- a/git/githistory/ref_updater.go
+++ b/git/githistory/ref_updater.go
@@ -52,7 +52,7 @@ func (r *refUpdater) UpdateRefs() error {
 			return err
 		}
 
-		list.Entry(fmt.Sprintf("%s\t%s -> %x", ref, ref.Sha, to))
+		list.Entry(fmt.Sprintf("  %s\t%s -> %x", ref.Name, ref.Sha, to))
 	}
 
 	return nil

--- a/test/test-migrate-fixtures.sh
+++ b/test/test-migrate-fixtures.sh
@@ -138,7 +138,7 @@ setup_multiple_remote_branches() {
 #
 #   remove_and_create_local_repo "$reponame"
 remove_and_create_local_repo() {
-  local reponame="$(base64 < /dev/urandom | head -c 8)-$1"
+  local reponame="$(base64 < /dev/urandom | head -c 8 | sed -e 's/\///')-$1"
 
   git init "$reponame"
   cd "$reponame"
@@ -149,7 +149,7 @@ remove_and_create_local_repo() {
 #
 #   remove_and_create_remote_repo "$reponame"
 remove_and_create_remote_repo() {
-  local reponame="$(base64 < /dev/urandom | head -c 8)-$1"
+  local reponame="$(base64 < /dev/urandom | head -c 8 | sed -e 's/\///')-$1"
 
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"

--- a/test/test-migrate-fixtures.sh
+++ b/test/test-migrate-fixtures.sh
@@ -140,7 +140,7 @@ setup_multiple_remote_branches() {
 remove_and_create_local_repo() {
   local reponame="$1"
 
-  rm -rf "$reponame" || true
+  [ -e "$reponame" ] && rm -rf "$reponame"
 
   git init "$reponame"
   cd "$reponame"
@@ -153,7 +153,8 @@ remove_and_create_local_repo() {
 remove_and_create_remote_repo() {
   local reponame="$1"
 
-  rm -rf "$reponame" "$REMOTEDIR/$reponame.git" || true
+  [ -e "$reponame" ] && rm -rf "$reponame"
+  [ -e "$REMOTEDIR/$reponame.git" ] && rm -rf "$REMOTEDIR/$reponame.git"
 
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"

--- a/test/test-migrate-fixtures.sh
+++ b/test/test-migrate-fixtures.sh
@@ -20,6 +20,32 @@ assert_ref_unmoved() {
 
 # setup_multiple_local_branches creates a repository as follows:
 #
+#   A---B
+#        \
+#         refs/heads/master
+#
+# - Commit 'A' has 120, in a.txt, and a corresponding entry in .gitattributes.
+setup_local_branch_with_gitattrs() {
+  set -e
+
+  reponame="migrate-single-remote-branch-with-attrs"
+
+  remove_and_create_local_repo "$reponame"
+
+  base64 < /dev/urandom | head -c 120 > a.txt
+
+  git add a.txt
+  git commit -m "initial commit"
+
+  git lfs track "*.txt"
+  git lfs track "*.other"
+
+  git add .gitattributes
+  git commit -m "add .gitattributes"
+}
+
+# setup_multiple_local_branches creates a repository as follows:
+#
 #     B
 #    / \
 #   A   refs/heads/my-feature

--- a/test/test-migrate-fixtures.sh
+++ b/test/test-migrate-fixtures.sh
@@ -138,9 +138,7 @@ setup_multiple_remote_branches() {
 #
 #   remove_and_create_local_repo "$reponame"
 remove_and_create_local_repo() {
-  local reponame="$1"
-
-  [ -e "$reponame" ] && rm -rf "$reponame"
+  local reponame="$(base64 < /dev/urandom | head -c 8)-$1"
 
   git init "$reponame"
   cd "$reponame"
@@ -151,10 +149,7 @@ remove_and_create_local_repo() {
 #
 #   remove_and_create_remote_repo "$reponame"
 remove_and_create_remote_repo() {
-  local reponame="$1"
-
-  [ -e "$reponame" ] && rm -rf "$reponame"
-  [ -e "$REMOTEDIR/$reponame.git" ] && rm -rf "$REMOTEDIR/$reponame.git"
+  local reponame="$(base64 < /dev/urandom | head -c 8)-$1"
 
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"

--- a/test/test-migrate-fixtures.sh
+++ b/test/test-migrate-fixtures.sh
@@ -18,7 +18,7 @@ assert_ref_unmoved() {
   fi
 }
 
-# setup_single_remote_branch creates a repository as follows:
+# setup_multiple_local_branches creates a repository as follows:
 #
 #     B
 #    / \

--- a/test/test-migrate-import.sh
+++ b/test/test-migrate-import.sh
@@ -22,8 +22,8 @@ begin_test "migrate import (default branch)"
   assert_local_object "$txt_oid" "120"
   refute_local_object "$md_feature_oid" "30"
 
-  master_attrs="$(git cat-file -p refs/heads/master:.gitattributes)"
-  [ ! $(git cat-file -p refs/heads/my-feature:.gitattributes) ]
+  master_attrs="$(git cat-file -p "refs/heads/master:.gitattributes")"
+  [ ! $(git cat-file -p "refs/heads/my-feature:.gitattributes") ]
 
   echo "$master_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
   echo "$master_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"
@@ -51,8 +51,8 @@ begin_test "migrate import (given branch)"
   assert_local_object "$md_feature_oid" "30"
   assert_local_object "$txt_oid" "120"
 
-  master_attrs="$(git cat-file -p refs/heads/master:.gitattributes)"
-  feature_attrs="$(git cat-file -p refs/heads/my-feature:.gitattributes)"
+  master_attrs="$(git cat-file -p "refs/heads/master:.gitattributes")"
+  feature_attrs="$(git cat-file -p "refs/heads/my-feature:.gitattributes")"
 
   echo "$master_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
   echo "$master_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"
@@ -79,8 +79,8 @@ begin_test "migrate import (default branch with filter)"
   refute_local_object "$txt_oid" "120"
   refute_local_object "$md_feature_oid" "30"
 
-  master_attrs="$(git cat-file -p refs/heads/master:.gitattributes)"
-  [ ! $(git cat-file -p refs/heads/my-feature:.gitattributes) ]
+  master_attrs="$(git cat-file -p "refs/heads/master:.gitattributes")"
+  [ ! $(git cat-file -p "refs/heads/my-feature:.gitattributes") ]
 
   echo "$master_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
   echo "$master_attrs" | grep -vq "*.txt filter=lfs diff=lfs merge=lfs"
@@ -106,8 +106,8 @@ begin_test "migrate import (given branch with filter)"
   assert_local_object "$md_feature_oid" "30"
   refute_local_object "$txt_oid" "120"
 
-  master_attrs="$(git cat-file -p refs/heads/master:.gitattributes)"
-  feature_attrs="$(git cat-file -p refs/heads/my-feature:.gitattributes)"
+  master_attrs="$(git cat-file -p "refs/heads/master:.gitattributes")"
+  feature_attrs="$(git cat-file -p "refs/heads/my-feature:.gitattributes")"
 
   echo "$master_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
   echo "$master_attrs" | grep -vq "*.txt filter=lfs diff=lfs merge=lfs"
@@ -122,10 +122,10 @@ begin_test "migrate import (default branch, exclude remote refs)"
 
   setup_single_remote_branch
 
-  md_remote_oid="$(calc_oid "$(git cat-file -p refs/remotes/origin/master:a.md)")"
-  txt_remote_oid="$(calc_oid "$(git cat-file -p refs/remotes/origin/master:a.txt)")"
-  md_oid="$(calc_oid "$(git cat-file -p refs/heads/master:a.md)")"
-  txt_oid="$(calc_oid "$(git cat-file -p refs/heads/master:a.txt)")"
+  md_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/master:a.md")")"
+  txt_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/master:a.txt")")"
+  md_oid="$(calc_oid "$(git cat-file -p "refs/heads/master:a.md")")"
+  txt_oid="$(calc_oid "$(git cat-file -p "refs/heads/master:a.txt")")"
 
   git lfs migrate import
 
@@ -137,8 +137,8 @@ begin_test "migrate import (default branch, exclude remote refs)"
   refute_local_object "$md_remote_oid" "140"
   refute_local_object "$txt_remote_oid" "120"
 
-  master_attrs="$(git cat-file -p refs/heads/master:.gitattributes)"
-  [ ! $(git cat-file -p refs/remotes/origin/master:.gitattributes) ]
+  master_attrs="$(git cat-file -p "refs/heads/master:.gitattributes")"
+  [ ! $(git cat-file -p "refs/remotes/origin/master:.gitattributes") ]
 
   echo "$master_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
   echo "$master_attrs" | grep -vq "*.txt filter=lfs diff=lfs merge=lfs"
@@ -151,12 +151,12 @@ begin_test "migrate import (given branch, exclude remote refs)"
 
   setup_multiple_remote_branches
 
-  md_master_oid="$(calc_oid "$(git cat-file -p refs/heads/master:a.md)")"
-  md_remote_oid="$(calc_oid "$(git cat-file -p refs/remotes/origin/master:a.md)")"
-  md_feature_oid="$(calc_oid "$(git cat-file -p refs/heads/my-feature:a.md)")"
-  txt_master_oid="$(calc_oid "$(git cat-file -p refs/heads/master:a.txt)")"
-  txt_remote_oid="$(calc_oid "$(git cat-file -p refs/remotes/origin/master:a.txt)")"
-  txt_feature_oid="$(calc_oid "$(git cat-file -p refs/heads/my-feature:a.txt)")"
+  md_master_oid="$(calc_oid "$(git cat-file -p "refs/heads/master:a.md")")"
+  md_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/master:a.md")")"
+  md_feature_oid="$(calc_oid "$(git cat-file -p "refs/heads/my-feature:a.md")")"
+  txt_master_oid="$(calc_oid "$(git cat-file -p "refs/heads/master:a.txt")")"
+  txt_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/master:a.txt")")"
+  txt_feature_oid="$(calc_oid "$(git cat-file -p "refs/heads/my-feature:a.txt")")"
 
   git lfs migrate import my-feature
 
@@ -172,9 +172,9 @@ begin_test "migrate import (given branch, exclude remote refs)"
   refute_local_object "$md_remote_oid" "11"
   refute_local_object "$txt_remote_oid" "10"
 
-  master_attrs="$(git cat-file -p refs/heads/master:.gitattributes)"
-  [ ! $(git cat-file -p refs/remotes/origin/master:.gitattributes) ]
-  feature_attrs="$(git cat-file -p refs/heads/my-feature:.gitattributes)"
+  master_attrs="$(git cat-file -p "refs/heads/master:.gitattributes")"
+  [ ! $(git cat-file -p "refs/remotes/origin/master:.gitattributes") ]
+  feature_attrs="$(git cat-file -p "refs/heads/my-feature:.gitattributes")"
 
   echo "$master_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
   echo "$master_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"
@@ -189,12 +189,12 @@ begin_test "migrate import (include/exclude ref)"
 
   setup_multiple_remote_branches
 
-  md_master_oid="$(calc_oid "$(git cat-file -p refs/heads/master:a.md)")"
-  md_remote_oid="$(calc_oid "$(git cat-file -p refs/remotes/origin/master:a.md)")"
-  md_feature_oid="$(calc_oid "$(git cat-file -p refs/heads/my-feature:a.md)")"
-  txt_master_oid="$(calc_oid "$(git cat-file -p refs/heads/master:a.txt)")"
-  txt_remote_oid="$(calc_oid "$(git cat-file -p refs/remotes/origin/master:a.txt)")"
-  txt_feature_oid="$(calc_oid "$(git cat-file -p refs/heads/my-feature:a.txt)")"
+  md_master_oid="$(calc_oid "$(git cat-file -p "refs/heads/master:a.md")")"
+  md_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/master:a.md")")"
+  md_feature_oid="$(calc_oid "$(git cat-file -p "refs/heads/my-feature:a.md")")"
+  txt_master_oid="$(calc_oid "$(git cat-file -p "refs/heads/master:a.txt")")"
+  txt_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/master:a.txt")")"
+  txt_feature_oid="$(calc_oid "$(git cat-file -p "refs/heads/my-feature:a.txt")")"
 
   git lfs migrate import \
     --include-ref=refs/heads/my-feature \
@@ -210,9 +210,9 @@ begin_test "migrate import (include/exclude ref)"
   refute_local_object "$md_remote_oid" "11"
   refute_local_object "$txt_remote_oid" "10"
 
-  [ ! $(git cat-file -p refs/heads/master:.gitattributes) ]
-  [ ! $(git cat-file -p refs/remotes/origin/master:.gitattributes) ]
-  feature_attrs="$(git cat-file -p refs/heads/my-feature:.gitattributes)"
+  [ ! $(git cat-file -p "refs/heads/master:.gitattributes") ]
+  [ ! $(git cat-file -p "refs/remotes/origin/master:.gitattributes") ]
+  feature_attrs="$(git cat-file -p "refs/heads/my-feature:.gitattributes")"
 
   echo "$feature_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
   echo "$feature_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"
@@ -225,12 +225,12 @@ begin_test "migrate import (include/exclude ref with filter)"
 
   setup_multiple_remote_branches
 
-  md_master_oid="$(calc_oid "$(git cat-file -p refs/heads/master:a.md)")"
-  md_remote_oid="$(calc_oid "$(git cat-file -p refs/remotes/origin/master:a.md)")"
-  md_feature_oid="$(calc_oid "$(git cat-file -p refs/heads/my-feature:a.md)")"
-  txt_master_oid="$(calc_oid "$(git cat-file -p refs/heads/master:a.txt)")"
-  txt_remote_oid="$(calc_oid "$(git cat-file -p refs/remotes/origin/master:a.txt)")"
-  txt_feature_oid="$(calc_oid "$(git cat-file -p refs/heads/my-feature:a.txt)")"
+  md_master_oid="$(calc_oid "$(git cat-file -p "refs/heads/master:a.md")")"
+  md_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/master:a.md")")"
+  md_feature_oid="$(calc_oid "$(git cat-file -p "refs/heads/my-feature:a.md")")"
+  txt_master_oid="$(calc_oid "$(git cat-file -p "refs/heads/master:a.txt")")"
+  txt_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/master:a.txt")")"
+  txt_feature_oid="$(calc_oid "$(git cat-file -p "refs/heads/my-feature:a.txt")")"
 
   git lfs migrate import \
     --include="*.txt" \
@@ -246,9 +246,9 @@ begin_test "migrate import (include/exclude ref with filter)"
   refute_local_object "$md_remote_oid" "11"
   refute_local_object "$txt_remote_oid" "10"
 
-  [ ! $(git cat-file -p refs/heads/master:.gitattributes) ]
-  [ ! $(git cat-file -p refs/remotes/origin/master:.gitattributes) ]
-  feature_attrs="$(git cat-file -p refs/heads/my-feature:.gitattributes)"
+  [ ! $(git cat-file -p "refs/heads/master:.gitattributes") ]
+  [ ! $(git cat-file -p "refs/remotes/origin/master:.gitattributes") ]
+  feature_attrs="$(git cat-file -p "refs/heads/my-feature:.gitattributes")"
 
   echo "$feature_attrs" | grep -vq "*.md filter=lfs diff=lfs merge=lfs"
   echo "$feature_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"

--- a/test/test-migrate-import.sh
+++ b/test/test-migrate-import.sh
@@ -22,8 +22,11 @@ begin_test "migrate import (default branch)"
   assert_local_object "$txt_oid" "120"
   refute_local_object "$md_feature_oid" "30"
 
-  master_attrs="$(git cat-file -p "refs/heads/master:.gitattributes")"
-  [ ! $(git cat-file -p "refs/heads/my-feature:.gitattributes") ]
+  master="$(git rev-parse refs/heads/master)"
+  feature="$(git rev-parse refs/heads/my-feature)"
+
+  master_attrs="$(git cat-file -p "$master:.gitattributes")"
+  [ ! $(git cat-file -p "$feature:.gitattributes") ]
 
   echo "$master_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
   echo "$master_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"
@@ -51,8 +54,11 @@ begin_test "migrate import (given branch)"
   assert_local_object "$md_feature_oid" "30"
   assert_local_object "$txt_oid" "120"
 
-  master_attrs="$(git cat-file -p "refs/heads/master:.gitattributes")"
-  feature_attrs="$(git cat-file -p "refs/heads/my-feature:.gitattributes")"
+  master="$(git rev-parse refs/heads/master)"
+  feature="$(git rev-parse refs/heads/my-feature)"
+
+  master_attrs="$(git cat-file -p "$master:.gitattributes")"
+  feature_attrs="$(git cat-file -p "$feature:.gitattributes")"
 
   echo "$master_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
   echo "$master_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"
@@ -79,8 +85,11 @@ begin_test "migrate import (default branch with filter)"
   refute_local_object "$txt_oid" "120"
   refute_local_object "$md_feature_oid" "30"
 
-  master_attrs="$(git cat-file -p "refs/heads/master:.gitattributes")"
-  [ ! $(git cat-file -p "refs/heads/my-feature:.gitattributes") ]
+  master="$(git rev-parse refs/heads/master)"
+  feature="$(git rev-parse refs/heads/my-feature)"
+
+  master_attrs="$(git cat-file -p "$master:.gitattributes")"
+  [ ! $(git cat-file -p "$feature:.gitattributes") ]
 
   echo "$master_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
   echo "$master_attrs" | grep -vq "*.txt filter=lfs diff=lfs merge=lfs"
@@ -106,8 +115,11 @@ begin_test "migrate import (given branch with filter)"
   assert_local_object "$md_feature_oid" "30"
   refute_local_object "$txt_oid" "120"
 
-  master_attrs="$(git cat-file -p "refs/heads/master:.gitattributes")"
-  feature_attrs="$(git cat-file -p "refs/heads/my-feature:.gitattributes")"
+  master="$(git rev-parse refs/heads/master)"
+  feature="$(git rev-parse refs/heads/my-feature)"
+
+  master_attrs="$(git cat-file -p "$master:.gitattributes")"
+  feature_attrs="$(git cat-file -p "$feature:.gitattributes")"
 
   echo "$master_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
   echo "$master_attrs" | grep -vq "*.txt filter=lfs diff=lfs merge=lfs"
@@ -137,8 +149,11 @@ begin_test "migrate import (default branch, exclude remote refs)"
   refute_local_object "$md_remote_oid" "140"
   refute_local_object "$txt_remote_oid" "120"
 
-  master_attrs="$(git cat-file -p "refs/heads/master:.gitattributes")"
-  [ ! $(git cat-file -p "refs/remotes/origin/master:.gitattributes") ]
+  master="$(git rev-parse refs/heads/master)"
+  remote="$(git rev-parse refs/remotes/origin/master)"
+
+  master_attrs="$(git cat-file -p "$master:.gitattributes")"
+  [ ! $(git cat-file -p "$remote:.gitattributes") ]
 
   echo "$master_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
   echo "$master_attrs" | grep -vq "*.txt filter=lfs diff=lfs merge=lfs"
@@ -172,9 +187,13 @@ begin_test "migrate import (given branch, exclude remote refs)"
   refute_local_object "$md_remote_oid" "11"
   refute_local_object "$txt_remote_oid" "10"
 
-  master_attrs="$(git cat-file -p "refs/heads/master:.gitattributes")"
-  [ ! $(git cat-file -p "refs/remotes/origin/master:.gitattributes") ]
-  feature_attrs="$(git cat-file -p "refs/heads/my-feature:.gitattributes")"
+  master="$(git rev-parse refs/heads/master)"
+  feature="$(git rev-parse refs/heads/my-feature)"
+  remote="$(git rev-parse refs/remotes/origin/master)"
+
+  master_attrs="$(git cat-file -p "$master:.gitattributes")"
+  [ ! $(git cat-file -p "$remote:.gitattributes") ]
+  feature_attrs="$(git cat-file -p "$feature:.gitattributes")"
 
   echo "$master_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
   echo "$master_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"
@@ -210,9 +229,13 @@ begin_test "migrate import (include/exclude ref)"
   refute_local_object "$md_remote_oid" "11"
   refute_local_object "$txt_remote_oid" "10"
 
-  [ ! $(git cat-file -p "refs/heads/master:.gitattributes") ]
-  [ ! $(git cat-file -p "refs/remotes/origin/master:.gitattributes") ]
-  feature_attrs="$(git cat-file -p "refs/heads/my-feature:.gitattributes")"
+  master="$(git rev-parse refs/heads/master)"
+  feature="$(git rev-parse refs/heads/my-feature)"
+  remote="$(git rev-parse refs/remotes/origin/master)"
+
+  [ ! $(git cat-file -p "$master:.gitattributes") ]
+  [ ! $(git cat-file -p "$remote:.gitattributes") ]
+  feature_attrs="$(git cat-file -p "$feature:.gitattributes")"
 
   echo "$feature_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
   echo "$feature_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"
@@ -246,9 +269,13 @@ begin_test "migrate import (include/exclude ref with filter)"
   refute_local_object "$md_remote_oid" "11"
   refute_local_object "$txt_remote_oid" "10"
 
-  [ ! $(git cat-file -p "refs/heads/master:.gitattributes") ]
-  [ ! $(git cat-file -p "refs/remotes/origin/master:.gitattributes") ]
-  feature_attrs="$(git cat-file -p "refs/heads/my-feature:.gitattributes")"
+  master="$(git rev-parse refs/heads/master)"
+  feature="$(git rev-parse refs/heads/my-feature)"
+  remote="$(git rev-parse refs/remotes/origin/master)"
+
+  [ ! $(git cat-file -p "$master:.gitattributes") ]
+  [ ! $(git cat-file -p "$remote:.gitattributes") ]
+  feature_attrs="$(git cat-file -p "$feature:.gitattributes")"
 
   echo "$feature_attrs" | grep -vq "*.md filter=lfs diff=lfs merge=lfs"
   echo "$feature_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"

--- a/test/test-migrate-import.sh
+++ b/test/test-migrate-import.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+
+. "test/test-migrate-fixtures.sh"
+. "test/testlib.sh"
+
+begin_test "migrate import (default branch)"
+(
+  set -e
+
+  setup_multiple_local_branches
+
+  md_oid="$(calc_oid "$(git cat-file -p :a.md)")"
+  txt_oid="$(calc_oid "$(git cat-file -p :a.txt)")"
+  md_feature_oid="$(calc_oid "$(git cat-file -p my-feature:a.md)")"
+
+  git lfs migrate import
+
+  assert_pointer "refs/heads/master" "a.md" "$md_oid" "140"
+  assert_pointer "refs/heads/master" "a.txt" "$txt_oid" "120"
+
+  assert_local_object "$md_oid" "140"
+  assert_local_object "$txt_oid" "120"
+  refute_local_object "$md_feature_oid" "30"
+
+  master_attrs="$(git cat-file -p refs/heads/master:.gitattributes)"
+  [ ! $(git cat-file -p refs/heads/my-feature:.gitattributes) ]
+
+  echo "$master_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
+  echo "$master_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"
+)
+end_test
+
+begin_test "migrate import (given branch)"
+(
+  set -e
+
+  setup_multiple_local_branches
+
+  md_oid="$(calc_oid "$(git cat-file -p :a.md)")"
+  txt_oid="$(calc_oid "$(git cat-file -p :a.txt)")"
+  md_feature_oid="$(calc_oid "$(git cat-file -p my-feature:a.md)")"
+
+  git lfs migrate import my-feature
+
+  assert_pointer "refs/heads/my-feature" "a.md" "$md_feature_oid" "30"
+  assert_pointer "refs/heads/my-feature" "a.txt" "$txt_oid" "120"
+  assert_pointer "refs/heads/master" "a.md" "$md_oid" "140"
+  assert_pointer "refs/heads/master" "a.txt" "$txt_oid" "120"
+
+  assert_local_object "$md_oid" "140"
+  assert_local_object "$md_feature_oid" "30"
+  assert_local_object "$txt_oid" "120"
+
+  master_attrs="$(git cat-file -p refs/heads/master:.gitattributes)"
+  feature_attrs="$(git cat-file -p refs/heads/my-feature:.gitattributes)"
+
+  echo "$master_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
+  echo "$master_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"
+  echo "$feature_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
+  echo "$feature_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"
+)
+end_test
+
+begin_test "migrate import (default branch with filter)"
+(
+  set -e
+
+  setup_multiple_local_branches
+
+  md_oid="$(calc_oid "$(git cat-file -p :a.md)")"
+  txt_oid="$(calc_oid "$(git cat-file -p :a.txt)")"
+  md_feature_oid="$(calc_oid "$(git cat-file -p my-feature:a.md)")"
+
+  git lfs migrate import --include "*.md"
+
+  assert_pointer "refs/heads/master" "a.md" "$md_oid" "140"
+
+  assert_local_object "$md_oid" "140"
+  refute_local_object "$txt_oid" "120"
+  refute_local_object "$md_feature_oid" "30"
+
+  master_attrs="$(git cat-file -p refs/heads/master:.gitattributes)"
+  [ ! $(git cat-file -p refs/heads/my-feature:.gitattributes) ]
+
+  echo "$master_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
+  echo "$master_attrs" | grep -vq "*.txt filter=lfs diff=lfs merge=lfs"
+)
+end_test
+
+begin_test "migrate import (given branch with filter)"
+(
+  set -e
+
+  setup_multiple_local_branches
+
+  md_oid="$(calc_oid "$(git cat-file -p :a.md)")"
+  txt_oid="$(calc_oid "$(git cat-file -p :a.txt)")"
+  md_feature_oid="$(calc_oid "$(git cat-file -p my-feature:a.md)")"
+
+  git lfs migrate import --include "*.md" my-feature
+
+  assert_pointer "refs/heads/my-feature" "a.md" "$md_feature_oid" "30"
+  assert_pointer "refs/heads/my-feature~1" "a.md" "$md_oid" "140"
+
+  assert_local_object "$md_oid" "140"
+  assert_local_object "$md_feature_oid" "30"
+  refute_local_object "$txt_oid" "120"
+
+  master_attrs="$(git cat-file -p refs/heads/master:.gitattributes)"
+  feature_attrs="$(git cat-file -p refs/heads/my-feature:.gitattributes)"
+
+  echo "$master_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
+  echo "$master_attrs" | grep -vq "*.txt filter=lfs diff=lfs merge=lfs"
+  echo "$feature_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
+  echo "$feature_attrs" | grep -vq "*.txt filter=lfs diff=lfs merge=lfs"
+)
+end_test
+
+begin_test "migrate import (default branch, exclude remote refs)"
+(
+  set -e
+
+  setup_single_remote_branch
+
+  md_remote_oid="$(calc_oid "$(git cat-file -p refs/remotes/origin/master:a.md)")"
+  txt_remote_oid="$(calc_oid "$(git cat-file -p refs/remotes/origin/master:a.txt)")"
+  md_oid="$(calc_oid "$(git cat-file -p refs/heads/master:a.md)")"
+  txt_oid="$(calc_oid "$(git cat-file -p refs/heads/master:a.txt)")"
+
+  git lfs migrate import
+
+  assert_pointer "refs/heads/master" "a.md" "$md_oid" "50"
+  assert_pointer "refs/heads/master" "a.txt" "$txt_oid" "30"
+
+  assert_local_object "$md_oid" "50"
+  assert_local_object "$txt_oid" "30"
+  refute_local_object "$md_remote_oid" "140"
+  refute_local_object "$txt_remote_oid" "120"
+
+  master_attrs="$(git cat-file -p refs/heads/master:.gitattributes)"
+  [ ! $(git cat-file -p refs/remotes/origin/master:.gitattributes) ]
+
+  echo "$master_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
+  echo "$master_attrs" | grep -vq "*.txt filter=lfs diff=lfs merge=lfs"
+)
+end_test
+
+begin_test "migrate import (given branch, exclude remote refs)"
+(
+  set -e
+
+  setup_multiple_remote_branches
+
+  md_master_oid="$(calc_oid "$(git cat-file -p refs/heads/master:a.md)")"
+  md_remote_oid="$(calc_oid "$(git cat-file -p refs/remotes/origin/master:a.md)")"
+  md_feature_oid="$(calc_oid "$(git cat-file -p refs/heads/my-feature:a.md)")"
+  txt_master_oid="$(calc_oid "$(git cat-file -p refs/heads/master:a.txt)")"
+  txt_remote_oid="$(calc_oid "$(git cat-file -p refs/remotes/origin/master:a.txt)")"
+  txt_feature_oid="$(calc_oid "$(git cat-file -p refs/heads/my-feature:a.txt)")"
+
+  git lfs migrate import my-feature
+
+  assert_pointer "refs/heads/master" "a.md" "$md_master_oid" "21"
+  assert_pointer "refs/heads/my-feature" "a.md" "$md_feature_oid" "31"
+  assert_pointer "refs/heads/master" "a.txt" "$txt_master_oid" "20"
+  assert_pointer "refs/heads/my-feature" "a.txt" "$txt_feature_oid" "30"
+
+  assert_local_object "$md_feature_oid" "31"
+  assert_local_object "$md_master_oid" "21"
+  assert_local_object "$txt_feature_oid" "30"
+  assert_local_object "$txt_master_oid" "20"
+  refute_local_object "$md_remote_oid" "11"
+  refute_local_object "$txt_remote_oid" "10"
+
+  master_attrs="$(git cat-file -p refs/heads/master:.gitattributes)"
+  [ ! $(git cat-file -p refs/remotes/origin/master:.gitattributes) ]
+  feature_attrs="$(git cat-file -p refs/heads/my-feature:.gitattributes)"
+
+  echo "$master_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
+  echo "$master_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"
+  echo "$feature_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
+  echo "$feature_attrs" | grep -vq "*.txt filter=lfs diff=lfs merge=lfs"
+)
+end_test
+
+begin_test "migrate import (include/exclude ref)"
+(
+  set -e
+
+  setup_multiple_remote_branches
+
+  md_master_oid="$(calc_oid "$(git cat-file -p refs/heads/master:a.md)")"
+  md_remote_oid="$(calc_oid "$(git cat-file -p refs/remotes/origin/master:a.md)")"
+  md_feature_oid="$(calc_oid "$(git cat-file -p refs/heads/my-feature:a.md)")"
+  txt_master_oid="$(calc_oid "$(git cat-file -p refs/heads/master:a.txt)")"
+  txt_remote_oid="$(calc_oid "$(git cat-file -p refs/remotes/origin/master:a.txt)")"
+  txt_feature_oid="$(calc_oid "$(git cat-file -p refs/heads/my-feature:a.txt)")"
+
+  git lfs migrate import \
+    --include-ref=refs/heads/my-feature \
+    --exclude-ref=refs/heads/master
+
+  assert_pointer "refs/heads/my-feature" "a.md" "$md_feature_oid" "31"
+  assert_pointer "refs/heads/my-feature" "a.txt" "$txt_feature_oid" "30"
+
+  assert_local_object "$md_feature_oid" "31"
+  refute_local_object "$md_master_oid" "21"
+  assert_local_object "$txt_feature_oid" "30"
+  refute_local_object "$txt_master_oid" "20"
+  refute_local_object "$md_remote_oid" "11"
+  refute_local_object "$txt_remote_oid" "10"
+
+  [ ! $(git cat-file -p refs/heads/master:.gitattributes) ]
+  [ ! $(git cat-file -p refs/remotes/origin/master:.gitattributes) ]
+  feature_attrs="$(git cat-file -p refs/heads/my-feature:.gitattributes)"
+
+  echo "$feature_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
+  echo "$feature_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"
+)
+end_test
+
+begin_test "migrate import (include/exclude ref with filter)"
+(
+  set -e
+
+  setup_multiple_remote_branches
+
+  md_master_oid="$(calc_oid "$(git cat-file -p refs/heads/master:a.md)")"
+  md_remote_oid="$(calc_oid "$(git cat-file -p refs/remotes/origin/master:a.md)")"
+  md_feature_oid="$(calc_oid "$(git cat-file -p refs/heads/my-feature:a.md)")"
+  txt_master_oid="$(calc_oid "$(git cat-file -p refs/heads/master:a.txt)")"
+  txt_remote_oid="$(calc_oid "$(git cat-file -p refs/remotes/origin/master:a.txt)")"
+  txt_feature_oid="$(calc_oid "$(git cat-file -p refs/heads/my-feature:a.txt)")"
+
+  git lfs migrate import \
+    --include="*.txt" \
+    --include-ref=refs/heads/my-feature \
+    --exclude-ref=refs/heads/master
+
+  assert_pointer "refs/heads/my-feature" "a.txt" "$txt_feature_oid" "30"
+
+  refute_local_object "$md_feature_oid" "31"
+  refute_local_object "$md_master_oid" "21"
+  assert_local_object "$txt_feature_oid" "30"
+  refute_local_object "$txt_master_oid" "20"
+  refute_local_object "$md_remote_oid" "11"
+  refute_local_object "$txt_remote_oid" "10"
+
+  [ ! $(git cat-file -p refs/heads/master:.gitattributes) ]
+  [ ! $(git cat-file -p refs/remotes/origin/master:.gitattributes) ]
+  feature_attrs="$(git cat-file -p refs/heads/my-feature:.gitattributes)"
+
+  echo "$feature_attrs" | grep -vq "*.md filter=lfs diff=lfs merge=lfs"
+  echo "$feature_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"
+)
+end_test

--- a/test/test-track-attrs.sh
+++ b/test/test-track-attrs.sh
@@ -16,9 +16,9 @@ begin_test "track (--no-modify-attrs)"
   git add a.dat
 
   # Git assumes that identical results from `stat(1)` between the index and
-  # working copy are stat dirty. To prevent this, wait at least two seconds to
+  # working copy are stat dirty. To prevent this, wait at least one second to
   # yield different `stat(1)` results.
-  sleep 2
+  sleep 1
 
   git commit -m "add a.dat"
 

--- a/test/test-track-attrs.sh
+++ b/test/test-track-attrs.sh
@@ -16,9 +16,9 @@ begin_test "track (--no-modify-attrs)"
   git add a.dat
 
   # Git assumes that identical results from `stat(1)` between the index and
-  # working copy are stat dirty. To prevent this, wait at least one second to
+  # working copy are stat dirty. To prevent this, wait at least two seconds to
   # yield different `stat(1)` results.
-  sleep 1
+  sleep 2
 
   git commit -m "add a.dat"
 


### PR DESCRIPTION
This pull request implements the `git-lfs-migrate(1)` 'import' subcommand.

The 'import' subcommand is designed to convert large blobs stored in Git history to LFS pointer files based on the `--include`, `--exclude`, and `--include-ref`, `--exclude-ref` flags. It works by calling the `commands.clean()` function with the blob loaded in memory, and then a) storing that blob's contents in `.git/lfs/objects` and b) writing out an LFS pointer file in its place in the githistory.

Regarding some of the notes from #2146 about when/where to insert .gitattributes changes @technoweenie:

> > When is `.gitattributes` built? I think it'd be cool to slip into the first commit or something.
> 
> Right now I'm adding a `.gitattributes` entry into the first commit that has any paths matching those in the `-I` or `-X` filter, but this could easily be changed to go anywhere before that point in history. I think my preference would be to delay adding the `.gitattributes` entry until the first commit at which that object appears, since that brings us closer to the 1:1 mapping of old history to new, and to me, is clearer in terms of not having a (potentially) huge `.gitattributes` entry up front.
> 

and @andyneff:

> I am actually more inclined to lean towards @ttaylorr's first implementation. I like the idea that the commits before the LFS files are still the same shas, and thus the graphs are topologically connected to each other. I don't know. I just feels good to me ;)

I initially implemented this according to my original suggestion of appending patterns to the `.gitattributes` file when a file of that kind was first rewritten. This is problematic for two reasons:

1. It involves duplicate work to figure out which pattern included/excluded a file (see: #2341).
2. It does _not_ work for `-X`, `--exclude` flags. The `BlobFn` (used to rewrite blobs) is only called on blobs that _do_ match the filter, not ones that don't. This prevents us from ever seeing tree entries that are excluded from the filterset, thus never presenting us an opportunity to add the negative matches to the `.gitattributes`.

Instead, I add the `.gitattributes` changes to the first commit that we migrate by writing lines like:

```gitattributes
pattern merge=lfs filter=lfs diff=lfs -text
```

and adding negative entries for `--exclude`'d patterns like:

```gitattributes
pattern text -merge -filter -diff
```

We keep track of these in a set of patterns that the LFS migrator has tracked, and merge them each time with the .gitattributes in the root tree therefore persisting any .gitattributes changes that exist in the original history. See:

```go
// Create a blob of the attributes that are optionally
// present in the "t" tree's .gitattributes blob, and
// union in the patterns that we've tracked.
//
// Perform this Union() operation each time we visit a
// root tree such that if the underlying .gitattributes
// is present and has a diff between commits in the
// range of commits to migrate, those changes are
// preserved.
blob, err := trackedToBlob(db, theirs.Clone().Union(ours))
```

Here's some example output:

1. Generate some commits ahead of the remote ref that contain data to be migrated to LFS:

```sh
~/g/git-lfs (migrate-demo) $ for i in $(seq 1 10); do
  base64 < /dev/urandom | head -c 64 > a.dat
  git add a.dat
  git commit -m "a.dat: $i"
  done
# ...
```

2. Run `git lfs migrate info` on that data:

```
~/g/git-lfs (migrate-demo) $ git lfs migrate info --above=0b --include="*.dat"
migrate: Sorting commits: ..., done
migrate: Rewriting commits: 100% (10/10), done
*.dat   640 B   10/10 files(s)  100%
```

3. Run `git lfs migrate import` to rewrite those commits such that the large files are tracked with LFS:

```
~/g/git-lfs (migrate-demo) $ git lfs migrate import --include="*.dat"
migrate: Sorting commits: ..., done
migrate: Rewriting commits: 100% (11/11), done
  migrate-demo  f18bb746d44e8ea5065fc779bb1acdf3cdae7ed8 -> 35b0fe0a7bf3ae6952ec9584895a7fb6ebcd498b
migrate: Updating refs: ..., done
```

4. Observe the initial commit to show that a) original `.gitattributes` contents are persisted, b) new `.gitattributes` patterns are added accordingly, and c) the `*.dat` file was added to Git LFS.

```diff
~/g/git-lfs (migrate-demo) $ git show 3f65c4db7313e9f4fe0c546fcbba8d10593f2025
commit 3f65c4db7313e9f4fe0c546fcbba8d10593f2025
Author: Taylor Blau <me@ttaylorr.com>
Date:   Fri Jun 23 13:07:12 2017 -0600

    a.dat: 1

diff --git a/.gitattributes b/.gitattributes
index e4c71dbf..3716304e 100644
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 * text=auto
 * eol=lf
 *.bat eol=crlf
+*.dat filter=lfs diff=lfs merge=lfs -text
diff --git a/a.dat b/a.dat
new file mode 100644
index 00000000..ec26fbcd
--- /dev/null
+++ b/a.dat
@@ -0,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86df498e7a88666447e0c540defbef3f2b2091eecba3c0b7c9ac21962aaef576
+size 64
```

5. Observe an interdiff to show that changes are persisted through the migration and the diffs apply cleanly:

```diff
~/g/git-lfs (migrate-demo) $ git show 94a7b26a4260b04af84c7ce9c7fae6e6586345a6
commit 94a7b26a4260b04af84c7ce9c7fae6e6586345a6
Author: Taylor Blau <me@ttaylorr.com>
Date:   Fri Jun 23 13:07:12 2017 -0600

    a.dat: 2

diff --git a/a.dat b/a.dat
index ec26fbcd..b7fa3fba 100644
--- a/a.dat
+++ b/a.dat
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:86df498e7a88666447e0c540defbef3f2b2091eecba3c0b7c9ac21962aaef576
+oid sha256:bb1df455c4d90dbc0c6903500c036096eeec78f1abc151997a80387c81ccd7e0
 size 64
```

6. Observe that `HEAD` contains a checked-out LFS object, a pointer file in the index, and a corresponding entry in `.git/lfs/objects`:

```
~/g/git-lfs (migrate-demo) $ git cat-file -p :a.dat
version https://git-lfs.github.com/spec/v1
oid sha256:b91016d0851cd677a9209a0c0d11c7e9b2d5654f2baeb6485579b899cf6ffa01
size 64
~/g/git-lfs (migrate-demo) $ cat a.dat
yVnUDK0PSDqmoSvY4W/zD/a3GD/rEuPEx/kbwnjFK4E9jMLp0xRiLzCqmwwkPROO%                                                          
~/g/git-lfs (migrate-demo) $ cat .git/lfs/objects/b9/10/b91016d0851cd677a9209a0c0d11c7e9b2d5654f2baeb6485579b899cf6ffa01 
yVnUDK0PSDqmoSvY4W/zD/a3GD/rEuPEx/kbwnjFK4E9jMLp0xRiLzCqmwwkPROO%                                                          
```

Closes: #2146.

---

/cc @git-lfs/core 
/refs #2146 