### PR TITLE
commands: remove --above=1mb default from 'git lfs migrate info'

### DIFF
--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -208,7 +208,7 @@ func getHistoryRewriter(cmd *cobra.Command, db *odb.ObjectDatabase) *githistory.
 func init() {
 	info := NewCommand("info", migrateInfoCommand)
 	info.Flags().IntVar(&migrateInfoTopN, "top", 5, "--top=<n>")
-	info.Flags().StringVar(&migrateInfoAboveFmt, "above", "1mb", "--above=<n>")
+	info.Flags().StringVar(&migrateInfoAboveFmt, "above", "", "--above=<n>")
 	info.Flags().StringVar(&migrateInfoUnitFmt, "unit", "", "--unit=<unit>")
 
 	importCmd := NewCommand("import", migrateImportCommand)

--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -53,8 +53,8 @@ The 'info' mode has these additional options:
     unit, e.g., "1b", "20 MB", "3 TiB", etc.
 
     If a set of files sharing a common extension has no files in that set whose
-    individual size is above the given `--above` (or its default, 1mb), no files
-    no entry for that set will be shown.
+    individual size is above the given `--above` no files no entry for that set
+    will be shown.
 
 * `--top=<n>`
     Only include the top 'n' entries, ordered by how many total files match the

--- a/test/test-migrate-info.sh
+++ b/test/test-migrate-info.sh
@@ -11,7 +11,7 @@ begin_test "migrate info (default branch)"
 
   original_head="$(git rev-parse HEAD)"
 
-  diff -u <(git lfs migrate info --above=0b 2>&1 | tail -n 2) <(cat <<-EOF
+  diff -u <(git lfs migrate info 2>&1 | tail -n 2) <(cat <<-EOF
 	*.md 	140 B	1/1 files(s)	100%
 	*.txt	120 B	1/1 files(s)	100%
 	EOF)
@@ -31,7 +31,7 @@ begin_test "migrate info (given branch)"
   original_master="$(git rev-parse refs/heads/master)"
   original_feature="$(git rev-parse refs/heads/my-feature)"
 
-  diff -u <(git lfs migrate info --above=0b my-feature 2>&1 | tail -n 2) <(cat <<-EOF
+  diff -u <(git lfs migrate info my-feature 2>&1 | tail -n 2) <(cat <<-EOF
 	*.md 	170 B	2/2 files(s)	100%
 	*.txt	120 B	1/1 files(s)	100%
 	EOF)
@@ -52,7 +52,7 @@ begin_test "migrate info (default branch with filter)"
 
   original_head="$(git rev-parse HEAD)"
 
-  diff -u <(git lfs migrate info --above=0b --include "*.md" 2>&1 | tail -n 1) <(cat <<-EOF
+  diff -u <(git lfs migrate info --include "*.md" 2>&1 | tail -n 1) <(cat <<-EOF
 	*.md	140 B	1/1 files(s)	100%
 	EOF)
 
@@ -71,7 +71,7 @@ begin_test "migrate info (given branch with filter)"
   original_master="$(git rev-parse refs/heads/master)"
   original_feature="$(git rev-parse refs/heads/my-feature)"
 
-  diff -u <(git lfs migrate info --above=0b --include "*.md" my-feature 2>&1 | tail -n 1) <(cat <<-EOF
+  diff -u <(git lfs migrate info --include "*.md" my-feature 2>&1 | tail -n 1) <(cat <<-EOF
 	*.md	170 B	2/2 files(s)	100%
 	EOF)
 
@@ -94,7 +94,7 @@ begin_test "migrate info (default branch, exclude remote refs)"
   original_remote="$(git rev-parse refs/remotes/origin/master)"
   original_master="$(git rev-parse refs/heads/master)"
 
-  diff -u <(git lfs migrate info --above=0b 2>&1 | tail -n 2) <(cat <<-EOF
+  diff -u <(git lfs migrate info 2>&1 | tail -n 2) <(cat <<-EOF
 	*.md 	50 B	1/1 files(s)	100%
 	*.txt	30 B	1/1 files(s)	100%
 	EOF)
@@ -117,7 +117,7 @@ begin_test "migrate info (given branch, exclude remote refs)"
   original_master="$(git rev-parse refs/heads/master)"
   original_feature="$(git rev-parse refs/heads/my-feature)"
 
-  diff -u <(git lfs migrate info --above=0b my-feature 2>&1 | tail -n 2) <(cat <<-EOF
+  diff -u <(git lfs migrate info my-feature 2>&1 | tail -n 2) <(cat <<-EOF
 	*.md 	52 B	2/2 files(s)	100%
 	*.txt	50 B	2/2 files(s)	100%
 	EOF)
@@ -142,7 +142,6 @@ begin_test "migrate info (include/exclude ref)"
   original_feature="$(git rev-parse refs/heads/my-feature)"
 
   diff -u <(git lfs migrate info \
-    --above=0b \
     --include-ref=refs/heads/my-feature \
     --exclude-ref=refs/heads/master 2>&1 | tail -n 2) <(cat <<-EOF
 	*.md 	31 B	1/1 files(s)	100%
@@ -167,7 +166,6 @@ begin_test "migrate info (include/exclude ref with filter)"
   original_feature="$(git rev-parse refs/heads/my-feature)"
 
   diff -u <(git lfs migrate info \
-    --above=0b \
     --include="*.txt" \
     --include-ref=refs/heads/my-feature \
     --exclude-ref=refs/heads/master 2>&1 | tail -n 1) <(cat <<-EOF
@@ -226,7 +224,7 @@ begin_test "migrate info (given unit)"
 
   original_head="$(git rev-parse HEAD)"
 
-  diff -u <(git lfs migrate info --above=0b --unit=kb 2>&1 | tail -n 2) <(cat <<-EOF
+  diff -u <(git lfs migrate info --unit=kb 2>&1 | tail -n 2) <(cat <<-EOF
 	*.md 	0.1	1/1 files(s)	100%
 	*.txt	0.1	1/1 files(s)	100%
 	EOF)

--- a/tools/humanize/humanize.go
+++ b/tools/humanize/humanize.go
@@ -54,9 +54,15 @@ func ParseBytes(str string) (uint64, error) {
 		sep = sep + 1
 	}
 
-	f, err := strconv.ParseFloat(strings.Replace(str[:sep], ",", "", -1), 64)
-	if err != nil {
-		return 0, err
+	var f float64
+
+	if s := strings.Replace(str[:sep], ",", "", -1); len(s) > 0 {
+		var err error
+
+		f, err = strconv.ParseFloat(s, 64)
+		if err != nil {
+			return 0, err
+		}
 	}
 
 	m, err := ParseByteUnit(str[sep:])

--- a/tools/humanize/humanize_test.go
+++ b/tools/humanize/humanize_test.go
@@ -61,13 +61,14 @@ func (c *FormatBytesUnitTestCase) Assert(t *testing.T) {
 
 func TestParseBytes(t *testing.T) {
 	for desc, c := range map[string]*ParseBytesTestCase{
-		"parse byte (empty)": {"10", uint64(10 * math.Pow(2, 0)), nil},
-		"parse byte":         {"10B", uint64(10 * math.Pow(2, 0)), nil},
-		"parse kibibyte":     {"20KIB", uint64(20 * math.Pow(2, 10)), nil},
-		"parse mebibyte":     {"30MIB", uint64(30 * math.Pow(2, 20)), nil},
-		"parse gibibyte":     {"40GIB", uint64(40 * math.Pow(2, 30)), nil},
-		"parse tebibyte":     {"50TIB", uint64(50 * math.Pow(2, 40)), nil},
-		"parse pebibyte":     {"60PIB", uint64(60 * math.Pow(2, 50)), nil},
+		"parse byte (zero, empty)": {"", uint64(0), nil},
+		"parse byte (empty)":       {"10", uint64(10 * math.Pow(2, 0)), nil},
+		"parse byte":               {"10B", uint64(10 * math.Pow(2, 0)), nil},
+		"parse kibibyte":           {"20KIB", uint64(20 * math.Pow(2, 10)), nil},
+		"parse mebibyte":           {"30MIB", uint64(30 * math.Pow(2, 20)), nil},
+		"parse gibibyte":           {"40GIB", uint64(40 * math.Pow(2, 30)), nil},
+		"parse tebibyte":           {"50TIB", uint64(50 * math.Pow(2, 40)), nil},
+		"parse pebibyte":           {"60PIB", uint64(60 * math.Pow(2, 50)), nil},
 
 		"parse byte (lowercase)":     {"10b", uint64(10 * math.Pow(2, 0)), nil},
 		"parse kibibyte (lowercase)": {"20kib", uint64(20 * math.Pow(2, 10)), nil},


### PR DESCRIPTION
This pull request sets the default value of `--above` in `git lfs migrate info` to be empty, which in fact means that it will be set to 0b.

As I recall, the reason we added this was to give a better sense of which files were taking up the most space in a repository, if, for instance, not all files of a given extension are uniformly large/small.

In practice, I've found that this can be potentially confusing to first-time users of the command. By setting the default to empty, we encourage a flow of:

1. Run `git lfs migrate info`, which has reasonable defaults.
2. See that a given extension(s) is/are taking up lots of space.
3. Drill down into `git lfs migrate info --include="*.ext" --above="3mb"`.

---

/cc @git-lfs/core 