### PR TITLE
git/githistory/log: prevent 'NaN' showing up in *PercentageTask

### DIFF
--- a/git/githistory/log/percentage_task.go
+++ b/git/githistory/log/percentage_task.go
@@ -40,7 +40,13 @@ func NewPercentageTask(msg string, total uint64) *PercentageTask {
 func (c *PercentageTask) Count(n uint64) (new uint64) {
 	new = atomic.AddUint64(&c.n, n)
 
-	percentage := 100 * float64(new) / float64(c.total)
+	var percentage float64
+	if c.total == 0 {
+		percentage = 100
+	} else {
+		percentage = 100 * float64(new) / float64(c.total)
+	}
+
 	msg := fmt.Sprintf("%s: %3.f%% (%d/%d)",
 		c.msg, percentage, new, c.total)
 

--- a/git/githistory/log/percentage_task.go
+++ b/git/githistory/log/percentage_task.go
@@ -38,7 +38,9 @@ func NewPercentageTask(msg string, total uint64) *PercentageTask {
 // Count returns the new total number of (atomically managed) elements that have
 // been completed.
 func (c *PercentageTask) Count(n uint64) (new uint64) {
-	new = atomic.AddUint64(&c.n, n)
+	if new = atomic.AddUint64(&c.n, n); new > c.total {
+		panic("git/githistory/log: counted too many items")
+	}
 
 	var percentage float64
 	if c.total == 0 {

--- a/git/githistory/log/percentage_task_test.go
+++ b/git/githistory/log/percentage_task_test.go
@@ -60,3 +60,12 @@ func TestPercentageTaskIsThrottled(t *testing.T) {
 	assert.True(t, throttled,
 		"git/githistory/log: expected *PercentageTask to be Throttle()-d")
 }
+
+func TestPercentageTaskPanicsWhenOvercounted(t *testing.T) {
+	task := NewPercentageTask("example", 0)
+	defer func() {
+		assert.Equal(t, "git/githistory/log: counted too many items", recover())
+	}()
+
+	task.Count(1)
+}

--- a/git/githistory/log/percentage_task_test.go
+++ b/git/githistory/log/percentage_task_test.go
@@ -17,6 +17,20 @@ func TestPercentageTaskCalculuatesPercentages(t *testing.T) {
 	assert.Equal(t, "example:  30% (3/10)", <-task.Updates())
 }
 
+func TestPercentageTaskCalculatesPercentWithoutTotal(t *testing.T) {
+	task := NewPercentageTask("example", 0)
+
+	select {
+	case v, ok := <-task.Updates():
+		if ok {
+			assert.Equal(t, "example: 100% (0/0)", v)
+		} else {
+			t.Fatal("expected channel to be open")
+		}
+	default:
+	}
+}
+
 func TestPercentageTaskCallsDoneWhenComplete(t *testing.T) {
 	task := NewPercentageTask("example", 10)
 


### PR DESCRIPTION
This pull request fixes a bug pointed out in #2450, via https://github.com/git-lfs/git-lfs/issues/2450#issuecomment-319116502:

> ```
> ~/D/harfbuzz (master) $ git lfs migrate info
> migrate: Sorting commits: ..., done
> migrate: Rewriting commits: NaN% (0/0), done
> ```

When there are zero commits to migrate, the migrator should show that it is 100% of the way done, not `NaN%`.

Since we guarantee that the `*PercentageTask` cannot be overcounted in de896f2, we guarentee that 100% is a correct value for all valid calls to the `Count()` method in 78195ec.

---

/cc @git-lfs/core 
/cc #2450 