### PR TITLE
config: warn on unsafe keys in '.lfsconfig'

### DIFF
--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -297,6 +297,23 @@ be scoped inside the configuration for a remote.
   The default is `true`; you can disable this behaviour and have all files
   writeable by setting either variable to 0, 'no' or 'false'.
 
+## LFSCONFIG
+
+The .lfsconfig file in a repository is read and interpreted in the same format
+as the file stored in .git/config. It allows a subset of keys to be used,
+including and limited to:
+
+- lfs.fetchexclude
+- lfs.fetchinclude
+- lfs.gitprotocol
+- lfs.pushurl
+- lfs.url
+- lfs.extension.{name}.clean
+- lfs.extension.{name}.smudge
+- lfs.extension.{name}.priority
+- remote.{name}.lfsurl
+- remote.{name}.{*}.access
+
 ## EXAMPLES
 
 *  Configure a custom LFS endpoint for your repository:

--- a/test/test-config.sh
+++ b/test/test-config.sh
@@ -140,3 +140,21 @@ begin_test "url alias must be prefix"
   grep "Endpoint=badalias:rest (auth=none)" env.log
 )
 end_test
+
+begin_test "config: ignoring unsafe lfsconfig keys"
+(
+  set -e
+
+  reponame="config-unsafe-lfsconfig-keys"
+  git init "$reponame"
+  cd "$reponame"
+
+  # Insert an 'unsafe' key into this repository's '.lfsconfig'.
+  git config --file=./lfsconfig core.askpass unsafe
+
+  git lfs status 2>&1 | tee status.log
+
+  grep "WARNING: These unsafe lfsconfig keys were ignored:" status.log
+  grep "  core.askpass" status.log
+)
+end_test

--- a/test/test-config.sh
+++ b/test/test-config.sh
@@ -150,7 +150,7 @@ begin_test "config: ignoring unsafe lfsconfig keys"
   cd "$reponame"
 
   # Insert an 'unsafe' key into this repository's '.lfsconfig'.
-  git config --file=./lfsconfig core.askpass unsafe
+  git config --file=.lfsconfig core.askpass unsafe
 
   git lfs status 2>&1 | tee status.log
 


### PR DESCRIPTION
This pull request addresses https://github.com/git-lfs/git-lfs/issues/2490 by adding a warning to all LFS commands when an unsafe configuration is present in a repository's .lfsconfig:

> It might be useful to:
> 
> * print a warning when a setting is ignored, and
> * update [`docs/man/git-lfs-config.5.ronn`](https://github.com/git-lfs/git-lfs/blob/master/docs/man/git-lfs-config.5.ronn) to specify what "safe keys" can be used in `.lfsconfig`.

- 038e4a3: add a warning when unsafe keys are detected in the `.lfsconfig`
- 8970e6e: create a section in `git-lfs-config(5).ronn` containing a list of 'safe' keys.

Closes: #2490.

---

/cc @git-lfs/core 
/cc @aleb