### PR TITLE
lfs: trace hook install, uninstall, upgrade

### DIFF
--- a/lfs/hook.go
+++ b/lfs/hook.go
@@ -67,14 +67,18 @@ func (h *Hook) Dir() string {
 // directory. It returns and halts at any errors, and returns nil if the
 // operation was a success.
 func (h *Hook) Install(force bool) error {
+	msg := fmt.Sprintf("Install hook: %s, force=%s, path=%s", h.Type, force, h.Path())
+
 	if err := os.MkdirAll(h.Dir(), 0755); err != nil {
 		return err
 	}
 
 	if h.Exists() && !force {
+		tracerx.Printf(msg + ", upgrading...")
 		return h.Upgrade()
 	}
 
+	tracerx.Printf(msg)
 	return h.write()
 }
 
@@ -109,19 +113,20 @@ func (h *Hook) Uninstall() error {
 		return errors.New("Not in a git repository")
 	}
 
+	msg := fmt.Sprintf("Uninstall hook: %s, path=%s", h.Type, h.Path())
+
 	match, err := h.matchesCurrent()
 	if err != nil {
 		return err
 	}
 
 	if !match {
+		tracerx.Printf(msg + ", doesn't match...")
 		return nil
 	}
 
-	path := h.Path()
-
-	tracerx.Printf("hook %s: remove: %s", h.Type, path)
-	return os.RemoveAll(path)
+	tracerx.Printf(msg)
+	return os.RemoveAll(h.Path())
 }
 
 // matchesCurrent returns whether or not an existing git hook is able to be

--- a/lfs/hook.go
+++ b/lfs/hook.go
@@ -82,10 +82,7 @@ func (h *Hook) Install(force bool) error {
 // end, and sets the mode to octal 0755. It writes to disk unconditionally, and
 // returns at any error.
 func (h *Hook) write() error {
-	path := h.Path()
-	tracerx.Printf("hook %s: write %q", h.Type, path)
-
-	return ioutil.WriteFile(path, []byte(h.Contents+"\n"), 0755)
+	return ioutil.WriteFile(h.Path(), []byte(h.Contents+"\n"), 0755)
 }
 
 // Upgrade upgrades the (assumed to be) existing git hook to the current

--- a/lfs/hook.go
+++ b/lfs/hook.go
@@ -69,10 +69,7 @@ func (h *Hook) Dir() string {
 // directory. It returns and halts at any errors, and returns nil if the
 // operation was a success.
 func (h *Hook) Install(force bool) error {
-	dir := h.Dir()
-
-	tracerx.Printf("hook %s: mkdirall %q", h.Type, dir)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(h.Dir(), 0755); err != nil {
 		return err
 	}
 

--- a/lfs/hook.go
+++ b/lfs/hook.go
@@ -40,8 +40,6 @@ func NewStandardHook(theType string, upgradeables []string) *Hook {
 func (h *Hook) Exists() bool {
 	_, err := os.Stat(h.Path())
 
-	tracerx.Printf("hook %s: stat: %q (exists: %t)", h.Type, h.Path, !os.IsNotExist(err))
-
 	return !os.IsNotExist(err)
 }
 

--- a/lfs/hook.go
+++ b/lfs/hook.go
@@ -67,7 +67,7 @@ func (h *Hook) Dir() string {
 // directory. It returns and halts at any errors, and returns nil if the
 // operation was a success.
 func (h *Hook) Install(force bool) error {
-	msg := fmt.Sprintf("Install hook: %s, force=%s, path=%s", h.Type, force, h.Path())
+	msg := fmt.Sprintf("Install hook: %s, force=%t, path=%s", h.Type, force, h.Path())
 
 	if err := os.MkdirAll(h.Dir(), 0755); err != nil {
 		return err

--- a/lfs/hook.go
+++ b/lfs/hook.go
@@ -142,13 +142,11 @@ func (h *Hook) matchesCurrent() (bool, error) {
 
 	contents := strings.TrimSpace(string(by))
 	if contents == h.Contents || len(contents) == 0 {
-		tracerx.Printf("hook %s: matches contents", h.Type)
 		return true, nil
 	}
 
 	for _, u := range h.Upgradeables {
 		if u == contents {
-			tracerx.Printf("hook %s: matches upgradable contents", h.Type)
 			return true, nil
 		}
 	}

--- a/lfs/setup.go
+++ b/lfs/setup.go
@@ -3,8 +3,6 @@ package lfs
 import (
 	"bytes"
 	"fmt"
-
-	"github.com/rubyist/tracerx"
 )
 
 var (
@@ -73,15 +71,9 @@ func GetHookInstallSteps() string {
 // InstallHooks installs all hooks in the `hooks` var.
 func InstallHooks(force bool) error {
 	for _, h := range hooks {
-		tfmt := "Install hook: %s (force=%t)"
-
 		if err := h.Install(force); err != nil {
-			tracerx.Printf(tfmt+"; %v", h.Type, force, err)
-
 			return err
 		}
-
-		tracerx.Printf(tfmt, h.Type, force)
 	}
 
 	return nil
@@ -90,15 +82,9 @@ func InstallHooks(force bool) error {
 // UninstallHooks removes all hooks in range of the `hooks` var.
 func UninstallHooks() error {
 	for _, h := range hooks {
-		tfmt := "Uninstall hook: %s"
-
 		if err := h.Uninstall(); err != nil {
-			tracerx.Printf(tfmt+"; %v", h.Type, err)
-
 			return err
 		}
-
-		tracerx.Printf(tfmt, h.Type)
 	}
 
 	return nil

--- a/lfs/setup.go
+++ b/lfs/setup.go
@@ -3,6 +3,8 @@ package lfs
 import (
 	"bytes"
 	"fmt"
+
+	"github.com/rubyist/tracerx"
 )
 
 var (
@@ -71,9 +73,15 @@ func GetHookInstallSteps() string {
 // InstallHooks installs all hooks in the `hooks` var.
 func InstallHooks(force bool) error {
 	for _, h := range hooks {
+		tfmt := "Install hook: %s (force=%t)"
+
 		if err := h.Install(force); err != nil {
+			tracerx.Printf(tfmt+"; %v", h.Type, force, err)
+
 			return err
 		}
+
+		tracerx.Printf(tfmt, h.Type, force)
 	}
 
 	return nil

--- a/lfs/setup.go
+++ b/lfs/setup.go
@@ -90,9 +90,15 @@ func InstallHooks(force bool) error {
 // UninstallHooks removes all hooks in range of the `hooks` var.
 func UninstallHooks() error {
 	for _, h := range hooks {
+		tfmt := "Uninstall hook: %s"
+
 		if err := h.Uninstall(); err != nil {
+			tracerx.Printf(tfmt+"; %v", h.Type, err)
+
 			return err
 		}
+
+		tracerx.Printf(tfmt, h.Type)
 	}
 
 	return nil


### PR DESCRIPTION
This pull request adds tracing output to the `git lfs install`, `git lfs uninstall`, and `git lfs upgrade` commands when installing `.git/hooks`, similar to that suggested in: https://github.com/git-lfs/git-lfs/issues/2363#issuecomment-311985990 & https://github.com/git-lfs/git-lfs/issues/2363#issuecomment-311994628.

This should make it easier to diagnose situations where hooks aren't being installed correctly, as we'll now have information about:

1. Which files are being `stat(1)`-ed
2. Which directories are being created
3. Which files are being written
4. Whether files that do exist are marked as upgrade-able.

---

/cc @git-lfs/core 
/cc https://github.com/git-lfs/git-lfs/issues/2363