### PR TITLE
lfsapi: enable credential caching by default

### DIFF
--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -60,7 +60,7 @@ be scoped inside the configuration for a remote.
 * `lfs.cachecredentials`
 
   Enables in-memory SSH and Git Credential caching for a single 'git lfs'
-  command. Default: false. This will default to true in v2.1.0.
+  command. Default: enabled.
 
 * `lfs.storage`
 

--- a/lfsapi/lfsapi.go
+++ b/lfsapi/lfsapi.go
@@ -78,7 +78,7 @@ func NewClient(osEnv Env, gitEnv Env) (*Client, error) {
 	}
 
 	var sshResolver SSHResolver = &sshAuthClient{os: osEnv}
-	if gitEnv.Bool("lfs.cachecredentials", false) {
+	if gitEnv.Bool("lfs.cachecredentials", true) {
 		sshResolver = withSSHCache(sshResolver)
 	}
 


### PR DESCRIPTION
This pull request enables the credential caching introduced in #2080 by default, as was noted (and forgotten about) in the original manpages.

---

/cc @git-lfs/core 