### PR TITLE
git/githistory: fix hanging on empty set of commits

### DIFF
--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -382,6 +382,12 @@ func (r *Rewriter) commitsToMigrate(opt *RewriteOptions) ([][]byte, error) {
 		commits = append(commits, scanner.OID())
 	}
 
+	if len(commits) == 0 {
+		// If git-rev-list(1) returned an empty set, mark the log waiter
+		// (see above) as complete.
+		waiter.Complete()
+	}
+
 	if err = scanner.Err(); err != nil {
 		return nil, err
 	}

--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -375,18 +375,10 @@ func (r *Rewriter) commitsToMigrate(opt *RewriteOptions) ([][]byte, error) {
 
 	var commits [][]byte
 	for scanner.Scan() {
-		if len(commits) == 0 {
-			waiter.Complete()
-		}
-
 		commits = append(commits, scanner.OID())
 	}
 
-	if len(commits) == 0 {
-		// If git-rev-list(1) returned an empty set, mark the log waiter
-		// (see above) as complete.
-		waiter.Complete()
-	}
+	waiter.Complete()
 
 	if err = scanner.Err(); err != nil {
 		return nil, err

--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -366,6 +366,7 @@ func (r *Rewriter) rewriteBlob(from []byte, path string, fn BlobRewriteFn) ([]by
 // If any error was encountered, it will be returned.
 func (r *Rewriter) commitsToMigrate(opt *RewriteOptions) ([][]byte, error) {
 	waiter := r.l.Waiter("migrate: Sorting commits")
+	defer waiter.Complete()
 
 	scanner, err := git.NewRevListScanner(
 		opt.Include, opt.Exclude, r.scannerOpts())
@@ -377,8 +378,6 @@ func (r *Rewriter) commitsToMigrate(opt *RewriteOptions) ([][]byte, error) {
 	for scanner.Scan() {
 		commits = append(commits, scanner.OID())
 	}
-
-	waiter.Complete()
 
 	if err = scanner.Err(); err != nil {
 		return nil, err

--- a/test/test-migrate-info.sh
+++ b/test/test-migrate-info.sh
@@ -252,3 +252,18 @@ begin_test "migrate info (doesn't show empty info entries)"
   assert_ref_unmoved "HEAD" "$original_head" "$migrated_head"
 )
 end_test
+
+begin_test "migrate info (empty set)"
+(
+  set -e
+
+  setup_multiple_local_branches
+
+  migrate="$(git lfs migrate info \
+    --include-ref=refs/heads/master \
+    --exclude-ref=refs/heads/master 2>/dev/null
+  )"
+
+  [ "0" -eq "$(echo -n "$migrate" | wc -l | awk '{ print $1 }')" ]
+)
+end_test


### PR DESCRIPTION
This pull request fixes a hang that occurs when the set of commits to migrate is empty, as pointed out in #2380.

In `*git/odb.Rewriter.commitsToMigrate()`, we store a set of `[][]byte`, where each `[]byte` entry is a commit's SHA1 which should be migrated. Our logic looks something like this:

```go
 func (r *Rewriter) commitsToMigrate(opt *RewriteOptions) ([][]byte, error) {
 	waiter := r.l.Waiter("migrate: Sorting commits")

 	scanner, err := git.NewRevListScanner(...)

 	var commits [][]byte
 	for scanner.Scan() {
 		if len(commits) == 0 {
 			waiter.Complete()
 		}

 		commits = append(commits, scanner.OID())
 	}

 	return commits
}
``` 

This has the behavior of flashing a `"migrate: Sorting commits"` message to the terminal, appending `"..., done"` when the first result was received from `git-rev-list(1)`. If, however, the loop inside of `for scanner.Scan()` wasn't entered, the `Waiter` never receives a `Complete()` call.

The `*git/githistory/log` package [picks up the next task][1] (`r.l.Waiter()`, `r.l.Counter()`, etc.) without blocking, but [cannot receive any updates on it][2] causing any channel write whose buffer is full to block. This results in the subsequent [rewriting commits log task][3] to block infinitely, for the waiter is never closed.

There are two cases where an early return would cause such a block:

1. Errors, like `scanner.Err() != nil`, `git.RevListScanner()` returning a non-nil error, etc. These don't require the `"migrate: Sorting commits..."` message to print `"..., done"`, since they cause LFS to exit before spinning up the next logging task.
2. Empty result sets from `git-rev-list(1)`, which is fixed in this PR.

Closes: #2380.

---

/cc @git-lfs/core 
/cc @shana 

[1]: https://github.com/git-lfs/git-lfs/blob/v2.2.0/git/githistory/log/log.go#L162-L179
[2]: https://github.com/git-lfs/git-lfs/blob/v2.2.0/git/githistory/log/log.go#L128-L132
[3]: https://github.com/git-lfs/git-lfs/blob/v2.2.0/git/githistory/rewriter.go#L171