### PR TITLE
commands: allow $GIT_LFS_TRACK_NO_INSTALL_HOOKS to disable hook installation

### DIFF
--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -42,7 +42,9 @@ func trackCommand(cmd *cobra.Command, args []string) {
 		os.Exit(128)
 	}
 
-	lfs.InstallHooks(false)
+	if !cfg.Os.Bool("GIT_LFS_TRACK_NO_INSTALL_HOOKS", false) {
+		lfs.InstallHooks(false)
+	}
 
 	if len(args) == 0 {
 		listPatterns()

--- a/test/test-track.sh
+++ b/test/test-track.sh
@@ -488,3 +488,25 @@ begin_test "track (symlinked repository)"
   popd > /dev/null
 )
 end_test
+
+begin_test "track (\$GIT_LFS_TRACK_NO_INSTALL_HOOKS)"
+(
+  set -e
+
+  reponame="track-no-setup-hooks"
+  git init "$reponame"
+  cd "$reponame"
+
+  [ ! -f .git/hooks/pre-push ]
+  [ ! -f .git/hooks/post-checkout ]
+  [ ! -f .git/hooks/post-commit ]
+  [ ! -f .git/hooks/post-merge ]
+
+  GIT_LFS_TRACK_NO_INSTALL_HOOKS=1 git lfs track
+
+  [ ! -f .git/hooks/pre-push ]
+  [ ! -f .git/hooks/post-checkout ]
+  [ ! -f .git/hooks/post-commit ]
+  [ ! -f .git/hooks/post-merge ]
+)
+end_test


### PR DESCRIPTION
This pull request allows callers to disable the hook installation component of running `git lfs track` via an environment variable `GIT_LFS_TRACK_NO_INSTALL_HOOKS`.

If set to a truth-y value, this skips the `lfs.InstallHooks(false)` call made by `git lfs track`. It is implemented as an environment flag since this is not functionality that we are intending to expose to users, rather, this is intended to be used by other programs leveraging Git LFS. It is absent from the manpage for the same reason.

---

/cc @git-lfs/core @joshaber 