### PR TITLE
git/odb/pack: introduce '*Index' type

### DIFF
--- a/git/odb/pack/errors.go
+++ b/git/odb/pack/errors.go
@@ -1,0 +1,15 @@
+package pack
+
+import "fmt"
+
+// UnsupportedVersionErr is a type implementing 'error' which indicates a
+// the presence of an unsupported packfile version.
+type UnsupportedVersionErr struct {
+	// Got is the unsupported version that was detected.
+	Got uint32
+}
+
+// Error implements 'error.Error()'.
+func (u *UnsupportedVersionErr) Error() string {
+	return fmt.Sprintf("git/odb/pack: unsupported version: %d", u.Got)
+}

--- a/git/odb/pack/errors_test.go
+++ b/git/odb/pack/errors_test.go
@@ -1,0 +1,13 @@
+package pack
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnsupportedVersionErr(t *testing.T) {
+	u := &UnsupportedVersionErr{Got: 3}
+
+	assert.Error(t, u, "git/odb/pack: unsupported version: 3")
+}

--- a/git/odb/pack/index.go
+++ b/git/odb/pack/index.go
@@ -1,0 +1,35 @@
+package pack
+
+import (
+	"io"
+)
+
+// Index stores information about the location of objects in a corresponding
+// packfile.
+type Index struct {
+	// version is the encoding version used by this index.
+	//
+	// Currently, versions 1 and 2 are supported.
+	version IndexVersion
+	// fanout is the L1 fanout table stored in this index. For a given index
+	// "i" into the array, the value stored at that index specifies the
+	// number of objects in the packfile/index that are lexicographically
+	// less than or equal to that index.
+	//
+	// See: https://github.com/git/git/blob/v2.13.0/Documentation/technical/pack-format.txt#L41-L45
+	fanout []uint32
+
+	// f is the underlying set of encoded data comprising this index file.
+	f io.ReaderAt
+}
+
+// Count returns the number of objects in the packfile.
+func (i *Index) Count() int {
+	return int(i.fanout[255])
+}
+
+// readAt is a convenience method that allow reading into the underlying data
+// source from other callers within this package.
+func (i *Index) readAt(p []byte, at int64) (n int, err error) {
+	return i.f.ReadAt(p, at)
+}

--- a/git/odb/pack/index_decode.go
+++ b/git/odb/pack/index_decode.go
@@ -1,0 +1,82 @@
+package pack
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"io"
+)
+
+var (
+	// ErrShortFanout is an error representing situations where the entire
+	// fanout table could not be read, and is thus too short.
+	ErrShortFanout = errors.New("git/odb/pack: too short fanout table")
+
+	// indexHeader is the first four "magic" bytes of index files version 2
+	// or newer.
+	indexHeader = []byte{0xff, 0x74, 0x4f, 0x63}
+)
+
+// DecodeIndex decodes an index whose underlying data is supplied by "r".
+//
+// DecodeIndex reads only the header and fanout table, and does not eagerly
+// parse index entries.
+//
+// If there was an error parsing, it will be returned immediately.
+func DecodeIndex(r io.ReaderAt) (*Index, error) {
+	version, err := decodeIndexHeader(r)
+	if err != nil {
+		return nil, err
+	}
+
+	fanout, err := decodeIndexFanout(r, version.Width())
+	if err != nil {
+		return nil, err
+	}
+
+	return &Index{
+		version: version,
+		fanout:  fanout,
+
+		f: r,
+	}, nil
+}
+
+// decodeIndexHeader determines which version the index given by "r" is.
+func decodeIndexHeader(r io.ReaderAt) (IndexVersion, error) {
+	hdr := make([]byte, 4)
+	if _, err := r.ReadAt(hdr, 0); err != nil {
+		return VersionUnknown, err
+	}
+
+	if bytes.Equal(hdr, indexHeader) {
+		vb := make([]byte, 4)
+		if _, err := r.ReadAt(vb, 4); err != nil {
+			return VersionUnknown, err
+		}
+
+		version := IndexVersion(binary.BigEndian.Uint32(vb))
+
+		return version, &UnsupportedVersionErr{uint32(version)}
+	}
+	return IndexVersion(0), nil
+}
+
+// decodeIndexFanout decodes the fanout table given by "r" and beginning at the
+// given offset.
+func decodeIndexFanout(r io.ReaderAt, offset int64) ([]uint32, error) {
+	b := make([]byte, 256*4)
+	if _, err := r.ReadAt(b, offset); err != nil {
+		if err == io.EOF {
+			return nil, ErrShortFanout
+		}
+		return nil, err
+	}
+
+	fanout := make([]uint32, 256)
+	for i, _ := range fanout {
+		fanout[i] = binary.BigEndian.Uint32(b[(i * 4):])
+	}
+
+	return fanout, nil
+}

