### PR TITLE
test: Fix '{assert,refute}_file_writable' typo in testhelpers

### DIFF
--- a/test/test-post-checkout.sh
+++ b/test/test-post-checkout.sh
@@ -71,8 +71,8 @@ begin_test "post-checkout"
   # without the post-checkout hook, any changed files would now be writeable
   refute_file_writable file1.dat
   refute_file_writable file2.dat
-  assert_file_writable file3.big
-  assert_file_writable file4.big
+  assert_file_writeable file3.big
+  assert_file_writeable file4.big
 
   # checkout branch
   git checkout branch2
@@ -81,9 +81,9 @@ begin_test "post-checkout"
   refute_file_writable file1.dat
   refute_file_writable file2.dat
   refute_file_writable file5.dat
-  assert_file_writable file3.big
-  assert_file_writable file4.big
-  assert_file_writable file6.big
+  assert_file_writeable file3.big
+  assert_file_writeable file4.big
+  assert_file_writeable file6.big
 
   # Confirm that contents of existing files were updated even though were read-only
   [ "$(cat file2.dat)" == "file 2 updated in branch2" ]
@@ -106,12 +106,12 @@ begin_test "post-checkout"
   # now lock files, then remove & restore
   git lfs lock file1.dat
   git lfs lock file2.dat
-  assert_file_writable file1.dat
-  assert_file_writable file2.dat
+  assert_file_writeable file1.dat
+  assert_file_writeable file2.dat
   rm -f *.dat
   git checkout file1.dat file2.dat file5.dat
-  assert_file_writable file1.dat
-  assert_file_writable file2.dat
+  assert_file_writeable file1.dat
+  assert_file_writeable file2.dat
   refute_file_writable file5.dat
 
 )

--- a/test/test-post-checkout.sh
+++ b/test/test-post-checkout.sh
@@ -69,8 +69,8 @@ begin_test "post-checkout"
   [ ! -e file5.dat ]
   [ ! -e file6.big ]
   # without the post-checkout hook, any changed files would now be writeable
-  refute_file_writable file1.dat
-  refute_file_writable file2.dat
+  refute_file_writeable file1.dat
+  refute_file_writeable file2.dat
   assert_file_writeable file3.big
   assert_file_writeable file4.big
 
@@ -78,9 +78,9 @@ begin_test "post-checkout"
   git checkout branch2
   [ -e file5.dat ]
   [ -e file6.big ]
-  refute_file_writable file1.dat
-  refute_file_writable file2.dat
-  refute_file_writable file5.dat
+  refute_file_writeable file1.dat
+  refute_file_writeable file2.dat
+  refute_file_writeable file5.dat
   assert_file_writeable file3.big
   assert_file_writeable file4.big
   assert_file_writeable file6.big
@@ -99,9 +99,9 @@ begin_test "post-checkout"
   [ "$(cat file1.dat)" == "file 1 updated commit 2" ]
   [ "$(cat file2.dat)" == "file 2 updated in branch2" ]
   [ "$(cat file5.dat)" == "file 5 creation in branch2" ]
-  refute_file_writable file1.dat
-  refute_file_writable file2.dat
-  refute_file_writable file5.dat
+  refute_file_writeable file1.dat
+  refute_file_writeable file2.dat
+  refute_file_writeable file5.dat
 
   # now lock files, then remove & restore
   git lfs lock file1.dat
@@ -112,7 +112,7 @@ begin_test "post-checkout"
   git checkout file1.dat file2.dat file5.dat
   assert_file_writeable file1.dat
   assert_file_writeable file2.dat
-  refute_file_writable file5.dat
+  refute_file_writeable file5.dat
 
 )
 end_test

--- a/test/test-post-commit.sh
+++ b/test/test-post-commit.sh
@@ -27,8 +27,8 @@ begin_test "post-commit"
   # New lockable files should have been made read-only now since not locked
   refute_file_writable pcfile1.dat
   refute_file_writable pcfile2.dat
-  assert_file_writable pcfile3.big
-  assert_file_writable pcfile4.big
+  assert_file_writeable pcfile3.big
+  assert_file_writeable pcfile4.big
 
   git push -u origin master
 
@@ -43,8 +43,8 @@ begin_test "post-commit"
   git commit -m "Updated"
 
   # files should remain writeable since locked
-  assert_file_writable pcfile1.dat
-  assert_file_writable pcfile2.dat 
+  assert_file_writeable pcfile1.dat
+  assert_file_writeable pcfile2.dat 
 
 )
 end_test

--- a/test/test-post-commit.sh
+++ b/test/test-post-commit.sh
@@ -25,8 +25,8 @@ begin_test "post-commit"
   git commit -m "Committed large files"
 
   # New lockable files should have been made read-only now since not locked
-  refute_file_writable pcfile1.dat
-  refute_file_writable pcfile2.dat
+  refute_file_writeable pcfile1.dat
+  refute_file_writeable pcfile2.dat
   assert_file_writeable pcfile3.big
   assert_file_writeable pcfile4.big
 

--- a/test/test-post-merge.sh
+++ b/test/test-post-merge.sh
@@ -72,15 +72,15 @@ begin_test "post-merge"
   # without the post-checkout hook, any changed files would now be writeable
   refute_file_writable file1.dat
   refute_file_writable file2.dat
