### PR TITLE
commands/track: resolve symlinks before comparing attr paths

### DIFF
--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -56,6 +56,7 @@ func trackCommand(cmd *cobra.Command, args []string) {
 	}
 
 	wd, _ := tools.Getwd()
+	wd = tools.ResolveSymlinks(wd)
 	relpath, err := filepath.Rel(config.LocalWorkingDir, wd)
 	if err != nil {
 		Exit("Current directory %q outside of git working directory %q.", wd, config.LocalWorkingDir)

--- a/test/test-track.sh
+++ b/test/test-track.sh
@@ -463,3 +463,28 @@ begin_test "track escaped pattern"
   assert_attributes_count "\\#" "filter=lfs" 1
 )
 end_test
+
+begin_test "track (symlinked repository)"
+(
+  set -e
+
+  reponame="tracked-symlinked-repository"
+  git init "$reponame"
+  cd "$reponame"
+
+  touch a.dat
+
+  pushd .. > /dev/null
+    dir="tracked-symlinked-repository-tmp"
+
+    mkdir -p "$dir"
+
+    ln -s "../$reponame" "./$dir"
+
+    cd "$dir/$reponame"
+
+    [ "Tracking \"a.dat\"" = "$(git lfs track "a.dat")" ]
+    [ "\"a.dat\" already supported" = "$(git lfs track "a.dat")" ]
+  popd > /dev/null
+)
+end_test


### PR DESCRIPTION
This pull request fixes a bug pointed out in https://github.com/git-lfs/git-lfs/issues/2452, where `git lfs track` cannot detect paths already tracked in a repository's `.gitattributes` file(s) when the current working directory is symlinked.

The issue arrises when we try and compare the attr path in `.gitattributes`, with the given argument(s). To do this, we first:

1. Relativize the result of calling `os.Getwd()` against the Git repository's root path. This will give us `/dir` for a directory `/Users/ttaylorr/go/src/github.com/git-lfs/git-lfs/dir` and a repository root of `/Users/ttaylorr/go/src/github.com/git-lfs/git-lfs`.
2. Compare, for all arguments, all known tracked patterns in any `.gitattributes` file the fully qualified path in the file, with the relativized filepath given as an argument.
3. If they are equal, the filepath is already tracked: `"<file>" is already supported`.
4. Otherwise, perform some additional equality checks and then add optionally change the `.gitattributes` file.

Step 2 will fail when the current working directory is symlinked, because the relativized paths _may_ look different.

To fix this, we first follow the links up the chain to the apex and instead compare against that path.

Closes: #2452.

---

/cc @git-lfs/core 
/cc #2452 