### PR TITLE
progress: fix writing updates to $GIT_LFS_PROGRESS

### DIFF
--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -53,7 +53,7 @@ func smudge(to io.Writer, from io.Reader, filename string, skip bool, filter *fi
 	}
 
 	lfs.LinkOrCopyFromReference(ptr.Oid, ptr.Size)
-	cb, file, err := lfs.CopyCallbackFile("smudge", filename, 1, 1)
+	cb, file, err := lfs.CopyCallbackFile("download", filename, 1, 1)
 	if err != nil {
 		return 0, err
 	}

--- a/lfs/pointer_smudge.go
+++ b/lfs/pointer_smudge.go
@@ -76,7 +76,12 @@ func PointerSmudge(writer io.Writer, ptr *Pointer, workingfile string, download 
 func downloadFile(writer io.Writer, ptr *Pointer, workingfile, mediafile string, manifest *tq.Manifest, cb progress.CopyCallback) (int64, error) {
 	fmt.Fprintf(os.Stderr, "Downloading %s (%s)\n", workingfile, humanize.FormatBytes(uint64(ptr.Size)))
 
-	q := tq.NewTransferQueue(tq.Download, manifest, "")
+	// NOTE: if given, "cb" is a progress.CopyCallback which writes updates
+	// to the logpath specified by GIT_LFS_PROGRESS.
+	//
+	// Either way, forward it into the *tq.TransferQueue so that updates are
+	// sent over correctly.
+	q := tq.NewTransferQueue(tq.Download, manifest, "", tq.WithProgressCallback(cb))
 	q.Add(filepath.Base(workingfile), mediafile, ptr.Oid, ptr.Size)
 	q.Wait()
 

--- a/progress/logger.go
+++ b/progress/logger.go
@@ -11,7 +11,7 @@ type progressLogger struct {
 
 // Write will write to the file and perform a Sync() if writing succeeds.
 func (l *progressLogger) Write(b []byte) error {
-	if l.writeData {
+	if !l.writeData {
 		return nil
 	}
 	if _, err := l.log.Write(b); err != nil {

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -583,6 +583,10 @@ func (q *TransferQueue) ensureAdapterBegun(e lfsapi.Endpoint) error {
 	cb := func(name string, total, read int64, current int) error {
 		q.meter.TransferBytes(q.direction.String(), name, read, total, current)
 		if q.cb != nil {
+			// NOTE: this is the mechanism by which the logpath
+			// specified by GIT_LFS_PROGRESS is written to.
+			//
+			// See: lfs.downloadFile() for more.
 			q.cb(total, read, current)
 		}
 		return nil


### PR DESCRIPTION
This pull request fixes a two bugs that we've had since v2.0.0 which broke `$GIT_LFS_PROGRESS` for clean/smudge operations.

The first bug affects smudging files. Since the early days, we've used the `progress.CopyCallback` type to instruct the `*progress.progressLogger` type to log updates to a file given by `$GIT_LFS_PROGRESS`. [[source][1]]. When we introduced the `tq` subpackage, we followed up with https://github.com/git-lfs/git-lfs/pull/1775, which doesn't pass the given `progress.CopyCallback` to the `*tq.TransferQueue`.

To address this, we: 

1. e031ee6: teach a new option instance that can be given to the `tq` constructor for passing `progress.CopyCallback`s around.
2. 92fdd06: pass the given `progress.CopyCallback` into the `tq`, ensuring that updates are sent to `$GIT_LFS_PROGRESS`.
3. 5009112: Fix the direction from 'smudge' to 'download' the former of which is invalid [[source][2]]. 

The second bug was a hidden negated conditional in the `*progress.progressLogger` type's `Write()` function. The `*progress.progressLogger` keeps track of a bool `writeData` which is true if data is allowed to be written to the underlying `*os.File`, and false otherwise. [[source][3]].

In https://github.com/git-lfs/git-lfs/pull/1746, a change was made to move the false case into the conditional, i.e.:

```go
func (m *progressMeter) Write(b []byte) (n int, err error) {
        if m.writeData {
                return
        }
} 
```

But the conditional `if m.writeData` was not negated. This is fixed in https://github.com/git-lfs/git-lfs/commit/2708fbac4af428743626a14ee65f79bcf811afd9.

---

/cc @git-lfs/core 
/cc @joshaber

[1]: https://github.com/git-lfs/git-lfs/commit/0204cb2abe5415de4705e0d03ebae6412758ad5d
[2]: https://github.com/git-lfs/git-lfs/blob/v2.2.1/docs/man/git-lfs-config.5.ronn#L266-L267
[3]: https://github.com/git-lfs/git-lfs/commit/e4e1c5db523ac84f41958f003459ecb6246ed69f