### PR TITLE
Update gitignore to add some temp files that get created when building debs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ debian/git-lfs/
 debian/*.log
 debian/files
 debian/*.substvars
+debian/debhelper-build-stamp
+debian/.debhelper
+/.pc
 obj-*
 
 rpm/BUILD*


### PR DESCRIPTION
See subject.  There are a few files that are sometimes created when building debs (I think relating to newer versions of debian tools?)