### PR TITLE
trim whitespace from GIT_ASKPASS provided passwords

### DIFF
--- a/lfsapi/creds.go
+++ b/lfsapi/creds.go
@@ -197,7 +197,7 @@ func (a *AskPassCredentialHelper) Fill(what Creds) (Creds, error) {
 	// store it in the creds instance that we will return to the caller.
 	creds := make(Creds)
 	creds["username"] = strings.TrimSpace(user.String())
-	creds["password"] = pass.String()
+	creds["password"] = strings.TrimSpace(pass.String())
 
 	return creds, nil
 }

--- a/test/cmd/lfs-askpass.go
+++ b/test/cmd/lfs-askpass.go
@@ -25,5 +25,5 @@ func main() {
 		}
 	}
 
-	fmt.Print(answer)
+	fmt.Println(answer)
 }

--- a/test/test-askpass.sh
+++ b/test/test-askpass.sh
@@ -25,6 +25,7 @@ begin_test "askpass: push with GIT_ASKPASS"
 
   grep "filling with GIT_ASKPASS: lfs-askpass Username for \"$GITSERVER/$reponame\"" push.log
   grep "filling with GIT_ASKPASS: lfs-askpass Password for \"$GITSERVER_USER/$reponame\"" push.log
+  grep "master -> master" push.log
 )
 end_test
 
@@ -60,5 +61,6 @@ begin_test "askpass: push with core.askPass"
 
   grep "filling with GIT_ASKPASS: lfs-askpass Username for \"$GITSERVER/$reponame\"" push.log
   grep "filling with GIT_ASKPASS: lfs-askpass Password for \"$GITSERVER_USER/$reponame\"" push.log
+  grep "master -> master" push.log
 )
 end_test


### PR DESCRIPTION
This trims whitespace from passwords provided by `GIT_ASKPASS`, bringing it up to speed with the username.