### PR TITLE
installer: Insert the app directory at the beginning of PATH

### DIFF
--- a/script/windows-installer/inno-setup-git-lfs-installer.iss
+++ b/script/windows-installer/inno-setup-git-lfs-installer.iss
@@ -52,9 +52,9 @@ Source: ..\..\git-lfs-x64.exe; DestDir: "{app}"; Flags: ignoreversion; DestName:
 Source: ..\..\git-lfs-x86.exe; DestDir: "{app}"; Flags: ignoreversion; DestName: "git-lfs.exe"; AfterInstall: InstallGitLFS; Check: not Is64BitInstallMode
 
 [Registry]
-Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; ValueType: expandsz; ValueName: "Path"; ValueData: "{olddata};{app}"; Check: IsAdminLoggedOn and NeedsAddPath('{app}')
+Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; ValueType: expandsz; ValueName: "Path"; ValueData: "{app};{olddata}"; Check: IsAdminLoggedOn and NeedsAddPath('{app}')
 Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; ValueType: string; ValueName: "GIT_LFS_PATH"; ValueData: "{app}"; Check: IsAdminLoggedOn
-Root: HKCU; Subkey: "Environment"; ValueType: expandsz; ValueName: "Path"; ValueData: "{olddata};{app}"; Check: (not IsAdminLoggedOn) and NeedsAddPath('{app}')
+Root: HKCU; Subkey: "Environment"; ValueType: expandsz; ValueName: "Path"; ValueData: "{app};{olddata}"; Check: (not IsAdminLoggedOn) and NeedsAddPath('{app}')
 Root: HKCU; Subkey: "Environment"; ValueType: string; ValueName: "GIT_LFS_PATH"; ValueData: "{app}"; Check: not IsAdminLoggedOn
 
 [Code]


### PR DESCRIPTION
This way binaries that come with this installer are given precedence
over any previously installed Git LFS binaries shipping with Git for
Windows. Users can then run this installer to get a more recent version
of Git LFS than the one coming with Git for Windows without the need to
wait for a new Git for Windows release with updated bundled Git LFS
binaries.

Closes #2587.