### PR TITLE
git: make filter status a sentinel

### DIFF
--- a/commands/command_filter_process.go
+++ b/commands/command_filter_process.go
@@ -165,7 +165,7 @@ func filterCommand(cmd *cobra.Command, args []string) {
 			malformedOnWindows = append(malformedOnWindows, req.Header["pathname"])
 		}
 
-		var status string
+		var status git.FilterProcessStatus
 		if delayed {
 			// If delayed, there is no need to call w.Flush() since
 			// no data was written. Calculate the status from the
@@ -341,22 +341,22 @@ func pathnames(ts []*tq.Transfer) []string {
 
 // statusFromErr returns the status code that should be sent over the filter
 // protocol based on a given error, "err".
-func statusFromErr(err error) string {
+func statusFromErr(err error) git.FilterProcessStatus {
 	if err != nil && err != io.EOF {
-		return "error"
+		return git.StatusError
 	}
-	return "success"
+	return git.StatusSuccess
 }
 
 // delayedStatusFromErr returns the status code that should be sent over the
 // filter protocol based on a given error, "err" when the blob smudge operation
 // was delayed.
-func delayedStatusFromErr(err error) string {
+func delayedStatusFromErr(err error) git.FilterProcessStatus {
 	status := statusFromErr(err)
 
 	switch status {
-	case "success":
-		return "delayed"
+	case git.StatusSuccess:
+		return git.StatusDelay
 	default:
 		return status
 	}

--- a/git/filter_process_scanner.go
+++ b/git/filter_process_scanner.go
@@ -198,8 +198,8 @@ func (o *FilterProcessScanner) WriteList(list []string) error {
 	return o.pl.writePacketList(list)
 }
 
-func (o *FilterProcessScanner) WriteStatus(status string) error {
-	return o.pl.writePacketList([]string{"status=" + status})
+func (o *FilterProcessScanner) WriteStatus(status FilterProcessStatus) error {
+	return o.pl.writePacketList([]string{"status=" + status.String()})
 }
 
 // isStringInSlice returns whether a given string "what" is contained in a

--- a/git/filter_process_status.go
+++ b/git/filter_process_status.go
@@ -1,0 +1,33 @@
+package git
+
+import "fmt"
+
+// FilterProcessStatus is a constant type representing the various valid
+// responses for `status=` in the Git filtering process protocol.
+type FilterProcessStatus uint8
+
+const (
+	// StatusSuccess is a valid response when a successful event has
+	// occurred.
+	StatusSuccess FilterProcessStatus = iota + 1
+	// StatusDelay is a valid response when a delay has occurred.
+	StatusDelay
+	// StatusError is a valid response when an error has occurred.
+	StatusError
+)
+
+// String implements fmt.Stringer by returning a protocol-compliant
+// representation of the receiving status, or panic()-ing if the Status is
+// unknown.
+func (s FilterProcessStatus) String() string {
+	switch s {
+	case StatusSuccess:
+		return "success"
+	case StatusDelay:
+		return "delayed"
+	case StatusError:
+		return "error"
+	}
+
+	panic(fmt.Sprintf("git: unknown FilterProcessStatus '%d'", s))
+}


### PR DESCRIPTION
This pull request makes the argument to `git.(*FilterProcessScanner)` a sentinel constant type instead of a string.

This change was promoted by https://github.com/git-lfs/git-lfs/pull/2511#discussion_r135134618, wherein @larsxschneider suggests that we should implement the `delayedStatusFromErr` by calling `statusFromErr`, and then promoting the "success" return value to "delayed".

I think this is a great idea, since it unifies the protocol-related parts of this code. However, it also tightly couples these two functions together: if `success` changes in the protocol, we have to update it not only in the `statusFromErr` function, but in the `delayedStatusFromErr` function as well.

To avoid this problem, let's introduce a sentinel type that transparently holds the protocol encoding by implementing the `fmt.Stringer` interface. We can then do comparisons on the named constant instead of the value, and isolate the changes to the constant's definition(s).

---

/cc @git-lfs/core 
/cc @larsxschneider 
/cc #2466 