### PR TITLE
commands/install: teach --manual to `git-lfs-install(1)`

### DIFF
--- a/commands/command_install.go
+++ b/commands/command_install.go
@@ -11,6 +11,7 @@ import (
 var (
 	forceInstall      = false
 	localInstall      = false
+	manualInstall     = false
 	systemInstall     = false
 	skipSmudgeInstall = false
 	skipRepoInstall   = false
@@ -59,6 +60,16 @@ func cmdInstallOptions() lfs.InstallOptions {
 
 func installHooksCommand(cmd *cobra.Command, args []string) {
 	updateForce = forceInstall
+
+	// TODO(@ttaylorr): this is a hack since the `git-lfs-install(1)` calls
+	// into the function that implements `git-lfs-update(1)`. Given that,
+	// there is no way to pass flags into that function, other than
+	// hijacking the flags that `git-lfs-update(1)` already owns.
+	//
+	// At a later date, extract `git-lfs-update(1)`-related logic into its
+	// own function, and translate this flag as a boolean argument to it.
+	updateManual = manualInstall
+
 	updateCommand(cmd, args)
 }
 
@@ -69,6 +80,8 @@ func init() {
 		cmd.Flags().BoolVarP(&systemInstall, "system", "", false, "Set the Git LFS config in system-wide scope.")
 		cmd.Flags().BoolVarP(&skipSmudgeInstall, "skip-smudge", "s", false, "Skip automatic downloading of objects on clone or pull.")
 		cmd.Flags().BoolVarP(&skipRepoInstall, "skip-repo", "", false, "Skip repo setup, just install global filters.")
+		cmd.Flags().BoolVarP(&manualInstall, "manual", "m", false, "Print instructions for manual install.")
+
 		cmd.AddCommand(NewCommand("hooks", installHooksCommand))
 		cmd.PreRun = setupLocalStorage
 	})

--- a/docs/man/git-lfs-install.1.ronn
+++ b/docs/man/git-lfs-install.1.ronn
@@ -26,6 +26,10 @@ filters if they are not already set.
 * `--local`:
     Sets the "lfs" smudge and clean filters in the local repository's git
     config, instead of the global git config (~/.gitconfig).
+* `--manual`:
+    Print instructions for manually updating your hooks to include git-lfs
+    functionality. Use this option if `git lfs install` fails because of existing
+    hooks and you want to retain their functionality.
 * `--system`:
     Sets the "lfs" smudge and clean filters in the system git config, e.g. /etc/gitconfig
     instead of the global git config (~/.gitconfig).


### PR DESCRIPTION
This pull request follows up on a comment left by @technoweenie<sup>[[1][1]]</sup>:

> Also, `git lfs install --manual` doesn't work. I think it just needs [this `update` flag](https://github.com/git-lfs/git-lfs/blob/2fe41e90149a8d02c8d33e4b25f2a314bda1e346/commands/command_update.go#L62).

This teaches the `--manual` mode to `git lfs install`, by hijacking flags owned by the `git-lfs-update(1)` command (since `git-lfs-install(1)` runs `updateCommand()` to implement itself).

I've added a note that this should be addressed in the future, but I think that this is ship-able today.

---

/cc @git-lfs/core 

[1]: https://github.com/git-lfs/git-lfs/pull/2392#issuecomment-314495588