### PR TITLE
script/packagecloud: release LFS on fedora/26

### DIFF
--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -37,6 +37,7 @@ $distro_name_map = {
     fedora/23
     fedora/24
     fedora/25
+    fedora/26
   ),
   "debian/7" => %w(
     debian/wheezy


### PR DESCRIPTION
This pull-request adds fedora/26 to the list of targets for Packagecloud, which will make all future builds available on the latest release of Fedora.