### PR TITLE
commands: print IP addresses in error logs

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -231,7 +231,7 @@ func Debug(format string, args ...interface{}) {
 }
 
 // LoggedError prints the given message formatted with its arguments (if any) to
-// Stderr. If an empty string is passed as the "format" arguemnt, only the
+// Stderr. If an empty string is passed as the "format" argument, only the
 // standard error logging message will be printed, and the error's body will be
 // omitted.
 //

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -334,6 +335,46 @@ func logPanic(loggedError error) string {
 	return full
 }
 
+func ipAddresses() []string {
+	ips := make([]string, 0, 1)
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		ips = append(ips, "Error getting network interface: "+err.Error())
+		return ips
+	}
+	for _, i := range ifaces {
+		if i.Flags&net.FlagUp == 0 {
+			continue // interface down
+		}
+		if i.Flags&net.FlagLoopback != 0 {
+			continue // loopback interface
+		}
+		addrs, _ := i.Addrs()
+		l := make([]string, 0, 1)
+		if err != nil {
+			ips = append(ips, "Error getting IP address: "+err.Error())
+			continue
+		}
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+			if ip == nil || ip.IsLoopback() {
+				continue
+			}
+			l = append(l, ip.String())
+		}
+		if len(l) > 0 {
+			ips = append(ips, strings.Join(l, " "))
+		}
+	}
+	return ips
+}
+
 func logPanicToWriter(w io.Writer, loggedError error, le string) {
 	// log the version
 	gitV, err := git.Config.Version()
@@ -367,6 +408,12 @@ func logPanicToWriter(w io.Writer, loggedError error, le string) {
 	// log the environment
 	for _, env := range lfs.Environ(cfg, getTransferManifest()) {
 		fmt.Fprint(w, env+le)
+	}
+
+	fmt.Fprint(w, le+"Client IP addresses:"+le)
+
+	for _, ip := range ipAddresses() {
+		fmt.Fprint(w, ip+le)
 	}
 }
 


### PR DESCRIPTION
It can be hard to trace Git LFS errors on the server without client IP
address. Fix this by adding the IP address to the error log output.

#### Attention
Is this OK from a privacy perspective? I think it is OK as we log the file to the local machine that knows the IP address anyways. A user that is concerned about the IP address could remove it from an error report. The same is already the case if the error output contains sensitive filenames of a repo.