### PR TITLE
test: ensure that empty pointers are empty

### DIFF
--- a/test/test-malformed-pointers.sh
+++ b/test/test-malformed-pointers.sh
@@ -75,12 +75,16 @@ begin_test "empty pointers"
     add empty.dat
   git commit -m "add empty pointer"
 
+  [ "0" -eq "$(git cat-file -p :empty.dat | wc -c)" ]
+  [ "0" -eq "$(wc -c < empty.dat)" ]
+
   git push origin master
 
   pushd .. >/dev/null
     clone_repo "$reponame" "$reponame-assert"
 
     [ "0" -eq "$(grep -c "empty.dat" clone.log)" ]
+    [ "0" -eq "$(git cat-file -p :empty.dat | wc -c)" ]
     [ "0" -eq "$(wc -c < empty.dat)" ]
   popd >/dev/null
 )


### PR DESCRIPTION
This pull request adds additional assertions to the "empty pointers" test in test/test-malformed-pointers.sh file, following https://github.com/git-lfs/git-lfs/issues/2447 and https://github.com/git-lfs/git-lfs/issues/2449.

By checking the length of `git cat-file -p :empty.dat`, we ensure that an empty file gets cleaned as an empty pointer.

---

/cc @git-lfs/core 
/cc @mathstuf 