### PR TITLE
commands: mark 'git lfs clone' as deprecated

### DIFF
--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -20,17 +20,12 @@ var (
 	cloneFlags git.CloneFlags
 
 	cloneSkipRepoInstall bool
-
-	// cloneIsDeprecated marks whether or not the clone command is
-	// deprecated. It is false until Git v2.15.0 is released, including the
-	// 'delay' capability.
-	cloneIsDeprecated = false
 )
 
 func cloneCommand(cmd *cobra.Command, args []string) {
 	requireGitVersion()
 
-	if cloneIsDeprecated {
+	if git.Config.IsGitVersionAtLeast("2.15.0") {
 		msg := []string{
 			"WARNING: 'git lfs clone' is deprecated and will not be updated",
 			"          with new flags from 'git clone'",

--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -39,7 +39,7 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 			"speeds to 'git lfs clone'.",
 		}
 
-		fmt.Fprintln(os.Stderr, strings.Join(msg, "\n")+"\n")
+		fmt.Fprintln(os.Stderr, strings.Join(msg, "\n"))
 	}
 
 	// We pass all args to git clone

--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -19,10 +20,27 @@ var (
 	cloneFlags git.CloneFlags
 
 	cloneSkipRepoInstall bool
+
+	// cloneIsDeprecated marks whether or not the clone command is
+	// deprecated. It is false until Git v2.15.0 is released, including the
+	// 'delay' capability.
+	cloneIsDeprecated = false
 )
 
 func cloneCommand(cmd *cobra.Command, args []string) {
 	requireGitVersion()
+
+	if cloneIsDeprecated {
+		msg := []string{
+			"WARNING: 'git-lfs(1) clone' is deprecated and will not be updated",
+			"          with new flags from 'git clone'",
+			"",
+			"'git-clone(1)' has been updated in upstream Git to have comparable",
+			"speeds to 'git-lfs(1) clone'.",
+		}
+
+		fmt.Fprintln(os.Stderr, strings.Join(msg, "\n")+"\n")
+	}
 
 	// We pass all args to git clone
 	err := git.CloneWithoutFilters(cloneFlags, args)

--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -32,11 +32,11 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 
 	if cloneIsDeprecated {
 		msg := []string{
-			"WARNING: 'git-lfs(1) clone' is deprecated and will not be updated",
+			"WARNING: 'git lfs clone' is deprecated and will not be updated",
 			"          with new flags from 'git clone'",
 			"",
-			"'git-clone(1)' has been updated in upstream Git to have comparable",
-			"speeds to 'git-lfs(1) clone'.",
+			"'git clone' has been updated in upstream Git to have comparable",
+			"speeds to 'git lfs clone'.",
 		}
 
 		fmt.Fprintln(os.Stderr, strings.Join(msg, "\n")+"\n")

--- a/test/test-clone-deprecated.sh
+++ b/test/test-clone-deprecated.sh
@@ -2,7 +2,7 @@
 
 . "test/testlib.sh"
 
-ensure_git_version_isnt $VERISON_LOWER "2.15.0"
+ensure_git_version_isnt $VERSION_LOWER "2.15.0"
 
 begin_test "clone (deprecated on new versions of Git)"
 (

--- a/test/test-clone-deprecated.sh
+++ b/test/test-clone-deprecated.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+. "test/testlib.sh"
+
+ensure_git_version_isnt $VERISON_LOWER "2.15.0"
+
+begin_test "clone (deprecated on new versions of Git)"
+(
+  set -e
+
+  reponame="clone-deprecated-recent-versions"
+  setup_remote_repo "$reponame"
+
+  mkdir -p "$reponame"
+  pushd "$reponame" > /dev/null
+    git lfs clone "$reponame" 2>&1 | tee clone.log
+    grep "WARNING: 'git lfs clone' is deprecated and will not be updated" clone.log
+  popd
+)
+end_test

--- a/test/test-clone-deprecated.sh
+++ b/test/test-clone-deprecated.sh
@@ -13,7 +13,7 @@ begin_test "clone (deprecated on new versions of Git)"
 
   mkdir -p "$reponame"
   pushd "$reponame" > /dev/null
-    git lfs clone "$reponame" 2>&1 | tee clone.log
+    git lfs clone "$GITSERVER/$reponame" 2>&1 | tee clone.log
     grep "WARNING: 'git lfs clone' is deprecated and will not be updated" clone.log
   popd
 )

--- a/test/test-clone-deprecated.sh
+++ b/test/test-clone-deprecated.sh
@@ -15,6 +15,6 @@ begin_test "clone (deprecated on new versions of Git)"
   pushd "$reponame" > /dev/null
     git lfs clone "$GITSERVER/$reponame" 2>&1 | tee clone.log
     grep "WARNING: 'git lfs clone' is deprecated and will not be updated" clone.log
-  popd
+  popd > /dev/null
 )
 end_test


### PR DESCRIPTION
This pull request marks the `git-lfs(1) 'clone'` command as deprecated, and puts that deprecation behind a "feature flag".

Since merging #2511, `git clone` is as fast as `git lfs clone` in the majority of cases. To avoid the maintenance cost of the `git lfs clone` command, we mark it as deprecated here, and point callers in the direction of `git clone`. @technoweenie points out a great reason for doing this in https://github.com/git-lfs/git-lfs/issues/2466#issuecomment-322290355:

> > git lfs clone could certainly go 😄 ! Maybe we can mark it as deprecated with a warning on invocation in the 2.x series already?
> 
> I'm all for deprecating it. We should recommend users update Git, but keep the command around for any stragglers. Also, reject PRs for support of any _new_ `clone` flags, since new flags would mean you have a new enough Git with delay support :) 👍

Removing this command also decreases the size of LFS's surface area. Less commands that LFS provides on top of Git make the experience of using LFS more seamless and familiar. I think that's a good thing 👍 .

---

/cc @git-lfs/core 
/cc #2466 