### PR TITLE
commands: only pass --jobs to 'git clone' if set

### DIFF
--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -153,7 +153,7 @@ func init() {
 		cmd.Flags().StringVarP(&cloneFlags.ShallowExclude, "shallow-exclude", "", "", "See 'git clone --help'")
 		cmd.Flags().BoolVarP(&cloneFlags.ShallowSubmodules, "shallow-submodules", "", false, "See 'git clone --help'")
 		cmd.Flags().BoolVarP(&cloneFlags.NoShallowSubmodules, "no-shallow-submodules", "", false, "See 'git clone --help'")
-		cmd.Flags().Int64VarP(&cloneFlags.Jobs, "jobs", "j", 1, "See 'git clone --help'")
+		cmd.Flags().Int64VarP(&cloneFlags.Jobs, "jobs", "j", -1, "See 'git clone --help'")
 
 		cmd.Flags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")
 		cmd.Flags().StringVarP(&excludeArg, "exclude", "X", "", "Exclude a list of paths")


### PR DESCRIPTION
Running `git lfs clone` always passes the `--jobs` option to `git clone`. This won't fly if you have git < 2.9:

```
error: unknown option `jobs'
usage: git clone [<options>] [--] <repo> [<dir>]
```

Fixes #2366 by setting the flag default to -1.