### PR TITLE
all: bump version to '2.2.1-pre'

### DIFF
--- a/config/version.go
+++ b/config/version.go
@@ -12,7 +12,7 @@ var (
 )
 
 const (
-	Version = "2.2.0"
+	Version = "2.2.1-pre"
 )
 
 func init() {

--- a/rpm/SPECS/git-lfs.spec
+++ b/rpm/SPECS/git-lfs.spec
@@ -1,5 +1,5 @@
 Name:           git-lfs
-Version:        2.2.0
+Version:        2.2.1-pre
 Release:        1%{?dist}
 Summary:        Git extension for versioning large files
 

--- a/versioninfo.json
+++ b/versioninfo.json
@@ -13,6 +13,6 @@
 		"FileDescription": "Git LFS",
 		"LegalCopyright": "GitHub, Inc. and Git LFS contributors",
 		"ProductName": "Git Large File Storage (LFS)",
-		"ProductVersion": "2.2.0"
+		"ProductVersion": "2.2.1-pre"
 	}
 }


### PR DESCRIPTION
This pull request bumps the version on the `release-2.2` branch to '2.2.1-pre', which will be the next version released from this branch.

To my memory, we haven't done `-pre` version tag bumps on the `release-*` branches before, but I think that this is a good pattern to start, since it will make it easier to distribute builds outside of the release cycle.

If this seems 👎, though, I'm happy to pass on it.

---

/cc @git-lfs/core  