### PR TITLE
git/odb/pack: use overflow safe midpoint calculation

### DIFF
--- a/git/odb/pack/index.go
+++ b/git/odb/pack/index.go
@@ -69,7 +69,7 @@ func (i *Index) Entry(name []byte) (*IndexEntry, error) {
 		last = bounds
 
 		// Find the midpoint between the upper and lower bounds.
-		mid := (bounds.Left() + bounds.Right()) / 2
+		mid := bounds.Left() + ((bounds.Right() - bounds.Left()) / 2)
 
 		// Search for the given object at that midpoint.
 		entry, cmp, err := i.version.Search(i, name, mid)


### PR DESCRIPTION
This pull request addresses a potential integer overflow when performing the binary search used to find objects in pack index files. When the sum of the two boundaries is large, it can overflow the maximum size of type `int64`, causing undefined behavior.

As @peff points out in https://github.com/git-lfs/git-lfs/pull/2423#pullrequestreview-52074137:

> [...] this is subject to overflow when the size of the bounds approaches the capacity of your left/right integer types.

He suggests:

> One overflow-safe way is `bounds.Left() + (bounds.Right() - bounds.Left()) / 2`.

Since the `(bounds.Right() - bounds.Left())` sub-expression is evaluated first, that will never overflow, since they are both `int64`s.

EDIT: this was tested in the same manner as described in https://github.com/git-lfs/git-lfs/pull/2423#issuecomment-317777195, and produced the same results (`OK`) both before and after this change:

```bash
~/g/git-lfs (master) $ OBJECTS="$(git verify-pack -v .git/objects/pack/pack-5b2c32d3c1d5708b8edc9abfa5f34c7e2e431c2f.idx | cut -d '' -f 1 | grep -E "^[[:alnum:]]{40}$")"

~/g/git-lfs (master) $ echo "$OBJECTS" | go run ~/github/verify-pack/cmd/verify-pack/main.go .git/objects/pack/pack-5b2c32d3c1d5708b8edc9abfa5f34c7e2e431c2f.idx | shasum -a 256
7bfa44dd8fb4df5823a7a31db81c8b4cf0204485f55c9f41b624f757028ced5e  -

~/g/git-lfs (git-odb-pack-int-overflow) $ git checkout git-odb-pack-int-overflow
Switched to branch 'git-odb-pack-int-overflow'
Your branch is up-to-date with 'origin/git-odb-pack-int-overflow'.

~/g/git-lfs (git-odb-pack-int-overflow) $ echo "$OBJECTS" | go run ~/github/verify-pack/cmd/verify-pack/main.go .git/objects/pack/pack-5b2c32d3c1d5708b8edc9abfa5f34c7e2e431c2f.idx | shasum -a 256
7bfa44dd8fb4df5823a7a31db81c8b4cf0204485f55c9f41b624f757028ced5e  -
```

---

/cc @git-lfs/core @peff
/cc #2415 