### PR TITLE
reject invalid urls immediately

### DIFF
--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -46,7 +46,8 @@ func (c *Client) NewRequest(method string, e Endpoint, suffix string, body inter
 	}
 
 	if !httpRE.MatchString(prefix) {
-		return nil, fmt.Errorf("missing protocol: %q", prefix)
+		urlfragment := strings.SplitN(prefix, "?", 2)[0]
+		return nil, fmt.Errorf("missing protocol: %q", urlfragment)
 	}
 
 	req, err := http.NewRequest(method, joinURL(prefix, suffix), nil)

--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -22,6 +23,8 @@ import (
 var UserAgent = "git-lfs"
 
 const MediaType = "application/vnd.git-lfs+json; charset=utf-8"
+
+var httpRE = regexp.MustCompile(`\Ahttps?://`)
 
 func (c *Client) NewRequest(method string, e Endpoint, suffix string, body interface{}) (*http.Request, error) {
 	sshRes, err := c.SSH.Resolve(e, method)
@@ -39,6 +42,10 @@ func (c *Client) NewRequest(method string, e Endpoint, suffix string, body inter
 	prefix := e.Url
 	if len(sshRes.Href) > 0 {
 		prefix = sshRes.Href
+	}
+
+	if !httpRE.MatchString(prefix) {
+		return nil, fmt.Errorf("missing protocol: %q", prefix)
 	}
 
 	req, err := http.NewRequest(method, joinURL(prefix, suffix), nil)

--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -20,11 +20,12 @@ import (
 	"github.com/rubyist/tracerx"
 )
 
-var UserAgent = "git-lfs"
-
 const MediaType = "application/vnd.git-lfs+json; charset=utf-8"
 
-var httpRE = regexp.MustCompile(`\Ahttps?://`)
+var (
+	UserAgent = "git-lfs"
+	httpRE    = regexp.MustCompile(`\Ahttps?://`)
+)
 
 func (c *Client) NewRequest(method string, e Endpoint, suffix string, body interface{}) (*http.Request, error) {
 	sshRes, err := c.SSH.Resolve(e, method)

--- a/tq/adapterbase.go
+++ b/tq/adapterbase.go
@@ -3,6 +3,7 @@ package tq
 import (
 	"fmt"
 	"net/http"
+	"regexp"
 	"sync"
 
 	"github.com/git-lfs/git-lfs/lfsapi"
@@ -185,7 +186,13 @@ func (a *adapterBase) worker(workerNum int, ctx interface{}) {
 	a.workerWait.Done()
 }
 
+var httpRE = regexp.MustCompile(`\Ahttps?://`)
+
 func (a *adapterBase) newHTTPRequest(method string, rel *Action) (*http.Request, error) {
+	if !httpRE.MatchString(rel.Href) {
+		return nil, fmt.Errorf("missing protocol: %q", rel.Href)
+	}
+
 	req, err := http.NewRequest(method, rel.Href, nil)
 	if err != nil {
 		return nil, err

--- a/tq/adapterbase.go
+++ b/tq/adapterbase.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strings"
 	"sync"
 
 	"github.com/git-lfs/git-lfs/lfsapi"
@@ -190,7 +191,8 @@ var httpRE = regexp.MustCompile(`\Ahttps?://`)
 
 func (a *adapterBase) newHTTPRequest(method string, rel *Action) (*http.Request, error) {
 	if !httpRE.MatchString(rel.Href) {
-		return nil, fmt.Errorf("missing protocol: %q", rel.Href)
+		urlfragment := strings.SplitN(rel.Href, "?", 2)[0]
+		return nil, fmt.Errorf("missing protocol: %q", urlfragment)
 	}
 
 	req, err := http.NewRequest(method, rel.Href, nil)


### PR DESCRIPTION
This skips the request immediately, and provides a better error message (with the problem described at the front, before the long url).

BEFORE:

```
Fetching master
Git LFS: (0 of 2 files) 0 B / 178.50 KB
batch response: Post lfs.github.localhost/technoweenie/lfs-test/objects/batch: unsupported protocol scheme ""
error: failed to fetch some objects from 'lfs.github.localhost/technoweenie/lfs-test'
```

AFTER:

```
Fetching master
Git LFS: (0 of 2 files) 0 B / 178.50 KB
batch request: missing protocol: "lfs.github.localhost/technoweenie/lfs-test"
error: failed to fetch some objects from 'lfs.github.localhost/technoweenie/lfs-test'
```