### PR TITLE
git/odb/pack: implement Index.Entry() to find object offsets

### DIFF
--- a/git/odb/pack/bounds.go
+++ b/git/odb/pack/bounds.go
@@ -1,0 +1,88 @@
+package pack
+
+import "fmt"
+
+// bounds encapsulates the window of search for a single iteration of binary
+// search.
+//
+// Callers may choose to treat the return values from Left() and Right() as
+// inclusive or exclusive. *bounds makes no assumptions on the inclusivity of
+// those values.
+//
+// See: *git/odb/pack.Index for more.
+type bounds struct {
+	// left is the left or lower bound of the bounds.
+	left int64
+	// right is the rightmost or upper bound of the bounds.
+	right int64
+}
+
+// newBounds returns a new *bounds instance with the given left and right
+// values.
+func newBounds(left, right int64) *bounds {
+	return &bounds{
+		left:  left,
+		right: right,
+	}
+}
+
+// Left returns the leftmost value or lower bound of this *bounds instance.
+func (b *bounds) Left() int64 {
+	return b.left
+}
+
+// right returns the rightmost value or upper bound of this *bounds instance.
+func (b *bounds) Right() int64 {
+	return b.right
+}
+
+// WithLeft returns a new copy of this *bounds instance, replacing the left
+// value with the given argument.
+func (b *bounds) WithLeft(new int64) *bounds {
+	return &bounds{
+		left:  new,
+		right: b.right,
+	}
+}
+
+// WithRight returns a new copy of this *bounds instance, replacing the right
+// value with the given argument.
+func (b *bounds) WithRight(new int64) *bounds {
+	return &bounds{
+		left:  b.left,
+		right: new,
+	}
+}
+
+// Equal returns whether or not the receiving *bounds instance is equal to the
+// given one:
+//
+//   - If both the argument and receiver are nil, they are given to be equal.
+//   - If both the argument and receiver are not nil, and they share the same
+//     Left() and Right() values, they are equal.
+//   - If both the argument and receiver are not nil, but they do not share the
+//     same Left() and Right() values, they are not equal.
+//   - If either the argument or receiver is nil, but the other is not, they are
+//     not equal.
+func (b *bounds) Equal(other *bounds) bool {
+	if b == nil {
+		if other == nil {
+			return true
+		}
+		return false
+	}
+
+	if other == nil {
+		return false
+	}
+
+	return b.left == other.left &&
+		b.right == other.right
+}
+
+// String returns a string representation of this bounds instance, given as:
+//
+//   [<left>,<right>]
+func (b *bounds) String() string {
+	return fmt.Sprintf("[%d,%d]", b.Left(), b.Right())
+}

--- a/git/odb/pack/bounds_test.go
+++ b/git/odb/pack/bounds_test.go
@@ -1,0 +1,78 @@
+package pack
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBoundsLeft(t *testing.T) {
+	assert.EqualValues(t, 1, newBounds(1, 2).Left())
+}
+
+func TestBoundsRight(t *testing.T) {
+	assert.EqualValues(t, 2, newBounds(1, 2).Right())
+}
+
+func TestBoundsWithLeftReturnsNewBounds(t *testing.T) {
+	b1 := newBounds(1, 2)
+	b2 := b1.WithLeft(3)
+
+	assert.EqualValues(t, 1, b1.Left())
+	assert.EqualValues(t, 2, b1.Right())
+
+	assert.EqualValues(t, 3, b2.Left())
+	assert.EqualValues(t, 2, b2.Right())
+}
+
+func TestBoundsWithRightReturnsNewBounds(t *testing.T) {
+	b1 := newBounds(1, 2)
+	b2 := b1.WithRight(3)
+
+	assert.EqualValues(t, 1, b1.Left())
+	assert.EqualValues(t, 2, b1.Right())
+
+	assert.EqualValues(t, 1, b2.Left())
+	assert.EqualValues(t, 3, b2.Right())
+}
+
+func TestBoundsEqualWithIdenticalBounds(t *testing.T) {
+	b1 := newBounds(1, 2)
+	b2 := newBounds(1, 2)
+
+	assert.True(t, b1.Equal(b2))
+}
+
+func TestBoundsEqualWithDifferentBounds(t *testing.T) {
+	b1 := newBounds(1, 2)
+	b2 := newBounds(3, 4)
+
+	assert.False(t, b1.Equal(b2))
+}
+
+func TestBoundsEqualWithNilReceiver(t *testing.T) {
+	bnil := (*bounds)(nil)
+	b2 := newBounds(1, 2)
+
+	assert.False(t, bnil.Equal(b2))
+}
+
+func TestBoundsEqualWithNilArgument(t *testing.T) {
+	b1 := newBounds(1, 2)
+	bnil := (*bounds)(nil)
+
+	assert.False(t, b1.Equal(bnil))
+}
+
+func TestBoundsEqualWithNilArgumentAndReceiver(t *testing.T) {
+	b1 := (*bounds)(nil)
+	b2 := (*bounds)(nil)
+
+	assert.True(t, b1.Equal(b2))
+}
+
+func TestBoundsString(t *testing.T) {
+	b1 := newBounds(1, 2)
+
+	assert.Equal(t, "[1,2]", b1.String())
+}

