### PR TITLE
git/odb/pack: use 'ErrNotFound' when index entries are missing

### DIFF
--- a/git/odb/pack/index.go
+++ b/git/odb/pack/index.go
@@ -2,6 +2,8 @@ package pack
 
 import (
 	"io"
+
+	"github.com/git-lfs/git-lfs/errors"
 )
 
 // Index stores information about the location of objects in a corresponding
@@ -26,6 +28,18 @@ type Index struct {
 // Count returns the number of objects in the packfile.
 func (i *Index) Count() int {
 	return int(i.fanout[255])
+}
+
+var (
+	// errNotFound is an error returned by Index.Entry() (see: below) when
+	// an object cannot be found in the index.
+	errNotFound = errors.New("git/odb/pack: object not found in index")
+)
+
+// IsNotFound returns whether a given error represents a missing object in the
+// index.
+func IsNotFound(err error) bool {
+	return err == errNotFound
 }
 
 // Entry returns an entry containing the offset of a given SHA1 "name".

--- a/git/odb/pack/index.go
+++ b/git/odb/pack/index.go
@@ -47,8 +47,9 @@ func IsNotFound(err error) bool {
 // Entry operates in O(log(n))-time in the worst case, where "n" is the number
 // of objects that begin with the first byte of "name".
 //
-// If the entry cannot be found, (nil, nil) will be returned. If there was an
-// error searching for or parsing an entry, it will be returned as (nil, err).
+// If the entry cannot be found, (nil, ErrNotFound) will be returned. If there
+// was an error searching for or parsing an entry, it will be returned as (nil,
+// err).
 //
 // Otherwise, (entry, nil) will be returned.
 func (i *Index) Entry(name []byte) (*IndexEntry, error) {
@@ -63,7 +64,7 @@ func (i *Index) Entry(name []byte) (*IndexEntry, error) {
 			//
 			// Either way, we won't be able to find the object.
 			// Return immediately to prevent infinite looping.
-			return nil, nil
+			return nil, errNotFound
 		}
 		last = bounds
 
@@ -95,12 +96,7 @@ func (i *Index) Entry(name []byte) (*IndexEntry, error) {
 
 	}
 
-	// Theoretically not possible to reach this point, since we terminate
-	// inside of the loop either if the bounds are unchanged, or the object
-	// is found.
-	//
-	// Retain this in order to compile.
-	return nil, nil
+	return nil, errNotFound
 }
 
 // readAt is a convenience method that allow reading into the underlying data

--- a/git/odb/pack/index_test.go
+++ b/git/odb/pack/index_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/binary"
 	"testing"
 
+	"github.com/git-lfs/git-lfs/errors"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -71,6 +73,16 @@ func TestIndexCount(t *testing.T) {
 	idx := &Index{fanout: fanout}
 
 	assert.EqualValues(t, 255, idx.Count())
+}
+
+func TestIndexIsNotFound(t *testing.T) {
+	assert.True(t, IsNotFound(errNotFound),
+		"expected 'errNotFound' to satisfy 'IsNotFound()'")
+}
+
+func TestIndexIsNotFoundForOtherErrors(t *testing.T) {
+	assert.False(t, IsNotFound(errors.New("git/odb/pack: misc")),
+		"expected 'err' not to satisfy 'IsNotFound()'")
 }
 
 // init generates some fixture data and then constructs an *Index instance using

--- a/git/odb/pack/index_test.go
+++ b/git/odb/pack/index_test.go
@@ -50,7 +50,7 @@ func TestIndexSearchOutOfBounds(t *testing.T) {
 		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
 	})
 
-	assert.NoError(t, err)
+	assert.True(t, IsNotFound(err), "expected err to be 'not found'")
 	assert.Nil(t, e)
 }
 
@@ -60,7 +60,7 @@ func TestIndexEntryNotFound(t *testing.T) {
 		0x6, 0x6, 0x6, 0x6, 0x6, 0x6, 0x6, 0x6, 0x6, 0x6,
 	})
 
-	assert.NoError(t, err)
+	assert.True(t, IsNotFound(err), "expected err to be 'not found'")
 	assert.Nil(t, e)
 }
 


### PR DESCRIPTION
This pull request introduces a new API to the `git/odb/pack` package: `pack.IsNotFound(err)`.

I took this idea from the `os` package in the standard library, which returns errors from `os.Stat()` that satisfy `os.IsNotExist()`<sup>[[1](https://golang.org/pkg/os/#IsNotExist)]</sup>:

> IsNotExist returns a boolean indicating whether the error is known to report that a file or directory does not exist.
>
> It is satisfied by ErrNotExist as well as some syscall errors.

This pull request is designed to make calling `Entry()` more ergonomic. Previously, calls from another package would look like this:

```go
var idx *pack.Index

entry, err := idx.Entry([]byte{...})
if err != nil {
        return err
}

if entry == nil {
        return nil
}

// ...
```

Whereas now it could look like:

```go
var idx *pack.Index

entry, err := idx.Entry([]byte{...})
if err != nil {
        if pack.IsNotExist(err) {
                 return nil
        }
        return err
}

// ...
```

---

/cc @git-lfs/core 
/cc #2415 
