### PR TITLE
git/odb/pack: scaffolding for packed object reads

### DIFF
--- a/git/odb/pack/chain.go
+++ b/git/odb/pack/chain.go
@@ -1,0 +1,21 @@
+package pack
+
+// Chain represents an element in the delta-base chain corresponding to a packed
+// object.
+type Chain interface {
+	// Unpack unpacks the data encoded in the delta-base chain up to and
+	// including the receiving Chain implementation by applying the
+	// delta-base chain successively to itself.
+	//
+	// If there was an error in the delta-base resolution, i.e., the chain
+	// is malformed, has a bad instruction, or there was an mmap-related
+	// read error, this function is expected to return that error.
+	//
+	// In the event that a non-nil error is returned, it is assumed that the
+	// unpacked data this function returns is malformed, or otherwise
+	// corrupt.
+	Unpack() ([]byte, error)
+
+	// Type returns the type of the receiving chain element.
+	Type() PackedObjectType
+}

--- a/git/odb/pack/chain_test.go
+++ b/git/odb/pack/chain_test.go
@@ -1,0 +1,12 @@
+package pack
+
+type ChainSimple struct {
+	X   []byte
+	Err error
+}
+
+func (c *ChainSimple) Unpack() ([]byte, error) {
+	return c.X, c.Err
+}
+
+func (c *ChainSimple) Type() PackedObjectType { return TypeNone }

--- a/git/odb/pack/object.go
+++ b/git/odb/pack/object.go
@@ -1,0 +1,27 @@
+package pack
+
+// Object is an encapsulation of an object found in a packfile, or a packed
+// object.
+type Object struct {
+	// data is the front-most element of the delta-base chain, and when
+	// resolved, yields the uncompressed data of this object.
+	data Chain
+	// typ is the underlying object's type. It is not the type of the
+	// front-most chain element, rather, the type of the actual object.
+	typ PackedObjectType
+}
+
+// Unpack resolves the delta-base chain and returns an uncompressed, unpacked,
+// and full representation of the data encoded by this object.
+//
+// If there was any error in unpacking this object, it is returned immediately,
+// and the object's data can be assumed to be corrupt.
+func (o *Object) Unpack() ([]byte, error) {
+	return o.data.Unpack()
+}
+
+// Type returns the underlying object's type. Rather than the type of the
+// front-most delta-base component, it is the type of the object itself.
+func (o *Object) Type() PackedObjectType {
+	return o.typ
+}

