### PR TITLE
Backport #2393 for v2.2.x: lfs: trace hook install, uninstall, upgrade

### DIFF
--- a/lfs/hook.go
+++ b/lfs/hook.go
@@ -11,6 +11,7 @@ import (
 	"github.com/git-lfs/git-lfs/config"
 	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/git"
+	"github.com/rubyist/tracerx"
 )
 
 var (
@@ -38,7 +39,8 @@ func NewStandardHook(theType string, upgradeables []string) *Hook {
 
 func (h *Hook) Exists() bool {
 	_, err := os.Stat(h.Path())
-	return err == nil
+
+	return !os.IsNotExist(err)
 }
 
 // Path returns the desired (or actual, if installed) location where this hook
@@ -65,14 +67,18 @@ func (h *Hook) Dir() string {
 // directory. It returns and halts at any errors, and returns nil if the
 // operation was a success.
 func (h *Hook) Install(force bool) error {
+	msg := fmt.Sprintf("Install hook: %s, force=%t, path=%s", h.Type, force, h.Path())
+
 	if err := os.MkdirAll(h.Dir(), 0755); err != nil {
 		return err
 	}
 
 	if h.Exists() && !force {
+		tracerx.Printf(msg + ", upgrading...")
 		return h.Upgrade()
 	}
 
+	tracerx.Printf(msg)
 	return h.write()
 }
 
@@ -107,15 +113,19 @@ func (h *Hook) Uninstall() error {
 		return errors.New("Not in a git repository")
 	}
 
+	msg := fmt.Sprintf("Uninstall hook: %s, path=%s", h.Type, h.Path())
+
 	match, err := h.matchesCurrent()
 	if err != nil {
 		return err
 	}
 
 	if !match {
+		tracerx.Printf(msg + ", doesn't match...")
 		return nil
 	}
 
+	tracerx.Printf(msg)
 	return os.RemoveAll(h.Path())
 }
 


### PR DESCRIPTION
This backports #2393.