### PR TITLE
improve Allowincompletepush

### DIFF
--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -101,7 +101,7 @@ func newUploadContext(remote string, dryRun bool) *uploadContext {
 		ourLocks:       make(map[string]locking.Lock),
 		theirLocks:     make(map[string]locking.Lock),
 		trackedLocksMu: new(sync.Mutex),
-		allowMissing:   cfg.Git.Bool("lfs.allowincompletepush", false),
+		allowMissing:   cfg.Git.Bool("lfs.allowincompletepush", true),
 	}
 
 	ctx.meter = buildProgressMeter(ctx.DryRun)

--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -156,7 +156,7 @@ be scoped inside the configuration for a remote.
 * `lfs.allowincompletepush`
 
   When pushing, allow objects to be missing from the local cache without halting
-  a Git push.
+  a Git push. Default: true.
 
 ### Fetch settings
 

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -264,6 +264,9 @@ begin_test "pre-push with missing and present pointers"
   git add present.dat missing.dat
   git commit -m "add present.dat and missing.dat"
 
+  git rm missing.dat
+  git commit -m "remove missing"
+
   # :fire: the "missing" object
   missing_oid_part_1="$(echo "$missing_oid" | cut -b 1-2)"
   missing_oid_part_2="$(echo "$missing_oid" | cut -b 3-4)"

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -333,7 +333,8 @@ begin_test "pre-push allowincompletepush=f reject missing pointers"
     exit 1
   fi
 
-  grep "no such file or directory" push.log
+  grep "no such file or directory" push.log || # unix
+    grep "cannot find the file" push.log       # windows
 
   refute_server_object "$reponame" "$present_oid"
   refute_server_object "$reponame" "$missing_oid"

--- a/test/test-push-missing.sh
+++ b/test/test-push-missing.sh
@@ -46,6 +46,8 @@ begin_test "push missing objects"
   refute_local_object "$corrupt_oid" "$corrupt_len"
   assert_local_object "$present_oid" "$present_len"
 
+  git config lfs.allowincompletepush false
+
   git push origin master 2>&1 | tee push.log
 
   if [ "0" -eq "${PIPESTATUS[0]}" ]; then

--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -697,7 +697,8 @@ begin_test "push reject missing objects (lfs.allowincompletepush=f)"
     exit 1
   fi
 
-  grep "no such file or directory" push.log
+  grep "no such file or directory" push.log || # unix
+    grep "cannot find the file" push.log       # windows
   grep "failed to push some refs" push.log
 
   refute_server_object "$reponame" "$present_oid"

--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -649,7 +649,6 @@ begin_test "push with missing objects (lfs.allowincompletepush=t)"
     exit 1
   fi
 
-
   grep "LFS upload missing objects" push.log
   grep "  (missing) missing.dat ($missing_oid)" push.log
 

--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -634,6 +634,9 @@ begin_test "push with missing objects (lfs.allowincompletepush)"
   git add missing.dat present.dat
   git commit -m "add objects"
 
+  git rm missing.dat
+  git commit -m "remove missing"
+
   # :fire: the "missing" object
   missing_oid_part_1="$(echo "$missing_oid" | cut -b 1-2)"
   missing_oid_part_2="$(echo "$missing_oid" | cut -b 3-4)"

--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -611,7 +611,7 @@ begin_test "push with deprecated _links"
   assert_server_object "$reponame" "$contents_oid"
 )
 
-begin_test "push with missing objects (lfs.allowincompletepush)"
+begin_test "push with missing objects (lfs.allowincompletepush=t)"
 (
   set -e
 
@@ -643,18 +643,65 @@ begin_test "push with missing objects (lfs.allowincompletepush)"
   missing_oid_path=".git/lfs/objects/$missing_oid_part_1/$missing_oid_part_2/$missing_oid"
   rm "$missing_oid_path"
 
-  git config "lfs.allowincompletepush" "true"
-
   git push origin master 2>&1 | tee push.log
   if [ "0" -ne "${PIPESTATUS[0]}" ]; then
     echo >&2 "fatal: expected \`git push origin master\` to succeed ..."
     exit 1
   fi
 
+
   grep "LFS upload missing objects" push.log
   grep "  (missing) missing.dat ($missing_oid)" push.log
 
   assert_server_object "$reponame" "$present_oid"
+  refute_server_object "$reponame" "$missing_oid"
+)
+end_test
+
+begin_test "push reject missing objects (lfs.allowincompletepush=f)"
+(
+  set -e
+
+  reponame="push-reject-missing-objects"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  present="present"
+  present_oid="$(calc_oid "$present")"
+  printf "$present" > present.dat
+
+  missing="missing"
+  missing_oid="$(calc_oid "$missing")"
+  printf "$missing" > missing.dat
+
+  git add missing.dat present.dat
+  git commit -m "add objects"
+
+  git rm missing.dat
+  git commit -m "remove missing"
+
+  # :fire: the "missing" object
+  missing_oid_part_1="$(echo "$missing_oid" | cut -b 1-2)"
+  missing_oid_part_2="$(echo "$missing_oid" | cut -b 3-4)"
+  missing_oid_path=".git/lfs/objects/$missing_oid_part_1/$missing_oid_part_2/$missing_oid"
+  rm "$missing_oid_path"
+
+  git config "lfs.allowincompletepush" "false"
+
+  git push origin master 2>&1 | tee push.log
+  if [ "1" -ne "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected \`git push origin master\` to succeed ..."
+    exit 1
+  fi
+
+  grep "no such file or directory" push.log
+  grep "failed to push some refs" push.log
+
+  refute_server_object "$reponame" "$present_oid"
   refute_server_object "$reponame" "$missing_oid"
 )
 end_test


### PR DESCRIPTION
This implements two fixes to make LFS pushes better:

1. `lfs.allowincompletepush` is now on by default. It's easier to push repositories when you're missing LFS content. It still warns about those missing files, but at least you're not blocked.
2. Fixed an issue where the `ensureFile()` helper wasn't obeying the `lfs.allowincompletepush`. That helper detects cases where a `.git/lfs/objects/{oid}` file is missing, and attempts to fill it in from the file in the working directory. Fails on any modified or deleted files in the current HEAD, of course.