### PR TITLE
locks: set write flag on absolute path, not relative

### DIFF
--- a/locking/locks.go
+++ b/locking/locks.go
@@ -107,8 +107,13 @@ func (c *Client) LockFile(path string) (Lock, error) {
 		return Lock{}, errors.Wrap(err, "lock cache")
 	}
 
+	abs, err := getAbsolutePath(path)
+	if err != nil {
+		return Lock{}, errors.Wrap(err, "make lockpath absolute")
+	}
+
 	// Ensure writeable on return
-	if err := tools.SetFileWriteFlag(path, true); err != nil {
+	if err := tools.SetFileWriteFlag(abs, true); err != nil {
 		return Lock{}, err
 	}
 
@@ -144,9 +149,14 @@ func (c *Client) UnlockFile(path string, force bool) error {
 		return err
 	}
 
+	abs, err := getAbsolutePath(path)
+	if err != nil {
+		return errors.Wrap(err, "make lockpath absolute")
+	}
+
 	// Make non-writeable if required
 	if c.SetLockableFilesReadOnly && c.IsFileLockable(path) {
-		return tools.SetFileWriteFlag(path, false)
+		return tools.SetFileWriteFlag(abs, false)
 	}
 	return nil
 

--- a/locking/locks.go
+++ b/locking/locks.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/filepathfilter"
+	"github.com/git-lfs/git-lfs/git"
 	"github.com/git-lfs/git-lfs/lfsapi"
 	"github.com/git-lfs/git-lfs/tools"
 	"github.com/git-lfs/git-lfs/tools/kv"
@@ -112,6 +113,21 @@ func (c *Client) LockFile(path string) (Lock, error) {
 	}
 
 	return lock, nil
+}
+
+// getAbsolutePath takes a repository-relative path and makes it absolute.
+//
+// For instance, given a repository in /usr/local/src/my-repo and a file called
+// dir/foo/bar.txt, getAbsolutePath will return:
+//
+//   /usr/local/src/my-repo/dir/foo/bar.txt
+func getAbsolutePath(p string) (string, error) {
+	root, err := git.RootDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(root, p), nil
 }
 
 // UnlockFile attempts to unlock a file on the current remote

--- a/test/test-lock.sh
+++ b/test/test-lock.sh
@@ -117,3 +117,23 @@ begin_test "locking a nested file"
   grep "foo/bar/baz/a.dat" locks.log
 )
 end_test
+
+begin_test "creating a lock (within subdirectory)"
+(
+  set -e
+
+  reponame="lock_create_within_subdirectory"
+  setup_remote_repo_with_file "$reponame" "sub/a.dat"
+
+  cd sub
+
+  git lfs lock --json "a.dat" | tee lock.json
+  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected 'git lfs lock \'a.dat\'' to succeed"
+    exit 1
+  fi
+
+  id=$(assert_lock lock.json a.dat)
+  assert_server_lock "$reponame" "$id"
+)
+end_test

--- a/test/test-lock.sh
+++ b/test/test-lock.sh
@@ -133,7 +133,7 @@ begin_test "creating a lock (within subdirectory)"
     exit 1
   fi
 
-  id=$(assert_lock lock.json a.dat)
+  id=$(assert_lock lock.json sub/a.dat)
   assert_server_lock "$reponame" "$id"
 )
 end_test

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -397,9 +397,12 @@ clone_repo_clientcert() {
 setup_remote_repo_with_file() {
   local reponame="$1"
   local filename="$2"
+  local dirname="$(dirname "$filename")"
 
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "clone_$reponame"
+
+  mkdir -p "$dirname"
 
   git lfs track "$filename"
   echo "$filename" > "$filename"


### PR DESCRIPTION
This pull request fixes a bug pointed out by @jonico in https://github.com/git-lfs/git-lfs/issues/2492:

> * cd into a directory of a Git repository with a lockable file already tracked by lfs
> * call `git lfs lock` on that file, referring to it with its file name (no path) only
> * git lfs will report that it could not lock because it could not find the file

This is due to the fact that we attempt to set the write flag on a repository-relative path, which is only relative to your current working directory if you are in the root of your repository. For instance, if you lock a file `b.dat` in `sub`, in repository `/usr/local/src/repo`, the absolute lock path is `/usr/local/src/repo/sub/b.dat`, and the repository-absolute path is `sub/b.dat`.

We pass the later into the `tools.SetFileWriteFlag` which performs a working directory-relative `os.Stat()`. To fix this, we make the path absolute before passing into the `tools.SetFileWriteFlag`.

Closes: https://github.com/git-lfs/git-lfs/issues/2492.

---

/cc @git-lfs/core 
/cc @jonico 