--- a/git/odb/pack/index_decode_test.go
+++ b/git/odb/pack/index_decode_test.go
@@ -1,0 +1,27 @@
+package pack
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDecodeIndexUnsupportedVersion(t *testing.T) {
+	buf := make([]byte, 0, 4+4)
+	buf = append(buf, 0xff, 0x74, 0x4f, 0x63)
+	buf = append(buf, 0x0, 0x0, 0x0, 0x3)
+
+	idx, err := DecodeIndex(bytes.NewReader(buf))
+
+	assert.EqualError(t, err, "git/odb/pack: unsupported version: 3")
+	assert.Nil(t, idx)
+}
+
+func TestDecodeIndexEmptyContents(t *testing.T) {
+	idx, err := DecodeIndex(bytes.NewReader(make([]byte, 0)))
+
+	assert.Equal(t, io.EOF, err)
+	assert.Nil(t, idx)
+}

--- a/git/odb/pack/index_entry.go
+++ b/git/odb/pack/index_entry.go
@@ -1,0 +1,8 @@
+package pack
+
+// IndexEntry specifies data encoded into an entry in the pack index.
+type IndexEntry struct {
+	// PackOffset is the number of bytes before the associated object in a
+	// packfile.
+	PackOffset uint64
+}

--- a/git/odb/pack/index_test.go
+++ b/git/odb/pack/index_test.go
@@ -1,0 +1,18 @@
+package pack
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIndexCount(t *testing.T) {
+	fanout := make([]uint32, 256)
+	for i := 0; i < len(fanout); i++ {
+		fanout[i] = uint32(i)
+	}
+
+	idx := &Index{fanout: fanout}
+
+	assert.EqualValues(t, 255, idx.Count())
+}

--- a/git/odb/pack/index_version.go
+++ b/git/odb/pack/index_version.go
@@ -1,0 +1,20 @@
+package pack
+
+import (
+	"fmt"
+)
+
+// IndexVersion is a constant type that represents the version of encoding used
+// by a particular index version.
+type IndexVersion uint32
+
+const (
+	// VersionUnknown is the zero-value for IndexVersion, and represents an
+	// unknown version.
+	VersionUnknown IndexVersion = 0
+)
+
+// Width returns the width of the header given in the respective version.
+func (v IndexVersion) Width() int64 {
+	panic(fmt.Sprintf("git/odb/pack: width unknown for pack version %d", v))
+}

--- a/git/odb/pack/index_version_test.go
+++ b/git/odb/pack/index_version_test.go
@@ -1,0 +1,22 @@
+package pack
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIndexVersionWidthPanicsOnUnknownVersion(t *testing.T) {
+	v := IndexVersion(5)
+
+	defer func() {
+		err := recover()
+		if err == nil {
+			t.Fatal("git/odb/pack: expected IndexVersion.Width() to panic()")
+		}
+
+		assert.Equal(t, "git/odb/pack: width unknown for pack version 5", err)
+	}()
+
+	v.Width()
+}


### PR DESCRIPTION
This pull request introduces the `*Index` type, and creates a new package `git/odb/pack` to hold it.

The goal of this new package is twofold:

1. Parse index files to find packfile offsets.
2. Parse and assemble objects within packfiles.

This pull request is the first in a series of four aimed at accomplishing the first goal. Contained in this pull request is the scaffolding necessary to get us going for parsing actual index files. That means:

- An `*Index` type, which will eventually get a `Entry([]byte) uint64, error)` method to resolve object names to their offsets in a packfile.
- An `IndexVersion` type, which will learn how to parse index entries in later pull requests in this series.
- A `DecodeIndex()` function, which will learn how to use the above `IndexVersion` instances to parse the index header, and eventually find objects in the index.

To address a point raised in #2415:

> @peff wisely points out that I can use [`mmap(2)`](https://en.wikipedia.org/wiki/Mmap) in order to avoid the `seek(1)` cost of bouncing around a file on disk. To me, this means that the 2nd option of lazily loading each entry makes more sense, since:

This is the implementation that I pursued in this series. The idea is that, in order to save memory (and to avoid parsing objects that wont be searched for) we delay parsing index entires until they are asked for.

The next two pull requests in the series will introduce implementations of `IndexVersion.Search()` which have the following signature:

```go
func (i IndexVersion) Search(idx *Index, name []byte, at uint64) (*IndexEntry, int, error) {
        // ...
}
```

Or, in other words: given an index, an object to search for, and a location to search in, return either an entry (match), a comparison value (no match), or an error otherwise.

We can use this comparison value (see: `bytes.Compare()`) in order to direct the next window of our binary search through the index file in order to produce an entry in `O(log(n))` time.

---

/cc @git-lfs/core 
/cc #2415 