### PR TITLE
git/githistory/log: use *Update to share message origin time

### DIFF
--- a/git/githistory/log/list_task.go
+++ b/git/githistory/log/list_task.go
@@ -1,6 +1,9 @@
 package log
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // ListTask is a Task implementation that logs all updates in a list where each
 // entry is line-delimited.
@@ -11,24 +14,30 @@ import "fmt"
 //   msg: ..., done
 type ListTask struct {
 	msg string
-	ch  chan string
+	ch  chan *Update
 }
 
 // NewListTask instantiates a new *ListTask instance with the given message.
 func NewListTask(msg string) *ListTask {
 	return &ListTask{
 		msg: msg,
-		ch:  make(chan string, 1),
+		ch:  make(chan *Update, 1),
 	}
 }
 
 // Entry logs a line-delimited task entry.
 func (l *ListTask) Entry(update string) {
-	l.ch <- fmt.Sprintf("%s\n", update)
+	l.ch <- &Update{
+		S:  fmt.Sprintf("%s\n", update),
+		At: time.Now(),
+	}
 }
 
 func (l *ListTask) Complete() {
-	l.ch <- fmt.Sprintf("%s: ...", l.msg)
+	l.ch <- &Update{
+		S:  fmt.Sprintf("%s: ...", l.msg),
+		At: time.Now(),
+	}
 	close(l.ch)
 }
 
@@ -38,4 +47,4 @@ func (l *ListTask) Throttled() bool { return false }
 
 // Updates implements the Task.Updates function and returns a channel of updates
 // to log to the sink.
-func (l *ListTask) Updates() <-chan string { return l.ch }
+func (l *ListTask) Updates() <-chan *Update { return l.ch }

