### PR TITLE
lfsapi: retry requests changing access from none IF Auth header is empty

### DIFF
--- a/lfsapi/auth.go
+++ b/lfsapi/auth.go
@@ -49,10 +49,10 @@ func (c *Client) DoWithAuth(remote string, req *http.Request) (*http.Response, e
 				c.Endpoints.SetAccess(apiEndpoint.Url, newAccess)
 			}
 
-			if access == NoneAccess || creds != nil {
+			if creds != nil || (access == NoneAccess && len(req.Header.Get("Authorization")) == 0) {
 				tracerx.Printf("api: http response indicates %q authentication. Resubmitting...", newAccess)
-				req.Header.Del("Authorization")
 				if creds != nil {
+					req.Header.Del("Authorization")
 					credHelper.Reject(creds)
 				}
 				return c.DoWithAuth(remote, req)


### PR DESCRIPTION
This fixes an inconsistency in the first auth attempt vs subsequent auth attempts, as described in https://github.com/git-lfs/git-lfs/issues/2618#issuecomment-332593686. There's a quirk where if `ssh git-lfs-authenticate` returns a bad `Authorization` header, LFS will only ask for credentials on the first attempt. This is because it notices the `lfs.<url>.access` is empty, and changes it from `nil` to `basic`. Subsequent attempts already have `lfs.<url>.access` set, so it never asks your git credential helper.

LFS accepts auth from the following sources (in order of preference). Some methods are set according to the Git config, and can't be changed during an LFS command.

* `(*lfsapi.Client) NewRequest()` calls `ssh git-lfs-authenticate` for SSH git remotes. This response can return an `Authorization` header.

https://github.com/git-lfs/git-lfs/blob/master/lfsapi/client.go#L30-L60

* The remote could point to an https url with embedded credentials.
* The user could have a netrc file.
* Git can ask, if `GIT_ASKPASS` is configured.
* Git can ask, using a credential helper to cache it, if configured.

Of these, the only thing that LFS can effectively retry is when the git credential helper is used. Otherwise, every API request will have to be made multiple times because the default configured passwords (from ssh, the remote url, or netrc) are wrong.

* If `ssh git-lfs-authenticate` is returning bad credentials, it should be fixed with the ssh command.
* If the remote contains incorrect embedded `user@pass` credentials, it should be fixed in the git config.
* If netrc credentials are incorrect, it should be fixed.