### PR TITLE
fix filepathfilter HasPrefix()

### DIFF
--- a/filepathfilter/filepathfilter.go
+++ b/filepathfilter/filepathfilter.go
@@ -80,6 +80,10 @@ L:
 			}
 		}
 
+		if len(f.include) == 0 {
+			return true
+		}
+
 		for _, p := range f.include {
 			if p.HasPrefix(prefix) {
 				return true

--- a/filepathfilter/filepathfilter_test.go
+++ b/filepathfilter/filepathfilter_test.go
@@ -183,7 +183,7 @@ func TestFilterHasPrefix(t *testing.T) {
 		t.Run(desc, c.Assert)
 	}
 
-	prefixes = []string{"foo/bar/baz"} //, "foo/bar/baz/"}
+	prefixes = []string{"foo/bar/baz", "foo/bar/baz/"}
 	for desc, c := range map[string]*filterPrefixTest{
 		"exclude path prefix pattern": {false, prefixes, nil, []string{"/foo/bar/baz"}},
 		"exclude path pattern":        {false, prefixes, nil, []string{"foo/bar/baz"}},

--- a/test/test-migrate-import.sh
+++ b/test/test-migrate-import.sh
@@ -324,6 +324,21 @@ begin_test "migrate import (bare repository)"
 )
 end_test
 
+begin_test "migrate import (nested sub-trees, no filter)"
+(
+  set -e
+
+  setup_single_local_branch_deep_trees
+
+  oid="$(calc_oid "$(git cat-file -p :foo/bar/baz/a.txt)")"
+  size="$(git cat-file -p :foo/bar/baz/a.txt | wc -c | awk '{ print $1 }')"
+
+  git lfs migrate import --everything
+
+  assert_local_object "$oid" "$size"
+)
+end_test
+
 begin_test "migrate import (prefix include(s))"
 (
   set -e

--- a/test/test-migrate-info.sh
+++ b/test/test-migrate-info.sh
@@ -180,6 +180,24 @@ begin_test "migrate info (include/exclude ref with filter)"
 )
 end_test
 
+begin_test "migrate info (nested sub-trees, no filter)"
+(
+  set -e
+
+  setup_single_local_branch_deep_trees
+
+  original_master="$(git rev-parse refs/heads/master)"
+
+  diff -u <(git lfs migrate info 2>/dev/null) <(cat <<-EOF
+	*.txt	120 B	1/1 files(s)	100%
+	EOF)
+
+  migrated_master="$(git rev-parse refs/heads/master)"
+
+  assert_ref_unmoved "refs/heads/master" "$original_master" "$migrated_master"
+)
+end_test
+
 begin_test "migrate info (above threshold)"
 (
   set -e


### PR DESCRIPTION
I noticed that `HasPrefix()` returns false if there are no _include_ patterns. I think if none of the _exclude_ patterns have rejected it, then it should return `true`.

There is one existing test case this fails on: a prefix of `foo/bar/baz/`, with an exclude pattern of `/foo/bar/baz` or `foo/bar/baz`. It's commented out.

Without this fix, `git lfs migrate` will only scan the root directory if no `--include` flag is given.