### PR TITLE
tq: make Add() accept new items during batch processing

### DIFF
--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -306,33 +306,33 @@ func (q *TransferQueue) collectBatches() {
 	defer q.collectorWait.Done()
 
 	var closing bool
-	batch := q.makeBatch()
+	next := q.makeBatch()
 
 	for {
-		for !closing && (len(batch) < q.batchSize) {
+		for !closing && (len(next) < q.batchSize) {
 			t, ok := <-q.incoming
 			if !ok {
 				closing = true
 				break
 			}
 
-			batch = append(batch, t)
+			next = append(next, t)
 		}
 
 		// Before enqueuing the next batch, sort by descending object
 		// size.
-		sort.Sort(sort.Reverse(batch))
+		sort.Sort(sort.Reverse(next))
 
 		retries, err := q.enqueueAndCollectRetriesFor(batch)
 		if err != nil {
 			q.errorc <- err
 		}
 
-		if closing && len(retries) == 0 {
+		if closing && len(next) == 0 {
 			break
 		}
 
-		batch = retries
+		next = retries
 	}
 }
 

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -72,6 +72,18 @@ func (r *retryCounter) CanRetry(oid string) (int, bool) {
 // all other workers are sitting idle.
 type batch []*objectTuple
 
+// Concat concatenates two batches together, returning a single, clamped batch as
+// "left", and the remainder of elements as "right". If the union of the
+// receiver and "other" has cardinality less than "size", "right" will be
+// returned as nil.
+func (b batch) Concat(other batch, size int) (left, right batch) {
+	u := batch(append(b, other...))
+	if len(u) <= size {
+		return u, nil
+	}
+	return u[:size], u[size:]
+}
+
 func (b batch) ToTransfers() []*Transfer {
 	transfers := make([]*Transfer, 0, len(b))
 	for _, t := range b {


### PR DESCRIPTION
This pull request teaches `tq.(*TransferQueue).Add()` to accept new items into the `q.incoming` queue of items while a batch is processing.

This is done to improve the performance of the 'delay' filter capability (see: #2466 for more). Prior to this pull request, a delayed checkout was performed like:

1. Git and LFS handshake and negotiate supported capabilities. 
2. Git writes 100 items to LFS before LFS blocks while processing the items in the first batch.
3. If there are more items in the checkout, see step 2.
4. Checkout complete.

This means that we are doing nothing for however long it takes for Git to tell LFS about an entry in the checkout while a batch is processing. 

Instead, accept new items while a batch is processing and save the time that it takes for Git to tell LFS about new items in the checkout. To do so, we keep a secondary batch called "pending", which is appended to from the `<-q.incoming` channel while a batch is processing. When a batch finishes processing, the union of "next" and "pending" are taken, with the first 100 elements becoming the next batch, and the rest are given back to "pending". This process repeats itself until there are no items remaining.

In #1758, I said that the benefit to having `Add()` be a blocking operation until an item was accepted into a new batch was:

> **Back-pressure**. If the `*TransferQueue` can't accept more items, there's no sense in wasting a large amount of disk and CPU usage scanning the Git data. Previously, instances of `git rev-list`, `git cat-file` and `git cat-file --batch` would run ad nauseam even if the `TransferQueue` couldn't accept new items. Now, `Add()` will block after a maximum buffer depth has been reached. In other words, by default, `Add()` will accept 200 (twice the default batch size of 100) items before apply back-pressure up to the `gitscanner`, causing it to wait.

This statement is no longer true, since the amount of memory required per object is negligible as compared to the `tq` package as it was prior to #1758.

---

/cc @git-lfs/core 
/cc #2466 