### PR TITLE
lfs: remove unused LargeSizeThreshold constant

### DIFF
--- a/lfs/lfs.go
+++ b/lfs/lfs.go
@@ -17,10 +17,6 @@ import (
 	"github.com/rubyist/tracerx"
 )
 
-var (
-	LargeSizeThreshold = 5 * 1024 * 1024
-)
-
 // LocalMediaDir returns the root of lfs objects
 func LocalMediaDir() string {
 	if localstorage.Objects() != nil {


### PR DESCRIPTION
The constant was introduced in dca7f73 ("really basic pre-commit hook
that rejects commits with files > 5MB", 2013-09-23) and is not used
anymore. Cleanup the code and remove it.