### PR TITLE
git/githistory: only update local refs

### DIFF
--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -410,10 +410,29 @@ func (r *Rewriter) commitsToMigrate(opt *RewriteOptions) ([][]byte, error) {
 // refsToMigrate returns a list of references to migrate, or an error if loading
 // those references failed.
 func (r *Rewriter) refsToMigrate() ([]*git.Ref, error) {
+	var refs []*git.Ref
+	var err error
+
 	if root, ok := r.db.Root(); ok {
-		return git.AllRefsIn(root)
+		refs, err = git.AllRefsIn(root)
+	} else {
+		refs, err = git.AllRefs()
 	}
-	return git.AllRefs()
+
+	if err != nil {
+		return nil, err
+	}
+
+	var local []*git.Ref
+	for _, ref := range refs {
+		if ref.Type == git.RefTypeRemoteBranch || ref.Type == git.RefTypeRemoteTag {
+			continue
+		}
+
+		local = append(local, ref)
+	}
+
+	return local, nil
 }
 
 // scannerOpts returns a *git.ScanRefsOptions instance to be given to the


### PR DESCRIPTION
This pull request fixes a correctness issue with ref-updating migration modes where non-local refs would be moved in certain cases.

The problem with moving non-local references is that it is only correct if a 'git push' has been accepted against the remote which owns that reference. For example, if I update my copy of `refs/remotes/origin/master`, but don't actually push `master` to that remote, my copy of `refs/remotes/origin/master` is out of sync.

This can happen when running migrations that update local references which point to the same SHA-1 as a remote reference.

- When migrating, maintain a cache of old SHA-1's to the points on the graph that they moved to (i.e., I migrated commit X to a new commit of SHA-1 "Y".)
- Once migration is complete, iterate through all references in a repository.
- For each reference, lookup the translated location of the SHA-1 that the reference currently points at, and issue a `git update-ref` creating a reflog entry and moving the reference.

Given the above, if `refs/heads/master` was migrated (and pointed to the same SHA-1 as `refs/remotes/origin/master` at the time that the migration occurred) `refs/remotes/origin/master` will also be migrated, which is incorrect until `git push origin master` has completed.

To address this, modify the `git/githistory.Rewriter` to only pass local references to the `*refUpdater` type, thus not modifying remote references. 

---

/cc @git-lfs/core 