### PR TITLE
ci: disable integration tests on 'next' branch of git

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ env:
     - GIT_SOURCE_REPO="https://github.com/git/git.git"
     - GIT_EARLIEST_SUPPORTED_VERSION="v2.0.0
     - GIT_LATEST_SOURCE_BRANCH="master"
-    - GIT_NEXT_SOURCE_BRANCH="next"
     - GIT_ASKPASS=""
 
 matrix:
@@ -25,16 +24,6 @@ matrix:
           git clone $GIT_SOURCE_REPO git-source;
           cd git-source;
           git checkout $GIT_LATEST_SOURCE_BRANCH;
-          make --jobs=2;
-          make install;
-          cd ..;
-    - env: git-latest-next-from-source
-      os: linux
-      before_script:
-        - >
-          git clone $GIT_SOURCE_REPO git-source;
-          cd git-source;
-          git checkout $GIT_NEXT_SOURCE_BRANCH;
           make --jobs=2;
           make install;
           cd ..;

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,6 @@ machine:
     GIT_SOURCE_REPO: https://github.com/git/git.git
     GIT_EARLIEST_SUPPORTED_VERSION: v2.0.0
     GIT_LATEST_SOURCE_BRANCH: master
-    GIT_NEXT_SOURCE_BRANCH: next
     XCODE_SCHEME: test
     XCODE_WORKSPACE: test
     XCODE_PROJECT: test
@@ -44,6 +43,4 @@ test:
     - script/install-git-source "$GIT_EARLIEST_SUPPORTED_VERSION"
     - PATH="$HOME/bin:$PATH" SKIPCOMPILE=1 script/integration
     - script/install-git-source "$GIT_LATEST_SOURCE_BRANCH"
-    - PATH="$HOME/bin:$PATH" SKIPCOMPILE=1 script/integration
-    - script/install-git-source "$GIT_NEXT_SOURCE_BRANCH"
     - PATH="$HOME/bin:$PATH" SKIPCOMPILE=1 script/integration


### PR DESCRIPTION
This pull request disables running our integration tests on the 'next' branch of Git.

This change was originally introduced in order to test @larsxschneider's 'delay' patch in #2511, but that has since been merged into the master branch of Git, and is already covered under an existing test runner.

To save time on CI and avoid redundancy, let's remove the extraneous branch.

---

/cc @git-lfs/core 
/cc #2466 