### PR TITLE
all: bump version to '2.3.0-pre'

### DIFF
--- a/config/version.go
+++ b/config/version.go
@@ -12,7 +12,7 @@ var (
 )
 
 const (
-	Version = "2.2.0"
+	Version = "2.3.0-pre"
 )
 
 func init() {

--- a/rpm/SPECS/git-lfs.spec
+++ b/rpm/SPECS/git-lfs.spec
@@ -1,5 +1,5 @@
 Name:           git-lfs
-Version:        2.2.0
+Version:        2.3.0-pre
 Release:        1%{?dist}
 Summary:        Git extension for versioning large files
 

--- a/versioninfo.json
+++ b/versioninfo.json
@@ -13,6 +13,6 @@
 		"FileDescription": "Git LFS",
 		"LegalCopyright": "GitHub, Inc. and Git LFS contributors",
 		"ProductName": "Git Large File Storage (LFS)",
-		"ProductVersion": "2.2.0"
+		"ProductVersion": "2.3.0-pre"
 	}
 }


### PR DESCRIPTION
This pull request bumps the version on master to `2.3.0-pre`, since the next version released from master will be 2.3.0.

---

/cc @git-lfs/core 