--- a/git/githistory/log/list_task_test.go
+++ b/git/githistory/log/list_task_test.go
@@ -12,7 +12,7 @@ func TestListTaskCallsDoneWhenComplete(t *testing.T) {
 
 	select {
 	case update, ok := <-task.Updates():
-		assert.Equal(t, "example: ...", update)
+		assert.Equal(t, "example: ...", update.S)
 		assert.True(t, ok,
 			"git/githistory/log: expected Updates() to remain open")
 	default:
@@ -36,7 +36,7 @@ func TestListTaskWritesEntries(t *testing.T) {
 	case update, ok := <-task.Updates():
 		assert.True(t, ok,
 			"git/githistory/log: expected ListTask.Updates() to remain open")
-		assert.Equal(t, "1\n", update)
+		assert.Equal(t, "1\n", update.S)
 	default:
 		t.Fatal("git/githistory/log: expected task.Updates() to have an update")
 	}

--- a/git/githistory/log/log.go
+++ b/git/githistory/log/log.go
@@ -107,7 +107,7 @@ func (l *Logger) enqueue(ts ...Task) {
 	if l == nil {
 		for _, t := range ts {
 			go func(t Task) {
-				for range <-t.Updates() {
+				for range t.Updates() {
 					// Discard all updates.
 				}
 			}(t)
@@ -196,17 +196,15 @@ func (l *Logger) logTask(task Task) {
 	logAll := !task.Throttled()
 	var last time.Time
 
-	var msg string
-	for msg = range task.Updates() {
-		now := time.Now()
-
-		if logAll || l.throttle == 0 || now.After(last.Add(l.throttle)) {
-			l.logLine(msg)
-			last = now
+	var update *Update
+	for update = range task.Updates() {
+		if logAll || l.throttle == 0 || update.At.After(last.Add(l.throttle)) {
+			l.logLine(update.S)
+			last = update.At
 		}
 	}
 
-	l.log(fmt.Sprintf("%s, done\n", msg))
+	l.log(fmt.Sprintf("%s, done\n", update.S))
 }
 
 // logLine writes a complete line and moves the cursor to the beginning of the

--- a/git/githistory/log/percentage_task_test.go
+++ b/git/githistory/log/percentage_task_test.go
@@ -9,12 +9,12 @@ import (
 func TestPercentageTaskCalculuatesPercentages(t *testing.T) {
 	task := NewPercentageTask("example", 10)
 
-	assert.Equal(t, "example:   0% (0/10)", <-task.Updates())
+	assert.Equal(t, "example:   0% (0/10)", (<-task.Updates()).S)
 
 	n := task.Count(3)
 	assert.EqualValues(t, 3, n)
 
-	assert.Equal(t, "example:  30% (3/10)", <-task.Updates())
+	assert.Equal(t, "example:  30% (3/10)", (<-task.Updates()).S)
 }
 
 func TestPercentageTaskCalculatesPercentWithoutTotal(t *testing.T) {
@@ -23,7 +23,7 @@ func TestPercentageTaskCalculatesPercentWithoutTotal(t *testing.T) {
 	select {
 	case v, ok := <-task.Updates():
 		if ok {
-			assert.Equal(t, "example: 100% (0/0)", v)
+			assert.Equal(t, "example: 100% (0/0)", v.S)
 		} else {
 			t.Fatal("expected channel to be open")
 		}
@@ -37,7 +37,7 @@ func TestPercentageTaskCallsDoneWhenComplete(t *testing.T) {
 	select {
 	case v, ok := <-task.Updates():
 		if ok {
-			assert.Equal(t, "example:   0% (0/10)", v)
+			assert.Equal(t, "example:   0% (0/10)", v.S)
 		} else {
 			t.Fatal("expected channel to be open")
 		}
@@ -45,7 +45,7 @@ func TestPercentageTaskCallsDoneWhenComplete(t *testing.T) {
 	}
 
 	assert.EqualValues(t, 10, task.Count(10))
-	assert.Equal(t, "example: 100% (10/10)", <-task.Updates())
+	assert.Equal(t, "example: 100% (10/10)", (<-task.Updates()).S)
 
 	if _, ok := <-task.Updates(); ok {
 		t.Fatalf("expected channel to be closed")

--- a/git/githistory/log/task.go
+++ b/git/githistory/log/task.go
@@ -1,15 +1,25 @@
 package log
 
+import "time"
+
 // Task is an interface which encapsulates an activity which can be logged.
 type Task interface {
 	// Updates returns a channel which is written to with the current state
 	// of the Task when an update is present. It is closed when the task is
 	// complete.
-	Updates() <-chan string
+	Updates() <-chan *Update
 
 	// Throttled returns whether or not updates from this task should be
 	// limited when being printed to a sink via *log.Logger.
 	//
 	// It is expected to return the same value for a given Task instance.
 	Throttled() bool
+}
+
+// Update is a single message sent (S) from a Task at a given time (At).
+type Update struct {
+	// S is the message sent in this update.
+	S string
+	// At is the time that this update was sent.
+	At time.Time
 }

--- a/git/githistory/log/waiting_task.go
+++ b/git/githistory/log/waiting_task.go
@@ -1,18 +1,24 @@
 package log
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // WaitingTask represents a task for which the total number of items to do work
 // is on is unknown.
 type WaitingTask struct {
 	// ch is used to transmit task updates.
-	ch chan string
+	ch chan *Update
 }
 
 // NewWaitingTask returns a new *WaitingTask.
 func NewWaitingTask(msg string) *WaitingTask {
-	ch := make(chan string, 1)
-	ch <- fmt.Sprintf("%s: ...", msg)
+	ch := make(chan *Update, 1)
+	ch <- &Update{
+		S:  fmt.Sprintf("%s: ...", msg),
+		At: time.Now(),
+	}
 
 	return &WaitingTask{ch: ch}
 }
@@ -24,7 +30,7 @@ func (w *WaitingTask) Complete() {
 
 // Done implements Task.Done and returns a channel which is closed when
 // Complete() is called.
-func (w *WaitingTask) Updates() <-chan string {
+func (w *WaitingTask) Updates() <-chan *Update {
 	return w.ch
 }
 

--- a/git/githistory/log/waiting_task_test.go
+++ b/git/githistory/log/waiting_task_test.go
@@ -9,7 +9,7 @@ import (
 func TestWaitingTaskDisplaysWaitingStatus(t *testing.T) {
 	task := NewWaitingTask("example")
 
-	assert.Equal(t, "example: ...", <-task.Updates())
+	assert.Equal(t, "example: ...", (<-task.Updates()).S)
 }
 
 func TestWaitingTaskCallsDoneWhenComplete(t *testing.T) {
@@ -18,7 +18,7 @@ func TestWaitingTaskCallsDoneWhenComplete(t *testing.T) {
 	select {
 	case v, ok := <-task.Updates():
 		if ok {
-			assert.Equal(t, "example: ...", v)
+			assert.Equal(t, "example: ...", v.S)
 		} else {
 			t.Fatal("expected channel to be open")
 		}


### PR DESCRIPTION
This pull request fixes #2360 by teaching `*git/githistory/log.Task` to send a message and a time.Time in a single update.

This fixes a race condition that is fairly prevalent on CI. The race occurs when CPU cycles are missed in this test code:

https://github.com/git-lfs/git-lfs/blob/d7c2c79ca6ee04a85ee87fdc32d8d3de32ed2389/git/githistory/log/log_test.go#L105-L112

Causing a greater duration than was requested to elapse. This has the downstream effect of making the logger think that enough time has passed in order to not throttle writes to the `io.Writer` sink, thus indicating to the test that the throttling mechanism is broken, which ultimately failing the test.

Instead of checking the wall clock at channel read time, we share the time as it was when the message was created, which allows us to "mock" the time, guarenteing that the tests will pass.

The important diff is:

```diff
diff --git a/git/githistory/log/log.go b/git/githistory/log/log.go
index 52b485ae..b6f0e2f6 100644
--- a/git/githistory/log/log.go
+++ b/git/githistory/log/log.go
@@ -196,17 +196,15 @@ func (l *Logger) logTask(task Task) {
        logAll := !task.Throttled()
        var last time.Time

-       var msg string
-       for msg = range task.Updates() {
-               now := time.Now()
-
-               if logAll || l.throttle == 0 || now.After(last.Add(l.throttle)) {
-                       l.logLine(msg)
-                       last = now
+       var update *Update
+       for update = range task.Updates() {
+               if logAll || l.throttle == 0 || update.At.After(last.Add(l.throttle)) {
+                       l.logLine(update.S)
+                       last = update.At
                }
        }
```

Closes: https://github.com/git-lfs/git-lfs/issues/2360.

---

/cc @git-lfs/core  