### PR TITLE
Backport #2382 for v2.2.x: git/odb: prevent cross-volume link error when saving objects

### DIFF
--- a/git/odb/file_storer.go
+++ b/git/odb/file_storer.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/git-lfs/git-lfs/errors"
+	"github.com/git-lfs/git-lfs/lfs"
 )
 
 // fileStorer implements the storer interface by writing to the .git/objects
@@ -55,7 +56,7 @@ func (fs *fileStorer) Store(sha []byte, r io.Reader) (n int64, err error) {
 		return 0, nil
 	}
 
-	tmp, err := ioutil.TempFile("", "")
+	tmp, err := lfs.TempFile("")
 	if err != nil {
 		return 0, err
 	}

--- a/git/odb/object_db.go
+++ b/git/odb/object_db.go
@@ -5,13 +5,13 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"sync/atomic"
 
 	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/git"
+	"github.com/git-lfs/git-lfs/lfs"
 )
 
 // ObjectDatabase enables the reading and writing of objects against a storage
@@ -96,7 +96,7 @@ func (o *ObjectDatabase) Commit(sha []byte) (*Commit, error) {
 // WriteBlob stores a *Blob on disk and returns the SHA it is uniquely
 // identified by, or an error if one was encountered.
 func (o *ObjectDatabase) WriteBlob(b *Blob) ([]byte, error) {
-	buf, err := ioutil.TempFile("", "")
+	buf, err := lfs.TempFile("")
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +164,7 @@ func (d *ObjectDatabase) encodeBuffer(object Object, buf io.ReadWriter) (sha []b
 		return nil, 0, err
 	}
 
-	tmp, err := ioutil.TempFile("", "")
+	tmp, err := lfs.TempFile("")
 	if err != nil {
 		return nil, 0, err
 	}


### PR DESCRIPTION
This backports #2382.