### PR TITLE
tq: increase default lfs.concurrenttransfers to 8

### DIFF
--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -78,7 +78,7 @@ be scoped inside the configuration for a remote.
 
 * `lfs.concurrenttransfers`
 
-  The number of concurrent uploads/downloads. Default 3.
+  The number of concurrent uploads/downloads. Default 8.
 
 * `lfs.basictransfersonly`
 

--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -185,7 +185,7 @@ func (c *Client) httpClient(host string) *http.Client {
 
 	concurrentTransfers := c.ConcurrentTransfers
 	if concurrentTransfers < 1 {
-		concurrentTransfers = 3
+		concurrentTransfers = 8
 	}
 
 	dialtime := c.DialTimeout

--- a/tq/manifest.go
+++ b/tq/manifest.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	defaultMaxRetries          = 8
-	defaultConcurrentTransfers = 3
+	defaultConcurrentTransfers = 8
 )
 
 type Manifest struct {


### PR DESCRIPTION
This pull request increases the default number of `lfs.concurrenttransfers` to 8.

---

/cc @git-lfs/core 
/cc #2466 