### PR TITLE
commands: teach 'git lfs ls-files' a '--debug' option

### DIFF
--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -10,6 +10,7 @@ import (
 
 var (
 	longOIDs = false
+	debug    = false
 )
 
 func lsFilesCommand(cmd *cobra.Command, args []string) {
@@ -38,7 +39,24 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 			return
 		}
 
-		Print("%s %s %s", p.Oid[0:showOidLen], lsFilesMarker(p), p.Name)
+		if debug {
+			Print(
+				"filepath: %s\n"+
+					"    size: %d\n"+
+					"checkout: %v\n"+
+					"download: %v\n"+
+					"     oid: %s %s\n"+
+					" version: %s\n",
+				p.Name,
+				p.Size,
+				fileExistsOfSize(p),
+				lfs.ObjectExistsOfSize(p.Oid, p.Size),
+				p.OidType,
+				p.Oid,
+				p.Version)
+		} else {
+			Print("%s %s %s", p.Oid[0:showOidLen], lsFilesMarker(p), p.Name)
+		}
 	})
 	defer gitscanner.Close()
 
@@ -63,5 +81,6 @@ func lsFilesMarker(p *lfs.WrappedPointer) string {
 func init() {
 	RegisterCommand("ls-files", lsFilesCommand, func(cmd *cobra.Command) {
 		cmd.Flags().BoolVarP(&longOIDs, "long", "l", false, "")
+		cmd.Flags().BoolVarP(&debug, "debug", "d", false, "")
 	})
 }

--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -47,12 +47,16 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 	}
 }
 
-func lsFilesMarker(p *lfs.WrappedPointer) string {
+// Returns true if a pointer appears to be properly smudge on checkout
+func fileExistsOfSize(p *lfs.WrappedPointer) bool {
 	info, err := os.Stat(p.Name)
-	if err == nil && info.Size() == p.Size {
+	return err == nil && info.Size() == p.Size
+}
+
+func lsFilesMarker(p *lfs.WrappedPointer) string {
+	if fileExistsOfSize(p) {
 		return "*"
 	}
-
 	return "-"
 }
 

--- a/docs/man/git-lfs-ls-files.1.ronn
+++ b/docs/man/git-lfs-ls-files.1.ronn
@@ -15,6 +15,10 @@ reference.  If no reference is given, scan the currently checked-out branch.
 * `-l` `--long`:
   Show the entire 64 character OID, instead of just first 10.
 
+* -d --debug:
+  Show as much information as possible about a LFS file. This is intended
+  for manual inspection; the exact format may change at any time.
+
 ## SEE ALSO
 
 git-lfs-status(1).

--- a/test/test-ls-files.sh
+++ b/test/test-ls-files.sh
@@ -24,6 +24,16 @@ begin_test "ls-files"
   git lfs ls-files | tee ls.log
   grep some.dat ls.log
   [ `wc -l < ls.log` = 1 ]
+
+  diff -u <(git lfs ls-files --debug) <(cat <<-EOF
+filepath: some.dat
+    size: 10
+checkout: true
+download: true
+     oid: sha256 5aa03f96c77536579166fba147929626cc3a97960e994057a9d80271a736d10f
+ version: https://git-lfs.github.com/spec/v1
+
+EOF)
 )
 end_test
 


### PR DESCRIPTION
There was no way to conveniently display LFS pointer file properties for
debugging. Teach 'git lfs ls-files' a '--debug' option that prints all
available information following the 'git ls-files' interface [1].

[1] https://github.com/git/git/commit/84974217151a66b65ae5b173045483ce5eeb5142

--

If you like the approach of this PR, then this would this would replace #1829.
My goal here is a quick way to check the sizes of the Git LFS files in a repo.