### PR TITLE
Backport #2389 for v2.2.x: migrate: don't checkout HEAD on bare repositories

### DIFF
--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -94,8 +94,12 @@ func migrateImportCommand(cmd *cobra.Command, args []string) {
 		UpdateRefs: true,
 	})
 
-	if err := git.Checkout("", nil, true); err != nil {
-		ExitWithError(err)
+	if bare, _ := git.IsBare(); !bare {
+		// Only perform `git-checkout(1) -f` if the repository is
+		// non-bare.
+		if err := git.Checkout("", nil, true); err != nil {
+			ExitWithError(err)
+		}
 	}
 }
 

--- a/git/git.go
+++ b/git/git.go
@@ -802,6 +802,22 @@ func IsVersionAtLeast(actualVersion, desiredVersion string) bool {
 	return actual >= atleast
 }
 
+// IsBare returns whether or not a repository is bare. It requires that the
+// current working directory is a repository.
+//
+// If there was an error determining whether or not the repository is bare, it
+// will be returned.
+func IsBare() (bool, error) {
+	s, err := subprocess.SimpleExec(
+		"git", "rev-parse", "--is-bare-repository")
+
+	if err != nil {
+		return false, err
+	}
+
+	return strconv.ParseBool(s)
+}
+
 // For compatibility with git clone we must mirror all flags in CloneWithoutFilters
 type CloneFlags struct {
 	// --template <template_directory>

--- a/test/test-migrate-fixtures.sh
+++ b/test/test-migrate-fixtures.sh
@@ -159,6 +159,20 @@ setup_multiple_remote_branches() {
   git checkout master
 }
 
+# make_bare converts the existing full checkout of a repository into a bare one,
+# and then `cd`'s into it.
+make_bare() {
+  reponame=$(basename "$(pwd)")
+  mv .git "../$reponame.git"
+
+  cd ..
+
+  rm -rf "$reponame"
+  cd "$reponame.git"
+
+  git config --bool core.bare true
+}
+
 # remove_and_create_local_repo removes, creates, and checks out a local
 # repository given by a particular name:
 #

--- a/test/test-migrate-import.sh
+++ b/test/test-migrate-import.sh
@@ -311,3 +311,15 @@ EOF)
 EOF)
 )
 end_test
+
+begin_test "migrate import (bare repository)"
+(
+  set -e
+
+  setup_multiple_local_branches
+  make_bare
+
+  git lfs migrate import \
+    --include-ref=master
+)
+end_test


### PR DESCRIPTION
This backports #2389.