### PR TITLE
tools: compare expiration to "time.Now" instead of "from"

### DIFF
--- a/tools/time_tools.go
+++ b/tools/time_tools.go
@@ -1,24 +1,26 @@
 package tools
 
-import "time"
+import (
+	"time"
+)
 
 // IsExpiredAtOrIn returns whether or not the result of calling TimeAtOrIn is
 // "expired" within "until" units of time from now.
-func IsExpiredAtOrIn(now time.Time, until time.Duration, at time.Time, in time.Duration) (time.Time, bool) {
-	expiration := TimeAtOrIn(now, at, in)
+func IsExpiredAtOrIn(from time.Time, until time.Duration, at time.Time, in time.Duration) (time.Time, bool) {
+	expiration := TimeAtOrIn(from, at, in)
 	if expiration.IsZero() {
 		return expiration, false
 	}
 
-	return expiration, expiration.Before(now.Add(until))
+	return expiration, expiration.Before(time.Now().Add(until))
 }
 
 // TimeAtOrIn returns either "at", or the "in" duration added to the current
 // time. TimeAtOrIn prefers to add a duration rather than return the "at"
 // parameter.
-func TimeAtOrIn(now, at time.Time, in time.Duration) time.Time {
+func TimeAtOrIn(from, at time.Time, in time.Duration) time.Time {
 	if in == 0 {
 		return at
 	}
-	return now.Add(in)
+	return from.Add(in)
 }


### PR DESCRIPTION
This pull request fixes a bug that @larsxschneider noticed in https://github.com/git-lfs/git-lfs/pull/2511#issuecomment-323599680 (and that @technoweenie explained in https://github.com/git-lfs/git-lfs/pull/2511#issuecomment-323601319):

> As for the SSH thing, my hunch is that the expiration timeout is not being respected. Is this happening at around the 10 minute mark?
> 
> [...]
> 
> - Does the Batch API try to refresh the Authorization header after it expires? I thought it recognizes that and automatically retries. Maybe there's a race condition, and it should refresh the token if expires_in is < 5 or something.
> - Does the SSH cred cacher respect the expires_in? It should be falling back to a real ssh call after expires_in seconds have passed.

I incorrectly noted that the behavior looks correct in https://github.com/git-lfs/git-lfs/issues/2519#issuecomment-324730475, but upon further investigation was able to find the bug.

To explain, here's how the `tools.IsExpiredAtOrIn()` function works:

1. Receive a starting time, a relative duration to expire, an absolute time to expire, and the current time.
2. If the relative duration is non-zero (i.e., the SSH `git-lfs-authenticate` call supports `ExpiresIn`), add that duration to the starting time "from", and mark that as the expiration time.
3. If now, mark the absolute "at" time as the expiration time.
4. Figure out if the current time is less than "in" units of time away from the expiration time as determined above.

The problem was in step four: previously, we were taking the current time to be the "now" parameter, where it actually should be `time.Now()`. The from parameter is given as the creation timestamp of the SSH credential cache entry, which will always be earlier (and therefore, non-expired) than the expiration timestamp.

Fix this by using `time.Now()` instead of `now` in order to determine if the time has passed.

Closes: https://github.com/git-lfs/git-lfs/issues/2519.

---

/cc @git-lfs/core 
/cc @larsxschneider 
/cc https://github.com/git-lfs/git-lfs/issues/2519    

