### PR TITLE
Allow using custom transfer agents directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,16 @@ binaries available for Mac, Windows, Linux, and FreeBSD. Check out the
 
 ## Getting Started
 
-You can install Git LFS in several different ways, depending on your setup and
-preferences.
+By default, the Git LFS client needs a Git LFS server to sync the large files
+it manages. This works out of the box when using popular git repository
+hosting providers like GitHub, Atlassian, etc. When you host your own
+vanilla git server, for example, you need to either use a separate
+[Git LFS server instance](https://github.com/git-lfs/git-lfs/wiki/Implementations),
+or use the [custom transfer adapter](docs/custom-transfers.md) with
+a transfer agent in blind mode, without having to use a Git LFS server instance.
+
+You can install the Git LFS client in several different ways, depending on
+your setup and preferences.
 
 * Linux users can install Debian or RPM packages from [PackageCloud](https://packagecloud.io/github/git-lfs/install).  See the [Installation Guide](./INSTALLING.md) for details.
 * Mac users can install from [Homebrew](https://github.com/Homebrew/homebrew) with `brew install git-lfs`, or from [MacPorts](https://www.macports.org) with `port install git-lfs`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 ## Reference Manual
 
 Each Git LFS subcommand is documented in the [official man pages](man). Any of
-these can be viewed from the command also:
+these can also be viewed from the command line:
 
 ```bash
 $ git lfs help <command>
@@ -16,5 +16,6 @@ Quick intro to Git LFS.
 
 ## Developer Docs
 
-Details of how the Git LFS client works are in the [official specification](spec.md).
-There is also an [API specification](api) that describes how the server works.
+Details of how the Git LFS **client** works are in the [official specification](spec.md).
+
+Details of how the GIT LFS **server** works are in the [API specification](api).

--- a/docs/custom-transfers.md
+++ b/docs/custom-transfers.md
@@ -8,20 +8,34 @@ returned from the LFS API for a given object. The core client also supports
 extensions to allow resuming of downloads (via `Range` headers) and uploads (via
 the [tus.io](http://tus.io) protocol).
 
-In the LFS API request the client includes a list of transfer types it can
-support. When replying, the API server will pick the best one of these it
-supports, and make any necessary adjustments to the returned object actions so
-they will work with that transfer type.
-
-## Custom Transfer Types
-
 Some people might want to be able to transfer content in other ways, however.
-To enable this, git-lfs has an option to configure Custom Transfers, which are
+To enable this, git-lfs allows configuring Custom Transfers, which are
 simply processes which must adhere to the protocol defined later in this
 document. git-lfs will invoke the process at the start of all transfers,
 and will communicate with the process via stdin/stdout for each transfer.
 
-## Configuration
+## Custom Transfer Type Selection
+
+In the LFS API request, the client includes a list of transfer types it
+supports. When replying, the API server will pick one of these and make any
+necessary adjustments to the returned object actions, in case the the picked
+transfer type needs custom details about how to do each transfer.
+
+## Using a Custom Transfer Type without the API server
+
+In some cases the transfer agent can figure out by itself how and where
+the transfers should be made, without having to query the API server.
+In this case it's possible to use the custom transfer agent directly,
+without querying the server, by using the following config option:
+
+* `lfs.standalonetransferagent`
+
+  Allows the specified custom transfer agent to be used directly
+  for transferring files, without asking the server how the transfers
+  should be made. The custom transfer agent has to be defined in a
+  `lfs.customtransfer.<name>` settings group.
+
+## Defining a Custom Transfer Type
 
 A custom transfer process is defined under a settings group called
 `lfs.customtransfer.<name>`, where `<name>` is an identifier (see

--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -91,6 +91,13 @@ be scoped inside the configuration for a remote.
   tus.io API. Once this feature is finalized, this setting will be removed,
   and tus.io uploads will be available for all clients.
 
+* `lfs.standalonetransferagent`
+
+  Allows the specified custom transfer agent to be used directly
+  for transferring files, without asking the server how the transfers
+  should be made. The custom transfer agent has to be defined in a
+  `lfs.customtransfer.<name>` settings group.
+
 * `lfs.customtransfer.<name>.path`
 
   `lfs.customtransfer.<name>` is a settings group which defines a custom

--- a/test/README.md
+++ b/test/README.md
@@ -115,8 +115,9 @@ The `set -e` command will bail on the test at the first command that returns a
 non zero exit status. Use simple shell commands like `grep` as assertions.
 
 The test suite has standard `setup` and `shutdown` functions that should be
-run only once.  If a test script is run by `script/integration`, it will skip
-the functions.  Setup does the following:
+run only once, before/after running the tests.  The `setup` and `shutdown`
+functions are run by `script/integration` and also by individual test scripts
+when they are executed directly. Setup does the following:
 
 * Resets temporary test directories.
 * Compiles git-lfs with the latest code changes.

--- a/test/cmd/lfstest-standalonecustomadapter.go
+++ b/test/cmd/lfstest-standalonecustomadapter.go
@@ -1,0 +1,210 @@
+// +build testtools
+
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/git-lfs/git-lfs/tools"
+)
+
+var backupDir string
+
+// This test custom adapter just copies the files to a folder.
+func main() {
+	scanner := bufio.NewScanner(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	errWriter := bufio.NewWriter(os.Stderr)
+	backupDir = os.Getenv("TEST_STANDALONE_BACKUP_PATH")
+	if backupDir == "" {
+		writeToStderr("TEST_STANDALONE_BACKUP_PATH backup dir not set", errWriter)
+		os.Exit(1)
+	}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		var req request
+		if err := json.Unmarshal([]byte(line), &req); err != nil {
+			writeToStderr(fmt.Sprintf("Unable to parse request: %v\n", line), errWriter)
+			continue
+		}
+
+		switch req.Event {
+		case "init":
+			writeToStderr(fmt.Sprintf("Initialised test custom adapter for %s\n", req.Operation), errWriter)
+			resp := &initResponse{}
+			sendResponse(resp, writer, errWriter)
+		case "download":
+			writeToStderr(fmt.Sprintf("Received download request for %s\n", req.Oid), errWriter)
+			performDownload(req.Oid, req.Size, writer, errWriter)
+		case "upload":
+			writeToStderr(fmt.Sprintf("Received upload request for %s\n", req.Oid), errWriter)
+			performUpload(req.Oid, req.Size, req.Path, writer, errWriter)
+		case "terminate":
+			writeToStderr("Terminating test custom adapter gracefully.\n", errWriter)
+			break
+		}
+	}
+
+}
+
+func writeToStderr(msg string, errWriter *bufio.Writer) {
+	if !strings.HasSuffix(msg, "\n") {
+		msg = msg + "\n"
+	}
+	errWriter.WriteString(msg)
+	errWriter.Flush()
+}
+
+func sendResponse(r interface{}, writer, errWriter *bufio.Writer) error {
+	b, err := json.Marshal(r)
+	if err != nil {
+		return err
+	}
+	// Line oriented JSON
+	b = append(b, '\n')
+	_, err = writer.Write(b)
+	if err != nil {
+		return err
+	}
+	writer.Flush()
+	writeToStderr(fmt.Sprintf("Sent message %v", string(b)), errWriter)
+	return nil
+}
+
+func sendTransferError(oid string, code int, message string, writer, errWriter *bufio.Writer) {
+	resp := &transferResponse{"complete", oid, "", &transferError{code, message}}
+	err := sendResponse(resp, writer, errWriter)
+	if err != nil {
+		writeToStderr(fmt.Sprintf("Unable to send transfer error: %v\n", err), errWriter)
+	}
+}
+
+func sendProgress(oid string, bytesSoFar int64, bytesSinceLast int, writer, errWriter *bufio.Writer) {
+	resp := &progressResponse{"progress", oid, bytesSoFar, bytesSinceLast}
+	err := sendResponse(resp, writer, errWriter)
+	if err != nil {
+		writeToStderr(fmt.Sprintf("Unable to send progress update: %v\n", err), errWriter)
+	}
+}
+
+func performCopy(oid, src, dst string, size int64, writer, errWriter *bufio.Writer) error {
+	writeToStderr(fmt.Sprintf("Copying %s to %s\n", src, dst), errWriter)
+	srcFile, err := os.OpenFile(src, os.O_RDONLY, 0644)
+	if err != nil {
+		sendTransferError(oid, 10, err.Error(), writer, errWriter)
+		return err
+	}
+	defer srcFile.Close()
+
+	dstFile, err := os.Create(dst)
+	if err != nil {
+		sendTransferError(oid, 11, err.Error(), writer, errWriter)
+		return err
+	}
+	defer dstFile.Close()
+
+	// Turn callback into progress messages
+	cb := func(totalSize int64, readSoFar int64, readSinceLast int) error {
+		sendProgress(oid, readSoFar, readSinceLast, writer, errWriter)
+		return nil
+	}
+	_, err = tools.CopyWithCallback(dstFile, srcFile, size, cb)
+	if err != nil {
+		sendTransferError(oid, 4, fmt.Sprintf("cannot write data to dst %q: %v", dst, err), writer, errWriter)
+		os.Remove(dst)
+		return err
+	}
+	if err := dstFile.Close(); err != nil {
+		sendTransferError(oid, 5, fmt.Sprintf("can't close dst %q: %v", dst, err), writer, errWriter)
+		os.Remove(dst)
+		return err
+	}
+	return nil
+}
+
+func performDownload(oid string, size int64, writer, errWriter *bufio.Writer) {
+	dlFile, err := ioutil.TempFile("", "lfscustomdl")
+	if err != nil {
+		sendTransferError(oid, 1, err.Error(), writer, errWriter)
+		return
+	}
+	if err = dlFile.Close(); err != nil {
+		sendTransferError(oid, 2, err.Error(), writer, errWriter)
+		return
+	}
+	dlfilename := dlFile.Name()
+	backupPath := filepath.Join(backupDir, oid)
+	if err = performCopy(oid, backupPath, dlfilename, size, writer, errWriter); err != nil {
+		return
+	}
+
+	// completed
+	complete := &transferResponse{"complete", oid, dlfilename, nil}
+	if err := sendResponse(complete, writer, errWriter); err != nil {
+		writeToStderr(fmt.Sprintf("Unable to send completion message: %v\n", err), errWriter)
+	}
+}
+
+func performUpload(oid string, size int64, fromPath string, writer, errWriter *bufio.Writer) {
+	backupPath := filepath.Join(backupDir, oid)
+	if err := performCopy(oid, fromPath, backupPath, size, writer, errWriter); err != nil {
+		return
+	}
+
+	// completed
+	complete := &transferResponse{"complete", oid, "", nil}
+	if err := sendResponse(complete, writer, errWriter); err != nil {
+		writeToStderr(fmt.Sprintf("Unable to send completion message: %v\n", err), errWriter)
+	}
+}
+
+// Structs reimplemented so closer to a real external implementation
+type header struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+type action struct {
+	Href      string            `json:"href"`
+	Header    map[string]string `json:"header,omitempty"`
+	ExpiresAt time.Time         `json:"expires_at,omitempty"`
+}
+type transferError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// Combined request struct which can accept anything
+type request struct {
+	Event               string  `json:"event"`
+	Operation           string  `json:"operation"`
+	Concurrent          bool    `json:"concurrent"`
+	ConcurrentTransfers int     `json:"concurrenttransfers"`
+	Oid                 string  `json:"oid"`
+	Size                int64   `json:"size"`
+	Path                string  `json:"path"`
+	Action              *action `json:"action"`
+}
+
+type initResponse struct {
+	Error *transferError `json:"error,omitempty"`
+}
+type transferResponse struct {
+	Event string         `json:"event"`
+	Oid   string         `json:"oid"`
+	Path  string         `json:"path,omitempty"` // always blank for upload
+	Error *transferError `json:"error,omitempty"`
+}
+type progressResponse struct {
+	Event          string `json:"event"`
+	Oid            string `json:"oid"`
+	BytesSoFar     int64  `json:"bytesSoFar"`
+	BytesSinceLast int    `json:"bytesSinceLast"`
+}

--- a/test/test-custom-transfers.sh
+++ b/test/test-custom-transfers.sh
@@ -110,3 +110,82 @@ begin_test "custom-transfer-upload-download"
   [ "$(echo "$objectlist" | wc -l)" -eq 12 ]
 )
 end_test
+
+begin_test "custom-transfer-standalone"
+(
+  set -e
+
+  # setup a git repo to be used as a local repo, not remote
+  reponame="test-custom-transfer-standalone"
+  setup_remote_repo "$reponame"
+
+  # clone directly, not through lfstest-gitserver
+  clone_repo_url "$REMOTEDIR/$reponame.git" $reponame
+
+  # set up custom transfer adapter to use a specific transfer agent
+  git config lfs.customtransfer.testcustom.path lfstest-standalonecustomadapter
+  git config lfs.customtransfer.testcustom.concurrent false
+  git config lfs.standalonetransferagent testcustom
+  export TEST_STANDALONE_BACKUP_PATH="$(pwd)/test-custom-transfer-standalone-backup"
+  mkdir -p $TEST_STANDALONE_BACKUP_PATH
+  rm -rf $TEST_STANDALONE_BACKUP_PATH/*
+
+  git lfs track "*.dat" 2>&1 | tee track.log
+  grep "Tracking \"\*.dat\"" track.log
+  git add .gitattributes
+  git commit -m "Tracking"
+
+  # set up a decent amount of data so that there's work for multiple concurrent adapters
+  echo "[
+  {
+    \"CommitDate\":\"$(get_date -10d)\",
+    \"Files\":[
+      {\"Filename\":\"verify.dat\",\"Size\":18,\"Data\":\"send-verify-action\"},
+      {\"Filename\":\"file1.dat\",\"Size\":1024},
+      {\"Filename\":\"file2.dat\",\"Size\":750}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -7d)\",
+    \"Files\":[
+      {\"Filename\":\"file1.dat\",\"Size\":1050},
+      {\"Filename\":\"file3.dat\",\"Size\":660},
+      {\"Filename\":\"file4.dat\",\"Size\":230}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -5d)\",
+    \"Files\":[
+      {\"Filename\":\"file5.dat\",\"Size\":1200},
+      {\"Filename\":\"file6.dat\",\"Size\":300}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -2d)\",
+    \"Files\":[
+      {\"Filename\":\"file3.dat\",\"Size\":120},
+      {\"Filename\":\"file5.dat\",\"Size\":450},
+      {\"Filename\":\"file7.dat\",\"Size\":520},
+      {\"Filename\":\"file8.dat\",\"Size\":2048}]
+  }
+  ]" | lfstest-testutils addcommits
+
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git push origin master 2>&1 | tee pushcustom.log
+  # use PIPESTATUS otherwise we get exit code from tee
+  [ ${PIPESTATUS[0]} = "0" ]
+
+  grep "xfer: started custom adapter process" pushcustom.log
+  grep "xfer\[lfstest-standalonecustomadapter\]:" pushcustom.log
+  grep "12 of 12 files" pushcustom.log
+
+  rm -rf .git/lfs/objects
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git lfs fetch --all  2>&1 | tee fetchcustom.log
+  [ ${PIPESTATUS[0]} = "0" ]
+
+  grep "xfer: started custom adapter process" fetchcustom.log
+  grep "xfer\[lfstest-standalonecustomadapter\]:" fetchcustom.log
+  grep "12 of 12 files" fetchcustom.log
+
+  grep "Terminating test custom adapter gracefully" fetchcustom.log
+
+  objectlist=`find .git/lfs/objects -type f`
+  [ "$(echo "$objectlist" | wc -l)" -eq 12 ]
+)
+end_test

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -324,6 +324,22 @@ clone_repo() {
   echo "$out"
 }
 
+# clone_repo_url clones a Git repository to the subdirectory $dir under $TRASHDIR.
+# setup_remote_repo() needs to be run first. Output is written to clone.log.
+clone_repo_url() {
+  cd "$TRASHDIR"
+
+  local repo="$1"
+  local dir="$2"
+  echo "clone git repository $repo to $dir"
+  out=$(git clone "$repo" "$dir" 2>&1)
+  cd "$dir"
+
+  git config credential.helper lfstest
+  echo "$out" > clone.log
+  echo "$out"
+}
+
 
 # clone_repo_ssl clones a repository from the test Git server to the subdirectory
 # $dir under $TRASHDIR, using the SSL endpoint.

--- a/tq/manifest.go
+++ b/tq/manifest.go
@@ -13,17 +13,18 @@ const (
 )
 
 type Manifest struct {
-	// MaxRetries is the maximum number of retries a single object can
+	// maxRetries is the maximum number of retries a single object can
 	// attempt to make before it will be dropped.
-	maxRetries           int
-	concurrentTransfers  int
-	basicTransfersOnly   bool
-	tusTransfersAllowed  bool
-	downloadAdapterFuncs map[string]NewAdapterFunc
-	uploadAdapterFuncs   map[string]NewAdapterFunc
-	apiClient            *lfsapi.Client
-	tqClient             *tqClient
-	mu                   sync.Mutex
+	maxRetries              int
+	concurrentTransfers     int
+	basicTransfersOnly      bool
+	standaloneTransferAgent string
+	tusTransfersAllowed     bool
+	downloadAdapterFuncs    map[string]NewAdapterFunc
+	uploadAdapterFuncs      map[string]NewAdapterFunc
+	apiClient               *lfsapi.Client
+	tqClient                *tqClient
+	mu                      sync.Mutex
 }
 
 func (m *Manifest) APIClient() *lfsapi.Client {
@@ -69,6 +70,7 @@ func NewManifestWithClient(apiClient *lfsapi.Client) *Manifest {
 			m.concurrentTransfers = v
 		}
 		m.basicTransfersOnly = git.Bool("lfs.basictransfersonly", false)
+		m.standaloneTransferAgent, _ = git.Get("lfs.standalonetransferagent")
 		tusAllowed = git.Bool("lfs.tustransfers", false)
 		configureCustomAdapters(git, m)
 	}


### PR DESCRIPTION
Some custom transfer agents figure out everything by themselves and don't need
any authentication or transfer details from the API server.

Added the `lfs.standalonetransferagent` config option for specifying which
custom agent should be used directly.
