### PR TITLE
docs/man: recommend global per-host locking config

### DIFF
--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -259,7 +259,7 @@ be scoped inside the configuration for a remote.
 
   Supports URL config lookup as described in:
   https://git-scm.com/docs/git-config#git-config-httplturlgt. To set this value
-  per-host: `git config lfs.https://github.com/.locksverify 0`.
+  per-host: `git config --global lfs.https://github.com/.locksverify 0`.
 
 * `lfs.skipdownloaderrors`
 

--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -259,7 +259,7 @@ be scoped inside the configuration for a remote.
 
   Supports URL config lookup as described in:
   https://git-scm.com/docs/git-config#git-config-httplturlgt. To set this value
-  per-host: `git config --global lfs.https://github.com/.locksverify 0`.
+  per-host: `git config --global lfs.https://github.com/.locksverify [true|false]`.
 
 * `lfs.skipdownloaderrors`
 


### PR DESCRIPTION
The locking config per-host is supposed to affect all repositories on a 
given client machine. However, the help page suggests to set this value 
for a single repository only. Improve the example by using the global 
Git config.