### PR TITLE
lfs: clean contents larger than 1024 bytes over stdin

### DIFF
--- a/lfs/pointer_clean.go
+++ b/lfs/pointer_clean.go
@@ -88,7 +88,7 @@ func copyToTemp(reader io.Reader, fileSize int64, cb progress.CopyCallback) (oid
 	}
 
 	var from io.Reader = bytes.NewReader(by)
-	if int64(len(by)) < fileSize {
+	if fileSize < 0 || int64(len(by)) < fileSize {
 		// If there is still more data to be read from the file, tack on
 		// the original reader and continue the read from there.
 		from = io.MultiReader(from, reader)


### PR DESCRIPTION
This pull request fixes a bug in `git-lfs-clean(1)` that was pointed out by @mohseenrm in https://github.com/git-lfs/git-lfs/issues/2487: 

> Issue: `git lfs clean` produces incorrect output for files over 1024 bytes

I introduced this bug in https://github.com/git-lfs/git-lfs/commit/482eba2176a39bfaa44f812af78b10e68015670d, wherein an optimization is introduced to combine readers when necessary to avoid blocking on `read()s` with no data when attached as a `process` filter.

482eba2176a39bfaa44f812af78b10e68015670d is implemented by passing a `fileSize` parameter, which is used to determine if all of the file has been read, or if there is more data waiting. When `git lfs clean` is invoked over `stdin`, it assumes the filesize is -1, which then fails the following check:

https://github.com/git-lfs/git-lfs/blob/6432d540bbca967fd91029f0d122131cd5ccb1d0/lfs/pointer_clean.go#L90-L95

and assumes that it has read the entire file.

To fix this, we teach `lfs.copyToTemp()` that when given a `fileSize` of -1, always continue reading from the given `io.Reader`.

Closes: https://github.com/git-lfs/git-lfs/issues/2487.

---

/cc @git-lfs/core 
/cc @mohseenrm