### PR TITLE
commands: show no output for entries with no matching files

### DIFF
--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -40,6 +40,10 @@ The 'info' mode has these additional options:
     may be specified as a number of bytes, or a number followed by a storage
     unit, e.g., "1b", "20 MB", "3 TiB", etc.
 
+    If a set of files sharing a common extension has no files in that set whose
+    individual size is above the given `--above` (or its default, 1mb), no files
+    no entry for that set will be shown.
+
 * `--top=<n>`
     Only include the top 'n' entries, ordered by how many total files match the
     given pathspec.

--- a/test/test-migrate-info.sh
+++ b/test/test-migrate-info.sh
@@ -190,9 +190,8 @@ begin_test "migrate info (above threshold)"
 
   original_head="$(git rev-parse HEAD)"
 
-  diff -u <(git lfs migrate info --above=130B 2>&1 | tail -n 2) <(cat <<-EOF
-	*.md 	140 B	1/1 files(s)	100%
-	*.txt	0 B  	0/1 files(s)	  0%
+  diff -u <(git lfs migrate info --above=130B 2>&1 | tail -n 1) <(cat <<-EOF
+	*.md	140 B	1/1 files(s)	100%
 	EOF)
 
   migrated_head="$(git rev-parse HEAD)"
@@ -231,6 +230,22 @@ begin_test "migrate info (given unit)"
 	*.md 	0.1	1/1 files(s)	100%
 	*.txt	0.1	1/1 files(s)	100%
 	EOF)
+
+  migrated_head="$(git rev-parse HEAD)"
+
+  assert_ref_unmoved "HEAD" "$original_head" "$migrated_head"
+)
+end_test
+
+begin_test "migrate info (doesn't show empty info entries)"
+(
+  set -e
+
+  setup_multiple_local_branches
+
+  original_head="$(git rev-parse HEAD)"
+
+  [ "0" -eq "$(git lfs migrate info --above=1mb 2>/dev/null | wc -l)" ]
 
   migrated_head="$(git rev-parse HEAD)"
 


### PR DESCRIPTION
This pull request removes info entries in the `git lfs migrate info` command for entries that have no files above the given (or default) `--above` threshold.

For example, the following output would have been generated before this PR on a file a.txt whose size is 10 bytes.

```
$ git lfs migrate info
*.txt      0 B   0/1 files    0% 
```

Will now show:

```
$ git lfs migrate info
```

Giving `--above=0b` (or `--above=0`, as of #2355) will show the file again.

---

/cc @git-lfs/core 
/refs #2146 