### PR TITLE
git/odb: prevent cross-volume link error when saving objects

### DIFF
--- a/git/odb/file_storer.go
+++ b/git/odb/file_storer.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/git-lfs/git-lfs/errors"
+	"github.com/git-lfs/git-lfs/lfs"
 )
 
 // fileStorer implements the storer interface by writing to the .git/objects
@@ -55,7 +56,7 @@ func (fs *fileStorer) Store(sha []byte, r io.Reader) (n int64, err error) {
 		return 0, nil
 	}
 
-	tmp, err := ioutil.TempFile("", "")
+	tmp, err := lfs.TempFile("")
 	if err != nil {
 		return 0, err
 	}

--- a/git/odb/object_db.go
+++ b/git/odb/object_db.go
@@ -5,13 +5,13 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"sync/atomic"
 
 	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/git"
+	"github.com/git-lfs/git-lfs/lfs"
 )
 
 // ObjectDatabase enables the reading and writing of objects against a storage
@@ -96,7 +96,7 @@ func (o *ObjectDatabase) Commit(sha []byte) (*Commit, error) {
 // WriteBlob stores a *Blob on disk and returns the SHA it is uniquely
 // identified by, or an error if one was encountered.
 func (o *ObjectDatabase) WriteBlob(b *Blob) ([]byte, error) {
-	buf, err := ioutil.TempFile("", "")
+	buf, err := lfs.TempFile("")
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +164,7 @@ func (d *ObjectDatabase) encodeBuffer(object Object, buf io.ReadWriter) (sha []b
 		return nil, 0, err
 	}
 
-	tmp, err := ioutil.TempFile("", "")
+	tmp, err := lfs.TempFile("")
 	if err != nil {
 		return nil, 0, err
 	}


### PR DESCRIPTION
This pull request prevents a [cross-volume link error][1] that can occur when committing objects to the object database when a repository is on a non-default volume. This was pointed out in: #2381.

In order to save an object to the database, we do these things:

1. Write a non-zlib compressed copy of the objects body into a temporary buffer (`*bytes.Buffer` for Trees, Commits, `*os.File` for blobs).
2. Create a new buffer on disk with the object header and length, still uncompressed.
3. Stream the above buffer through a `crypto/sha1` Hash to calculate the SHA1 of the object contents.
4. Compress the above.
5. Link the compressed file into the `.git/objects` directory of the repository.

The issue occurs in step 5. If we created a file on a different volume than the on the repository is stored in, and the operating system doesn't support cross-device linking, then an error will occur.

To prevent this from happening, we use `lfs.TempFile` instead of `io/ioutil.TempFile`, which stores temporary objects in `.git/lfs/tmp` instead of `/tmp`. This guarantees that we will always be linking files from a folder on the device that they are being linked into.

I'd like to take a further look at the process required to store objects (see: above), but I think this is a good small step in case I don't have a chance to look at the object committing process before 2.2.x.

Closes #2381.

---

/cc @git-lfs/core 

[1]: https://github.com/golang/go/blob/go1.8.3/src/syscall/zerrors_linux_amd64.go#L1399