### PR TITLE
commands: teach '--everything' to 'git lfs migrate'

### DIFF
--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -24,6 +24,9 @@ git-lfs-migrate(1) - Migrate history to or from git-lfs
 * `--exclude-ref`=<refname>:
     See [INCLUDE AND EXCLUDE (REFS)].
 
+* `--everything`:
+    See [INCLUDE AND EXCLUDE (REFS)].
+
 * [branch ...]:
     Migrate only the set of branches listed. If not given, `git-lfs-migrate(1)`
     will migrate the currently checked out branch.
@@ -104,6 +107,9 @@ The following configuration:
   --exclude-ref=refs/remotes/origin/master
 
 Would, therefore, include commits: F, E, D, C, B, but exclude commit A.
+
+The presence of flag --everything indicates that all local references should be
+migrated.
 
 ## SEE ALSO
 


### PR DESCRIPTION
This pull request teaches the `--everything` flag to the `import` and `info` modes of `git-lfs-migrate(1)`.

`--everything` indicates that all local references should be migrated. In other words `--everything` means "migrate the entire section of my repository's local copy that is reachable by _any_ reference". Practically, this means "migrate everything".

Previously, in order to do this, users had to do some combination of:

```sh
git show-ref --heads --tags \
  | cut -d ' ' -f 2 \
  | sed -e 's/^/--include-ref=/' \
  | xargs git lfs migrate import
```

which is correct, but not useable. The presence of `--everything` has the same practical effect as making the included refspec the output of `git show-ref --heads --tags` (via `git.LocalRefs()`).

---

/cc @git-lfs/core 