### PR TITLE
git/odb: remove temporary files after migration

### DIFF
--- a/git/odb/object_db.go
+++ b/git/odb/object_db.go
@@ -100,7 +100,7 @@ func (o *ObjectDatabase) WriteBlob(b *Blob) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer buf.Close()
+	defer os.Rename(buf.Name())
 
 	sha, _, err := o.encodeBuffer(b, buf)
 	if err != nil {
@@ -168,7 +168,7 @@ func (d *ObjectDatabase) encodeBuffer(object Object, buf io.ReadWriter) (sha []b
 	if err != nil {
 		return nil, 0, err
 	}
-	defer tmp.Close()
+	defer os.Remove(tmp.Name())
 
 	to := NewObjectWriter(tmp)
 	if _, err = to.WriteHeader(object.Type(), int64(cn)); err != nil {

--- a/git/odb/object_db.go
+++ b/git/odb/object_db.go
@@ -100,7 +100,7 @@ func (o *ObjectDatabase) WriteBlob(b *Blob) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer os.Rename(buf.Name())
+	defer os.Remove(buf.Name())
 
 	sha, _, err := o.encodeBuffer(b, buf)
 	if err != nil {


### PR DESCRIPTION
This pull request changes an `*os.File.Close()` call into an `os.Remove()` call to avoid keeping many objects in `.git/lfs/tmp` after migrations (as pointed out in: https://github.com/git-lfs/git-lfs/issues/2380#issuecomment-313134306).

EDIT: I deliberately skipped checking the return value from `os.Remove()`, since the presence of files in the `.git/lfs/tmp` directory doesn't affect the migration, so it's non-fatal if they can't be removed.

---

/cc @git-lfs/core 
/cc https://github.com/git-lfs/git-lfs/issues/2380#issuecomment-313134306