### PR TITLE
git/odb/pack: introduce *Packfile type for single-pack lookups

### DIFF
--- a/git/odb/pack/chain.go
+++ b/git/odb/pack/chain.go
@@ -1,0 +1,21 @@
+package pack
+
+// Chain represents an element in the delta-base chain corresponding to a packed
+// object.
+type Chain interface {
+	// Unpack unpacks the data encoded in the delta-base chain up to and
+	// including the receiving Chain implementation by applying the
+	// delta-base chain successively to itself.
+	//
+	// If there was an error in the delta-base resolution, i.e., the chain
+	// is malformed, has a bad instruction, or there was an mmap-related
+	// read error, this function is expected to return that error.
+	//
+	// In the event that a non-nil error is returned, it is assumed that the
+	// unpacked data this function returns is malformed, or otherwise
+	// corrupt.
+	Unpack() ([]byte, error)
+
+	// Type returns the type of the receiving chain element.
+	Type() PackedObjectType
+}

--- a/git/odb/pack/chain_base.go
+++ b/git/odb/pack/chain_base.go
@@ -1,0 +1,49 @@
+package pack
+
+import (
+	"compress/zlib"
+	"io"
+)
+
+// ChainBase represents the "base" component of a delta-base chain.
+type ChainBase struct {
+	// offset returns the offset into the given io.ReaderAt where the read
+	// will begin.
+	offset int64
+	// size is the total uncompressed size of the data in the base chain.
+	size int64
+	// typ is the type of data that this *ChainBase encodes.
+	typ PackedObjectType
+
+	// r is the io.ReaderAt yielding a stream of zlib-compressed data.
+	r io.ReaderAt
+}
+
+// Unpack inflates and returns the uncompressed data encoded in the base
+// element.
+//
+// If there was any error in reading the compressed data (invalid headers,
+// etc.), it will be returned immediately.
+func (b *ChainBase) Unpack() ([]byte, error) {
+	zr, err := zlib.NewReader(&OffsetReaderAt{
+		r: b.r,
+		o: b.offset,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer zr.Close()
+
+	buf := make([]byte, b.size)
+	if _, err := io.ReadFull(zr, buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+// ChainBase returns the type of the object it encodes.
+func (b *ChainBase) Type() PackedObjectType {
+	return b.typ
+}

--- a/git/odb/pack/chain_base_test.go
+++ b/git/odb/pack/chain_base_test.go
@@ -1,0 +1,60 @@
+package pack
+
+import (
+	"bytes"
+	"compress/zlib"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChainBaseDecompressesData(t *testing.T) {
+	const contents = "Hello, world!\n"
+
+	compressed, err := compress(contents)
+	assert.NoError(t, err)
+
+	var buf bytes.Buffer
+
+	_, err = buf.Write([]byte{0x0, 0x0, 0x0, 0x0})
+	assert.NoError(t, err)
+
+	_, err = buf.Write(compressed)
+	assert.NoError(t, err)
+
+	_, err = buf.Write([]byte{0x0, 0x0, 0x0, 0x0})
+	assert.NoError(t, err)
+
+	base := &ChainBase{
+		offset: 4,
+		size:   int64(len(contents)),
+
+		r: bytes.NewReader(buf.Bytes()),
+	}
+
+	unpacked, err := base.Unpack()
+	assert.NoError(t, err)
+	assert.Equal(t, contents, string(unpacked))
+}
+
+func TestChainBaseTypeReturnsType(t *testing.T) {
+	b := &ChainBase{
+		typ: TypeCommit,
+	}
+
+	assert.Equal(t, TypeCommit, b.Type())
+}
+
+func compress(base string) ([]byte, error) {
+	var buf bytes.Buffer
+
+	zw := zlib.NewWriter(&buf)
+	if _, err := zw.Write([]byte(base)); err != nil {
+		return nil, err
+	}
+
+	if err := zw.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/git/odb/pack/chain_delta.go
+++ b/git/odb/pack/chain_delta.go
@@ -1,0 +1,175 @@
+package pack
+
+import (
+	"github.com/git-lfs/git-lfs/errors"
+)
+
+// ChainDelta represents a "delta" component of a delta-base chain.
+type ChainDelta struct {
+	// Base is the base delta-base chain that this delta should be applied
+	// to. It can be a ChainBase in the simple case, or it can itself be a
+	// ChainDelta, which resolves against another ChainBase, when the
+	// delta-base chain is of length greater than 2.
+	base Chain
+	// delta is the set of copy/add instructions to apply on top of the
+	// base.
+	delta []byte
+}
+
+// Unpack applies the delta operation to the previous delta-base chain, "base".
+//
+// If any of the delta-base instructions were invalid, an error will be
+// returned.
+func (d *ChainDelta) Unpack() ([]byte, error) {
+	base, err := d.base.Unpack()
+	if err != nil {
+		return nil, err
+	}
+
+	return patch(base, d.delta)
+}
+
+// Type returns the type of the base of the delta-base chain.
+func (d *ChainDelta) Type() PackedObjectType {
+	return d.base.Type()
+}
+
+// patch applies the delta instructions in "delta" to the base given as "base".
+// It returns the result of applying those patch instructions to base, but does
+// not modify base itself.
+//
+// If any of the delta instructions were malformed, or otherwise could not be
+// applied to the given base, an error will returned, along with an empty set of
+// data.
+func patch(base, delta []byte) ([]byte, error) {
+	srcSize, pos := patchDeltaHeader(delta, 0)
+	if srcSize != int64(len(base)) {
+		// The header of the delta gives the size of the source contents
+		// that it is a patch over.
+		//
+		// If this does not match with the srcSize, return an error
+		// early so as to avoid a possible bounds error below.
+		return nil, errors.New("git/odb/pack: invalid delta data")
+	}
+
+	var dest []byte
+
+	// The remainder of the delta header contains the destination size, and
+	// moves the "pos" offset to the correct position to begin the set of
+	// delta instructions.
+	destSize, pos := patchDeltaHeader(delta, pos)
+
+	for pos < len(delta) {
+		c := int(delta[pos])
+		pos += 1
+
+		if c&0x80 != 0 {
+			// If the most significant bit (MSB, at position 0x80)
+			// is set, this is a copy instruction. Advance the
+			// position one byte backwards, and initialize variables
+			// for the copy offset and size instructions.
+			pos -= 1
+
+			var co, cs int
+
+			// The lower-half of "c" (0000 1111) defines a "bitmask"
+			// for the copy offset.
+			if c&0x1 != 0 {
+				pos += 1
+				co = int(delta[pos])
+			}
+			if c&0x2 != 0 {
+				pos += 1
+				co |= (int(delta[pos]) << 8)
+			}
+			if c&0x4 != 0 {
+				pos += 1
+				co |= (int(delta[pos]) << 16)
+			}
+			if c&0x8 != 0 {
+				pos += 1
+				co |= (int(delta[pos]) << 24)
+			}
+
+			// The upper-half of "c" (1111 0000) defines a "bitmask"
+			// for the size of the copy instruction.
+			if c&0x10 != 0 {
+				pos += 1
+				cs = int(delta[pos])
+			}
+			if c&0x20 != 0 {
+				pos += 1
+				cs |= (int(delta[pos]) << 8)
+			}
+			if c&0x40 != 0 {
+				pos += 1
+				cs |= (int(delta[pos]) << 16)
+			}
+
+			if cs == 0 {
+				// If the copy size is zero, we assume that it
+				// is the next whole number after the max uint32
+				// value.
+				cs = 0x10000
+			}
+			pos += 1
+
+			// Once we have the copy offset and length defined, copy
+			// that number of bytes from the base into the
+			// destination. Since we are copying from the base and
+			// not the delta, the position into the delta ("pos")
+			// need not be updated.
+			dest = append(dest, base[co:co+cs]...)
+		} else if c != 0 {
+			// If the most significant bit (MSB) is _not_ set, we
+			// instead process a copy instruction, where "c" is the
+			// number of successive bytes in the delta patch to add
+			// to the output.
+			//
+			// Copy the bytes and increment the read pointer
+			// forward.
+			dest = append(dest, delta[pos:int(pos)+c]...)
+
+			pos += int(c)
+		} else {
+			// Otherwise, "c" is 0, and is an invalid delta
+			// instruction.
+			//
+			// Return immediately.
+			return nil, errors.New(
+				"git/odb/pack: invalid delta data")
+		}
+	}
+
+	if destSize != int64(len(dest)) {
+		// If after patching the delta against the base, the destination
+		// size is different than the expected destination size, we have
+		// an invalid set of patch instructions.
+		//
+		// Return immediately.
+		return nil, errors.New("git/odb/pack: invalid delta data")
+	}
+	return dest, nil
+}
+
+// patchDeltaHeader examines the header within delta at the given offset, and
+// returns the size encoded within it, as well as the ending offset where begins
+// the next header, or the patch instructions.
+func patchDeltaHeader(delta []byte, pos int) (size int64, end int) {
+	var shift uint
+	var c int64
+
+	for shift == 0 || c&0x80 != 0 {
+		if len(delta) <= pos {
+			panic("git/odb/pack: invalid delta header")
+		}
+
+		c = int64(delta[pos])
+
+		pos++
+		size |= (c & 0x7f) << shift
+		shift += 7
+	}
+
+	return size, pos
+}

--- a/git/odb/pack/chain_delta_test.go
+++ b/git/odb/pack/chain_delta_test.go
@@ -1,0 +1,112 @@
+package pack
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChainDeltaUnpackCopiesFromBase(t *testing.T) {
+	c := &ChainDelta{
+		base: &ChainSimple{
+			X: []byte{0x0, 0x1, 0x2, 0x3},
+		},
+		delta: []byte{
+			0x04, // Source size: 4.
+			0x03, // Destination size: 3.
+
+			0x80 | 0x01 | 0x10, // Copy, omask=0001, smask=0001.
+			0x1,                // Offset: 1.
+			0x3,                // Size: 3.
+		},
+	}
+
+	data, err := c.Unpack()
+	assert.NoError(t, err)
+	assert.Equal(t, []byte{0x1, 0x2, 0x3}, data)
+}
+
+func TestChainDeltaUnpackAddsToBase(t *testing.T) {
+	c := &ChainDelta{
+		base: &ChainSimple{
+			X: make([]byte, 0),
+		},
+		delta: []byte{
+			0x0, // Source size: 0.
+			0x3, // Destination size: 3.
+
+			0x3, // Add, size=3.
+
+			0x1, 0x2, 0x3, // Contents: ...
+		},
+	}
+
+	data, err := c.Unpack()
+	assert.NoError(t, err)
+	assert.Equal(t, []byte{0x1, 0x2, 0x3}, data)
+}
+
+func TestChainDeltaWithMultipleInstructions(t *testing.T) {
+	c := &ChainDelta{
+		base: &ChainSimple{
+			X: []byte{'H', 'e', 'l', 'l', 'o', '!', '\n'},
+		},
+		delta: []byte{
+			0x07, // Source size: 7.
+			0x0e, // Destination size: 14.
+
+			0x80 | 0x01 | 0x10, // Copy, omask=0001, smask=0001.
+			0x0,                // Offset: 1.
+			0x5,                // Size: 5.
+
+			0x7,                               // Add, size=7.
+			',', ' ', 'w', 'o', 'r', 'l', 'd', // Contents: ...
+
+			0x80 | 0x01 | 0x10, // Copy, omask=0001, smask=0001.
+			0x05,               // Offset: 5.
+			0x02,               // Size: 2.
+		},
+	}
+
+	data, err := c.Unpack()
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("Hello, world!\n"), data)
+}
+
+func TestchainDeltaWithInvalidDeltaInstruction(t *testing.T) {
+	c := &ChainDelta{
+		base: &ChainSimple{
+			X: make([]byte, 0),
+		},
+		delta: []byte{
+			0x0, // Source size: 0.
+			0x1, // Destination size: 3.
+
+			0x0, // Invalid instruction.
+		},
+	}
+
+	data, err := c.Unpack()
+	assert.EqualError(t, err, "git/odb/pack: invalid delta data")
+	assert.Nil(t, data)
+}
+
+func TestChainDeltaWithExtraInstructions(t *testing.T) {
+	c := &ChainDelta{
+		base: &ChainSimple{
+			X: make([]byte, 0),
+		},
+		delta: []byte{
+			0x0, // Source size: 0.
+			0x3, // Destination size: 3.
+
+			0x4, // Add, size=4 (invalid).
+
+			0x1, 0x2, 0x3, 0x4, // Contents: ...
+		},
+	}
+
+	data, err := c.Unpack()
+	assert.EqualError(t, err, "git/odb/pack: invalid delta data")
+	assert.Nil(t, data)
+}

--- a/git/odb/pack/chain_test.go
+++ b/git/odb/pack/chain_test.go
@@ -1,0 +1,12 @@
+package pack
+
+type ChainSimple struct {
+	X   []byte
+	Err error
+}
+
+func (c *ChainSimple) Unpack() ([]byte, error) {
+	return c.X, c.Err
+}
+
+func (c *ChainSimple) Type() PackedObjectType { return TypeNone }

--- a/git/odb/pack/io.go
+++ b/git/odb/pack/io.go
@@ -1,0 +1,27 @@
+package pack
+
+import "io"
+
+// OffsetReaderAt transforms an io.ReaderAt into an io.Reader by beginning and
+// advancing all reads at the given offset.
+type OffsetReaderAt struct {
+	// r is the data source for this instance of *OffsetReaderAt.
+	r io.ReaderAt
+
+	// o if the number of bytes read from the underlying data source, "r".
+	// It is incremented upon reads.
+	o int64
+}
+
+// Read implements io.Reader.Read by reading into the given []byte, "p" from the
+// last known offset provided to the OffsetReaderAt.
+//
+// It returns any error encountered from the underlying data stream, and
+// advances the reader forward by "n", the number of bytes read from the
+// underlying data stream.
+func (r *OffsetReaderAt) Read(p []byte) (n int, err error) {
+	n, err = r.r.ReadAt(p, r.o)
+	r.o += int64(n)
+
+	return n, err
+}

--- a/git/odb/pack/io_test.go
+++ b/git/odb/pack/io_test.go
@@ -1,0 +1,53 @@
+package pack
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/git-lfs/git-lfs/errors"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOffsetReaderAtReadsAtOffset(t *testing.T) {
+	bo := &OffsetReaderAt{
+		r: bytes.NewReader([]byte{0x0, 0x1, 0x2, 0x3}),
+		o: 1,
+	}
+
+	var x1 [1]byte
+	n1, e1 := bo.Read(x1[:])
+
+	assert.NoError(t, e1)
+	assert.Equal(t, 1, n1)
+
+	assert.EqualValues(t, 0x1, x1[0])
+
+	var x2 [1]byte
+	n2, e2 := bo.Read(x2[:])
+
+	assert.NoError(t, e2)
+	assert.Equal(t, 1, n2)
+	assert.EqualValues(t, 0x2, x2[0])
+}
+
+func TestOffsetReaderPropogatesErrors(t *testing.T) {
+	expected := errors.New("git/odb/pack: testing")
+	bo := &OffsetReaderAt{
+		r: &ErrReaderAt{Err: expected},
+		o: 1,
+	}
+
+	n, err := bo.Read(make([]byte, 1))
+
+	assert.Equal(t, expected, err)
+	assert.Equal(t, 0, n)
+}
+
+type ErrReaderAt struct {
+	Err error
+}
+
+func (e *ErrReaderAt) ReadAt(p []byte, at int64) (n int, err error) {
+	return 0, e.Err
+}

--- a/git/odb/pack/object.go
+++ b/git/odb/pack/object.go
@@ -1,0 +1,27 @@
+package pack
+
+// Object is an encapsulation of an object found in a packfile, or a packed
+// object.
+type Object struct {
+	// data is the front-most element of the delta-base chain, and when
+	// resolved, yields the uncompressed data of this object.
+	data Chain
+	// typ is the underlying object's type. It is not the type of the
+	// front-most chain element, rather, the type of the actual object.
+	typ PackedObjectType
+}
+
+// Unpack resolves the delta-base chain and returns an uncompressed, unpacked,
+// and full representation of the data encoded by this object.
+//
+// If there was any error in unpacking this object, it is returned immediately,
+// and the object's data can be assumed to be corrupt.
+func (o *Object) Unpack() ([]byte, error) {
+	return o.data.Unpack()
+}
+
+// Type returns the underlying object's type. Rather than the type of the
+// front-most delta-base component, it is the type of the object itself.
+func (o *Object) Type() PackedObjectType {
+	return o.typ
+}

--- a/git/odb/pack/object_test.go
+++ b/git/odb/pack/object_test.go
@@ -1,0 +1,47 @@
+package pack
+
+import (
+	"testing"
+
+	"github.com/git-lfs/git-lfs/errors"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestObjectTypeReturnsObjectType(t *testing.T) {
+	o := &Object{
+		typ: TypeCommit,
+	}
+
+	assert.Equal(t, TypeCommit, o.Type())
+}
+
+func TestObjectUnpackUnpacksData(t *testing.T) {
+	expected := []byte{0x1, 0x2, 0x3, 0x4}
+
+	o := &Object{
+		data: &ChainSimple{
+			X: expected,
+		},
+	}
+
+	data, err := o.Unpack()
+
+	assert.Equal(t, expected, data)
+	assert.NoError(t, err)
+}
+
+func TestObjectUnpackPropogatesErrors(t *testing.T) {
+	expected := errors.New("git/odb/pack: testing")
+
+	o := &Object{
+		data: &ChainSimple{
+			Err: expected,
+		},
+	}
+
+	data, err := o.Unpack()
+
+	assert.Nil(t, data)
+	assert.Equal(t, expected, err)
+}

--- a/git/odb/pack/packfile.go
+++ b/git/odb/pack/packfile.go
@@ -1,7 +1,9 @@
 package pack
 
 import (
+	"compress/zlib"
 	"io"
+	"io/ioutil"
 
 	"github.com/git-lfs/git-lfs/errors"
 )
@@ -125,8 +127,19 @@ func (p *Packfile) find(offset int64) (Chain, error) {
 
 		// Now load the delta to apply to the base, given at the offset
 		// "offset" and for length "size".
-		delta := make([]byte, size)
-		if _, err := p.r.ReadAt(delta, offset); err != nil {
+		//
+		// NB: The delta instructions are zlib compressed, so ensure
+		// that we uncompress the instructions first.
+		zr, err := zlib.NewReader(&OffsetReaderAt{
+			o: offset,
+			r: p.r,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		delta, err := ioutil.ReadAll(zr)
+		if err != nil {
 			return nil, err
 		}
 

--- a/git/odb/pack/packfile.go
+++ b/git/odb/pack/packfile.go
@@ -1,0 +1,218 @@
+package pack
+
+import (
+	"io"
+
+	"github.com/git-lfs/git-lfs/errors"
+)
+
+// Packfile encapsulates the behavior of accessing an unpacked representation of
+// all of the objects encoded in a single packfile.
+type Packfile struct {
+	// Version is the version of the packfile.
+	Version uint32
+	// Objects is the total number of objects in the packfile.
+	Objects uint32
+	// idx is the corresponding "pack-*.idx" file giving the positions of
+	// objects in this packfile.
+	idx *Index
+
+	// r is an io.ReaderAt that allows read access to the packfile itself.
+	r io.ReaderAt
+}
+
+// Close closes the packfile if the underlying data stream is closeable. If so,
+// it returns any error involved in closing.
+func (p *Packfile) Close() error {
+	if close, ok := p.r.(io.Closer); ok {
+		return close.Close()
+	}
+	return nil
+}
+
+// Object returns a reference to an object packed in the receiving *Packfile. It
+// does not attempt to unpack the packfile, rather, that is accomplished by
+// calling Unpack() on the returned *Object.
+//
+// If there was an error loading or buffering the base, it will be returned
+// without an object.
+//
+// If the object given by the SHA-1 name, "name", could not be found,
+// (nil, errNotFound) will be returned.
+//
+// If the object was able to be loaded successfully, it will be returned without
+// any error.
+func (p *Packfile) Object(name []byte) (*Object, error) {
+	// First, try and determine the offset of the last entry in the
+	// delta-base chain by loading it from the corresponding pack index.
+	entry, err := p.idx.Entry(name)
+	if err != nil {
+		if !IsNotFound(err) {
+			// If the error was not an errNotFound, re-wrap it with
+			// additional context.
+			err = errors.Wrap(err,
+				"git/odb/pack: could not load index")
+		}
+		return nil, err
+	}
+
+	// If all goes well, then unpack the object at that given offset.
+	r, err := p.find(int64(entry.PackOffset))
+	if err != nil {
+		return nil, err
+	}
+
+	return &Object{
+		data: r,
+		typ:  r.Type(),
+	}, nil
+}
+
+// find finds and returns a Chain element corresponding to the offset of its
+// last element as given by the "offset" argument.
+//
+// If find returns a ChainBase, it loads that data into memory, but does not
+// zlib-flate it. Otherwise, if find returns a ChainDelta, it loads all of the
+// leading elements in the chain recursively, but does not apply one delta to
+// another.
+func (p *Packfile) find(offset int64) (Chain, error) {
+	// Read the first byte in the chain element.
+	buf := make([]byte, 1)
+	if _, err := p.r.ReadAt(buf, offset); err != nil {
+		return nil, err
+	}
+
+	// Store the original offset; this will be compared to when loading
+	// chain elements of type OBJ_OFS_DELTA.
+	objectOffset := offset
+
+	// Of the first byte, (0123 4567):
+	//   - Bit 0 is the M.S.B., and indicates whether there is more data
+	//     encoded in the length.
+	//   - Bits 1-3 ((buf[0] >> 4) & 0x7) are the object type.
+	//   - Bits 4-7 (buf[0] & 0xf) are the first 4 bits of the variable
+	//     length size of the encoded delta or base.
+	typ := PackedObjectType((buf[0] >> 4) & 0x7)
+	size := uint64(buf[0] & 0xf)
+	shift := uint(4)
+	offset += 1
+
+	for buf[0]&0x80 != 0 {
+		// If there is more data to be read, read it.
+		if _, err := p.r.ReadAt(buf, offset); err != nil {
+			return nil, err
+		}
+
+		// And update the size, bitshift, and offset accordingly.
+		size |= (uint64(buf[0]&0x7f) << shift)
+		shift += 7
+		offset += 1
+	}
+
+	switch typ {
+	case TypeObjectOffsetDelta, TypeObjectReferenceDelta:
+		// If the type of delta-base element is a delta, (either
+		// OBJ_OFS_DELTA, or OBJ_REFS_DELTA), we must load the base,
+		// which itself could be either of the two above, or a
+		// OBJ_COMMIT, OBJ_BLOB, etc.
+		//
+		// Recursively load the base, and keep track of the updated
+		// offset.
+		base, offset, err := p.findBase(typ, offset, objectOffset)
+		if err != nil {
+			return nil, err
+		}
+
+		// Now load the delta to apply to the base, given at the offset
+		// "offset" and for length "size".
+		delta := make([]byte, size)
+		if _, err := p.r.ReadAt(delta, offset); err != nil {
+			return nil, err
+		}
+
+		// Then compose the two and return it as a *ChainDelta.
+		return &ChainDelta{
+			base:  base,
+			delta: delta,
+		}, nil
+	case TypeCommit, TypeTree, TypeBlob, TypeTag:
+		// Otherwise, the object's contents are given to be the
+		// following zlib-compressed data.
+		//
+		// The length of the compressed data itself is not known,
+		// rather, "size" determines the length of the data after
+		// inflation.
+		return &ChainBase{
+			offset: offset,
+			size:   int64(size),
+			typ:    typ,
+
+			r: p.r,
+		}, nil
+	}
+	// Otherwise, we received an invalid object type.
+	return nil, errUnrecognizedObjectType
+}
+
+// findBase finds the base (an object, or another delta) for a given
+// OBJ_OFS_DELTA or OBJ_REFS_DELTA at the given offset.
+//
+// It returns the preceding Chain, as well as an updated read offset into the
+// underlying packfile data.
+//
+// If any of the above could not be completed successfully, findBase returns an
+// error.
+func (p *Packfile) findBase(typ PackedObjectType, offset, objOffset int64) (Chain, int64, error) {
+	var baseOffset int64
+
+	// We assume that we have to read at least 20 bytes (the SHA-1 length in
+	// the case of a OBJ_REF_DELTA, or greater than the length of the base
+	// offset encoded in an OBJ_OFS_DELTA).
+	var sha [20]byte
+	if _, err := p.r.ReadAt(sha[:], offset); err != nil {
+		return nil, baseOffset, err
+	}
+
+	switch typ {
+	case TypeObjectOffsetDelta:
+		// If the object is of type OBJ_OFS_DELTA, read a
+		// variable-length integer, and find the object at that
+		// location.
+		i := 0
+		c := int64(sha[i])
+		baseOffset = c & 0x7f
+
+		for c&0x80 != 0 {
+			i += 1
+			c = int64(sha[i])
+
+			baseOffset += 1
+			baseOffset <<= 7
+			baseOffset |= c & 0x7f
+		}
+
+		baseOffset = objOffset - baseOffset
+		offset += int64(i) + 1
+	case TypeObjectReferenceDelta:
+		// If the delta is an OBJ_REFS_DELTA, find the location of its
+		// base by reading the SHA-1 name and looking it up in the
+		// corresponding pack index file.
+		e, err := p.idx.Entry(sha[:])
+		if err != nil {
+			return nil, baseOffset, err
+		}
+
+		baseOffset = int64(e.PackOffset)
+		offset += 20
+	default:
+		// If we did not receive an OBJ_OFS_DELTA, or OBJ_REF_DELTA, the
+		// type given is not a delta-fied type. Return an error.
+		return nil, baseOffset, errors.Errorf(
+			"git/odb/pack: type %s is not deltafied", typ)
+	}
+
+	// Once we have determined the base offset of the object's chain base,
+	// read the delta-base chain beginning at that offset.
+	r, err := p.find(baseOffset)
+	return r, offset, err
+}

--- a/git/odb/pack/packfile_decode.go
+++ b/git/odb/pack/packfile_decode.go
@@ -1,0 +1,44 @@
+package pack
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"io"
+)
+
+var (
+	// packHeader is the expected header that begins all valid packfiles.
+	packHeader = []byte{'P', 'A', 'C', 'K'}
+
+	// errBadPackHeader is a sentinel error value returned when the given
+	// pack header does not match the expected one.
+	errBadPackHeader = errors.New("git/odb/pack: bad pack header")
+)
+
+// DecodePackfile opens the packfile given by the io.ReaderAt "r" for reading.
+// It does not apply any delta-base chains, nor does it do reading otherwise
+// beyond the header.
+//
+// If the header is malformed, or otherwise cannot be read, an error will be
+// returned without a corresponding packfile.
+func DecodePackfile(r io.ReaderAt) (*Packfile, error) {
+	header := make([]byte, 12)
+	if _, err := r.ReadAt(header[:], 0); err != nil {
+		return nil, err
+	}
+
+	if !bytes.HasPrefix(header, packHeader) {
+		return nil, errBadPackHeader
+	}
+
+	version := binary.BigEndian.Uint32(header[4:])
+	objects := binary.BigEndian.Uint32(header[8:])
+
+	return &Packfile{
+		Version: version,
+		Objects: objects,
+
+		r: r,
+	}, nil
+}

--- a/git/odb/pack/packfile_decode_test.go
+++ b/git/odb/pack/packfile_decode_test.go
@@ -1,0 +1,41 @@
+package pack
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDecodePackfileDecodesIntegerVersion(t *testing.T) {
+	p, err := DecodePackfile(bytes.NewReader([]byte{
+		'P', 'A', 'C', 'K', // Pack header.
+		0x0, 0x0, 0x0, 0x2, // Pack version.
+		0x0, 0x0, 0x0, 0x0, // Number of packed objects.
+	}))
+
+	assert.NoError(t, err)
+	assert.EqualValues(t, 2, p.Version)
+}
+
+func TestDecodePackfileDecodesIntegerCount(t *testing.T) {
+	p, err := DecodePackfile(bytes.NewReader([]byte{
+		'P', 'A', 'C', 'K', // Pack header.
+		0x0, 0x0, 0x0, 0x2, // Pack version.
+		0x0, 0x0, 0x1, 0x2, // Number of packed objects.
+	}))
+
+	assert.NoError(t, err)
+	assert.EqualValues(t, 258, p.Objects)
+}
+
+func TestDecodePackfileReportsBadHeaders(t *testing.T) {
+	p, err := DecodePackfile(bytes.NewReader([]byte{
+		'W', 'R', 'O', 'N', 'G', // Malformed pack header.
+		0x0, 0x0, 0x0, 0x0, // Pack version.
+		0x0, 0x0, 0x0, 0x0, // Number of packed objects.
+	}))
+
+	assert.Equal(t, errBadPackHeader, err)
+	assert.Nil(t, p)
+}

--- a/git/odb/pack/packfile_test.go
+++ b/git/odb/pack/packfile_test.go
@@ -1,0 +1,266 @@
+package pack
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/git-lfs/git-lfs/errors"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPackObjectReturnsObjectWithSingleBaseAtLowOffset(t *testing.T) {
+	const original = "Hello, world!\n"
+	compressed, _ := compress(original)
+
+	p := &Packfile{
+		idx: IndexWith(map[string]uint32{
+			"cccccccccccccccccccccccccccccccccccccccc": 32,
+		}),
+		r: bytes.NewReader(append([]byte{
+			0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+			0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+			0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+			0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+
+			// (0001 1000) (msb=0, type=commit, size=14)
+			0x1e}, compressed...),
+		),
+	}
+
+	o, err := p.Object(DecodeHex(t, "cccccccccccccccccccccccccccccccccccccccc"))
+	assert.NoError(t, err)
+
+	assert.Equal(t, TypeCommit, o.Type())
+
+	unpacked, err := o.Unpack()
+	assert.Equal(t, []byte(original), unpacked)
+	assert.NoError(t, err)
+}
+
+func TestPackObjectReturnsObjectWithSingleBaseAtHighOffset(t *testing.T) {
+	original := strings.Repeat("four", 64)
+	compressed, _ := compress(original)
+
+	p := &Packfile{
+		idx: IndexWith(map[string]uint32{
+			"cccccccccccccccccccccccccccccccccccccccc": 32,
+		}),
+		r: bytes.NewReader(append([]byte{
+			0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+			0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+			0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+			0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+
+			// (1001 0000) (msb=1, type=commit, size=0)
+			0x90,
+			// (1000 0000) (msb=0, size=1 -> size=256)
+			0x10},
+
+			compressed...,
+		)),
+	}
+
+	o, err := p.Object(DecodeHex(t, "cccccccccccccccccccccccccccccccccccccccc"))
+	assert.NoError(t, err)
+
+	assert.Equal(t, TypeCommit, o.Type())
+
+	unpacked, err := o.Unpack()
+	assert.Equal(t, []byte(original), unpacked)
+	assert.NoError(t, err)
+}
+
+func TestPackObjectReturnsObjectWithDeltaBaseOffset(t *testing.T) {
+	const original = "Hello"
+	compressed, _ := compress(original)
+
+	p := &Packfile{
+		idx: IndexWith(map[string]uint32{
+			"cccccccccccccccccccccccccccccccccccccccc": 32,
+		}),
+		r: bytes.NewReader(append(append([]byte{
+			0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+			0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+			0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+			0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+
+			0x35, // (0011 0101) (msb=0, type=blob, size=5)
+		}, compressed...), []byte{
+			0x6a, // (0110 1010) (msb=0, type=obj_ofs_delta, size=10)
+			0x11, // (0001 0001) (ofs_delta=-17, len(compressed))
+			0x7,  // (0000 0111) (instruction=add, size=7)
+
+			// Contents: ...
+			',', ' ', 'w', 'o', 'r', 'l', 'd', '!', '\n',
+		}...)),
+	}
+
+	o, err := p.Object(DecodeHex(t, "cccccccccccccccccccccccccccccccccccccccc"))
+	assert.NoError(t, err)
+
+	assert.Equal(t, TypeBlob, o.Type())
+
+	unpacked, err := o.Unpack()
+	assert.Equal(t, []byte(original), unpacked)
+	assert.NoError(t, err)
+}
+
+func TestPackfileObjectReturnsObjectWithDeltaBaseReference(t *testing.T) {
+	const original = "Hello!\n"
+	compressed, _ := compress(original)
+
+	p := &Packfile{
+		idx: IndexWith(map[string]uint32{
+			"cccccccccccccccccccccccccccccccccccccccc": 32,
+			"dddddddddddddddddddddddddddddddddddddddd": 52,
+		}),
+		r: bytes.NewReader(append(append([]byte{
+			0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+			0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+			0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+			0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+
+			0x37, // (0011 0101) (msb=0, type=blob, size=7)
+		}, compressed...), []byte{
+			0x7f, // (0111 1111) (msb=0, type=obj_ref_delta, size=16)
+
+			// SHA-1 "cccccccccccccccccccccccccccccccccccccccc",
+			// original blob contents is "Hello!\n"
+			0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc,
+			0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc,
+
+			// BEGIN OBJECT:
+			//   "dddddddddddddddddddddddddddddddddddddddd":
+			0x07, // Source size: 7.
+			0x0d, // Destination size: 13.
+
+			0x91, // (1001 0001) (copy, smask=0001, omask=0001)
+			0x00, // (0000 0000) (offset=0)
+			0x05, // (0000 0101) (size=5)
+
+			0x6,                          // (0000 0111) (add, length=6)
+			' ', 'w', 'o', 'r', 'l', 'd', // (data ...)
+
+			0x91, // (1001 0001) (copy, smask=0001, omask=0001)
+			0x05, // (0000 0101) (offset=5)
+			0x02, // (0000 0010) (size=2)
+		}...)),
+	}
+
+	o, err := p.Object(DecodeHex(t, "dddddddddddddddddddddddddddddddddddddddd"))
+	assert.NoError(t, err)
+
+	assert.Equal(t, TypeBlob, o.Type())
+
+	unpacked, err := o.Unpack()
+	assert.Equal(t, []byte("Hello world!\n"), unpacked)
+	assert.NoError(t, err)
+}
+
+func TestPackfileClosesReadClosers(t *testing.T) {
+	r := new(ReaderAtCloser)
+	p := &Packfile{
+		r: r,
+	}
+
+	assert.NoError(t, p.Close())
+	assert.EqualValues(t, 1, r.N)
+}
+
+func TestPackfileClosePropogatesCloseErrors(t *testing.T) {
+	e := errors.New("git/odb/pack: testing")
+	p := &Packfile{
+		r: &ReaderAtCloser{E: e},
+	}
+
+	assert.Equal(t, e, p.Close())
+}
+
+type ReaderAtCloser struct {
+	E error
+	N uint64
+}
+
+func (r *ReaderAtCloser) ReadAt(p []byte, at int64) (int, error) {
+	return 0, nil
+}
+
+func (r *ReaderAtCloser) Close() error {
+	atomic.AddUint64(&r.N, 1)
+	return r.E
+}
+
+func IndexWith(offsets map[string]uint32) *Index {
+	header := []byte{
+		0xff, 0x74, 0x4f, 0x63,
+		0x00, 0x00, 0x00, 0x02,
+	}
+
+	ns := make([][]byte, 0, len(offsets))
+	for name, _ := range offsets {
+		x, _ := hex.DecodeString(name)
+		ns = append(ns, x)
+	}
+	sort.Slice(ns, func(i, j int) bool {
+		return bytes.Compare(ns[i], ns[j]) < 0
+	})
+
+	fanout := make([]uint32, 256)
+	for i := 0; i < len(fanout); i++ {
+		var n uint32
+
+		for _, name := range ns {
+			if name[0] <= byte(i) {
+				n++
+			}
+		}
+
+		fanout[i] = n
+	}
+
+	crcs := make([]byte, 4*len(offsets))
+	for i, _ := range ns {
+		binary.BigEndian.PutUint32(crcs[i*4:], 0)
+	}
+
+	offs := make([]byte, 4*len(offsets))
+	for i, name := range ns {
+		binary.BigEndian.PutUint32(offs[i*4:], offsets[hex.EncodeToString(name)])
+	}
+
+	buf := make([]byte, 0)
+	buf = append(buf, header...)
+	for _, f := range fanout {
+		x := make([]byte, 4)
+		binary.BigEndian.PutUint32(x, f)
+
+		buf = append(buf, x...)
+	}
+	for _, n := range ns {
+		buf = append(buf, n...)
+	}
+	buf = append(buf, crcs...)
+	buf = append(buf, offs...)
+
+	return &Index{
+		fanout: fanout,
+		r:      bytes.NewReader(buf),
+
+		version: new(V2),
+	}
+}
+
+func DecodeHex(t *testing.T, str string) []byte {
+	b, err := hex.DecodeString(str)
+	if err != nil {
+		t.Fatalf("git/odb/pack: unexpected hex.DecodeString error: %s", err)
+	}
+
+	return b
+}

--- a/git/odb/pack/type.go
+++ b/git/odb/pack/type.go
@@ -1,0 +1,58 @@
+package pack
+
+import (
+	"errors"
+	"fmt"
+)
+
+// PackedObjectType is a constant type that is defined for all valid object
+// types that a packed object can represent.
+type PackedObjectType uint8
+
+const (
+	// TypeNone is the zero-value for PackedObjectType, and represents the
+	// absence of a type.
+	TypeNone PackedObjectType = iota
+	// TypeCommit is the PackedObjectType for commit objects.
+	TypeCommit
+	// TypeTree is the PackedObjectType for tree objects.
+	TypeTree
+	// Typeblob is the PackedObjectType for blob objects.
+	TypeBlob
+	// TypeTag is the PackedObjectType for tag objects.
+	TypeTag
+
+	// TypeObjectOffsetDelta is the type for OBJ_OFS_DELTA-typed objects.
+	TypeObjectOffsetDelta PackedObjectType = 6
+	// TypeObjectReferenceDelta is the type for OBJ_REF_DELTA-typed objects.
+	TypeObjectReferenceDelta PackedObjectType = 7
+)
+
+// String implements fmt.Stringer and returns an encoding of the type valid for
+// use in the loose object format protocol (see: package 'git/odb' for more).
+//
+// If the receiving instance is not defined, String() will panic().
+func (t PackedObjectType) String() string {
+	switch t {
+	case TypeNone:
+		return "<none>"
+	case TypeCommit:
+		return "commit"
+	case TypeTree:
+		return "tree"
+	case TypeBlob:
+		return "blob"
+	case TypeTag:
+		return "tag"
+	case TypeObjectOffsetDelta:
+		return "obj_ofs_delta"
+	case TypeObjectReferenceDelta:
+		return "obj_ref_delta"
+	}
+
+	panic(fmt.Sprintf("git/odb/pack: unknown object type: %d", t))
+}
+
+var (
+	errUnrecognizedObjectType = errors.New("git/odb/pack: unrecognized object type")
+)

--- a/git/odb/pack/type_test.go
+++ b/git/odb/pack/type_test.go
@@ -1,0 +1,52 @@
+package pack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type PackedObjectStringTestCase struct {
+	T PackedObjectType
+
+	Expected string
+	Panic    bool
+}
+
+func (c *PackedObjectStringTestCase) Assert(t *testing.T) {
+	if c.Panic {
+		defer func() {
+			err := recover()
+
+			if err == nil {
+				t.Fatalf("git/odb/pack: expected panic()")
+			}
+
+			assert.Equal(t, c.Expected, fmt.Sprintf("%s", err))
+		}()
+	}
+
+	assert.Equal(t, c.Expected, c.T.String())
+}
+
+func TestPackedObjectTypeString(t *testing.T) {
+	for desc, c := range map[string]*PackedObjectStringTestCase{
+		"TypeNone": {T: TypeNone, Expected: "<none>"},
+
+		"TypeCommit": {T: TypeCommit, Expected: "commit"},
+		"TypeTree":   {T: TypeTree, Expected: "tree"},
+		"TypeBlob":   {T: TypeBlob, Expected: "blob"},
+		"TypeTag":    {T: TypeTag, Expected: "tag"},
+
+		"TypeObjectOffsetDelta": {T: TypeObjectOffsetDelta,
+			Expected: "obj_ofs_delta"},
+		"TypeObjectReferenceDelta": {T: TypeObjectReferenceDelta,
+			Expected: "obj_ref_delta"},
+
+		"unknown type": {T: PackedObjectType(5), Panic: true,
+			Expected: "git/odb/pack: unknown object type: 5"},
+	} {
+		t.Run(desc, c.Assert)
+	}
+}


### PR DESCRIPTION
❗️ This pull request has branches `git-odb-pack-chain-base` and `git-odb-pack-chain-delta` as parents. Until those are merged, here is an inter-diff: https://github.com/git-lfs/git-lfs/compare/4908c70...git-odb-pack-packfile.

This pull request introduces a `*Packfile` type to package `git/odb/pack` whose responsibility it is to assemble an existing delta-base chain that corresponds to the given SHA-1 object name.

This pull request comes in two parts:

1. d2e66cb: implement the `*Packfile` type.

This type is responsible for assembling a representation of the delta-base chain corresponding to a given object.

Delta-base chains work as follows:

A delta-base chain has one base component, and zero or more delta components applied on top of the base. To resolve a delta-base chain, the base is first resolved, and then each delta component is applied successively. Delta components are referenced either by a negative offset (type: `OBJ_OFS_DELTA`), or by a 20 byte SHA-1 referring to the object that contains the delta-base chain (type: `OBJ_REF_DELTA`, whichever is shorter). Once a delta-base chain is assembled, it can be resolved easily.

The algorithm for assembling a delta-base chain as described above is executed as follows:

- Given an object, find the last element in the delta-base chain by asking for the offset of that object's SHA-1 in the receiving `*Packfile`'s corresponding `*Index`.
- Determine the type and length of that link in the delta-base chain.
- If the current chain component is a `*ChainBase`, parse it, and return the assembled `Chain`.
- If the current chain component is an `OBJ_REF_DELTA`, find the object it is referencing, passing its SHA-1 to step 1.
- If the current chain component is an `OJB_OFS_DELTA`, seek backwards, reading the base and delta instructions, constructing a `*ChainDelta` corresponding to that data. Repeat until step 2.

Specifically, the `*Packfile` type implements the above algorithm:

- `Object` resolves the delta-base chain by determining the given SHA-1's offset in the pack, and then passing that offset to `find()`.
- `find()` returns either a `*ChainBase`, or a `*ChainDelta` by determining the base for a given delta, and then recursively applying the `find` function to it.
- `findBase` finds the offset of a base (and passes it to `find`).

2. 6455926: teach `DecodePackfile` to instantiate instances of `*Packfile`, as above.

This function memory maps a packfile, and returns it. `DecodePackfile` does not apply any of the delta base chains, rather, it reads the header, version and object count to ensure that a valid packfile is present.

---

/cc @git-lfs/core @peff 
/cc #2415 