### PR TITLE
don't fetch for unborn repositories

### DIFF
--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -101,8 +101,6 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 				Exit("Error performing 'git lfs pull' for submodules: %v", err)
 			}
 		}
-	} else {
-		Print("Repository is unborn, unable to fetch any LFS assets")
 	}
 
 	if !cloneSkipRepoInstall {

--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -85,9 +85,7 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 		remote = "origin"
 	}
 
-	ref, err := git.CurrentRef()
-
-	if ref != nil {
+	if ref, err := git.CurrentRef(); err == nil {
 		includeArg, excludeArg := getIncludeExcludeArgs(cmd)
 		filter := buildFilepathFilter(cfg, includeArg, excludeArg)
 		if cloneFlags.NoCheckout || cloneFlags.Bare {

--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -101,6 +101,8 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 				Exit("Error performing 'git lfs pull' for submodules: %v", err)
 			}
 		}
+	} else {
+		Print("Repository is unborn, unable to fetch any LFS assets")
 	}
 
 	if !cloneSkipRepoInstall {

--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -85,17 +85,21 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 		remote = "origin"
 	}
 
-	includeArg, excludeArg := getIncludeExcludeArgs(cmd)
-	filter := buildFilepathFilter(cfg, includeArg, excludeArg)
-	if cloneFlags.NoCheckout || cloneFlags.Bare {
-		// If --no-checkout or --bare then we shouldn't check out, just fetch instead
-		cfg.CurrentRemote = remote
-		fetchRef("HEAD", filter)
-	} else {
-		pull(remote, filter)
-		err := postCloneSubmodules(args)
-		if err != nil {
-			Exit("Error performing 'git lfs pull' for submodules: %v", err)
+	ref, err := git.CurrentRef()
+
+	if ref != nil {
+		includeArg, excludeArg := getIncludeExcludeArgs(cmd)
+		filter := buildFilepathFilter(cfg, includeArg, excludeArg)
+		if cloneFlags.NoCheckout || cloneFlags.Bare {
+			// If --no-checkout or --bare then we shouldn't check out, just fetch instead
+			cfg.CurrentRemote = remote
+			fetchRef("HEAD", filter)
+		} else {
+			pull(remote, filter)
+			err := postCloneSubmodules(args)
+			if err != nil {
+				Exit("Error performing 'git lfs pull' for submodules: %v", err)
+			}
 		}
 	}
 

--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -93,7 +93,7 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 		if cloneFlags.NoCheckout || cloneFlags.Bare {
 			// If --no-checkout or --bare then we shouldn't check out, just fetch instead
 			cfg.CurrentRemote = remote
-			fetchRef("HEAD", filter)
+			fetchRef(ref.Name, filter)
 		} else {
 			pull(remote, filter)
 			err := postCloneSubmodules(args)

--- a/test/test-clone.sh
+++ b/test/test-clone.sh
@@ -575,3 +575,36 @@ begin_test "clone in current directory"
   popd
 )
 end_test
+
+begin_test "clone empty repository"
+(
+  set -e
+
+  reponame="clone_empty"
+  setup_remote_repo "$reponame"
+
+  cd "$TRASHDIR"
+  git lfs clone "$GITSERVER/$reponame" "$reponame" 2>&1 | tee clone.log
+  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected clone to succeed ..."
+    exit 1
+  fi
+)
+end_test
+
+begin_test "clone bare empty repository"
+(
+  set -e
+
+  reponame="clone_bare_empty"
+  setup_remote_repo "$reponame"
+
+  cd "$TRASHDIR"
+  git lfs clone "$GITSERVER/$reponame" "$reponame" --bare 2>&1 | tee clone.log
+  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected clone to succeed ..."
+    exit 1
+  fi
+  exit 1
+)
+end_test

--- a/test/test-clone.sh
+++ b/test/test-clone.sh
@@ -605,6 +605,5 @@ begin_test "clone bare empty repository"
     echo >&2 "fatal: expected clone to succeed ..."
     exit 1
   fi
-  exit 1
 )
 end_test


### PR DESCRIPTION
Fixes #2592 

![](https://media.giphy.com/media/EiF2Xr3x9K6I0/giphy.gif)

This currently works by checking for `HEAD` ref after a clone and quietly moving on, but I'm open to different approaches to tackling this if we want to make the actions here more resilient and less noisy for this error case.

Any pointers for adding new tests to catch this regression would also be welcome!