### PR TITLE
lfsapi: do not accept arguments to GIT_ASKPASS, core.askpass

### DIFF
--- a/lfsapi/creds.go
+++ b/lfsapi/creds.go
@@ -3,6 +3,7 @@ package lfsapi
 import (
 	"bytes"
 	"fmt"
+	"net/url"
 	"os/exec"
 	"strings"
 	"sync"
@@ -135,11 +136,6 @@ func (h CredentialHelpers) Approve(what Creds) error {
 type AskPassCredentialHelper struct {
 	// Program is the executable program's absolute or relative name.
 	Program string
-
-	// Prompt is an optional prompt appended to the end of the program's
-	// arguments, if given. This is implemented for consistency with the Git
-	// documentation.
-	Prompt string
 }
 
 // Fill implements fill by running the ASKPASS program and returning its output
@@ -151,15 +147,24 @@ type AskPassCredentialHelper struct {
 // If there was an error running the command, it is returned instead of a set of
 // filled credentials.
 func (a *AskPassCredentialHelper) Fill(what Creds) (Creds, error) {
+	var user bytes.Buffer
 	var pass bytes.Buffer
 	var err bytes.Buffer
 
-	cmd := exec.Command(a.Program, a.args()...)
-	cmd.Stderr = &err
-	cmd.Stdout = &pass
+	u := &url.URL{
+		Scheme: what["protocol"],
+		Host:   what["host"],
+		Path:   what["path"],
+	}
 
-	tracerx.Printf("creds: filling with GIT_ASKPASS: %s", strings.Join(cmd.Args, " "))
-	if err := cmd.Run(); err != nil {
+	// 'ucmd' will run the GIT_ASKPASS (or core.askpass) command prompting
+	// for a username.
+	ucmd := exec.Command(a.Program, a.args(fmt.Sprintf("Username for %q", u))...)
+	ucmd.Stderr = &err
+	ucmd.Stdout = &user
+
+	tracerx.Printf("creds: filling with GIT_ASKPASS: %s", strings.Join(ucmd.Args, " "))
+	if err := ucmd.Run(); err != nil {
 		return nil, err
 	}
 
@@ -167,7 +172,31 @@ func (a *AskPassCredentialHelper) Fill(what Creds) (Creds, error) {
 		return nil, errors.New(err.String())
 	}
 
+	if username := strings.TrimSpace(user.String()); len(username) > 0 {
+		// If a non-empty username was given, add it to the URL via func
+		// 'net/url.User()'.
+		u.User = url.User(username)
+	}
+
+	// Regardless, create 'pcmd' to run the GIT_ASKPASS (or core.askpass)
+	// command prompting for a password.
+	pcmd := exec.Command(a.Program, a.args(fmt.Sprintf("Password for %q", u))...)
+	pcmd.Stderr = &err
+	pcmd.Stdout = &pass
+
+	tracerx.Printf("creds: filling with GIT_ASKPASS: %s", strings.Join(pcmd.Args, " "))
+	if err := pcmd.Run(); err != nil {
+		return nil, err
+	}
+
+	if err.Len() > 0 {
+		return nil, errors.New(err.String())
+	}
+
+	// Finally, now that we have the username and password information,
+	// store it in the creds instance that we will return to the caller.
 	creds := make(Creds)
+	creds["username"] = strings.TrimSpace(user.String())
 	creds["password"] = pass.String()
 
 	return creds, nil
@@ -186,11 +215,11 @@ func (a *AskPassCredentialHelper) Reject(_ Creds) error { return nil }
 
 // See: https://git-scm.com/docs/gitcredentials#_requesting_credentials for
 // more.
-func (a *AskPassCredentialHelper) args() []string {
-	if len(a.Prompt) == 0 {
+func (a *AskPassCredentialHelper) args(prompt string) []string {
+	if len(prompt) == 0 {
 		return nil
 	}
-	return []string{a.Prompt}
+	return []string{prompt}
 }
 
 type CredentialHelper interface {

--- a/test/cmd/lfs-askpass.go
+++ b/test/cmd/lfs-askpass.go
@@ -1,0 +1,17 @@
+// +build testtools
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	var password string = "pass"
+	if env, ok := os.LookupEnv("LFS_ASKPASS_PASSWORD"); ok {
+		password = env
+	}
+
+	fmt.Println(password)
+}

--- a/test/cmd/lfs-askpass.go
+++ b/test/cmd/lfs-askpass.go
@@ -5,13 +5,25 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 )
 
 func main() {
-	var password string = "pass"
-	if env, ok := os.LookupEnv("LFS_ASKPASS_PASSWORD"); ok {
-		password = env
+	prompt := strings.Join(os.Args[1:], " ")
+
+	var answer string
+
+	if strings.Contains(prompt, "Username") {
+		answer = "user"
+		if env, ok := os.LookupEnv("LFS_ASKPASS_USERNAME"); ok {
+			answer = env
+		}
+	} else if strings.Contains(prompt, "Password") {
+		answer = "pass"
+		if env, ok := os.LookupEnv("LFS_ASKPASS_PASSWORD"); ok {
+			answer = env
+		}
 	}
 
-	fmt.Println(password)
+	fmt.Print(answer)
 }

--- a/test/test-askpass.sh
+++ b/test/test-askpass.sh
@@ -17,10 +17,10 @@ begin_test "askpass: push with GIT_ASKPASS"
   git commit -m "initial commit"
 
   # $password is defined from test/cmd/lfstest-gitserver.go (see: skipIfBadAuth)
-  password="pass"
-  GIT_ASKPASS="echo $password" GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push 2>&1 | tee push.log
+  export LFS_ASKPASS_PASSWORD="pass"
+  GIT_ASKPASS="lfs-askpass" GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push 2>&1 | tee push.log
 
-  grep "filling with GIT_ASKPASS: echo $password" push.log
+  grep "filling with GIT_ASKPASS: lfs-askpass" push.log
 )
 end_test
 
@@ -47,11 +47,11 @@ begin_test "askpass: push with core.askPass"
   git commit -m "initial commit"
 
   # $password is defined from test/cmd/lfstest-gitserver.go (see: skipIfBadAuth)
-  password="pass"
-  git config "core.askPass" "echo $password"
+  export LFS_ASKPASS_PASSWORD="pass"
+  git config "core.askPass" "lfs-askpass"
   cat .git/config
   GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push 2>&1 | tee push.log
 
-  grep "filling with GIT_ASKPASS: echo $password" push.log
+  grep "filling with GIT_ASKPASS: lfs-askpass" push.log
 )
 end_test

--- a/test/test-askpass.sh
+++ b/test/test-askpass.sh
@@ -17,10 +17,14 @@ begin_test "askpass: push with GIT_ASKPASS"
   git commit -m "initial commit"
 
   # $password is defined from test/cmd/lfstest-gitserver.go (see: skipIfBadAuth)
+  export LFS_ASKPASS_USERNAME="user"
   export LFS_ASKPASS_PASSWORD="pass"
   GIT_ASKPASS="lfs-askpass" GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push 2>&1 | tee push.log
 
-  grep "filling with GIT_ASKPASS: lfs-askpass" push.log
+  GITSERVER_USER="$(printf $GITSERVER | sed -e 's/http:\/\//http:\/\/user@/')"
+
+  grep "filling with GIT_ASKPASS: lfs-askpass Username for \"$GITSERVER/$reponame\"" push.log
+  grep "filling with GIT_ASKPASS: lfs-askpass Password for \"$GITSERVER_USER/$reponame\"" push.log
 )
 end_test
 
@@ -52,6 +56,9 @@ begin_test "askpass: push with core.askPass"
   cat .git/config
   GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push 2>&1 | tee push.log
 
-  grep "filling with GIT_ASKPASS: lfs-askpass" push.log
+  GITSERVER_USER="$(printf $GITSERVER | sed -e 's/http:\/\//http:\/\/user@/')"
+
+  grep "filling with GIT_ASKPASS: lfs-askpass Username for \"$GITSERVER/$reponame\"" push.log
+  grep "filling with GIT_ASKPASS: lfs-askpass Password for \"$GITSERVER_USER/$reponame\"" push.log
 )
 end_test


### PR DESCRIPTION
This pull request fixes a bug where program arguments would be incorrectly accepted by the `GIT_ASKPASS` parser, therefore breaking `GIT_ASKPASS` and `core.askpass` exec paths that have spaces or quotes in them.

---

/cc @git-lfs/core @joshaber 