### PR TITLE
git/{odb,githistory}: don't write unchanged objects

### DIFF
--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -321,6 +321,10 @@ func (r *Rewriter) rewriteTree(sha []byte, path string, fn BlobRewriteFn, tfn Tr
 	if err != nil {
 		return nil, err
 	}
+
+	if tree.Equal(rewritten) {
+		return sha, nil
+	}
 	return r.db.WriteTree(rewritten)
 }
 

--- a/git/odb/blob.go
+++ b/git/odb/blob.go
@@ -68,3 +68,18 @@ func (b *Blob) Close() error {
 	}
 	return b.closeFn()
 }
+
+// Equal returns whether the receiving and given blobs are equal, or in other
+// words, whether they are represented by the same SHA-1 when saved to the
+// object database.
+func (b *Blob) Equal(other *Blob) bool {
+	if (b == nil) != (other == nil) {
+		return false
+	}
+
+	if b != nil {
+		return b.Contents == other.Contents &&
+			b.Size == other.Size
+	}
+	return true
+}

--- a/git/odb/blob_test.go
+++ b/git/odb/blob_test.go
@@ -85,3 +85,37 @@ func TestBlobCanCloseWithoutCloseFn(t *testing.T) {
 
 	assert.Nil(t, b.Close())
 }
+
+func TestBlobEqualReturnsTrueWithUnchangedContents(t *testing.T) {
+	c := strings.NewReader("Hello, world!")
+
+	b1 := &Blob{Size: int64(c.Len()), Contents: c}
+	b2 := &Blob{Size: int64(c.Len()), Contents: c}
+
+	assert.True(t, b1.Equal(b2))
+}
+
+func TestBlobEqualReturnsFalseWithChangedContents(t *testing.T) {
+	c1 := strings.NewReader("Hello, world!")
+	c2 := strings.NewReader("Goodbye, world!")
+
+	b1 := &Blob{Size: int64(c1.Len()), Contents: c1}
+	b2 := &Blob{Size: int64(c2.Len()), Contents: c2}
+
+	assert.False(t, b1.Equal(b2))
+}
+
+func TestBlobEqualReturnsTrueWhenOneBlobIsNil(t *testing.T) {
+	b1 := &Blob{Size: 1, Contents: bytes.NewReader([]byte{0xa})}
+	b2 := (*Blob)(nil)
+
+	assert.False(t, b1.Equal(b2))
+	assert.False(t, b2.Equal(b1))
+}
+
+func TestBlobEqualReturnsTrueWhenBothBlobsAreNil(t *testing.T) {
+	b1 := (*Blob)(nil)
+	b2 := (*Blob)(nil)
+
+	assert.True(t, b1.Equal(b2))
+}

--- a/git/odb/commit.go
+++ b/git/odb/commit.go
@@ -2,6 +2,7 @@ package odb
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -182,4 +183,45 @@ func (c *Commit) Encode(to io.Writer) (n int, err error) {
 	}
 
 	return n + n4, err
+}
+
+// Equal returns whether the receiving and given commits are equal, or in other
+// words, whether they are represented by the same SHA-1 when saved to the
+// object database.
+func (c *Commit) Equal(other *Commit) bool {
+	if (c == nil) != (other == nil) {
+		return false
+	}
+
+	if c != nil {
+		if len(c.ParentIDs) != len(other.ParentIDs) {
+			return false
+		}
+		for i := 0; i < len(c.ParentIDs); i++ {
+			p1 := c.ParentIDs[i]
+			p2 := other.ParentIDs[i]
+
+			if !bytes.Equal(p1, p2) {
+				return false
+			}
+		}
+
+		if len(c.ExtraHeaders) != len(other.ExtraHeaders) {
+			return false
+		}
+		for i := 0; i < len(c.ExtraHeaders); i++ {
+			e1 := c.ExtraHeaders[i]
+			e2 := other.ExtraHeaders[i]
+
+			if e1.K != e2.K || e1.V != e2.V {
+				return false
+			}
+		}
+
+		return c.Author == other.Author &&
+			c.Committer == other.Committer &&
+			c.Message == other.Message &&
+			bytes.Equal(c.TreeID, other.TreeID)
+	}
+	return true
 }

--- a/git/odb/commit_test.go
+++ b/git/odb/commit_test.go
@@ -116,3 +116,152 @@ func assertLine(t *testing.T, buf *bytes.Buffer, wanted string, args ...interfac
 	assert.Nil(t, err)
 	assert.Equal(t, fmt.Sprintf(wanted, args...), strings.TrimSuffix(got, "\n"))
 }
