### PR TITLE
tq: teach Watch() to return <-chan *tq.Transfer

### DIFF
--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -301,8 +301,8 @@ func fetchAndReportToChan(allpointers []*lfs.WrappedPointer, filter *filepathfil
 				oidToPointers[pointer.Oid] = append(plist, pointer)
 			}
 
-			for oid := range dlwatch {
-				plist, ok := oidToPointers[oid]
+			for t := range dlwatch {
+				plist, ok := oidToPointers[t.Oid]
 				if !ok {
 					continue
 				}

--- a/commands/command_prune.go
+++ b/commands/command_prune.go
@@ -117,7 +117,7 @@ func prune(fetchPruneConfig config.FetchPruneConfig, verifyRemote, dryRun, verbo
 	var verifiedObjects tools.StringSet
 	var totalSize int64
 	var verboseOutput bytes.Buffer
-	var verifyc chan string
+	var verifyc chan *tq.Transfer
 	var verifywait sync.WaitGroup
 
 	if verifyRemote {
@@ -128,9 +128,9 @@ func prune(fetchPruneConfig config.FetchPruneConfig, verifyRemote, dryRun, verbo
 		verifyc = verifyQueue.Watch()
 		verifywait.Add(1)
 		go func() {
-			for oid := range verifyc {
-				verifiedObjects.Add(oid)
-				tracerx.Printf("VERIFIED: %v", oid)
+			for t := range verifyc {
+				verifiedObjects.Add(t.Oid)
+				tracerx.Printf("VERIFIED: %v", t.Oid)
 				progressChan <- PruneProgress{PruneProgressTypeVerify, 1}
 			}
 			verifywait.Done()

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -81,8 +81,8 @@ func pull(remote string, filter *filepathfilter.Filter) {
 	wg.Add(1)
 
 	go func() {
-		for oid := range dlwatch {
-			for _, p := range pointers.All(oid) {
+		for t := range dlwatch {
+			for _, p := range pointers.All(t.Oid) {
 				singleCheckout.Run(p)
 			}
 		}


### PR DESCRIPTION
This pull request changes the API of package `tq` as:

```diff
diff --git a/tq/transfer_queue.go b/tq/transfer_queue.go
index 67f4e9a7..2776e83f 100644
--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -640,3 +640,3 @@ func (q *TransferQueue) Wait() {
 // as it completes. The channel will be closed when the queue finishes processing.
-func (q *TransferQueue) Watch() chan string {
+func (q *TransferQueue) Watch() chan *tq.Transfer {
 	c := make(chan string, q.batchSize)
```

This is useful for supporting the 'delay' capability in the `git lfs filter-process` command. Previously, the `Watch()` channel returned an OID per completed object transfer, which we would then have to map back to a transfer name to determine which blobs were available when Git issued the `list_available_blobs` command.

With this pull request, we can instead maintain a `map[string]*tq.Transfer` (mapping from pathname to `*tq.Transfer`), which allows us to easily find, for example, the location on disk where the object is downloaded, as:

```go
m[req.Header["pathname"]].Path
```

This is required work for https://github.com/git-lfs/git-lfs/issues/2466.

---

/cc @git-lfs/core 
/cc https://github.com/git-lfs/git-lfs/issues/2466