### PR TITLE
commands,git: teach NegotiateCapabilities() to to return 'supcaps'

### DIFF
--- a/commands/command_filter_process.go
+++ b/commands/command_filter_process.go
@@ -39,7 +39,9 @@ func filterCommand(cmd *cobra.Command, args []string) {
 	if err := s.Init(); err != nil {
 		ExitWithError(err)
 	}
-	if err := s.NegotiateCapabilities(); err != nil {
+
+	_, err := s.NegotiateCapabilities()
+	if err != nil {
 		ExitWithError(err)
 	}
 

--- a/git/filter_process_scanner.go
+++ b/git/filter_process_scanner.go
@@ -98,25 +98,25 @@ func (o *FilterProcessScanner) Init() error {
 // capabilities given to LFS by the parent, an error will be returned. If there
 // was an error reading or writing capabilities between the two, an error will
 // be returned.
-func (o *FilterProcessScanner) NegotiateCapabilities() error {
+func (o *FilterProcessScanner) NegotiateCapabilities() ([]string, error) {
 	reqCaps := []string{"capability=clean", "capability=smudge"}
 
 	supCaps, err := o.pl.readPacketList()
 	if err != nil {
-		return fmt.Errorf("reading filter-process capabilities failed with %s", err)
+		return nil, fmt.Errorf("reading filter-process capabilities failed with %s", err)
 	}
 	for _, reqCap := range reqCaps {
 		if !isStringInSlice(supCaps, reqCap) {
-			return fmt.Errorf("filter '%s' not supported (your Git supports: %s)", reqCap, supCaps)
+			return nil, fmt.Errorf("filter '%s' not supported (your Git supports: %s)", reqCap, supCaps)
 		}
 	}
 
 	err = o.pl.writePacketList(reqCaps)
 	if err != nil {
-		return fmt.Errorf("writing filter-process capabilities failed with %s", err)
+		return nil, fmt.Errorf("writing filter-process capabilities failed with %s", err)
 	}
 
-	return nil
+	return supCaps, nil
 }
 
 // Request represents a single command sent to LFS from the parent Git process.

--- a/git/filter_process_scanner.go
+++ b/git/filter_process_scanner.go
@@ -95,9 +95,9 @@ func (o *FilterProcessScanner) Init() error {
 
 // NegotiateCapabilities executes the process of negotiating capabilities
 // between the filter client and server. If we don't support any of the
-// capabilities given to LFS by the parent, an error will be returned. If there
-// was an error reading or writing capabilities between the two, an error will
-// be returned.
+// capabilities given to LFS by Git, an error will be returned. If there was an
+// error reading or writing capabilities between the two, an error will be
+// returned.
 func (o *FilterProcessScanner) NegotiateCapabilities() ([]string, error) {
 	reqCaps := []string{"capability=clean", "capability=smudge"}
 

--- a/git/filter_process_scanner_test.go
+++ b/git/filter_process_scanner_test.go
@@ -70,8 +70,10 @@ func TestFilterProcessScannerNegotitatesSupportedCapabilities(t *testing.T) {
 	}))
 
 	fps := NewFilterProcessScanner(&from, &to)
-	err := fps.NegotiateCapabilities()
+	caps, err := fps.NegotiateCapabilities()
 
+	assert.Contains(t, caps, "capability=clean")
+	assert.Contains(t, caps, "capability=smudge")
 	assert.Nil(t, err)
 
 	out, err := newPktline(&to, nil).readPacketList()
@@ -89,9 +91,10 @@ func TestFilterProcessScannerDoesNotNegotitatesUnsupportedCapabilities(t *testin
 	}))
 
 	fps := NewFilterProcessScanner(&from, &to)
-	err := fps.NegotiateCapabilities()
+	caps, err := fps.NegotiateCapabilities()
 
 	require.NotNil(t, err)
+	assert.Empty(t, caps)
 	assert.Equal(t, "filter 'capability=clean' not supported (your Git supports: [capability=unsupported])", err.Error())
 	assert.Empty(t, to.Bytes())
 }


### PR DESCRIPTION
This pull request teaches the NegotiateCapabilities() method to return a string slice of capabilities supported by the `git-filter-client`.

Previously, we relied on an assumption that the list of required and supported capabilities negotiated between the `git-filter-client` and `git-filter-server` were constant (specifically: `capability=clean` and `capability=smudge`). Since `git` now supports the 'delay' capability, we need to be able to search through the list of capabilities supported by the `git-filter-client` to determine whether or not it is legal for `git lfs filter-process` to return a delayed checkout entry.

This is required work for: https://github.com/git-lfs/git-lfs/issues/2466.

---

/cc @git-lfs/core 
/cc https://github.com/git-lfs/git-lfs/issues/2466