### PR TITLE
commands: add --all flag to 'git lfs clone'

### DIFF
--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -92,6 +92,14 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 		cfg.CurrentRemote = remote
 		fetchRef("HEAD", filter)
 	} else {
+		if fetchAllArg {
+			if includeArg != nil || excludeArg != nil {
+				Exit("Cannot combine --all with --include or --exclude")
+			}
+			cfg.CurrentRemote = remote
+			fetchAll()
+		}
+
 		pull(remote, filter)
 		err := postCloneSubmodules(args)
 		if err != nil {
@@ -168,6 +176,7 @@ func init() {
 		cmd.Flags().BoolVarP(&cloneFlags.NoShallowSubmodules, "no-shallow-submodules", "", false, "See 'git clone --help'")
 		cmd.Flags().Int64VarP(&cloneFlags.Jobs, "jobs", "j", -1, "See 'git clone --help'")
 
+		cmd.Flags().BoolVarP(&fetchAllArg, "all", "a", false, "Fetch all LFS files ever referenced after the git clone")
 		cmd.Flags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")
 		cmd.Flags().StringVarP(&excludeArg, "exclude", "X", "", "Exclude a list of paths")
 


### PR DESCRIPTION
Adds a `--all` flag to `git lfs clone` that runs `git lfs fetch --all` right after the `git clone` command.

I realize the command is deprecated as of https://github.com/git-lfs/git-lfs/pull/2526. This is a simple change, and a little useful (see https://github.com/git-lfs/git-lfs/issues/2532#issuecomment-326634994 for use case). Is it worth keeping the `git lfs clone` command around, or should we continue on with the deprecation?

IMO, with the upcoming `delay` filter capabilities, the main need for `git lfs clone` is gone, so we should reject this PR.