### PR TITLE
Allow to set batch size in LFS config

### DIFF
--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -60,6 +60,10 @@ be scoped inside the configuration for a remote.
 
   These settings control how the upload and download of LFS content occurs.
 
+* `lfs.batchsize`
+
+  The number of objects in a batch. Default 100.
+
 * `lfs.concurrenttransfers`
 
   The number of concurrent uploads/downloads. Default 3.

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -11,10 +11,6 @@ import (
 	"github.com/rubyist/tracerx"
 )
 
-const (
-	defaultBatchSize = 100
-)
-
 type retryCounter struct {
 	MaxRetries int `git:"lfs.transfer.maxretries"`
 
@@ -152,6 +148,7 @@ func NewTransferQueue(dir Direction, manifest *Manifest, remote string, options 
 		transfers: make(map[string]*objectTuple),
 		trMutex:   &sync.Mutex{},
 		manifest:  manifest,
+		batchSize: manifest.batchSize,
 		rc:        newRetryCounter(),
 	}
 
@@ -161,9 +158,6 @@ func NewTransferQueue(dir Direction, manifest *Manifest, remote string, options 
 
 	q.rc.MaxRetries = q.manifest.maxRetries
 
-	if q.batchSize <= 0 {
-		q.batchSize = defaultBatchSize
-	}
 	if q.bufferDepth <= 0 {
 		q.bufferDepth = q.batchSize
 	}


### PR DESCRIPTION
Adjusting the batch size might increase download/upload performance
significantly.

E.g. in cases where concurrent download/upload of objects is very fast
but the server has high latency the latter becomes a bottleneck and
increasing batch size might help.