### PR TITLE
git/odb: fix closing object database test

### DIFF
--- a/git/object_scanner.go
+++ b/git/object_scanner.go
@@ -132,6 +132,10 @@ func (s *ObjectScanner) Scan(oid string) bool {
 // called upon. If there were any errors in freeing that (those) resource(s), it
 // it will be returned, otherwise nil.
 func (s *ObjectScanner) Close() error {
+	if s == nil {
+		return nil
+	}
+
 	if s.closeFn != nil {
 		return s.closeFn()
 	}

--- a/git/odb/object_db_test.go
+++ b/git/odb/object_db_test.go
@@ -203,6 +203,11 @@ func TestClosingAnObjectDatabaseMoreThanOnce(t *testing.T) {
 	db, err := FromFilesystem("/tmp")
 	assert.Nil(t, err)
 
+	// Make db's objectScanner field be nil, since /tmp doesn't contain a
+	// Git repository, which will cause closing `git-cat-file(1) --batch` to
+	// fail.
+	db.objectScanner = nil
+
 	assert.Nil(t, db.Close())
 	assert.EqualError(t, db.Close(), "git/odb: *ObjectDatabase already closed")
 }


### PR DESCRIPTION
This pull request fixes a failing test pointed out in https://github.com/git-lfs/git-lfs/issues/2456:

> ```
> --- FAIL: TestClosingAnObjectDatabaseMoreThanOnce (0.01s)
>         Error Trace:    object_db_test.go:206
> 	Error:		Expected nil, but got: Error in git cat-file --batch: exit status 128 fatal: Not a git repository (or any of the parent directories): .git
>
> FAIL
> FAIL	github.com/git-lfs/git-lfs/git/odb	0.056s
> ```

This issue occurs in the `TestClosingAnObjectDatabaseMoreThanOnce` test, which asserts that closing an `*ObjectDatabase` twice fails when mounted in a directory `/tmp`. Since `/tmp` doesn't contain a Git repository, the first call to `Close()` calls close on the `*ObjectScanner` and returns an error caused by a non-zero exit code when killing `git-cat-file(1) --batch`.

To address this: we make the `*ObjectScanner` field be nil (and teach `*ObjectScanner.Close()` how to respond to a call on a nil receiver), therefore bypassing the error.

Closes: #2456.

---

/cc @git-lfs/core 
/cc #2456 