### PR TITLE
commands: teach smudge, process-filter to warn about Windows size bug

### DIFF
--- a/commands/command_filter_process.go
+++ b/commands/command_filter_process.go
@@ -62,7 +62,7 @@ func filterCommand(cmd *cobra.Command, args []string) {
 			err = clean(w, req.Payload, req.Header["pathname"], -1)
 		case "smudge":
 			w = git.NewPktlineWriter(os.Stdout, smudgeFilterBufferCapacity)
-			err = smudge(w, req.Payload, req.Header["pathname"], skip, filter)
+			_, err = smudge(w, req.Payload, req.Header["pathname"], skip, filter)
 		default:
 			ExitWithError(fmt.Errorf("Unknown command %q", req.Header["command"]))
 		}

--- a/commands/command_filter_process.go
+++ b/commands/command_filter_process.go
@@ -4,13 +4,11 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"runtime"
 
 	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/filepathfilter"
 	"github.com/git-lfs/git-lfs/git"
 	"github.com/git-lfs/git-lfs/lfs"
-	"github.com/git-lfs/git-lfs/tools/humanize"
 	"github.com/spf13/cobra"
 )
 
@@ -74,7 +72,7 @@ func filterCommand(cmd *cobra.Command, args []string) {
 		if errors.IsNotAPointerError(err) {
 			malformed = append(malformed, req.Header["pathname"])
 			err = nil
-		} else if n > 4*humanize.Gigabyte {
+		} else if possiblyMalformedSmudge(n) {
 			malformedOnWindows = append(malformedOnWindows, req.Header["pathname"])
 		}
 
@@ -96,15 +94,13 @@ func filterCommand(cmd *cobra.Command, args []string) {
 	}
 
 	if len(malformedOnWindows) > 0 {
-		if runtime.GOOS == "windows" {
-			fmt.Fprintf(os.Stderr, "Encountered %d file(s) that may not have been copied correctly on Windows:\n")
+		fmt.Fprintf(os.Stderr, "Encountered %d file(s) that may not have been copied correctly on Windows:\n")
 
-			for _, m := range malformedOnWindows {
-				fmt.Fprintf(os.Stderr, "\t%s\n", m)
-			}
-
-			fmt.Fprintf(os.Stderr, "\nSee: `git lfs help smudge` for more details.\n")
+		for _, m := range malformedOnWindows {
+			fmt.Fprintf(os.Stderr, "\t%s\n", m)
 		}
+
+		fmt.Fprintf(os.Stderr, "\nSee: `git lfs help smudge` for more details.\n")
 	}
 
 	if err := s.Err(); err != nil && err != io.EOF {

--- a/docs/man/git-lfs-smudge.1.ronn
+++ b/docs/man/git-lfs-smudge.1.ronn
@@ -24,6 +24,13 @@ standard output.
 * `--skip`:
     Skip automatic downloading of objects on clone or pull.
 
+## KNOWN BUGS
+
+On Windows, Git does not handle files in the working tree larger than 4
+gigabytes.
+
+For more information, see: https://github.com/git-lfs/git-lfs/issues/2434.
+
 ## SEE ALSO
 
 git-lfs-install(1), gitattributes(5).

--- a/lfs/pointer.go
+++ b/lfs/pointer.go
@@ -60,7 +60,7 @@ func NewPointerExtension(name string, priority int, oid string) *PointerExtensio
 	return &PointerExtension{name, priority, oid, oidType}
 }
 
-func (p *Pointer) Smudge(writer io.Writer, workingfile string, download bool, manifest *tq.Manifest, cb progress.CopyCallback) error {
+func (p *Pointer) Smudge(writer io.Writer, workingfile string, download bool, manifest *tq.Manifest, cb progress.CopyCallback) (int64, error) {
 	return PointerSmudge(writer, p, workingfile, download, manifest, cb)
 }
 


### PR DESCRIPTION
This pull request teaches the `git lfs {smudge,filter-process}` commands to warn when smudging blobs larger than 4 GB on Windows.

From https://github.com/git-lfs/git-lfs/issues/2434#issuecomment-317582466:

> [...] I ran this by a Git core dev, and he mentioned that Git on Windows does not support files over 4GB. Unfortunately, this is not something we can fix in LFS. The best we can do now add a warning when large objects are added.

This pull request adds that warning.

Here's a quick breakdown of how things happened:

1. 3a080f9: teach `smudge()` (et. al.) to return `(int64, error)` as `io.Copy` does, to indicate the number of bytes smudged by a call to that function.
2. f6beec6: use the return value from that function to determine and potentially warn about files larger than 4gb being copied into the worktree.

@technoweenie also mentioned:

> [...] I think we should add an early warning in the filter smudge and process code, perhaps linking to a page offering this workaround.

I originally added a link back to https://github.com/git-lfs/git-lfs/issues/2434, but thought that adding a section to the manpage would be sufficient, and perhaps a little cleaner, since the manpages are distributed in the binary and don't require you to be online to view them.

Closes: https://github.com/git-lfs/git-lfs/issues/2434.

---

/cc @git-lfs/core 
/cc https://github.com/git-lfs/git-lfs/issues/2434