### PR TITLE
commands/migrate: use PersistentFlags() to share flags with subcommands

### DIFF
--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -241,24 +241,16 @@ func init() {
 	importCmd := NewCommand("import", migrateImportCommand)
 
 	RegisterCommand("migrate", nil, func(cmd *cobra.Command) {
-		// Adding flags directly to cmd.Flags() doesn't apply those
-		// flags to any subcommands of the root. Therefore, loop through
-		// each subcommand specifically, and include common arguments to
-		// each.
-		//
-		// Once done, link each orphaned command to the
-		// `git-lfs-migrate(1)` command as a subcommand (child).
+		cmd.PersistentFlags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")
+		cmd.PersistentFlags().StringVarP(&excludeArg, "exclude", "X", "", "Exclude a list of paths")
+
+		cmd.PersistentFlags().StringSliceVar(&migrateIncludeRefs, "include-ref", nil, "An explicit list of refs to include")
+		cmd.PersistentFlags().StringSliceVar(&migrateExcludeRefs, "exclude-ref", nil, "An explicit list of refs to exclude")
+		cmd.PersistentFlags().BoolVar(&migrateEverything, "everything", false, "Migrate all local references")
 
 		for _, subcommand := range []*cobra.Command{
 			importCmd, info,
 		} {
-			subcommand.Flags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")
-			subcommand.Flags().StringVarP(&excludeArg, "exclude", "X", "", "Exclude a list of paths")
-
-			subcommand.Flags().StringSliceVar(&migrateIncludeRefs, "include-ref", nil, "An explicit list of refs to include")
-			subcommand.Flags().StringSliceVar(&migrateExcludeRefs, "exclude-ref", nil, "An explicit list of refs to exclude")
-			subcommand.Flags().BoolVar(&migrateEverything, "everything", false, "Migrate all local references")
-
 			cmd.AddCommand(subcommand)
 		}
 	})

--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -248,10 +248,6 @@ func init() {
 		cmd.PersistentFlags().StringSliceVar(&migrateExcludeRefs, "exclude-ref", nil, "An explicit list of refs to exclude")
 		cmd.PersistentFlags().BoolVar(&migrateEverything, "everything", false, "Migrate all local references")
 
-		for _, subcommand := range []*cobra.Command{
-			importCmd, info,
-		} {
-			cmd.AddCommand(subcommand)
-		}
+		cmd.AddCommand(importCmd, info)
 	})
 }


### PR DESCRIPTION
This pull request uses cobra's `PersistentFlags()` option to avoid looping and reassigning flags to subcommands.

`PersistentFlags` are another flag set that is merged from a command's parent into the command's own flag set when `ParseFlag()` is called<sup>[[1](https://github.com/spf13/cobra/blob/b78744579491c1ceeaaa3b40205e56b0591b93a3/command.go#L1283-L1289
)][[2](
https://github.com/spf13/cobra/blob/b78744579491c1ceeaaa3b40205e56b0591b93a3/command.go#L1261-L1269)].

By using `PersistentFlags()`, we can avoid looping through each subcommand.

---

/cc @git-lfs/core