### PR TITLE
script/build: pass -{ld,gc}flags to compiler, if given

### DIFF
--- a/script/build.go
+++ b/script/build.go
@@ -19,12 +19,13 @@ import (
 )
 
 var (
-	BuildOS    = flag.String("os", runtime.GOOS, "OS to target: darwin, freebsd, linux, windows")
-	BuildArch  = flag.String("arch", "", "Arch to target: 386, amd64")
-	BuildAll   = flag.Bool("all", false, "Builds all architectures")
-	BuildDwarf = flag.Bool("dwarf", false, "Includes DWARF tables in build artifacts")
-	ShowHelp   = flag.Bool("help", false, "Shows help")
-	matrixKeys = map[string]string{
+	BuildOS      = flag.String("os", runtime.GOOS, "OS to target: darwin, freebsd, linux, windows")
+	BuildArch    = flag.String("arch", "", "Arch to target: 386, amd64")
+	BuildAll     = flag.Bool("all", false, "Builds all architectures")
+	BuildDwarf   = flag.Bool("dwarf", false, "Includes DWARF tables in build artifacts")
+	BuildLdFlags = flag.String("ldflags", "", "-ldflags to pass to the compiler")
+	ShowHelp     = flag.Bool("help", false, "Shows help")
+	matrixKeys   = map[string]string{
 		"darwin":  "Mac",
 		"freebsd": "FreeBSD",
 		"linux":   "Linux",
@@ -145,7 +146,9 @@ func buildCommand(dir, buildos, buildarch string) error {
 
 	args := make([]string, 1, 6)
 	args[0] = "build"
-	if len(LdFlags) > 0 {
+	if len(*BuildLdFlags) > 0 {
+		args = append(args, "-ldflags", *BuildLdFlags)
+	} else if len(LdFlags) > 0 {
 		args = append(args, "-ldflags", strings.Join(LdFlags, " "))
 	}
 	args = append(args, "-o", bin, ".")

--- a/script/build.go
+++ b/script/build.go
@@ -24,6 +24,7 @@ var (
 	BuildAll     = flag.Bool("all", false, "Builds all architectures")
 	BuildDwarf   = flag.Bool("dwarf", false, "Includes DWARF tables in build artifacts")
 	BuildLdFlags = flag.String("ldflags", "", "-ldflags to pass to the compiler")
+	BuildGcFlags = flag.String("gcflags", "", "-gcflags to pass to the compiler")
 	ShowHelp     = flag.Bool("help", false, "Shows help")
 	matrixKeys   = map[string]string{
 		"darwin":  "Mac",
@@ -151,6 +152,11 @@ func buildCommand(dir, buildos, buildarch string) error {
 	} else if len(LdFlags) > 0 {
 		args = append(args, "-ldflags", strings.Join(LdFlags, " "))
 	}
+
+	if len(*BuildGcFlags) > 0 {
+		args = append(args, "-gcflags", *BuildGcFlags)
+	}
+
 	args = append(args, "-o", bin, ".")
 
 	cmd := exec.Command("go", args...)


### PR DESCRIPTION
This pull request teaches `script/build.go` (accessible via `script/boostrap`) how to pass `-ldflags` and `gcflags` to the Go compiler, if they are given.

This is useful for debugging the `git-lfs` binary, where DWARF tables should be included and compiler optimizations and inlining should be disabled. I originally implemented this as:

```diff
diff --git a/script/build.go b/script/build.go
index fba6292a..f42cad59 100644
--- a/script/build.go
+++ b/script/build.go
@@ -23,6 +23,7 @@ var (
 	BuildArch  = flag.String("arch", "", "Arch to target: 386, amd64")
 	BuildAll   = flag.Bool("all", false, "Builds all architectures")
 	BuildDwarf = flag.Bool("dwarf", false, "Includes DWARF tables in build artifacts")
+	BuildDebug = flag.Bool("debug", false, "Prepares a git-lfs binary useful for debugging")
 	ShowHelp   = flag.Bool("help", false, "Shows help")
 	matrixKeys = map[string]string{
 		"darwin":  "Mac",
@@ -31,7 +32,7 @@ var (
 		"windows": "Windows",
 		"amd64":   "AMD64",
 	}
-	LdFlags []string
+	LdFlags, GcFlags []string
 )
 
 func mainBuild() {
@@ -55,10 +56,14 @@ func mainBuild() {
 			"github.com/git-lfs/git-lfs/config.GitCommit="+string(cmd),
 		))
 	}
-	if !*BuildDwarf {
+	if !*BuildDwarf || !*BuildDebug {
 		LdFlags = append(LdFlags, "-s", "-w")
 	}
 
+	if *BuildDebug {
+		GcFlags = append(GcFlags, "-N", "-l")
+	}
+
 	buildMatrix := make(map[string]Release)
 	errored := false
 
@@ -148,6 +153,9 @@ func buildCommand(dir, buildos, buildarch string) error {
 	if len(LdFlags) > 0 {
 		args = append(args, "-ldflags", strings.Join(LdFlags, " "))
 	}
+	if len(GcFlags) > 0 {
+		args = append(args, "-gcflags", strings.Join(GcFlags, " "))
+	}
 	args = append(args, "-o", bin, ".")
 
 	cmd := exec.Command("go", args...)
```

But I think the `-gcflags` and `-ldflags` approach is more flexible.

---

/cc @git-lfs/core 