+
+func TestCommitEqualReturnsTrueWithIdenticalCommits(t *testing.T) {
+	c1 := &Commit{
+		Author:    "Jane Doe <jane@example.com> 1503956287 -0400",
+		Committer: "Jane Doe <jane@example.com> 1503956287 -0400",
+		ParentIDs: [][]byte{make([]byte, 20)},
+		TreeID:    make([]byte, 20),
+		ExtraHeaders: []*ExtraHeader{
+			{K: "Signed-off-by", V: "Joe Smith"},
+		},
+		Message: "initial commit",
+	}
+	c2 := &Commit{
+		Author:    "Jane Doe <jane@example.com> 1503956287 -0400",
+		Committer: "Jane Doe <jane@example.com> 1503956287 -0400",
+		ParentIDs: [][]byte{make([]byte, 20)},
+		TreeID:    make([]byte, 20),
+		ExtraHeaders: []*ExtraHeader{
+			{K: "Signed-off-by", V: "Joe Smith"},
+		},
+		Message: "initial commit",
+	}
+
+	assert.True(t, c1.Equal(c2))
+}
+
+func TestCommitEqualReturnsFalseWithDifferentParentCounts(t *testing.T) {
+	c1 := &Commit{
+		ParentIDs: [][]byte{make([]byte, 20), make([]byte, 20)},
+	}
+	c2 := &Commit{
+		ParentIDs: [][]byte{make([]byte, 20)},
+	}
+
+	assert.False(t, c1.Equal(c2))
+}
+
+func TestCommitEqualReturnsFalseWithDifferentParentsIds(t *testing.T) {
+	c1 := &Commit{
+		ParentIDs: [][]byte{make([]byte, 20)},
+	}
+	c2 := &Commit{
+		ParentIDs: [][]byte{make([]byte, 20)},
+	}
+
+	c1.ParentIDs[0][1] = 0x1
+
+	assert.False(t, c1.Equal(c2))
+}
+
+func TestCommitEqualReturnsFalseWithDifferentHeaderCounts(t *testing.T) {
+	c1 := &Commit{
+		ExtraHeaders: []*ExtraHeader{
+			{K: "Signed-off-by", V: "Joe Smith"},
+			{K: "GPG-Signature", V: "..."},
+		},
+	}
+	c2 := &Commit{
+		ExtraHeaders: []*ExtraHeader{
+			{K: "Signed-off-by", V: "Joe Smith"},
+		},
+	}
+
+	assert.False(t, c1.Equal(c2))
+}
+
+func TestCommitEqualReturnsFalseWithDifferentHeaders(t *testing.T) {
+	c1 := &Commit{
+		ExtraHeaders: []*ExtraHeader{
+			{K: "Signed-off-by", V: "Joe Smith"},
+		},
+	}
+	c2 := &Commit{
+		ExtraHeaders: []*ExtraHeader{
+			{K: "Signed-off-by", V: "Jane Smith"},
+		},
+	}
+
+	assert.False(t, c1.Equal(c2))
+}
+
+func TestCommitEqualReturnsFalseWithDifferentAuthors(t *testing.T) {
+	c1 := &Commit{
+		Author: "Jane Doe <jane@example.com> 1503956287 -0400",
+	}
+	c2 := &Commit{
+		Author: "John Doe <john@example.com> 1503956287 -0400",
+	}
+
+	assert.False(t, c1.Equal(c2))
+}
+
+func TestCommitEqualReturnsFalseWithDifferentCommitters(t *testing.T) {
+	c1 := &Commit{
+		Committer: "Jane Doe <jane@example.com> 1503956287 -0400",
+	}
+	c2 := &Commit{
+		Committer: "John Doe <john@example.com> 1503956287 -0400",
+	}
+
+	assert.False(t, c1.Equal(c2))
+}
+
+func TestCommitEqualReturnsFalseWithDifferentMessages(t *testing.T) {
+	c1 := &Commit{
+		Message: "initial commit",
+	}
+	c2 := &Commit{
+		Message: "not the initial commit",
+	}
+
+	assert.False(t, c1.Equal(c2))
+}
+
+func TestCommitEqualReturnsFalseWithDifferentTreeIDs(t *testing.T) {
+	c1 := &Commit{
+		TreeID: make([]byte, 20),
+	}
+	c2 := &Commit{
+		TreeID: make([]byte, 20),
+	}
+
+	c1.TreeID[0] = 0x1
+
+	assert.False(t, c1.Equal(c2))
+}
+
+func TestCommitEqualReturnsFalseWhenOneCommitIsNil(t *testing.T) {
+	c1 := &Commit{
+		Author:    "Jane Doe <jane@example.com> 1503956287 -0400",
+		Committer: "Jane Doe <jane@example.com> 1503956287 -0400",
+		ParentIDs: [][]byte{make([]byte, 20)},
+		TreeID:    make([]byte, 20),
+		ExtraHeaders: []*ExtraHeader{
+			{K: "Signed-off-by", V: "Joe Smith"},
+		},
+		Message: "initial commit",
+	}
+	c2 := (*Commit)(nil)
+
+	assert.False(t, c1.Equal(c2))
+}
+
+func TestCommitEqualReturnsTrueWhenBothCommitsAreNil(t *testing.T) {
+	c1 := (*Commit)(nil)
+	c2 := (*Commit)(nil)
+
+	assert.True(t, c1.Equal(c2))
+}

