### PR TITLE
git: teach *PktlineWriter.Flush() to respond to nil receiver

### DIFF
--- a/git/pkt_line_writer.go
+++ b/git/pkt_line_writer.go
@@ -87,6 +87,10 @@ func (w *PktlineWriter) Write(p []byte) (int, error) {
 // writes the pkt-line's FLUSH packet, to signal that it is done writing this
 // chunk of data.
 func (w *PktlineWriter) Flush() error {
+	if w == nil {
+		return nil
+	}
+
 	if _, err := w.flush(); err != nil {
 		return err
 	}

--- a/git/pkt_line_writer_test.go
+++ b/git/pkt_line_writer_test.go
@@ -81,6 +81,10 @@ func TestPktlineWriterWritesMultiplePacketsGreaterThanMaxPacketLength(t *testing
 	assertPacketRead(t, pl, nil)
 }
 
+func TestPktlineWriterAllowsFlushesOnNil(t *testing.T) {
+	assert.NoError(t, (*PktlineWriter)(nil).Flush())
+}
+
 func TestPktlineWriterDoesntWrapItself(t *testing.T) {
 	itself := &PktlineWriter{}
 	nw := NewPktlineWriter(itself, 0)


### PR DESCRIPTION
This pull request teaches the `*git/PktlineWriter`'s `Flush()` function to respond to a `nil` receiver.

This is required work for adding the 'delay' capability into LFS, as is described in https://github.com/git-lfs/git-lfs/issues/2466. When delaying a file during checkout, no data is written to the pkt-line stream ([source](https://github.com/git/git/blob/487fe1ffcd3b3a38477b7e564f235bb7d1b89ecc/Documentation/gitattributes.txt#L524-L538)), and therefore the `*git.PktlineWriter` is not initialized during that scanner cycle.

Instead of applying:

```diff
diff --git a/commands/command_filter_process.go b/commands/command_filter_process.go
index a622aaad..bb745d3d 100644
--- a/commands/command_filter_process.go
+++ b/commands/command_filter_process.go
@@ -77,6 +77,11 @@ func filterCommand(cmd *cobra.Command, args []string) {
 		}
 
+		var ferr error
+		if w != nil {
+			ferr = w.Flush()
+		}
+
 		var status string
-		if ferr := w.Flush(); ferr != nil {
+		if ferr != nil {
 			status = statusFromErr(ferr)
 		} else {
```

instead teach `w.Flush()` to return `nil` when called on a `nil` receiver.

---

/cc @git-lfs/core 
/cc https://github.com/git-lfs/git-lfs/issues/2466