### PR TITLE
migrate: don't checkout HEAD on bare repositories

### DIFF
--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -94,8 +94,12 @@ func migrateImportCommand(cmd *cobra.Command, args []string) {
 		UpdateRefs: true,
 	})
 
-	if err := git.Checkout("", nil, true); err != nil {
-		ExitWithError(err)
+	if bare, _ := git.IsBare(); !bare {
+		// Only perform `git-checkout(1) -f` if the repository is
+		// non-bare.
+		if err := git.Checkout("", nil, true); err != nil {
+			ExitWithError(err)
+		}
 	}
 }
 

--- a/git/git.go
+++ b/git/git.go
@@ -802,6 +802,22 @@ func IsVersionAtLeast(actualVersion, desiredVersion string) bool {
 	return actual >= atleast
 }
 
+// IsBare returns whether or not a repository is bare. It requires that the
+// current working directory is a repository.
+//
+// If there was an error determining whether or not the repository is bare, it
+// will be returned.
+func IsBare() (bool, error) {
+	s, err := subprocess.SimpleExec(
+		"git", "rev-parse", "--is-bare-repository")
+
+	if err != nil {
+		return false, err
+	}
+
+	return strconv.ParseBool(s)
+}
+
 // For compatibility with git clone we must mirror all flags in CloneWithoutFilters
 type CloneFlags struct {
 	// --template <template_directory>

--- a/test/test-migrate-fixtures.sh
+++ b/test/test-migrate-fixtures.sh
@@ -159,6 +159,20 @@ setup_multiple_remote_branches() {
   git checkout master
 }
 
+# make_bare converts the existing full checkout of a repository into a bare one,
+# and then `cd`'s into it.
+make_bare() {
+  reponame=$(basename "$(pwd)")
+  mv .git "../$reponame.git"
+
+  cd ..
+
+  rm -rf "$reponame"
+  cd "$reponame.git"
+
+  git config --bool core.bare true
+}
+
 # remove_and_create_local_repo removes, creates, and checks out a local
 # repository given by a particular name:
 #

--- a/test/test-migrate-fixtures.sh
+++ b/test/test-migrate-fixtures.sh
@@ -159,15 +159,6 @@ setup_multiple_remote_branches() {
   git checkout master
 }
 
-# setup_multiple_local_branches_bare creates an identical setup to that of
-# setup_multiple_local_branches, save that this is a bare version.
-#
-# See: setup_multiple_local_branches.
-setup_multiple_local_branches_bare() {
-  setup_multiple_remote_branches
-  make_bare
-}
-
 # make_bare converts the existing full checkout of a repository into a bare one,
 # and then `cd`'s into it.
 make_bare() {

--- a/test/test-migrate-fixtures.sh
+++ b/test/test-migrate-fixtures.sh
@@ -159,6 +159,15 @@ setup_multiple_remote_branches() {
   git checkout master
 }
 
+# setup_multiple_local_branches_bare creates an identical setup to that of
+# setup_multiple_local_branches, save that this is a bare version.
+#
+# See: setup_multiple_local_branches.
+setup_multiple_local_branches_bare() {
+  setup_multiple_remote_branches
+  make_bare
+}
+
 # make_bare converts the existing full checkout of a repository into a bare one,
 # and then `cd`'s into it.
 make_bare() {

--- a/test/test-migrate-import.sh
+++ b/test/test-migrate-import.sh
@@ -317,6 +317,7 @@ begin_test "migrate import (bare repository)"
   set -e
 
   setup_multiple_local_branches_bare
+  make_bare
 
   git lfs migrate import \
     --include-ref=master

--- a/test/test-migrate-import.sh
+++ b/test/test-migrate-import.sh
@@ -311,3 +311,14 @@ EOF)
 EOF)
 )
 end_test
+
+begin_test "migrate import (bare repository)"
+(
+  set -e
+
+  setup_multiple_local_branches_bare
+
+  git lfs migrate import \
+    --include-ref=master
+)
+end_test

--- a/test/test-migrate-import.sh
+++ b/test/test-migrate-import.sh
@@ -316,7 +316,7 @@ begin_test "migrate import (bare repository)"
 (
   set -e
 
-  setup_multiple_local_branches_bare
+  setup_multiple_local_branches
   make_bare
 
   git lfs migrate import \


### PR DESCRIPTION
This pull request skips the final `git-checkout(1)` that we do on repositories after migrating them via `git-lfs-migrate(1) import`.

This was pointed out in https://github.com/git-lfs/git-lfs/issues/2380#issuecomment-313148926.

Before this PR:

```
~/D/foo.git (master) $ git rev-parse --is-bare-repository
true

~/D/foo.git (master) $ git lfs migrate import
migrate: Sorting commits: ..., done
migrate: Rewriting commits: 100% (1/1), done
  master        85d2a9aa2e1fa73548092096f563688e6cd3f2c6 -> a65ddcf4418a78b9e414ead8a5c86c4aebfbb0e1
migrate: Updating refs: ..., done
Error running git [checkout --force]: 'fatal: This operation must be run in a work tree' 'exit status 128'
```

Here's a quick look at how things went down:

1. 2a2a76c: teach `git.IsBare()` to determine if a repository is bare (via `git-rev-list --is-bare-repository`).
2. ca61a20: only call `git.Checkout()` if `!git.IsBare()`.
3. f3fc56c: teach `make_bare` to convert a full repository into a bare one
4. 9b0a2e8: call `git-lfs-migrate(1)` on a bare repository to ensure it doesn't fail.

---

/cc @git-lfs/core 
/cc #2380