### PR TITLE
git/odb/pack: implement *ChainBase for unpacking base components

### DIFF
--- a/git/odb/pack/chain_base.go
+++ b/git/odb/pack/chain_base.go
@@ -1,0 +1,49 @@
+package pack
+
+import (
+	"compress/zlib"
+	"io"
+)
+
+// ChainBase represents the "base" component of a delta-base chain.
+type ChainBase struct {
+	// offset returns the offset into the given io.ReaderAt where the read
+	// will begin.
+	offset int64
+	// size is the total uncompressed size of the data in the base chain.
+	size int64
+	// typ is the type of data that this *ChainBase encodes.
+	typ PackedObjectType
+
+	// r is the io.ReaderAt yielding a stream of zlib-compressed data.
+	r io.ReaderAt
+}
+
+// Unpack inflates and returns the uncompressed data encoded in the base
+// element.
+//
+// If there was any error in reading the compressed data (invalid headers,
+// etc.), it will be returned immediately.
+func (b *ChainBase) Unpack() ([]byte, error) {
+	zr, err := zlib.NewReader(&OffsetReaderAt{
+		r: b.r,
+		o: b.offset,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer zr.Close()
+
+	buf := make([]byte, b.size)
+	if _, err := io.ReadFull(zr, buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+// ChainBase returns the type of the object it encodes.
+func (b *ChainBase) Type() PackedObjectType {
+	return b.typ
+}

--- a/git/odb/pack/chain_base_test.go
+++ b/git/odb/pack/chain_base_test.go
@@ -1,0 +1,60 @@
+package pack
+
+import (
+	"bytes"
+	"compress/zlib"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChainBaseDecompressesData(t *testing.T) {
+	const contents = "Hello, world!\n"
+
+	compressed, err := compress(contents)
+	assert.NoError(t, err)
+
+	var buf bytes.Buffer
+
+	_, err = buf.Write([]byte{0x0, 0x0, 0x0, 0x0})
+	assert.NoError(t, err)
+
+	_, err = buf.Write(compressed)
+	assert.NoError(t, err)
+
+	_, err = buf.Write([]byte{0x0, 0x0, 0x0, 0x0})
+	assert.NoError(t, err)
+
+	base := &ChainBase{
+		offset: 4,
+		size:   int64(len(contents)),
+
+		r: bytes.NewReader(buf.Bytes()),
+	}
+
+	unpacked, err := base.Unpack()
+	assert.NoError(t, err)
+	assert.Equal(t, contents, string(unpacked))
+}
+
+func TestChainBaseTypeReturnsType(t *testing.T) {
+	b := &ChainBase{
+		typ: TypeCommit,
+	}
+
+	assert.Equal(t, TypeCommit, b.Type())
+}
+
+func compress(base string) ([]byte, error) {
+	var buf bytes.Buffer
+
+	zw := zlib.NewWriter(&buf)
+	if _, err := zw.Write([]byte(base)); err != nil {
+		return nil, err
+	}
+
+	if err := zw.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/git/odb/pack/io.go
+++ b/git/odb/pack/io.go
@@ -1,0 +1,27 @@
+package pack
+
+import "io"
+
+// OffsetReaderAt transforms an io.ReaderAt into an io.Reader by beginning and
+// advancing all reads at the given offset.
+type OffsetReaderAt struct {
+	// r is the data source for this instance of *OffsetReaderAt.
+	r io.ReaderAt
+
+	// o if the number of bytes read from the underlying data source, "r".
+	// It is incremented upon reads.
+	o int64
+}
+
+// Read implements io.Reader.Read by reading into the given []byte, "p" from the
+// last known offset provided to the OffsetReaderAt.
+//
+// It returns any error encountered from the underlying data stream, and
+// advances the reader forward by "n", the number of bytes read from the
+// underlying data stream.
+func (r *OffsetReaderAt) Read(p []byte) (n int, err error) {
+	n, err = r.r.ReadAt(p, r.o)
+	r.o += int64(n)
+
+	return n, err
+}

--- a/git/odb/pack/io_test.go
+++ b/git/odb/pack/io_test.go
@@ -1,0 +1,53 @@
+package pack
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/git-lfs/git-lfs/errors"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOffsetReaderAtReadsAtOffset(t *testing.T) {
+	bo := &OffsetReaderAt{
+		r: bytes.NewReader([]byte{0x0, 0x1, 0x2, 0x3}),
+		o: 1,
+	}
+
+	var x1 [1]byte
+	n1, e1 := bo.Read(x1[:])
+
+	assert.NoError(t, e1)
+	assert.Equal(t, 1, n1)
+
+	assert.EqualValues(t, 0x1, x1[0])
+
+	var x2 [1]byte
+	n2, e2 := bo.Read(x2[:])
+
+	assert.NoError(t, e2)
+	assert.Equal(t, 1, n2)
+	assert.EqualValues(t, 0x2, x2[0])
+}
+
+func TestOffsetReaderPropogatesErrors(t *testing.T) {
+	expected := errors.New("git/odb/pack: testing")
+	bo := &OffsetReaderAt{
+		r: &ErrReaderAt{Err: expected},
+		o: 1,
+	}
+
+	n, err := bo.Read(make([]byte, 1))
+
+	assert.Equal(t, expected, err)
+	assert.Equal(t, 0, n)
+}
+
+type ErrReaderAt struct {
+	Err error
+}
+
+func (e *ErrReaderAt) ReadAt(p []byte, at int64) (n int, err error) {
+	return 0, e.Err
+}


### PR DESCRIPTION
This pull request provides the first of two implementations of the `Chain` interface:

> In the following two pull requests in this series, two implementations of `Chain` will be provided: `*ChainBase` and `*ChainDelta`, which will decompress and apply patch deltas respectively.

`*ChainBase` handles the first kind of component of the delta-base chains found in Git packfiles: the base. A base encodes some base object's data in a zlib-compressed format, to which delta operations can be applied (patched).

Since the `*ChainBase` must handle zlib-compressed data, we run into the challenge of converting the `mmap(2)`'d `*os.File` (given as an `io.ReaderAt`) into an `io.Reader` that package `compress/zlib` can read from. This is done using the `*OffsetReaderAt` type, which implements the `io.Reader` interface by encoding an offset into an `io.ReaderAt`, and updating the offset each time a read is performed.

Because we cannot readily determine the length of the compressed object data in a packfile, we must take into account the greedy behavior from package `compress/zlib`. One approach to dealing with this is to find the next object, and limit reads from going beyond that. However, since we are not sharing `*OffsetReaderAt` instances with more than one `Chain` implementation, we can read past the end of the compressed data, and `compress/zlib` will simply ignore the extraneous bytes. [Here](https://play.golang.org/p/TPlQyCDCUo) is an example.

---

/cc @git-lfs/core @peff
/cc #2415 