### PR TITLE
test: skip test "track (--no-modify-attrs)" on Git <2.1.0

### DIFF
--- a/test/test-track-attrs.sh
+++ b/test/test-track-attrs.sh
@@ -2,7 +2,7 @@
 
 . "test/testlib.sh"
 
-ensure_git_version_isnt $VERSION_LOWER "1.9.0"
+ensure_git_version_isnt $VERSION_LOWER "2.1.0"
 
 begin_test "track (--no-modify-attrs)"
 (


### PR DESCRIPTION
This pull request skips the `track (--no-modify-attrs)` test on Git versions earlier than 2.1.0, as the cause of failure is currently unknown.

I opened up https://github.com/git-lfs/git-lfs/issues/2357 to track.

---

/cc @git-lfs/core 