### PR TITLE
update tracerx to add timestamps

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 7ac0f055e06001b80cc9cfc40de07c103b3b59abec0f3be0fca7cce49b71eec7
-updated: 2017-09-19T15:38:52.833333079-06:00
+hash: e19b925b9eaca9a10a7742b4a4b1dc8047bff437584538dda59f4f10e69fa6ca
+updated: 2017-09-27T12:34:48.032089491-04:00
 imports:
 - name: github.com/bgentry/go-netrc
   version: 9fd32a8b3d3d3f9d43c341bfe098430e07609480
@@ -14,7 +14,7 @@ imports:
 - name: github.com/pkg/errors
   version: c605e284fe17294bda444b34710735b29d1a9d90
 - name: github.com/rubyist/tracerx
-  version: d7bcc0bc315bed2a841841bee5dbecc8d7d7582f
+  version: 787959303086f44a8c361240dfac53d3e9d53ed2
 - name: github.com/spf13/cobra
   version: c55cdf33856a08e4822738728b41783292812889
 - name: github.com/spf13/pflag

--- a/glide.yaml
+++ b/glide.yaml
@@ -11,7 +11,7 @@ import:
 - package: github.com/olekukonko/ts
   version: ecf753e7c962639ab5a1fb46f7da627d4c0a04b8
 - package: github.com/rubyist/tracerx
-  version: d7bcc0bc315bed2a841841bee5dbecc8d7d7582f
+  version: 787959303086f44a8c361240dfac53d3e9d53ed2
 - package: github.com/spf13/cobra
   version: c55cdf33856a08e4822738728b41783292812889
 - package: github.com/spf13/pflag

--- a/vendor/github.com/rubyist/tracerx/tracerx.go
+++ b/vendor/github.com/rubyist/tracerx/tracerx.go
@@ -52,7 +52,7 @@ func Printf(format string, args ...interface{}) {
 func PrintfKey(key, format string, args ...interface{}) {
 	tracer := getTracer(key)
 	if tracer.enabled {
-		fmt.Fprintf(tracer.w, Prefix+format+"\n", args...)
+		fmt.Fprintf(tracer.w, time.Now().Format("15:04:05.000000 ")+Prefix+format+"\n", args...)
 		return
 	}
 }
@@ -70,7 +70,7 @@ func PerformanceSinceKey(key, what string, t time.Time) {
 
 	if tracer.performance {
 		since := time.Since(t)
-		fmt.Fprintf(tracer.w, "performance %s: %.9f s\n", what, since.Seconds())
+		fmt.Fprintf(tracer.w, time.Now().Format("15:04:05.000000 ")+"performance %s: %.9f s\n", what, since.Seconds())
 	}
 }
 


### PR DESCRIPTION
This updates `tracerx` to add timestamps to tracing output to match what git does.

Fixes #2619 

```
[scott@black tracerx]$ GIT_TRACE=1 git lfs locks
12:35:03.467185 git.c:560               trace: exec: 'git-lfs' 'locks'
12:35:03.467207 run-command.c:626       trace: run_command: 'git-lfs' 'locks'
12:35:03.469551 trace git-lfs: run_command: 'git' version
12:35:03.471019 trace git-lfs: run_command: 'git' config -l
12:35:03.471975 trace git-lfs: HTTP: GET https://github.com/rubyist/tracerx.git/info/lfs/locks
12:35:03.794442 trace git-lfs: HTTP: 200
12:35:03.796144 trace git-lfs: HTTP: {"locks":[],"next_cursor":""}
```