### PR TITLE
Fix progress

### DIFF
--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -68,7 +68,6 @@ func pull(remote string, filter *filepathfilter.Filter) {
 		}
 
 		meter.Add(p.Size)
-		meter.StartTransfer(p.Name)
 		tracerx.Printf("fetch %v [%v]", p.Name, p.Oid)
 		pointers.Add(p)
 		q.Add(downloadTransfer(p))

--- a/test/test-progress.sh
+++ b/test/test-progress.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+. "test/testlib.sh"
+
+reponame="$(basename "$0" ".sh")"
+
+begin_test "GIT_LFS_PROGRESS"
+(
+  set -e
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" repo
+
+  git lfs track "*.dat"
+  echo "a" > a.dat
+  echo "b" > b.dat
+  echo "c" > c.dat
+  echo "d" > d.dat
+  echo "e" > e.dat
+  git add .gitattributes *.dat
+  git commit -m "add files"
+  git push origin master 2>&1 | tee push.log
+  grep "(5 of 5 files)" push.log
+
+  cd ..
+  GIT_LFS_PROGRESS="$TRASHDIR/progress.log" git lfs clone "$GITSERVER/$reponame" clone
+  cat progress.log
+  grep "download 6/5" progress.log
+  grep "download 7/5" progress.log
+  grep "download 8/5" progress.log
+  grep "download 9/5" progress.log
+  grep "download 10/5" progress.log
+
+  GIT_LFS_SKIP_SMUDGE=1 git clone "$GITSERVER/$reponame" clone2
+  cd clone2
+
+  rm -rf "$TRASHDIR/progress.log" .git/lfs/objects
+  GIT_LFS_PROGRESS="$TRASHDIR/progress.log" git lfs fetch --all
+  cat ../progress.log
+  grep "download 1/5" ../progress.log
+  grep "download 2/5" ../progress.log
+  grep "download 3/5" ../progress.log
+  grep "download 4/5" ../progress.log
+  grep "download 5/5" ../progress.log
+
+  rm -rf "$TRASHDIR/progress.log"
+  GIT_LFS_PROGRESS="$TRASHDIR/progress.log" git lfs checkout
+  cat ../progress.log
+  grep "checkout 1/5" ../progress.log
+  grep "checkout 2/5" ../progress.log
+  grep "checkout 3/5" ../progress.log
+  grep "checkout 4/5" ../progress.log
+  grep "checkout 5/5" ../progress.log
+)
+end_test

--- a/test/test-progress.sh
+++ b/test/test-progress.sh
@@ -24,11 +24,11 @@ begin_test "GIT_LFS_PROGRESS"
   cd ..
   GIT_LFS_PROGRESS="$TRASHDIR/progress.log" git lfs clone "$GITSERVER/$reponame" clone
   cat progress.log
-  grep "download 6/5" progress.log
-  grep "download 7/5" progress.log
-  grep "download 8/5" progress.log
-  grep "download 9/5" progress.log
-  grep "download 10/5" progress.log
+  grep "download 1/5" progress.log
+  grep "download 2/5" progress.log
+  grep "download 3/5" progress.log
+  grep "download 4/5" progress.log
+  grep "download 5/5" progress.log
 
   GIT_LFS_SKIP_SMUDGE=1 git clone "$GITSERVER/$reponame" clone2
   cd clone2


### PR DESCRIPTION
Fixes 3 issues with `GIT_LFS_PROGRESS`:

1. It's reported twice for `lfs pull` or `lfs clone`, since `(*ProgressMeter) StartTransfer(string)` is called in the GitScanner before being added to the transfer queue AND in the transfer queue. https://github.com/git-lfs/git-lfs/issues/2599
2. The `checkout` never knows how many files there are, so the progress is reported as `1/1`, `2/2`, `3/3`, etc.
3. No tests :(

I'm not crazy about changing `checkout` to accumulate a `[]*WrappedPointer` slice, but it's the only way to know the total number of files to checkout before starting to check files out.