### PR TITLE
git: implement Fetch() to fetch remote refs

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -1151,6 +1151,12 @@ func CachedRemoteRefs(remoteName string) ([]*Ref, error) {
 	return ret, cmd.Wait()
 }
 
+// Fetch performs a fetch with no arguments against the given remotes.
+func Fetch(remotes ...string) error {
+	_, err := gitNoLFSSimple(append([]string{"fetch"}, remotes...)...)
+	return err
+}
+
 // RemoteRefs returns a list of branches & tags for a remote by actually
 // accessing the remote vir git ls-remote
 func RemoteRefs(remoteName string) ([]*Ref, error) {


### PR DESCRIPTION
This pull request implements `git.Fetch()`, which takes in a variable number of remotes, and performs a `git fetch` operation on them.

This is work done in anticipation of first calling `git-fetch(1)` from the migrator, to ensure that the necessary remote refs are present locally when comparing them against the output of `git-ls-remote(1)` in order to determine what should be included and not included in the migration.

---

/cc @git-lfs/core 