### PR TITLE
git: teach WriteList() to write list packets

### DIFF
--- a/git/filter_process_scanner.go
+++ b/git/filter_process_scanner.go
@@ -184,6 +184,12 @@ func (o *FilterProcessScanner) readRequest() (*Request, error) {
 	return req, nil
 }
 
+// WriteList writes a list of strings to the underlying pktline data stream in
+// pktline format.
+func (o *FilterProcessScanner) WriteList(list []string) error {
+	return o.pl.writePacketList(list)
+}
+
 func (o *FilterProcessScanner) WriteStatus(status string) error {
 	return o.pl.writePacketList([]string{"status=" + status})
 }

--- a/git/filter_process_scanner_test.go
+++ b/git/filter_process_scanner_test.go
@@ -134,6 +134,16 @@ func TestFilterProcessScannerRejectsInvalidHeaderPackets(t *testing.T) {
 	assert.Nil(t, req)
 }
 
+func TestFilterProcessScannerWritesLists(t *testing.T) {
+	var to bytes.Buffer
+
+	fps := NewFilterProcessScanner(nil, &to)
+	err := fps.WriteList([]string{"hello", "goodbye"})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "000ahello\n000cgoodbye\n0000", to.String())
+}
+
 // readRequest performs a single scan operation on the given
 // `*FilterProcessScanner`, "s", and returns: an error if there was one, or a
 // request if there was one.  If neither, it returns (nil, nil).


### PR DESCRIPTION
This pull request exposes the `*pktline.WriteList()` method as a public API through the `*git.FilterProcessScanner` type.

In implementing support for the 'delay' capability (see: https://github.com/git-lfs/git-lfs/issues/2466), I discover that we need a way to write a list of packets to the `git-filter-client` when asked for a list of available blobs, as seen below:

```go
switch req.Header["command"] {

// ...

case "list_available_blobs":
	s.WriteList(pathnames(available))
}
```

This pull request exposes and tests the `(*git.FilterProcessScanner).WriteList()` method to the public so it can be used in that manner.

This is required work for: https://github.com/git-lfs/git-lfs/issues/2466.

---

/cc @git-lfs/core 
/cc https://github.com/git-lfs/git-lfs/issues/2466