--- a/git/odb/pack/object_test.go
+++ b/git/odb/pack/object_test.go
@@ -1,0 +1,47 @@
+package pack
+
+import (
+	"testing"
+
+	"github.com/git-lfs/git-lfs/errors"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestObjectTypeReturnsObjectType(t *testing.T) {
+	o := &Object{
+		typ: TypeCommit,
+	}
+
+	assert.Equal(t, TypeCommit, o.Type())
+}
+
+func TestObjectUnpackUnpacksData(t *testing.T) {
+	expected := []byte{0x1, 0x2, 0x3, 0x4}
+
+	o := &Object{
+		data: &ChainSimple{
+			X: expected,
+		},
+	}
+
+	data, err := o.Unpack()
+
+	assert.Equal(t, expected, data)
+	assert.NoError(t, err)
+}
+
+func TestObjectUnpackPropogatesErrors(t *testing.T) {
+	expected := errors.New("git/odb/pack: testing")
+
+	o := &Object{
+		data: &ChainSimple{
+			Err: expected,
+		},
+	}
+
+	data, err := o.Unpack()
+
+	assert.Nil(t, data)
+	assert.Equal(t, expected, err)
+}

--- a/git/odb/pack/type.go
+++ b/git/odb/pack/type.go
@@ -1,0 +1,58 @@
+package pack
+
+import (
+	"errors"
+	"fmt"
+)
+
+// PackedObjectType is a constant type that is defined for all valid object
+// types that a packed object can represent.
+type PackedObjectType uint8
+
+const (
+	// TypeNone is the zero-value for PackedObjectType, and represents the
+	// absence of a type.
+	TypeNone PackedObjectType = iota
+	// TypeCommit is the PackedObjectType for commit objects.
+	TypeCommit
+	// TypeTree is the PackedObjectType for tree objects.
+	TypeTree
+	// Typeblob is the PackedObjectType for blob objects.
+	TypeBlob
+	// TypeTag is the PackedObjectType for tag objects.
+	TypeTag
+
+	// TypeObjectOffsetDelta is the type for OBJ_OFS_DELTA-typed objects.
+	TypeObjectOffsetDelta PackedObjectType = 6
+	// TypeObjectReferenceDelta is the type for OBJ_REF_DELTA-typed objects.
+	TypeObjectReferenceDelta PackedObjectType = 7
+)
+
+// String implements fmt.Stringer and returns an encoding of the type valid for
+// use in the loose object format protocol (see: package 'git/odb' for more).
+//
+// If the receiving instance is not defined, String() will panic().
+func (t PackedObjectType) String() string {
+	switch t {
+	case TypeNone:
+		return "<none>"
+	case TypeCommit:
+		return "commit"
+	case TypeTree:
+		return "tree"
+	case TypeBlob:
+		return "blob"
+	case TypeTag:
+		return "tag"
+	case TypeObjectOffsetDelta:
+		return "obj_ofs_delta"
+	case TypeObjectReferenceDelta:
+		return "obj_ref_delta"
+	}
+
+	panic(fmt.Sprintf("git/odb/pack: unknown object type: %d", t))
+}
+
+var (
+	errUnrecognizedObjectType = errors.New("git/odb/pack: unrecognized object type")
+)

--- a/git/odb/pack/type_test.go
+++ b/git/odb/pack/type_test.go
@@ -1,0 +1,52 @@
+package pack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type PackedObjectStringTestCase struct {
+	T PackedObjectType
+
+	Expected string
+	Panic    bool
+}
+
+func (c *PackedObjectStringTestCase) Assert(t *testing.T) {
+	if c.Panic {
+		defer func() {
+			err := recover()
+
+			if err == nil {
+				t.Fatalf("git/odb/pack: expected panic()")
+			}
+
+			assert.Equal(t, c.Expected, fmt.Sprintf("%s", err))
+		}()
+	}
+
+	assert.Equal(t, c.Expected, c.T.String())
+}
+
+func TestPackedObjectTypeString(t *testing.T) {
+	for desc, c := range map[string]*PackedObjectStringTestCase{
+		"TypeNone": {T: TypeNone, Expected: "<none>"},
+
+		"TypeCommit": {T: TypeCommit, Expected: "commit"},
+		"TypeTree":   {T: TypeTree, Expected: "tree"},
+		"TypeBlob":   {T: TypeBlob, Expected: "blob"},
+		"TypeTag":    {T: TypeTag, Expected: "tag"},
+
+		"TypeObjectOffsetDelta": {T: TypeObjectOffsetDelta,
+			Expected: "obj_ofs_delta"},
+		"TypeObjectReferenceDelta": {T: TypeObjectReferenceDelta,
+			Expected: "obj_ref_delta"},
+
+		"unknown type": {T: PackedObjectType(5), Panic: true,
+			Expected: "git/odb/pack: unknown object type: 5"},
+	} {
+		t.Run(desc, c.Assert)
+	}
+}


### PR DESCRIPTION
This pull request introduces some of the necessary scaffolding work to support packed object reads in package `git/odb/pack`.

The eventual design goal of this package is to have a `git/odb/pack.(*Packfile)` type that given a SHA-1 `[]byte`, returns an `(*Object)`, with the following type definitions:

```go
package git/odb/pack

type Object struct { ... }

func (o *Object) Type() PackedObjectType { ... }
func (o *Object) Unpack() ([]byte, error) { ... }
```

This pull request introduces the three types necessary to support a design as described above:

1. ef50370: The `PackedObjectType`, a const type that has valid values corresponding to the different types of objects that can be packed.
2. 9ea23ca: The `Object` type, with the above methods for determining the unpacked object's type, and for unpacking the object itself.
3. c7f13cd: The `Chain` interface, which is a recursive type that applies one or more layers of a delta-base chain.

In the following two pull requests in this series, two implementations of `Chain` will be provided: `*ChainBase` and `*ChainDelta`, which will decompress and apply patch deltas respectively.

The larger goal is to eventually introduce a type `*Set` in package `git/odb/pack` which allows searching for objects across several packfiles. We can then replace usage of the `git.(*ObjectScanner)` in `git/odb.(*ObjectDatabase)` with the `*Set` type when looking for the contents of packed objects. Given the `*Object` instance as described above, we can than reconstruct the loose object contents of a packed object and parse it using the existing APIs in package `git/odb`.

Here is an example of how that is currently done: https://github.com/git-lfs/git-lfs/blob/5e4f4ad3ba79eb7c9817e8a897be681ce83d9804/git/odb/object_db.go#L225-L237

---

/cc @git-lfs/core @peff
/cc #2415 