--- a/git/odb/tree.go
+++ b/git/odb/tree.go
@@ -2,6 +2,7 @@ package odb
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"sort"
@@ -149,6 +150,31 @@ func (t *Tree) Merge(others ...*TreeEntry) *Tree {
 	return &Tree{Entries: entries}
 }
 
+// Equal returns whether the receiving and given trees are equal, or in other
+// words, whether they are represented by the same SHA-1 when saved to the
+// object database.
+func (t *Tree) Equal(other *Tree) bool {
+	if (t == nil) != (other == nil) {
+		return false
+	}
+
+	if t != nil {
+		if len(t.Entries) != len(other.Entries) {
+			return false
+		}
+
+		for i := 0; i < len(t.Entries); i++ {
+			e1 := t.Entries[i]
+			e2 := other.Entries[i]
+
+			if !e1.Equal(e2) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
 // TreeEntry encapsulates information about a single tree entry in a tree
 // listing.
 type TreeEntry struct {
@@ -159,6 +185,21 @@ type TreeEntry struct {
 	Oid []byte
 	// Filemode is the filemode of this tree entry on disk.
 	Filemode int32
+}
+
+// Equal returns whether the receiving and given TreeEntry instances are
+// identical in name, filemode, and OID.
+func (e *TreeEntry) Equal(other *TreeEntry) bool {
+	if (e == nil) != (other == nil) {
+		return false
+	}
+
+	if e != nil {
+		return e.Name == other.Name &&
+			bytes.Equal(e.Oid, other.Oid) &&
+			e.Filemode == other.Filemode
+	}
+	return true
 }
 
 // Type is the type of entry (either blob: BlobObjectType, or a sub-tree:

--- a/git/odb/tree_test.go
+++ b/git/odb/tree_test.go
@@ -241,6 +241,91 @@ func TestSubtreeOrderReturnsEmptyForNilElements(t *testing.T) {
 	assert.Equal(t, "", o.Name(0))
 }
 
+func TestTreeEqualReturnsTrueWithUnchangedContents(t *testing.T) {
+	t1 := &Tree{Entries: []*TreeEntry{
+		{Name: "a.dat", Filemode: 0100644, Oid: make([]byte, 20)},
+	}}
+	t2 := &Tree{Entries: []*TreeEntry{
+		{Name: "a.dat", Filemode: 0100644, Oid: make([]byte, 20)},
+	}}
+
+	assert.True(t, t1.Equal(t2))
+}
+
+func TestTreeEqualReturnsFalseWithChangedContents(t *testing.T) {
+	t1 := &Tree{Entries: []*TreeEntry{
+		{Name: "a.dat", Filemode: 0100644, Oid: make([]byte, 20)},
+		{Name: "b.dat", Filemode: 0100644, Oid: make([]byte, 20)},
+	}}
+	t2 := &Tree{Entries: []*TreeEntry{
+		{Name: "a.dat", Filemode: 0100644, Oid: make([]byte, 20)},
+		{Name: "c.dat", Filemode: 0100644, Oid: make([]byte, 20)},
+	}}
+
+	assert.False(t, t1.Equal(t2))
+}
+
+func TestTreeEqualReturnsTrueWhenOneTreeIsNil(t *testing.T) {
+	t1 := &Tree{Entries: []*TreeEntry{
+		{Name: "a.dat", Filemode: 0100644, Oid: make([]byte, 20)},
+	}}
+	t2 := (*Tree)(nil)
+
+	assert.False(t, t1.Equal(t2))
+	assert.False(t, t2.Equal(t1))
+}
+
+func TestTreeEqualReturnsTrueWhenBothTreesAreNil(t *testing.T) {
+	t1 := (*Tree)(nil)
+	t2 := (*Tree)(nil)
+
+	assert.True(t, t1.Equal(t2))
+}
+
+func TestTreeEntryEqualReturnsTrueWhenEntriesAreTheSame(t *testing.T) {
+	e1 := &TreeEntry{Name: "a.dat", Filemode: 0100644, Oid: make([]byte, 20)}
+	e2 := &TreeEntry{Name: "a.dat", Filemode: 0100644, Oid: make([]byte, 20)}
+
+	assert.True(t, e1.Equal(e2))
+}
+
+func TestTreeEntryEqualReturnsFalseWhenDifferentNames(t *testing.T) {
+	e1 := &TreeEntry{Name: "a.dat", Filemode: 0100644, Oid: make([]byte, 20)}
+	e2 := &TreeEntry{Name: "b.dat", Filemode: 0100644, Oid: make([]byte, 20)}
+
+	assert.False(t, e1.Equal(e2))
+}
+
+func TestTreeEntryEqualReturnsFalseWhenDifferentOids(t *testing.T) {
+	e1 := &TreeEntry{Name: "a.dat", Filemode: 0100644, Oid: make([]byte, 20)}
+	e2 := &TreeEntry{Name: "a.dat", Filemode: 0100644, Oid: make([]byte, 20)}
+
+	e2.Oid[0] = 1
+
+	assert.False(t, e1.Equal(e2))
+}
+
+func TestTreeEntryEqualReturnsFalseWhenDifferentFilemodes(t *testing.T) {
+	e1 := &TreeEntry{Name: "a.dat", Filemode: 0100644, Oid: make([]byte, 20)}
+	e2 := &TreeEntry{Name: "a.dat", Filemode: 0100755, Oid: make([]byte, 20)}
+
+	assert.False(t, e1.Equal(e2))
+}
+
+func TestTreeEntryEqualReturnsFalseWhenOneEntryIsNil(t *testing.T) {
+	e1 := &TreeEntry{Name: "a.dat", Filemode: 0100644, Oid: make([]byte, 20)}
+	e2 := (*TreeEntry)(nil)
+
+	assert.False(t, e1.Equal(e2))
+}
+
+func TestTreeEntryEqualReturnsTrueWhenBothEntriesAreNil(t *testing.T) {
+	e1 := (*TreeEntry)(nil)
+	e2 := (*TreeEntry)(nil)
+
+	assert.True(t, e1.Equal(e2))
+}
+
 func assertTreeEntry(t *testing.T, buf *bytes.Buffer,
 	name string, oid []byte, mode int32) {
 


### PR DESCRIPTION
This pull request teaches a typesafe `Equal()` to `*Blob`'s, `*Commit`'s, and `*Tree`'s, and uses that function in the `git/githistory` package to avoid writing unchanged objects to disk.

Previously, the `git lfs migrate` command would write the contents of every object that it examined in the migration, regardless of whether that object's contents changed. This is sub-optimal, because it involves not only marshaling the contents of unchanged objects to a buffer and performing an expensive save, but also because it effectively has the behavior of unpacking all objects in a repository. That's no good.

To address this, this pull request opts for the following option that I originally proposed in https://github.com/git-lfs/git-lfs/issues/2359:

> Teach either:
> 
> 1. [...]
> 2. Packfile APIs in order to write either a) packed objects, or b) _skip writing packed objects if the object already exists in the database (loose or packed)_.

We can detect whether objects already exist in the object database in either a loose or packed format by determining whether or not the contents of the blob/tree/commit changed when rewriting it. In order to open the object, it must exist, so therefore, if it is unchanged, the object is already saved to the database.

By defining `(t *<T>) Equal(<T> other)` on each object type in package `git/odb`, and comparing the "rewritten" instances of each object against the original, we can avoid writing objects to the database (which involves several filesystem-level operations, `open()`, `write()`, a syscall to move, etc.) and instead return early, avoiding all of the previously mentioned operations.

This yields a significant performance boost. When examining the `git-lfs/git-lfs` repository prior to this change, it takes about 13.3 seconds to examing all ~6,000 commits:

```
~/g/git-lfs (master) $ time git lfs migrate info --include-ref=refs/heads/master
migrate: Sorting commits: ..., done
migrate: Rewriting commits: 100% (5714/5714), done
*.md    1.1 MB  191/191 files(s)        100%
*.go    106 KB    86/86 files(s)        100%
*.yml   89 KB     87/87 files(s)        100%
*.toml  35 KB     28/28 files(s)        100%
*.lock  30 KB     17/17 files(s)        100%
git lfs migrate info --include-ref=refs/heads/master  10.77s user 7.31s system 135% cpu 13.318 tota
```

Including this change, however, the operation takes only 0.7 seconds:

```
~/g/git-lfs (master!) $ time git lfs migrate info --include-ref=refs/heads/master
migrate: Sorting commits: ..., done
migrate: Rewriting commits: 100% (5714/5714), done
*.md    1.1 MB  191/191 files(s)        100%
*.go    106 KB    86/86 files(s)        100%
*.yml   89 KB     87/87 files(s)        100%
*.toml  35 KB     28/28 files(s)        100%
*.lock  30 KB     17/17 files(s)        100%
git lfs migrate info --include-ref=refs/heads/master  0.49s user 0.18s system 101% cpu 0.662 total
```

Closes: https://github.com/git-lfs/git-lfs/issues/2359.

---

/cc @git-lfs/core 