### PR TITLE
git: expand 'GetAttributePaths' check to include non-LFS lockables

### DIFF
--- a/git/attribs.go
+++ b/git/attribs.go
@@ -57,7 +57,14 @@ func GetAttributePaths(workingDir, gitDir string) []AttributePath {
 
 		for scanner.Scan() {
 			line := scanner.Text()
-			if strings.Contains(line, "filter=lfs") {
+
+			// Check for filter=lfs (signifying that LFS is tracking
+			// this file) or "lockable", which indicates that the
+			// file is lockable (and may or may not be tracked by
+			// Git LFS).
+			if strings.Contains(line, "filter=lfs") ||
+				strings.HasSuffix(line, "lockable") {
+
 				fields := strings.Fields(line)
 				pattern := fields[0]
 				if len(reldir) > 0 {


### PR DESCRIPTION
This pull request fixes a bug pointed out by @mrbobbybobberson in https://github.com/git-lfs/git-lfs/issues/2497#issuecomment-324173879.

According to our wiki:

> If you'd like to register a file type as lockable, without using LFS, you can edit the .gitattributes file directly:
>
> `*.yml lockable`
>
> Once file patterns in .gitattributes are lockable, Git LFS will make them readonly on the local file system automatically. This prevents users from accidentally editing a file without locking it first.

The post-commit hook should mark those files as read-only. This is correct (and verified by the `test/test-post-commit.sh` test) when files are _also_ tracked using Git LFS. When the `post-commit` hook runs, Git LFS tries to determine a filepathfilter that matches all of the files that are marked as lockable in any of the repository's .gitattributes file(s):

https://github.com/git-lfs/git-lfs/blob/200b8f08cac8f28c46dbf59ae4ca4cf9bcbb9c7d/locking/lockable.go#L39-L52

it does so by scanning the repository's .gitattributes(s) for any paths that are lockable, using this function:

https://github.com/git-lfs/git-lfs/blob/200b8f08cac8f28c46dbf59ae4ca4cf9bcbb9c7d/git/attribs.go#L27-L31

This function scans through each line of each `.gitattributes` file that it finds and returns some information about each one in a slice. Before inspecting each line, however, it first tries to determine if it's tracked by LFS:

https://github.com/git-lfs/git-lfs/blob/200b8f08cac8f28c46dbf59ae4ca4cf9bcbb9c7d/git/attribs.go#L44

For entries like:

```
*.dat lockable
```

this is not the case, as the string `"filter=lfs"` does not appear in that line. Since `lockable` is a part of the scope of Git LFS, include that check as a fallback when scanning each line.

This can go in the list of future improvements to make if we ever write a `.gitattributes` parser, but for now I think this will do.

Closes: https://github.com/git-lfs/git-lfs/issues/2497.

---

/cc @git-lfs/core 
/cc @mrbobbybobberson