### PR TITLE
commands: make 4gb smudge warning show on all platforms

### DIFF
--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"runtime"
 
 	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/filepathfilter"
@@ -115,7 +114,7 @@ func smudgeFilename(args []string) string {
 }
 
 func possiblyMalformedSmudge(n int64) bool {
-	return n > 4*humanize.Gigabyte && runtime.GOOS == "windows"
+	return n > 4*humanize.Gigabyte
 }
 
 func init() {


### PR DESCRIPTION
This pull request teaches the `git-lfs-smudge(1)` and `git-lfs-filter-process(1)` commands to display the 4gb object warning on all platforms, not just `runtime.GOOS == "windows"`.

In situations where multiple collaborators are working on a repository among different operating systems, it is useful for a contributor running macOS to know that he/she/they can potentially cause an issue for another collaborator running Windows when they commit a file larger than 4gb. 

---

/cc @git-lfs/core 
/cc https://github.com/git-lfs/git-lfs/pull/2459