### PR TITLE
fix multiple `git update-index` invocations

### DIFF
--- a/commands/pull.go
+++ b/commands/pull.go
@@ -98,11 +98,18 @@ func (i *gitIndexer) Add(path string) error {
 
 	if i.cmd == nil {
 		// Fire up the update-index command
-		stdin, err := git.StartUpdateIndexFromStdin(&i.output)
+		cmd := git.UpdateIndexFromStdin()
+		cmd.Stdout = &i.output
+		cmd.Stderr = &i.output
+		stdin, err := cmd.StdinPipe()
 		if err != nil {
 			return err
 		}
-
+		err = cmd.Start()
+		if err != nil {
+			return err
+		}
+		i.cmd = cmd
 		i.input = stdin
 	}
 

--- a/git/git.go
+++ b/git/git.go
@@ -458,16 +458,8 @@ func DefaultRemote() (string, error) {
 	return "", errors.New("Unable to pick default remote, too ambiguous")
 }
 
-func StartUpdateIndexFromStdin(w io.Writer) (io.WriteCloser, error) {
-	cmd := gitNoLFS("update-index", "-q", "--refresh", "--stdin")
-	cmd.Stdout = w
-	cmd.Stderr = w
-	stdin, err := cmd.StdinPipe()
-	if err == nil {
-		err = cmd.Start()
-	}
-
-	return stdin, err
+func UpdateIndexFromStdin() *subprocess.Cmd {
+	return gitNoLFS("update-index", "-q", "--refresh", "--stdin")
 }
 
 type gitConfig struct {


### PR DESCRIPTION
The gitIndexer starts a new `git update-index` process when the first
file is given to it. A reference to this process is stored in the `cmd`
variable of the gitIndexer struct. This variable was always `nil` after
the refactoring in ae4d2611 ("move `git update-index` invocation to git
package", 2017-08-02). Consequently, a new `git update-index` process
was invoked for every file.

Fix this by refactoring the `git update-index` invocation, again. This
time we return the subprocess pointer. This is necessary because we
want to call `Wait()` on the process when the gitIndexer is closed.

---

I noticed the bug in #2439 and realized that I introduced it with my recent refactoring. Sorry!
Has anyone a good idea how to check the number of invoked `git update-index` processes in a test case?