### PR TITLE
Migrate verbose option

### DIFF
--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -24,6 +24,9 @@ var (
 	// migrateEverything indicates the presence of the --everything flag,
 	// and instructs 'git lfs migrate' to migrate all local references.
 	migrateEverything bool
+
+	// migrateVerbose enables verbose logging
+	migrateVerbose bool
 )
 
 // migrate takes the given command and arguments, *odb.ObjectDatabase, as well
@@ -76,6 +79,7 @@ func rewriteOptions(args []string, opts *githistory.RewriteOptions, l *log.Logge
 		Exclude: exclude,
 
 		UpdateRefs: opts.UpdateRefs,
+		Verbose:    opts.Verbose,
 
 		BlobFn:         opts.BlobFn,
 		TreeCallbackFn: opts.TreeCallbackFn,
@@ -240,6 +244,7 @@ func init() {
 	info.Flags().StringVar(&migrateInfoUnitFmt, "unit", "", "--unit=<unit>")
 
 	importCmd := NewCommand("import", migrateImportCommand)
+	importCmd.Flags().BoolVar(&migrateVerbose, "verbose", false, "Verbose logging")
 
 	RegisterCommand("migrate", nil, func(cmd *cobra.Command) {
 		cmd.PersistentFlags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")

--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -100,10 +100,14 @@ func migrateImportCommand(cmd *cobra.Command, args []string) {
 		UpdateRefs: true,
 	})
 
+	// Only perform `git-checkout(1) -f` if the repository is
+	// non-bare.
 	if bare, _ := git.IsBare(); !bare {
-		// Only perform `git-checkout(1) -f` if the repository is
-		// non-bare.
-		if err := git.Checkout("", nil, true); err != nil {
+		t := l.Waiter("migrate: checkout")
+		err := git.Checkout("", nil, true)
+		t.Complete()
+
+		if err != nil {
 			ExitWithError(err)
 		}
 	}

--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -33,6 +33,7 @@ func migrateImportCommand(cmd *cobra.Command, args []string) {
 	exts := tools.NewOrderedSet()
 
 	migrate(args, rewriter, l, &githistory.RewriteOptions{
+		Verbose: migrateVerbose,
 		BlobFn: func(path string, b *odb.Blob) (*odb.Blob, error) {
 			if filepath.Base(path) == ".gitattributes" {
 				return b, nil

--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -20,6 +20,7 @@ import (
 
 func migrateImportCommand(cmd *cobra.Command, args []string) {
 	l := log.NewLogger(os.Stderr)
+	defer l.Close()
 
 	db, err := getObjectDatabase()
 	if err != nil {

--- a/commands/command_migrate_info.go
+++ b/commands/command_migrate_info.go
@@ -41,7 +41,6 @@ var (
 
 func migrateInfoCommand(cmd *cobra.Command, args []string) {
 	l := log.NewLogger(os.Stderr)
-	defer l.Close()
 
 	db, err := getObjectDatabase()
 	if err != nil {
@@ -93,6 +92,7 @@ func migrateInfoCommand(cmd *cobra.Command, args []string) {
 			return b, nil
 		},
 	})
+	l.Close()
 
 	entries := EntriesBySize(MapToEntries(exts))
 	entries = removeEmptyEntries(entries)

--- a/commands/command_migrate_info.go
+++ b/commands/command_migrate_info.go
@@ -41,6 +41,7 @@ var (
 
 func migrateInfoCommand(cmd *cobra.Command, args []string) {
 	l := log.NewLogger(os.Stderr)
+	defer l.Close()
 
 	db, err := getObjectDatabase()
 	if err != nil {

--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -66,7 +66,11 @@ The 'info' mode has these additional options:
 ### IMPORT
 
 The 'import' mode migrates large objects present in the Git history to pointer
-files tracked and stored with Git LFS.
+files tracked and stored with Git LFS. It supports all the core 'migrate'
+options and these additional ones:
+
+* `--verbose`
+    Print the commit oid and filename of migrated files to STDOUT.
 
 If `--include` or `--exclude` (`-I`, `-X`, respectively) are given, the
 .gitattributes will be modified to include any new filepath patterns as given by

--- a/git/githistory/log/log.go
+++ b/git/githistory/log/log.go
@@ -198,7 +198,7 @@ func (l *Logger) logTask(task Task) {
 
 	var update *Update
 	for update = range task.Updates() {
-		if logAll || l.throttle == 0 || update.At.After(last.Add(l.throttle)) {
+		if logAll || l.throttle == 0 || !update.Throttled(last.Add(l.throttle)) {
 			l.logLine(update.S)
 			last = update.At
 		}

--- a/git/githistory/log/percentage_task.go
+++ b/git/githistory/log/percentage_task.go
@@ -70,6 +70,15 @@ func (c *PercentageTask) Count(n uint64) (new uint64) {
 	return new
 }
 
+// Entry logs a line-delimited task entry.
+func (t *PercentageTask) Entry(update string) {
+	t.ch <- &Update{
+		S:     fmt.Sprintf("%s\n", update),
+		At:    time.Now(),
+		Force: true,
+	}
+}
+
 // Updates implements Task.Updates and returns a channel which is written to
 // when the state of this task changes, and closed when the task is completed.
 // has been completed.

--- a/git/githistory/log/percentage_task.go
+++ b/git/githistory/log/percentage_task.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"fmt"
+	"math"
 	"sync/atomic"
 	"time"
 )
@@ -52,7 +53,7 @@ func (c *PercentageTask) Count(n uint64) (new uint64) {
 
 	u := &Update{
 		S: fmt.Sprintf("%s: %3.f%% (%d/%d)",
-			c.msg, percentage, new, c.total),
+			c.msg, math.Floor(percentage), new, c.total),
 		At: time.Now(),
 	}
 

--- a/git/githistory/log/task.go
+++ b/git/githistory/log/task.go
@@ -22,4 +22,14 @@ type Update struct {
 	S string
 	// At is the time that this update was sent.
 	At time.Time
+
+	// Force determines if this update should not be throttled.
+	Force bool
+}
+
+// Throttled determines whether this update should be throttled, based on the
+// given earliest time of the next update. The caller should determine how often
+// updates should be throttled. An Update with Force=true is never throttled.
+func (u *Update) Throttled(next time.Time) bool {
+	return !(u.Force || u.At.After(next))
 }

--- a/git/githistory/ref_updater.go
+++ b/git/githistory/ref_updater.go
@@ -3,10 +3,12 @@ package githistory
 import (
 	"encoding/hex"
 	"fmt"
+	"strings"
 
 	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/git"
 	"github.com/git-lfs/git-lfs/git/githistory/log"
+	"github.com/git-lfs/git-lfs/tools"
 )
 
 // refUpdater is a type responsible for moving references from one point in the
@@ -37,6 +39,11 @@ func (r *refUpdater) UpdateRefs() error {
 	list := r.Logger.List("migrate: Updating refs")
 	defer list.Complete()
 
+	var maxNameLen int
+	for _, ref := range r.Refs {
+		maxNameLen = tools.MaxInt(maxNameLen, len(ref.Name))
+	}
+
 	for _, ref := range r.Refs {
 		sha1, err := hex.DecodeString(ref.Sha)
 		if err != nil {
@@ -52,7 +59,8 @@ func (r *refUpdater) UpdateRefs() error {
 			return err
 		}
 
-		list.Entry(fmt.Sprintf("  %s\t%s -> %x", ref.Name, ref.Sha, to))
+		namePadding := tools.MaxInt(maxNameLen-len(ref.Name), 0)
+		list.Entry(fmt.Sprintf("  %s%s\t%s -> %x", ref.Name, strings.Repeat(" ", namePadding), ref.Sha, to))
 	}
 
 	return nil

--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -287,8 +287,6 @@ func (r *Rewriter) Rewrite(opt *RewriteOptions) ([]byte, error) {
 		}
 	}
 
-	r.l.Close()
-
 	return tip, err
 }
 

--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -52,6 +52,9 @@ type RewriteOptions struct {
 	// moved, and a reflog entry will be created.
 	UpdateRefs bool
 
+	// Verbose mode prints migrated objects.
+	Verbose bool
+
 	// BlobFn specifies a function to rewrite blobs.
 	//
 	// It is called once per unique, unchanged path. That is to say, if
@@ -174,11 +177,16 @@ func (r *Rewriter) Rewrite(opt *RewriteOptions) ([]byte, error) {
 		return nil, err
 	}
 
-	var p *log.PercentageTask
+	var perc *log.PercentageTask
 	if opt.UpdateRefs {
-		p = r.l.Percentage("migrate: Rewriting commits", uint64(len(commits)))
+		perc = r.l.Percentage("migrate: Rewriting commits", uint64(len(commits)))
 	} else {
-		p = r.l.Percentage("migrate: Examining commits", uint64(len(commits)))
+		perc = r.l.Percentage("migrate: Examining commits", uint64(len(commits)))
+	}
+
+	var vPerc *log.PercentageTask
+	if opt.Verbose {
+		vPerc = perc
 	}
 
 	// Keep track of the last commit that we rewrote. Callers often want
@@ -193,7 +201,7 @@ func (r *Rewriter) Rewrite(opt *RewriteOptions) ([]byte, error) {
 		}
 
 		// Rewrite the tree given at that commit.
-		rewrittenTree, err := r.rewriteTree(original.TreeID, "", opt.blobFn(), opt.treeFn())
+		rewrittenTree, err := r.rewriteTree(oid, original.TreeID, "", opt.blobFn(), opt.treeFn(), vPerc)
 		if err != nil {
 			return nil, err
 		}
@@ -253,7 +261,7 @@ func (r *Rewriter) Rewrite(opt *RewriteOptions) ([]byte, error) {
 		r.cacheCommit(oid, newSha)
 
 		// Increment the percentage displayed in the terminal.
-		p.Count(1)
+		perc.Count(1)
 
 		// Move the tip forward.
 		tip = newSha
@@ -295,8 +303,8 @@ func (r *Rewriter) Rewrite(opt *RewriteOptions) ([]byte, error) {
 //
 // It returns the new SHA of the rewritten tree, or an error if the tree was
 // unable to be rewritten.
-func (r *Rewriter) rewriteTree(sha []byte, path string, fn BlobRewriteFn, tfn TreeCallbackFn) ([]byte, error) {
-	tree, err := r.db.Tree(sha)
+func (r *Rewriter) rewriteTree(commitOID []byte, treeOID []byte, path string, fn BlobRewriteFn, tfn TreeCallbackFn, perc *log.PercentageTask) ([]byte, error) {
+	tree, err := r.db.Tree(treeOID)
 	if err != nil {
 		return nil, err
 	}
@@ -319,9 +327,9 @@ func (r *Rewriter) rewriteTree(sha []byte, path string, fn BlobRewriteFn, tfn Tr
 
 		switch entry.Type() {
 		case odb.BlobObjectType:
-			oid, err = r.rewriteBlob(entry.Oid, path, fn)
+			oid, err = r.rewriteBlob(commitOID, entry.Oid, path, fn, perc)
 		case odb.TreeObjectType:
-			oid, err = r.rewriteTree(entry.Oid, path, fn, tfn)
+			oid, err = r.rewriteTree(commitOID, entry.Oid, path, fn, tfn, perc)
 		default:
 			oid = entry.Oid
 
@@ -343,7 +351,7 @@ func (r *Rewriter) rewriteTree(sha []byte, path string, fn BlobRewriteFn, tfn Tr
 	}
 
 	if tree.Equal(rewritten) {
-		return sha, nil
+		return treeOID, nil
 	}
 	return r.db.WriteTree(rewritten)
 }
@@ -365,7 +373,7 @@ func (r *Rewriter) allows(typ odb.ObjectType, abs string) bool {
 // database by the SHA1 "from" []byte. It writes and returns the new blob SHA,
 // or an error if either the BlobRewriteFn returned one, or if the object could
 // not be loaded/saved.
-func (r *Rewriter) rewriteBlob(from []byte, path string, fn BlobRewriteFn) ([]byte, error) {
+func (r *Rewriter) rewriteBlob(commitOID, from []byte, path string, fn BlobRewriteFn, perc *log.PercentageTask) ([]byte, error) {
 	blob, err := r.db.Blob(from)
 	if err != nil {
 		return nil, err
@@ -391,6 +399,10 @@ func (r *Rewriter) rewriteBlob(from []byte, path string, fn BlobRewriteFn) ([]by
 		// returned.
 		if err = blob.Close(); err != nil {
 			return nil, err
+		}
+
+		if perc != nil {
+			perc.Entry(fmt.Sprintf("migrate: commit %s: %s", hex.EncodeToString(commitOID), path))
 		}
 
 		return sha, nil


### PR DESCRIPTION
This adds an option to print the commit oid and path of every migrated file.  I'm not sure if this should be default or not, so I'm playing it safe for v2.3.1.

```
$ git lfs migrate import --include="*.gem" --include-ref=master --verbose
migrate: Sorting commits: ..., done
migrate: commit 4be47bd500d595ad735e077ea7b2b1b0ff399de4: vendor/cache/yajl-ruby-0.8.0.gem
migrate: Rewriting commits:   5% (21335/454650)
```