### PR TITLE
ci: run builds on 'next' branch of git.git

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - GIT_SOURCE_REPO="https://github.com/git/git.git"
     - GIT_EARLIEST_SUPPORTED_VERSION="v2.0.0
     - GIT_LATEST_SOURCE_BRANCH="master"
+    - GIT_NEXT_SOURCE_BRANCH="next"
 
 matrix:
   fast_finish: true
@@ -23,6 +24,16 @@ matrix:
           git clone $GIT_SOURCE_REPO git-source;
           cd git-source;
           git checkout $GIT_LATEST_SOURCE_BRANCH;
+          make --jobs=2;
+          make install;
+          cd ..;
+    - env: git-latest-next-from-source
+      os: linux
+      before_script:
+        - >
+          git clone $GIT_SOURCE_REPO git-source;
+          cd git-source;
+          git checkout $GIT_NEXT_SOURCE_BRANCH;
           make --jobs=2;
           make install;
           cd ..;

--- a/circle.yml
+++ b/circle.yml
@@ -4,6 +4,7 @@ machine:
     GIT_SOURCE_REPO: https://github.com/git/git.git
     GIT_EARLIEST_SUPPORTED_VERSION: v2.0.0
     GIT_LATEST_SOURCE_BRANCH: master
+    GIT_NEXT_SOURCE_BRANCH: master
     XCODE_SCHEME: test
     XCODE_WORKSPACE: test
     XCODE_PROJECT: test
@@ -43,4 +44,6 @@ test:
     - script/install-git-source "$GIT_EARLIEST_SUPPORTED_VERSION"
     - PATH="$HOME/bin:$PATH" SKIPCOMPILE=1 script/integration
     - script/install-git-source "$GIT_LATEST_SOURCE_BRANCH"
+    - PATH="$HOME/bin:$PATH" SKIPCOMPILE=1 script/integration
+    - script/install-git-source "$GIT_NEXT_SOURCE_BRANCH"
     - PATH="$HOME/bin:$PATH" SKIPCOMPILE=1 script/integration

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
     GIT_SOURCE_REPO: https://github.com/git/git.git
     GIT_EARLIEST_SUPPORTED_VERSION: v2.0.0
     GIT_LATEST_SOURCE_BRANCH: master
-    GIT_NEXT_SOURCE_BRANCH: master
+    GIT_NEXT_SOURCE_BRANCH: next
     XCODE_SCHEME: test
     XCODE_WORKSPACE: test
     XCODE_PROJECT: test


### PR DESCRIPTION
This pull request teaches CircleCI and Travis how to run CI with the version of Git present at the tip of branch 'next'.

This is useful for adding the 'delay' capability to `git lfs filter-process` (see: https://github.com/git-lfs/git-lfs/issues/2466), since the 'delay' capability is not yet in master, or a released version of Git. This will give us a chance to test the 'delay' functionality out in CI before it's released in Git.

Once Git releases a version that contains https://github.com/git/git/commit/2841e8f81cb2820024804b9341577be1d0ce1240, we can revert this pull request.

This is required work for: https://github.com/git-lfs/git-lfs/issues/2466.

---

/cc @git-lfs/core 
/cc https://github.com/git-lfs/git-lfs/issues/2466