--- a/git/odb/pack/index_test.go
+++ b/git/odb/pack/index_test.go
@@ -1,10 +1,66 @@
 package pack
 
 import (
+	"bytes"
+	"encoding/binary"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+var (
+	idx *Index
+)
+
+func TestIndexEntrySearch(t *testing.T) {
+	e, err := idx.Entry([]byte{
+		0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1,
+		0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1,
+	})
+
+	assert.NoError(t, err)
+	assert.EqualValues(t, 6, e.PackOffset)
+}
+
+func TestIndexEntrySearchClampLeft(t *testing.T) {
+	e, err := idx.Entry([]byte{
+		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+	})
+
+	assert.NoError(t, err)
+	assert.EqualValues(t, 0, e.PackOffset)
+}
+
+func TestIndexEntrySearchClampRight(t *testing.T) {
+	e, err := idx.Entry([]byte{
+		0xff, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04,
+		0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04,
+	})
+
+	assert.NoError(t, err)
+	assert.EqualValues(t, 0x4ff, e.PackOffset)
+}
+
+func TestIndexSearchOutOfBounds(t *testing.T) {
+	e, err := idx.Entry([]byte{
+		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+	})
+
+	assert.NoError(t, err)
+	assert.Nil(t, e)
+}
+
+func TestIndexEntryNotFound(t *testing.T) {
+	e, err := idx.Entry([]byte{
+		0x1, 0x6, 0x6, 0x6, 0x6, 0x6, 0x6, 0x6, 0x6, 0x6,
+		0x6, 0x6, 0x6, 0x6, 0x6, 0x6, 0x6, 0x6, 0x6, 0x6,
+	})
+
+	assert.NoError(t, err)
+	assert.Nil(t, e)
+}
 
 func TestIndexCount(t *testing.T) {
 	fanout := make([]uint32, 256)
@@ -15,4 +71,97 @@ func TestIndexCount(t *testing.T) {
 	idx := &Index{fanout: fanout}
 
 	assert.EqualValues(t, 255, idx.Count())
+}
+
+// init generates some fixture data and then constructs an *Index instance using
+// it.
+func init() {
+	// eps is the number of SHA1 names generated under each 0x<t> slot.
+	const eps = 5
+
+	hdr := []byte{
+		0xff, 0x74, 0x4f, 0x63, // Index file v2+ magic header
+		0x00, 0x00, 0x00, 0x02, // 4-byte version indicator
+	}
+
+	// Create a fanout table using uint32s (later marshalled using
+	// binary.BigEndian).
+	//
+	// Since we have an even distribution of SHA1s in the generated index,
+	// each entry will increase by the number of entries per slot (see: eps
+	// above).
+	fanout := make([]uint32, FanoutEntries)
+	for i := 0; i < len(fanout); i++ {
+		// Begin the index at (i+1), since the fanout table mandates
+		// objects less than the value at index "i".
+		fanout[i] = uint32((i + 1) * eps)
+	}
+
+	offs := make([]uint32, 0, 256*eps)
+	crcs := make([]uint32, 0, 256*eps)
+
+	names := make([][]byte, 0, 256*eps)
+	for i := 0; i < 256; i++ {
+		// For each name, generate a unique SHA using the prefix "i",
+		// and then suffix "j".
+		//
+		// In other words, when i=1, we will generate:
+		//   []byte{0x1 0x0 0x0 0x0 ...}
+		//   []byte{0x1 0x1 0x1 0x1 ...}
+		//   []byte{0x1 0x2 0x2 0x2 ...}
+		//
+		// and etc.
+		for j := 0; j < eps; j++ {
+			var sha [20]byte
+
+			sha[0] = byte(i)
+			for r := 1; r < len(sha); r++ {
+				sha[r] = byte(j)
+			}
+
+			cpy := make([]byte, len(sha))
+			copy(cpy, sha[:])
+
+			names = append(names, cpy)
+			offs = append(offs, uint32((i*eps)+j))
+			crcs = append(crcs, 0)
+		}
+	}
+
+	// Create a buffer to hold the index contents:
+	buf := bytes.NewBuffer(hdr)
+
+	// Write each value in the fanout table using a 32bit network byte-order
+	// integer.
+	for _, f := range fanout {
+		binary.Write(buf, binary.BigEndian, f)
+	}
+	// Write each SHA1 name to the table next.
+	for _, name := range names {
+		buf.Write(name)
+	}
+	// Then write each of the CRC values in network byte-order as a 32bit
+	// unsigned integer.
+	for _, crc := range crcs {
+		binary.Write(buf, binary.BigEndian, crc)
+	}
+	// Do the same with the offsets.
+	for _, off := range offs {
+		binary.Write(buf, binary.BigEndian, off)
+	}
+
+	idx = &Index{
+		fanout: fanout,
+		// version is unimportant here, use V2 since it's more common in
+		// the wild.
+		version: V2,
+
+		// *bytes.Buffer does not implement io.ReaderAt, but
+		// *bytes.Reader does.
+		//
+		// Call (*bytes.Buffer).Bytes() to get the data, and then
+		// construct a new *bytes.Reader with it to implement
+		// io.ReaderAt.
+		f: bytes.NewReader(buf.Bytes()),
+	}
 }


### PR DESCRIPTION
This pull request uses https://github.com/git-lfs/git-lfs/pull/2421 & https://github.com/git-lfs/git-lfs/pull/2422 to implement a [binary search][1] and entry parse operation over V1 and V2 index files. This is used to determine a given object's offset in the corresponding packfile.

In https://github.com/git-lfs/git-lfs/commit/b761e15ee4eac7255721f88a21d46ef80f9fcab4, we implement a `*bounds` type, which stores a `left` and `right` index used for the binary search. This is done in order to implement the `Equal()` method on `*bounds` in order to detect infinite loops, as:

```go
var last *bounds

for bounds.Left() < bounds.Right() {
  if last.Equal(bounds) {
    // If the bounds are unchanged, that means either that the object does not
    // exist in the packfile, or the fanout table is corrupt.
    //
    // Either way, we won't be able to find the object.  Return immediately to
    // prevent infinite looping.
    return nil, nil
  }
  last = bounds

  // ...
}
```

In https://github.com/git-lfs/git-lfs/commit/0c15b26c215f4b6372019906daed6bbb1fa3938c, we use the `*bounds` type implement a binary search through the index files in order to find the packfile offset for a given object. This works like the following:

1. Use the fanout table to figure out a lower and upper bound for where the object could be within the index file.
  a. If the bounds are unchanged from the last search, return immediately: we have a corrupt index.
  b. If `left >= right`, we don't have the object, so return `(nil, nil)` immediately.
2. For those offsets, pick a midpoint and try and parse the entry at that location.
3. If the entry at that location has a SHA-1 greater than the one we're looking for, narrow our search to the lower half of our sorted list.
4. If the entry at that location has a SHA-1 lesser than the one we're looking for, narrow our search to the upper half of our sorted list.
5. If the entry has a SHA-1 equal to the one that we were looking for, return it immediately.
6. Otherwise, with the modified bounds, go to step 2.

---

/cc @git-lfs/core @peff
/cc #2415 

[1]: https://en.wikipedia.org/wiki/Binary_search_algorithm