### PR TITLE
git/githistory: change "Rewriting commits" when not updating refs

### DIFF
--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -174,7 +174,12 @@ func (r *Rewriter) Rewrite(opt *RewriteOptions) ([]byte, error) {
 		return nil, err
 	}
 
-	p := r.l.Percentage("migrate: Rewriting commits", uint64(len(commits)))
+	var p *log.PercentageTask
+	if opt.UpdateRefs {
+		p = r.l.Percentage("migrate: Rewriting commits", uint64(len(commits)))
+	} else {
+		p = r.l.Percentage("migrate: Examining commits", uint64(len(commits)))
+	}
 
 	// Keep track of the last commit that we rewrote. Callers often want
 	// this so that they can perform a git-update-ref(1).


### PR DESCRIPTION
This pull request changes the log message when performing "rewrites" without ref updates to "Examining commits" instead of "Rewriting commits".

For example, before this pull request:

```
~/g/git-lfs (master) $ git lfs migrate import
migrate: Fetching remote refs: ..., done
migrate: Sorting commits: ..., done
migrate: Rewriting commits: 100% (0/0), done
migrate: Updating refs: ..., done

~/g/git-lfs (master) $ git lfs migrate info
migrate: Fetching remote refs: ..., done
migrate: Sorting commits: ..., done
migrate: Rewriting commits: 100% (0/0), done
```

And with this pull request:

```
~/g/git-lfs (migrate-different-msg-no-ref-updates) $ git lfs migrate import
migrate: Fetching remote refs: ..., done
migrate: Sorting commits: ..., done
migrate: Rewriting commits: 100% (0/0), done
migrate: Updating refs: ..., done

~/g/git-lfs (migrate-different-msg-no-ref-updates) $ git lfs migrate info
migrate: Fetching remote refs: ..., done
migrate: Sorting commits: ..., done
migrate: Examining commits: 100% (0/0), done
```

---

/cc @git-lfs/core 