-  assert_file_writable file3.big
-  assert_file_writable file4.big
+  assert_file_writeable file3.big
+  assert_file_writeable file4.big
 
   # merge branch, with readonly option disabled to demonstrate what would happen
   GIT_LFS_SET_LOCKABLE_READONLY=0 git merge origin/branch2
   # branch2 had hanges to file2.dat and file5.dat which were lockable
   # but because we disabled the readonly feature they will be writeable now
-  assert_file_writable file2.dat
-  assert_file_writable file5.dat
+  assert_file_writeable file2.dat
+  assert_file_writeable file5.dat
 
   # now let's do it again with the readonly option enabled
   git reset --hard HEAD^

--- a/test/test-post-merge.sh
+++ b/test/test-post-merge.sh
@@ -70,8 +70,8 @@ begin_test "post-merge"
   [ ! -e file5.dat ]
   [ ! -e file6.big ]
   # without the post-checkout hook, any changed files would now be writeable
-  refute_file_writable file1.dat
-  refute_file_writable file2.dat
+  refute_file_writeable file1.dat
+  refute_file_writeable file2.dat
   assert_file_writeable file3.big
   assert_file_writeable file4.big
 
@@ -87,8 +87,8 @@ begin_test "post-merge"
   git merge origin/branch2
 
   # This time they should be read-only
-  refute_file_writable file2.dat
-  refute_file_writable file5.dat
+  refute_file_writeable file2.dat
+  refute_file_writeable file5.dat
 
   # Confirm that contents of existing files were updated even though were read-only
   [ "$(cat file2.dat)" == "file 2 updated in branch2" ]

--- a/test/test-track.sh
+++ b/test/test-track.sh
@@ -424,9 +424,9 @@ begin_test "track lockable read-only/read-write"
   # bin should remain writeable, dat should have been made read-only
 
   assert_file_writeable test.bin
-  refute_file_writable test.dat
+  refute_file_writeable test.dat
   assert_file_writeable subfolder/test.bin
-  refute_file_writable subfolder/test.dat
+  refute_file_writeable subfolder/test.dat
 
   git add .gitattributes test.bin test.dat
   git commit -m "First commit"
@@ -437,8 +437,8 @@ begin_test "track lockable read-only/read-write"
   # now make bin lockable
   git lfs track --lockable "*.bin" | grep "Tracking \"\*.bin\""
   # bin should now be read-only
-  refute_file_writable test.bin
-  refute_file_writable subfolder/test.bin
+  refute_file_writeable test.bin
+  refute_file_writeable subfolder/test.bin
 
   # remove lockable again
   git lfs track --not-lockable "*.bin" | grep "Tracking \"\*.bin\""

--- a/test/test-track.sh
+++ b/test/test-track.sh
@@ -411,10 +411,10 @@ begin_test "track lockable read-only/read-write"
   echo "sub blah blah" > subfolder/test.bin
   echo "sub foo bar" > subfolder/test.dat
   # should start writeable
-  assert_file_writable test.bin
-  assert_file_writable test.dat
-  assert_file_writable subfolder/test.bin
-  assert_file_writable subfolder/test.dat
+  assert_file_writeable test.bin
+  assert_file_writeable test.dat
+  assert_file_writeable subfolder/test.bin
+  assert_file_writeable subfolder/test.dat
 
   # track *.bin, not lockable yet
   git lfs track "*.bin" | grep "Tracking \"\*.bin\""
@@ -423,17 +423,17 @@ begin_test "track lockable read-only/read-write"
 
   # bin should remain writeable, dat should have been made read-only
 
-  assert_file_writable test.bin
+  assert_file_writeable test.bin
   refute_file_writable test.dat
-  assert_file_writable subfolder/test.bin
+  assert_file_writeable subfolder/test.bin
   refute_file_writable subfolder/test.dat
 
   git add .gitattributes test.bin test.dat
   git commit -m "First commit"
 
   # bin should still be writeable
-  assert_file_writable test.bin
-  assert_file_writable subfolder/test.bin
+  assert_file_writeable test.bin
+  assert_file_writeable subfolder/test.bin
   # now make bin lockable
   git lfs track --lockable "*.bin" | grep "Tracking \"\*.bin\""
   # bin should now be read-only
@@ -443,8 +443,8 @@ begin_test "track lockable read-only/read-write"
   # remove lockable again
   git lfs track --not-lockable "*.bin" | grep "Tracking \"\*.bin\""
   # bin should now be writeable again
-  assert_file_writable test.bin
-  assert_file_writable subfolder/test.bin
+  assert_file_writeable test.bin
+  assert_file_writeable subfolder/test.bin
 )
 end_test
 

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -208,7 +208,7 @@ assert_attributes_count() {
   fi
 }
 
-assert_file_writable() {
+assert_file_writeable() {
   ls -l "$1" | grep -e "^-rw"
 }
 

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -212,7 +212,7 @@ assert_file_writeable() {
   ls -l "$1" | grep -e "^-rw"
 }
 
-refute_file_writable() {
+refute_file_writeable() {
   ls -l "$1" | grep -e "^-r-"
 }
 


### PR DESCRIPTION
This pull request fixes a minor typo I noticed in https://github.com/git-lfs/git-lfs/pull/2514.

---

/cc @git-lfs/core 