### PR TITLE
all: bump to 'v2.2.2-pre'

### DIFF
--- a/config/version.go
+++ b/config/version.go
@@ -12,7 +12,7 @@ var (
 )
 
 const (
-	Version = "2.2.1"
+	Version = "2.2.2-pre"
 )
 
 func init() {

--- a/rpm/SPECS/git-lfs.spec
+++ b/rpm/SPECS/git-lfs.spec
@@ -1,5 +1,5 @@
 Name:           git-lfs
-Version:        2.2.1
+Version:        2.2.2-pre
 Release:        1%{?dist}
 Summary:        Git extension for versioning large files
 

--- a/versioninfo.json
+++ b/versioninfo.json
@@ -13,6 +13,6 @@
 		"FileDescription": "Git LFS",
 		"LegalCopyright": "GitHub, Inc. and Git LFS contributors",
 		"ProductName": "Git Large File Storage (LFS)",
-		"ProductVersion": "2.2.1"
+		"ProductVersion": "2.2.2-pre"
 	}
 }


### PR DESCRIPTION
This pull request bumps the version tag to `2.2.2-pre` as in #2385. It is intended to be merged after #2402 in anticipation of a potential v2.2.2 release.

---

/cc @git-lfs/core 