### PR TITLE
commands,git/githistory: pass *log.Logger in externally

### DIFF
--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -1,13 +1,13 @@
 package commands
 
 import (
-	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/git"
 	"github.com/git-lfs/git-lfs/git/githistory"
+	"github.com/git-lfs/git-lfs/git/githistory/log"
 	"github.com/git-lfs/git-lfs/git/odb"
 	"github.com/spf13/cobra"
 )
@@ -23,7 +23,7 @@ var (
 
 // migrate takes the given command and arguments, *odb.ObjectDatabase, as well
 // as a BlobRewriteFn to apply, and performs a migration.
-func migrate(args []string, r *githistory.Rewriter, opts *githistory.RewriteOptions) {
+func migrate(args []string, r *githistory.Rewriter, l *log.Logger, opts *githistory.RewriteOptions) {
 	requireInRepo()
 
 	opts, err := rewriteOptions(args, opts)
@@ -197,12 +197,12 @@ func currentRefToMigrate() (*git.Ref, error) {
 
 // getHistoryRewriter returns a history rewriter that includes the filepath
 // filter given by the --include and --exclude arguments.
-func getHistoryRewriter(cmd *cobra.Command, db *odb.ObjectDatabase) *githistory.Rewriter {
+func getHistoryRewriter(cmd *cobra.Command, db *odb.ObjectDatabase, l *log.Logger) *githistory.Rewriter {
 	include, exclude := getIncludeExcludeArgs(cmd)
 	filter := buildFilepathFilter(cfg, include, exclude)
 
 	return githistory.NewRewriter(db,
-		githistory.WithFilter(filter), githistory.WithLogger(os.Stderr))
+		githistory.WithFilter(filter), githistory.WithLogger(l))
 }
 
 func init() {

--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -12,22 +12,25 @@ import (
 	"github.com/git-lfs/git-lfs/filepathfilter"
 	"github.com/git-lfs/git-lfs/git"
 	"github.com/git-lfs/git-lfs/git/githistory"
+	"github.com/git-lfs/git-lfs/git/githistory/log"
 	"github.com/git-lfs/git-lfs/git/odb"
 	"github.com/git-lfs/git-lfs/tools"
 	"github.com/spf13/cobra"
 )
 
 func migrateImportCommand(cmd *cobra.Command, args []string) {
+	l := log.NewLogger(os.Stderr)
+
 	db, err := getObjectDatabase()
 	if err != nil {
 		ExitWithError(err)
 	}
-	rewriter := getHistoryRewriter(cmd, db)
+	rewriter := getHistoryRewriter(cmd, db, l)
 
 	tracked := trackedFromFilter(rewriter.Filter())
 	exts := tools.NewOrderedSet()
 
-	migrate(args, rewriter, &githistory.RewriteOptions{
+	migrate(args, rewriter, l, &githistory.RewriteOptions{
 		BlobFn: func(path string, b *odb.Blob) (*odb.Blob, error) {
 			if filepath.Base(path) == ".gitattributes" {
 				return b, nil

--- a/commands/command_migrate_info.go
+++ b/commands/command_migrate_info.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/git/githistory"
+	"github.com/git-lfs/git-lfs/git/githistory/log"
 	"github.com/git-lfs/git-lfs/git/odb"
 	"github.com/git-lfs/git-lfs/tools"
 	"github.com/git-lfs/git-lfs/tools/humanize"
@@ -39,11 +40,13 @@ var (
 )
 
 func migrateInfoCommand(cmd *cobra.Command, args []string) {
+	l := log.NewLogger(os.Stderr)
+
 	db, err := getObjectDatabase()
 	if err != nil {
 		ExitWithError(err)
 	}
-	rewriter := getHistoryRewriter(cmd, db)
+	rewriter := getHistoryRewriter(cmd, db, l)
 
 	exts := make(map[string]*MigrateInfoEntry)
 
@@ -63,7 +66,7 @@ func migrateInfoCommand(cmd *cobra.Command, args []string) {
 
 	migrateInfoAbove = above
 
-	migrate(args, rewriter, &githistory.RewriteOptions{
+	migrate(args, rewriter, l, &githistory.RewriteOptions{
 		BlobFn: func(path string, b *odb.Blob) (*odb.Blob, error) {
 			ext := fmt.Sprintf("*%s", filepath.Ext(path))
 

--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -127,11 +127,17 @@ var (
 		}
 	}
 
+	// WithLoggerto logs updates caused by the *git/githistory.Rewriter to
+	// the given io.Writer "sink".
+	WithLoggerTo = func(sink io.Writer) rewriterOption {
+		return WithLogger(log.NewLogger(sink))
+	}
+
 	// WithLogger logs updates caused by the *git/githistory.Rewriter to the
-	// given io.Writer "sink".
-	WithLogger = func(sink io.Writer) rewriterOption {
+	// be given to the provided logger, "l".
+	WithLogger = func(l *log.Logger) rewriterOption {
 		return func(r *Rewriter) {
-			r.l = log.NewLogger(sink)
+			r.l = l
 		}
 	}
 


### PR DESCRIPTION
This pull request allows callers of the `git/githistory.NewRewriter()` function to pass in a `git/githistory/log.(*Logger)` that they created, instead of just supplying the `io.Writer` sink.

This allows callers to maintain a handle on the given logger without expanding the API of functions that `*HistoryRewriter` receives. Callers that hold a reference to the logger can add their own arbitrary tasks to it, while maintaining the same synchronicity guarentees that the `*Logger` type provides.

This is done in anticipation of the `git-lfs-migrate(1)` command being able to fetch remote refs before beginning a migration. Doing so will require the migrator to log that it is fetching so it does not appear to hang, and thus requires a change like the one presented in this pull request.

---

/cc @git-lfs/core 