### PR TITLE
migrate: allow traversal into subtrees when a path prefix is present

### DIFF
--- a/filepathfilter/filepathfilter.go
+++ b/filepathfilter/filepathfilter.go
@@ -61,6 +61,34 @@ func (f *Filter) Allows(filename string) bool {
 	return allowed
 }
 
+// HasPrefix returns whether the given prefix "prefix" is a prefix for all
+// included Patterns, and not a prefix for any excluded Patterns.
+func (f *Filter) HasPrefix(prefix string) bool {
+	if f == nil {
+		return true
+	}
+
+	parts := strings.Split(prefix, sep)
+
+L:
+	for i := len(parts); i > 0; i-- {
+		prefix := strings.Join(parts[:i], sep)
+
+		for _, p := range f.exclude {
+			if p.Match(prefix) {
+				break L
+			}
+		}
+
+		for _, p := range f.include {
+			if p.HasPrefix(prefix) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // AllowsPattern returns whether the given filename is permitted by the
 // inclusion/exclusion rules of this filter, as well as the pattern that either
 // allowed or disallowed that filename.

--- a/filepathfilter/filepathfilter_test.go
+++ b/filepathfilter/filepathfilter_test.go
@@ -111,6 +111,59 @@ type filterTest struct {
 	excludes        []string
 }
 
+type filterPrefixTest struct {
+	expected bool
+	includes []string
+	excludes []string
+}
+
+func TestFilterHasPrefix(t *testing.T) {
+	for desc, c := range map[string]*filterPrefixTest{
+		"path prefix pattern":       {true, []string{"/foo/bar/baz"}, nil},
+		"path pattern":              {true, []string{"foo/bar/baz"}, nil},
+		"simple ext pattern":        {true, []string{"*.dat"}, nil},
+		"pathless wildcard pattern": {true, []string{"foo*.dat"}, nil},
+		"double wildcard pattern":   {true, []string{"foo/**/baz"}, nil},
+
+		"exclude path prefix pattern":       {false, nil, []string{"/foo/bar/baz"}},
+		"exclude path pattern":              {false, nil, []string{"foo/bar/baz"}},
+		"exclude simple ext pattern":        {false, nil, []string{"*.dat"}},
+		"exclude pathless wildcard pattern": {false, nil, []string{"foo*.dat"}},
+		"exclude double wildcard pattern":   {false, nil, []string{"foo/**/baz"}},
+	} {
+		t.Run(desc, func(t *testing.T) {
+			f := New(c.includes, c.excludes)
+
+			prefixes := []string{"foo", "foo/", "foo/bar", "foo/bar/baz", "foo/bar/baz/"}
+			for _, prefix := range prefixes {
+				assert.Equal(t, c.expected, f.HasPrefix(prefix),
+					"type=%s, expected=%v, prefix=%s", desc, c.expected, prefix)
+			}
+
+			if runtime.GOOS == "windows" {
+				wpath := func(s string) string { return strings.Replace(s, "/", "\\", -1) }
+
+				includes := make([]string, 0, len(c.includes))
+				for _, include := range c.includes {
+					includes = append(includes, wpath(include))
+				}
+
+				excludes := make([]string, 0, len(c.excludes))
+				for _, exclude := range c.excludes {
+					excludes = append(excludes, wpath(exclude))
+				}
+
+				for _, prefix := range prefixes {
+					prefix = wpath(prefix)
+
+					assert.Equal(t, c.expected, f.HasPrefix, prefix,
+						"(GOOS=windows) type=%s, expected=%v, prefix=%s", desc, c.expected, prefix)
+				}
+			}
+		})
+	}
+}
+
 func TestFilterAllows(t *testing.T) {
 	cases := []filterTest{
 		// Null case

--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -325,7 +325,16 @@ func (r *Rewriter) rewriteTree(sha []byte, path string, fn BlobRewriteFn, tfn Tr
 }
 
 func (r *Rewriter) allows(typ odb.ObjectType, abs string) bool {
-	return r.Filter().Allows(abs)
+	switch typ {
+	case odb.BlobObjectType:
+		return r.Filter().Allows(abs)
+	case odb.TreeObjectType:
+		return r.Filter().HasPrefix(abs)
+	case odb.CommitObjectType:
+		return true
+	default:
+		panic(fmt.Sprintf("git/githistory: unknown entry type: %s", typ))
+	}
 }
 
 // rewriteBlob calls the given BlobRewriteFn "fn" on a blob given in the object

--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -285,7 +285,7 @@ func (r *Rewriter) rewriteTree(sha []byte, path string, fn BlobRewriteFn, tfn Tr
 	for _, entry := range tree.Entries {
 		path := filepath.Join(path, entry.Name)
 
-		if !r.filter.Allows(path) {
+		if !r.allows(entry.Type(), path) {
 			entries = append(entries, entry)
 			continue
 		}
@@ -322,6 +322,10 @@ func (r *Rewriter) rewriteTree(sha []byte, path string, fn BlobRewriteFn, tfn Tr
 		return nil, err
 	}
 	return r.db.WriteTree(rewritten)
+}
+
+func (r *Rewriter) allows(typ odb.ObjectType, abs string) bool {
+	return r.Filter().Allows(abs)
 }
 
 // rewriteBlob calls the given BlobRewriteFn "fn" on a blob given in the object

--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -182,7 +182,7 @@ func (r *Rewriter) Rewrite(opt *RewriteOptions) ([]byte, error) {
 		}
 
 		// Rewrite the tree given at that commit.
-		rewrittenTree, err := r.rewriteTree(original.TreeID, string(os.PathSeparator), opt.blobFn(), opt.treeFn())
+		rewrittenTree, err := r.rewriteTree(original.TreeID, "", opt.blobFn(), opt.treeFn())
 		if err != nil {
 			return nil, err
 		}
@@ -317,7 +317,7 @@ func (r *Rewriter) rewriteTree(sha []byte, path string, fn BlobRewriteFn, tfn Tr
 		}))
 	}
 
-	rewritten, err := tfn(path, &odb.Tree{Entries: entries})
+	rewritten, err := tfn(string(os.PathSeparator)+path, &odb.Tree{Entries: entries})
 	if err != nil {
 		return nil, err
 	}

--- a/git/githistory/rewriter_test.go
+++ b/git/githistory/rewriter_test.go
@@ -176,7 +176,7 @@ func TestRewriterVisitsUniqueEntriesWithIdenticalContents(t *testing.T) {
 
 func TestRewriterIgnoresPathsThatDontMatchFilter(t *testing.T) {
 	include := []string{"*.txt"}
-	exclude := []string{"subdir/**/*.txt"}
+	exclude := []string{"subdir/*.txt"}
 
 	filter := filepathfilter.New(include, exclude)
 

--- a/git/githistory/rewriter_test.go
+++ b/git/githistory/rewriter_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 	"io"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"reflect"
 	"strconv"
@@ -138,8 +137,8 @@ func TestRewriterDoesntVisitUnchangedSubtrees(t *testing.T) {
 
 	assert.Nil(t, err)
 
-	assert.Equal(t, 2, seen[root("a.txt")])
-	assert.Equal(t, 1, seen[root(filepath.Join("subdir", "b.txt"))])
+	assert.Equal(t, 2, seen["a.txt"])
+	assert.Equal(t, 1, seen[filepath.Join("subdir", "b.txt")])
 }
 
 func TestRewriterVisitsUniqueEntriesWithIdenticalContents(t *testing.T) {
@@ -148,7 +147,7 @@ func TestRewriterVisitsUniqueEntriesWithIdenticalContents(t *testing.T) {
 
 	tip, err := r.Rewrite(&RewriteOptions{Include: []string{"refs/heads/master"},
 		BlobFn: func(path string, b *odb.Blob) (*odb.Blob, error) {
-			if path == root("b.txt") {
+			if path == "b.txt" {
 				return b, nil
 			}
 
@@ -195,8 +194,8 @@ func TestRewriterIgnoresPathsThatDontMatchFilter(t *testing.T) {
 	})
 
 	assert.Nil(t, err)
-	assert.Equal(t, 1, seen[root("a.txt")])
-	assert.Equal(t, 0, seen[root(filepath.Join("subdir", "b.txt"))])
+	assert.Equal(t, 1, seen["a.txt"])
+	assert.Equal(t, 0, seen[filepath.Join("subdir", "b.txt")])
 }
 
 func TestRewriterAllowsAdditionalTreeEntries(t *testing.T) {
@@ -343,11 +342,4 @@ func TestHistoryRewriterReturnsFilter(t *testing.T) {
 
 	assert.Equal(t, expected, got,
 		"git/githistory: expected Rewriter.Filter() to return same *filepathfilter.Filter instance")
-}
-
-func root(path string) string {
-	if !strings.HasPrefix(path, string(os.PathSeparator)) {
-		path = string(os.PathSeparator) + path
-	}
-	return path
 }

--- a/test/test-migrate-fixtures.sh
+++ b/test/test-migrate-fixtures.sh
@@ -159,6 +159,26 @@ setup_multiple_remote_branches() {
   git checkout master
 }
 
+# setup_single_local_branch_deep_trees creates a repository as follows:
+#
+#   A
+#    \
+#     refs/heads/master
+#
+# - Commit 'A' has 120 bytes of data in 'foo/bar/baz/a.txt'.
+setup_single_local_branch_deep_trees() {
+  set -e
+
+  reponame="migrate-single-local-branch-with-deep-trees"
+  remove_and_create_local_repo "$reponame"
+
+  mkdir -p foo/bar/baz
+  base64 < /dev/urandom | head -c 120 > foo/bar/baz/a.txt
+
+  git add foo/bar/baz/a.txt
+  git commit -m "initial commit"
+}
+
 # make_bare converts the existing full checkout of a repository into a bare one,
 # and then `cd`'s into it.
 make_bare() {

--- a/test/test-migrate-import.sh
+++ b/test/test-migrate-import.sh
@@ -323,3 +323,20 @@ begin_test "migrate import (bare repository)"
     --include-ref=master
 )
 end_test
+
+begin_test "migrate import (prefix include(s))"
+(
+  set -e
+
+  includes="foo/bar/baz /foo foo/**/baz/a.txt *.txt"
+  for include in $includes; do
+    setup_single_local_branch_deep_trees
+
+    oid="$(calc_oid "$(git cat-file -p :foo/bar/baz/a.txt)")"
+
+    git lfs migrate import --include="$include"
+
+    assert_local_object "$oid" 120
+  done
+)
+end_test

--- a/test/test-migrate-import.sh
+++ b/test/test-migrate-import.sh
@@ -337,6 +337,8 @@ begin_test "migrate import (prefix include(s))"
     git lfs migrate import --include="$include"
 
     assert_local_object "$oid" 120
+
+    cd ..
   done
 )
 end_test

--- a/test/test-migrate-import.sh
+++ b/test/test-migrate-import.sh
@@ -328,7 +328,7 @@ begin_test "migrate import (prefix include(s))"
 (
   set -e
 
-  includes="foo/bar/baz /foo foo/**/baz/a.txt *.txt"
+  includes="foo${PATH_SEPARATOR}bar${PATH_SEPARATOR}baz ${PATH_SEPARATOR}foo foo${PATH_SEPARATOR}**${PATH_SEPARATOR}baz${PATH_SEPARATOR}a.txt *.txt"
   for include in $includes; do
     setup_single_local_branch_deep_trees
 

--- a/test/testenv.sh
+++ b/test/testenv.sh
@@ -7,6 +7,7 @@ UNAME=$(uname -s)
 IS_WINDOWS=0
 IS_MAC=0
 SHASUM="shasum -a 256"
+PATH_SEPARATOR="/"
 
 if [[ $UNAME == MINGW* || $UNAME == MSYS* || $UNAME == CYGWIN* ]]
 then
@@ -16,6 +17,7 @@ then
   # script by default, so use sha256sum directly. MacOS on the other hand
   # does not have sha256sum, so still use shasum as the default.
   SHASUM="sha256sum"
+  PATH_SEPARATOR="\\"
 elif [[ $UNAME == *Darwin* ]]
 then
   IS_MAC=1


### PR DESCRIPTION
This pull request fixes a bug pointed out by @jlbaxter in https://github.com/git-lfs/git-lfs/issues/2482#issuecomment-320790610:

> ```
> $ git lfs migrate import --include="Pods/GoogleMaps/Frameworks/GoogleMaps.framework/googlemaps"
> migrate: Sorting commits: ..., done
> migrate: Rewriting commits: 100% (14/14), done
> 
> $ git push
> # ...
> remote: error: GH001: Large files detected. You may want to try Git Large File Storage - https://git-lfs.github.com.
> remote: error: Trace: b86b8906dcc9cea93584324a9d38247e
> remote: error: See http://git.io/iEPt8g for more information.
> remote: error: File Pods/GoogleMaps/Frameworks/GoogleMaps.framework/googlemaps is 123.08 MB; this exceeds GitHub's file size limit of 100.00 MB
> ```

When the `*git/githistory.HistoryRewriter` traverses through the subtrees, it ensures that the absolute path for every nested subtree is a pattern match for the given `--include` and `--exclude` filter set. This works fine when there are no nested subtrees, as every blob will have a fully-qualified path.

When there are nested subtrees however, consider the following: a migration wants to touch files in foo/bar/baz. To traverse into 'baz', we must first traverse through 'foo', and 'bar'. Visiting 'foo' calls `filter.Match("foo")`, which returns false, since `foo` is not a match of `foo/bar/baz`.

As shown above, the logic for subtree culling is incorrect. Rather than asking if a subtree is a Match() of a given filter, we must ask if it is a Prefix(). In other words, we are asking if children of a given subtree _could_ match the filepath filter.

To solve this, here's what happened:

1. d907934: extract `r.allows()`, which we will later use to determine whether to call `Match()`, or `HasPrefix()` based on the entry type being a blob or tree, respectively.
2. 3e8ab9b: teach `HasPrefix` to `Pattern` implementations in package `filepathfilter`.
3. 4942644: modify `r.allows()` to switch on the object type.
4. 45baf90: integration tests.

---

/cc @git-lfs/core 