### PR TITLE
git/odb/pack: 💅 

### DIFF
--- a/git/odb/pack/index.go
+++ b/git/odb/pack/index.go
@@ -19,8 +19,8 @@ type Index struct {
 	// See: https://github.com/git/git/blob/v2.13.0/Documentation/technical/pack-format.txt#L41-L45
 	fanout []uint32
 
-	// f is the underlying set of encoded data comprising this index file.
-	f io.ReaderAt
+	// r is the underlying set of encoded data comprising this index file.
+	r io.ReaderAt
 }
 
 // Count returns the number of objects in the packfile.
@@ -92,7 +92,7 @@ func (i *Index) Entry(name []byte) (*IndexEntry, error) {
 // readAt is a convenience method that allow reading into the underlying data
 // source from other callers within this package.
 func (i *Index) readAt(p []byte, at int64) (n int, err error) {
-	return i.f.ReadAt(p, at)
+	return i.r.ReadAt(p, at)
 }
 
 // bounds returns the initial bounds for a given name using the fanout table to

--- a/git/odb/pack/index_decode.go
+++ b/git/odb/pack/index_decode.go
@@ -3,8 +3,9 @@ package pack
 import (
 	"bytes"
 	"encoding/binary"
-	"errors"
 	"io"
+
+	"github.com/git-lfs/git-lfs/errors"
 )
 
 const (

--- a/git/odb/pack/index_decode.go
+++ b/git/odb/pack/index_decode.go
@@ -82,7 +82,7 @@ func DecodeIndex(r io.ReaderAt) (*Index, error) {
 		version: version,
 		fanout:  fanout,
 
-		f: r,
+		r: r,
 	}, nil
 }
 

--- a/git/odb/pack/index_decode.go
+++ b/git/odb/pack/index_decode.go
@@ -8,47 +8,49 @@ import (
 )
 
 const (
-	// MagicWidth is the width of the magic header of packfiles version 2
-	// and newer.
-	MagicWidth = 4
-	// VersionWidth is the width of the version following the magic header.
-	VersionWidth = 4
-	// V2Width is the total width of the header in V2.
-	V2Width = MagicWidth + VersionWidth
-	// V1Width is the total width of the header in V1.
-	V1Width = 0
-
-	// FanoutEntries is the number of entries in the fanout table.
-	FanoutEntries = 256
-	// FanoutEntryWidth is the width of each entry in the fanout table.
-	FanoutEntryWidth = 4
-	// FanoutWidth is the width of the entire fanout table.
-	FanoutWidth = FanoutEntries * FanoutEntryWidth
-
-	// OffsetV1Start is the location of the first object outside of the V1
+	// indexMagicWidth is the width of the magic header of packfiles version
+	// 2 and newer.
+	indexMagicWidth = 4
+	// indexVersionWidth is the width of the version following the magic
 	// header.
-	OffsetV1Start = V1Width + FanoutWidth
-	// OffsetV2Start is the location of the first object outside of the V2
-	// header.
-	OffsetV2Start = V2Width + FanoutWidth
+	indexVersionWidth = 4
+	// indexV2Width is the total width of the header in V2.
+	indexV2Width = indexMagicWidth + indexVersionWidth
+	// indexV1Width is the total width of the header in V1.
+	indexV1Width = 0
 
-	// ObjectNameWidth is the width of a SHA1 object name.
-	ObjectNameWidth = 20
-	// ObjectCRCWidth is the width of the CRC accompanying each object in
-	// V2.
-	ObjectCRCWidth = 4
-	// ObjectSmallOffsetWidth is the width of the small offset encoded into
-	// each object.
-	ObjectSmallOffsetWidth = 4
-	// ObjectLargeOffsetWidth is the width of the optional large offset
+	// indexFanoutEntries is the number of entries in the fanout table.
+	indexFanoutEntries = 256
+	// indexFanoutEntryWidth is the width of each entry in the fanout table.
+	indexFanoutEntryWidth = 4
+	// indexFanoutWidth is the width of the entire fanout table.
+	indexFanoutWidth = indexFanoutEntries * indexFanoutEntryWidth
+
+	// indexOffsetV1Start is the location of the first object outside of the
+	// V1 header.
+	indexOffsetV1Start = indexV1Width + indexFanoutWidth
+	// indexOffsetV2Start is the location of the first object outside of the
+	// V2 header.
+	indexOffsetV2Start = indexV2Width + indexFanoutWidth
+
+	// indexObjectNameWidth is the width of a SHA1 object name.
+	indexObjectNameWidth = 20
+	// indexObjectCRCWidth is the width of the CRC accompanying each object
+	// in V2.
+	indexObjectCRCWidth = 4
+	// indexObjectSmallOffsetWidth is the width of the small offset encoded
+	// into each object.
+	indexObjectSmallOffsetWidth = 4
+	// indexObjectLargeOffsetWidth is the width of the optional large offset
 	// encoded into the small offset.
-	ObjectLargeOffsetWidth = 8
+	indexObjectLargeOffsetWidth = 8
 
-	// ObjectEntryV1Width is the width of one contiguous object entry in V1.
-	ObjectEntryV1Width = ObjectNameWidth + ObjectSmallOffsetWidth
-	// ObjectEntryV2Width is the width of one non-contiguous object entry in
-	// V2.
-	ObjectEntryV2Width = ObjectNameWidth + ObjectCRCWidth + ObjectSmallOffsetWidth
+	// indexObjectEntryV1Width is the width of one contiguous object entry
+	// in V1.
+	indexObjectEntryV1Width = indexObjectNameWidth + indexObjectSmallOffsetWidth
+	// indexObjectEntryV2Width is the width of one non-contiguous object
+	// entry in V2.
+	indexObjectEntryV2Width = indexObjectNameWidth + indexObjectCRCWidth + indexObjectSmallOffsetWidth
 )
 
 var (

--- a/git/odb/pack/index_decode_test.go
+++ b/git/odb/pack/index_decode_test.go
@@ -10,17 +10,17 @@ import (
 )
 
 func TestDecodeIndexV1InvalidFanout(t *testing.T) {
-	idx, err := DecodeIndex(bytes.NewReader(make([]byte, FanoutWidth-1)))
+	idx, err := DecodeIndex(bytes.NewReader(make([]byte, indexFanoutWidth-1)))
 
 	assert.Equal(t, ErrShortFanout, err)
 	assert.Nil(t, idx)
 }
 
 func TestDecodeIndexV2(t *testing.T) {
-	buf := make([]byte, 0, V2Width+FanoutWidth)
+	buf := make([]byte, 0, indexV2Width+indexFanoutWidth)
 	buf = append(buf, 0xff, 0x74, 0x4f, 0x63)
 	buf = append(buf, 0x0, 0x0, 0x0, 0x2)
-	for i := 0; i < FanoutEntries; i++ {
+	for i := 0; i < indexFanoutEntries; i++ {
 		x := make([]byte, 4)
 
 		binary.BigEndian.PutUint32(x, uint32(3))
@@ -36,10 +36,10 @@ func TestDecodeIndexV2(t *testing.T) {
 }
 
 func TestDecodeIndexV2InvalidFanout(t *testing.T) {
-	buf := make([]byte, 0, V2Width+FanoutWidth-FanoutEntryWidth)
+	buf := make([]byte, 0, indexV2Width+indexFanoutWidth-indexFanoutEntryWidth)
 	buf = append(buf, 0xff, 0x74, 0x4f, 0x63)
 	buf = append(buf, 0x0, 0x0, 0x0, 0x2)
-	buf = append(buf, make([]byte, FanoutWidth-1)...)
+	buf = append(buf, make([]byte, indexFanoutWidth-1)...)
 
 	idx, err := DecodeIndex(bytes.NewReader(buf))
 
@@ -48,7 +48,7 @@ func TestDecodeIndexV2InvalidFanout(t *testing.T) {
 }
 
 func TestDecodeIndexV1(t *testing.T) {
-	idx, err := DecodeIndex(bytes.NewReader(make([]byte, FanoutWidth)))
+	idx, err := DecodeIndex(bytes.NewReader(make([]byte, indexFanoutWidth)))
 
 	assert.NoError(t, err)
 	assert.Equal(t, V1, idx.version)

--- a/git/odb/pack/index_test.go
+++ b/git/odb/pack/index_test.go
@@ -162,6 +162,6 @@ func init() {
 		// Call (*bytes.Buffer).Bytes() to get the data, and then
 		// construct a new *bytes.Reader with it to implement
 		// io.ReaderAt.
-		f: bytes.NewReader(buf.Bytes()),
+		r: bytes.NewReader(buf.Bytes()),
 	}
 }

--- a/git/odb/pack/index_test.go
+++ b/git/odb/pack/index_test.go
@@ -90,7 +90,7 @@ func init() {
 	// Since we have an even distribution of SHA1s in the generated index,
 	// each entry will increase by the number of entries per slot (see: eps
 	// above).
-	fanout := make([]uint32, FanoutEntries)
+	fanout := make([]uint32, indexFanoutEntries)
 	for i := 0; i < len(fanout); i++ {
 		// Begin the index at (i+1), since the fanout table mandates
 		// objects less than the value at index "i".

--- a/git/odb/pack/index_v1.go
+++ b/git/odb/pack/index_v1.go
@@ -39,14 +39,14 @@ func v1ShaOffset(at int64) int64 {
 	return v1EntryOffset(at) +
 		// Skip past the 4-byte object offset in the desired entry to
 		// the SHA1.
-		ObjectSmallOffsetWidth
+		indexObjectSmallOffsetWidth
 }
 
 // v1EntryOffset returns the location of the packfile offset for the object
 // given at "at".
 func v1EntryOffset(at int64) int64 {
 	// Skip the L1 fanout table
-	return OffsetV1Start +
+	return indexOffsetV1Start +
 		// Skip the object entries before the one located at "at"
-		(ObjectEntryV1Width * at)
+		(indexObjectEntryV1Width * at)
 }

--- a/git/odb/pack/index_v1_test.go
+++ b/git/odb/pack/index_v1_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	V1IndexFanout = make([]uint32, FanoutEntries)
+	V1IndexFanout = make([]uint32, indexFanoutEntries)
 
 	V1IndexSmallEntry = []byte{
 		0x0, 0x0, 0x0, 0x1,
@@ -82,12 +82,12 @@ func init() {
 		V1IndexFanout[i] = 3
 	}
 
-	fanout := make([]byte, FanoutWidth)
+	fanout := make([]byte, indexFanoutWidth)
 	for i, n := range V1IndexFanout {
-		binary.BigEndian.PutUint32(fanout[i*FanoutEntryWidth:], n)
+		binary.BigEndian.PutUint32(fanout[i*indexFanoutEntryWidth:], n)
 	}
 
-	buf := make([]byte, 0, OffsetV1Start+(3*ObjectEntryV1Width))
+	buf := make([]byte, 0, indexOffsetV1Start+(3*indexObjectEntryV1Width))
 
 	buf = append(buf, fanout...)
 	buf = append(buf, V1IndexSmallEntry...)

--- a/git/odb/pack/index_v1_test.go
+++ b/git/odb/pack/index_v1_test.go
@@ -94,5 +94,5 @@ func init() {
 	buf = append(buf, V1IndexMediumEntry...)
 	buf = append(buf, V1IndexLargeEntry...)
 
-	V1Index.f = bytes.NewReader(buf)
+	V1Index.r = bytes.NewReader(buf)
 }

--- a/git/odb/pack/index_v2.go
+++ b/git/odb/pack/index_v2.go
@@ -48,20 +48,20 @@ func v2Search(idx *Index, name []byte, at int64) (*IndexEntry, int, error) {
 // v2ShaOffset returns the offset of a SHA1 given at "at" in the V2 index file.
 func v2ShaOffset(at int64) int64 {
 	// Skip the packfile index header and the L1 fanout table.
-	return OffsetV2Start +
+	return indexOffsetV2Start +
 		// Skip until the desired name in the sorted names table.
-		(ObjectNameWidth * at)
+		(indexObjectNameWidth * at)
 }
 
 // v2SmallOffsetOffset returns the offset of an object's small (4-byte) offset
 // given by "at".
 func v2SmallOffsetOffset(at, total int64) int64 {
 	// Skip the packfile index header and the L1 fanout table.
-	return OffsetV2Start +
+	return indexOffsetV2Start +
 		// Skip the name table.
-		(ObjectNameWidth * total) +
+		(indexObjectNameWidth * total) +
 		// Skip the CRC table.
-		(ObjectCRCWidth * total) +
+		(indexObjectCRCWidth * total) +
 		// Skip until the desired index in the small offsets table.
-		(ObjectSmallOffsetWidth * at)
+		(indexObjectSmallOffsetWidth * at)
 }

--- a/git/odb/pack/index_v2_test.go
+++ b/git/odb/pack/index_v2_test.go
@@ -13,7 +13,7 @@ var (
 		0xff, 0x74, 0x4f, 0x63,
 		0x00, 0x00, 0x00, 0x02,
 	}
-	V2IndexFanout = make([]uint32, FanoutEntries)
+	V2IndexFanout = make([]uint32, indexFanoutEntries)
 
 	V2IndexNames = []byte{
 		0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1,
@@ -90,12 +90,12 @@ func init() {
 		V2IndexFanout[i] = 3
 	}
 
-	fanout := make([]byte, FanoutWidth)
+	fanout := make([]byte, indexFanoutWidth)
 	for i, n := range V2IndexFanout {
-		binary.BigEndian.PutUint32(fanout[i*FanoutEntryWidth:], n)
+		binary.BigEndian.PutUint32(fanout[i*indexFanoutEntryWidth:], n)
 	}
 
-	buf := make([]byte, 0, OffsetV2Start+3*(ObjectEntryV2Width)+ObjectLargeOffsetWidth)
+	buf := make([]byte, 0, indexOffsetV2Start+3*(indexObjectEntryV2Width)+indexObjectLargeOffsetWidth)
 	buf = append(buf, V2IndexHeader...)
 	buf = append(buf, fanout...)
 	buf = append(buf, V2IndexNames...)

--- a/git/odb/pack/index_v2_test.go
+++ b/git/odb/pack/index_v2_test.go
@@ -102,5 +102,5 @@ func init() {
 	buf = append(buf, V2IndexCRCs...)
 	buf = append(buf, V2IndexOffsets...)
 
-	V2Index.f = bytes.NewReader(buf)
+	V2Index.r = bytes.NewReader(buf)
 }

--- a/git/odb/pack/index_version.go
+++ b/git/odb/pack/index_version.go
@@ -1,8 +1,9 @@
 package pack
 
 import (
-	"errors"
 	"fmt"
+
+	"github.com/git-lfs/git-lfs/errors"
 )
 
 // IndexVersion is a constant type that represents the version of encoding used

--- a/git/odb/pack/index_version.go
+++ b/git/odb/pack/index_version.go
@@ -19,9 +19,9 @@ const (
 func (v IndexVersion) Width() int64 {
 	switch v {
 	case V2:
-		return V2Width
+		return indexV2Width
 	case V1:
-		return V1Width
+		return indexV1Width
 	}
 	panic(fmt.Sprintf("git/odb/pack: width unknown for pack version %d", v))
 }


### PR DESCRIPTION
This pull request applies a few cosmetic changes to the `git/odb/pack` package introduced in the last series of PRs.

Here's a quick breakdown:

- bdc9ff0: rename `f io.ReaderAt` to `r io.ReaderAt` in the `*Index` type. `f` was originally chosen because it ordinarily represents an `mmap(2)`'d file, but it can be more generally an `io.ReaderAt`.
- edd354e: un-export index offset-related constants, by prepending them with `index<t>`.
- 28ae318: fix a few places that I imported `errors` from the standard library instead of our preferred `github.com/git-lfs/git-lfs/errors` package.

---

/cc @git-lfs/core 
/cc #2415 