### PR TITLE
don't replace pointers with objects if clean filter is not configured

### DIFF
--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"fmt"
+
 	"github.com/git-lfs/git-lfs/filepathfilter"
 	"github.com/git-lfs/git-lfs/git"
 	"github.com/git-lfs/git-lfs/lfs"
@@ -13,6 +15,12 @@ func checkoutCommand(cmd *cobra.Command, args []string) {
 	ref, err := git.CurrentRef()
 	if err != nil {
 		Panic(err, "Could not checkout")
+	}
+
+	singleCheckout := newSingleCheckout(cfg.Git, "")
+	if singleCheckout.Skip() {
+		fmt.Println("Cannot checkout LFS objects, Git LFS is not installed.")
+		return
 	}
 
 	var totalBytes int64
@@ -37,7 +45,6 @@ func checkoutCommand(cmd *cobra.Command, args []string) {
 	}
 	chgitscanner.Close()
 
-	singleCheckout := newSingleCheckout()
 	meter.Start()
 	for _, p := range pointers {
 		singleCheckout.Run(p)

--- a/commands/pull.go
+++ b/commands/pull.go
@@ -20,12 +20,10 @@ import (
 func newSingleCheckout(gitEnv config.Environment, remote string) abstractCheckout {
 	manifest := getTransferManifestOperationRemote("download", remote)
 
-	//
 	clean, ok := gitEnv.Get("filter.lfs.clean")
 	if !ok || len(clean) == 0 {
 		return &noOpCheckout{manifest: manifest}
 	}
-	// */
 
 	// Get a converter from repo-relative to cwd-relative
 	// Since writing data & calling git update-index must be relative to cwd

--- a/test/test-clone.sh
+++ b/test/test-clone.sh
@@ -369,8 +369,6 @@ begin_test "clone (with .lfsconfig)"
   contents_b_oid=$(calc_oid "$contents_b")
   printf "$contents_b" > "b.dat"
 
-
-
   git add a.dat b.dat .gitattributes
   git commit -m "add a.dat, b.dat" 2>&1 | tee commit.log
   grep "master (root-commit)" commit.log
@@ -457,6 +455,53 @@ begin_test "clone (with .lfsconfig)"
 )
 end_test
 
+begin_test "clone (without clean filter)"
+(
+  set -e
+
+  reponame="clone_with_clean"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.dat" 2>&1 | tee track.log
+  grep "Tracking \"\*.dat\"" track.log
+
+  contents_a="a"
+  contents_a_oid=$(calc_oid "$contents_a")
+  printf "$contents_a" > "a.dat"
+
+  git add *.dat .gitattributes
+  git commit -m "add a.dat, b.dat" 2>&1 | tee commit.log
+  grep "master (root-commit)" commit.log
+
+  git push origin master 2>&1 | tee push.log
+  grep "master -> master" push.log
+  grep "Git LFS: (1 of 1 files)" push.log
+
+  cd "$TRASHDIR"
+
+  git lfs uninstall
+  git config --list > config.txt
+  grep "filter.lfs.clean" config.txt && {
+    echo "clean filter still configured:"
+    cat config.txt
+    exit 1
+  }
+
+  local_reponame="clone_without_clean"
+  git lfs clone "$GITSERVER/$reponame" "$local_reponame" -I "a*.dat" | tee clone.txt
+  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected clone to succeed ..."
+    exit 1
+  fi
+  grep "Git LFS is not installed" clone.txt
+
+  cd "$local_reponame"
+  assert_local_object "$contents_a_oid" 1
+  [ "$(pointer $contents_a_oid 1)" = "$(cat a.dat)" ]
+)
+end_test
+
 begin_test "clone with submodules"
 (
   set -e
@@ -481,7 +526,6 @@ begin_test "clone with submodules"
   git commit -m "Nested submodule level 2"
   git push origin master
 
-
   clone_repo "$submodname1" submod1
   git lfs track "*.dat" 2>&1 | tee track.log
   grep "Tracking \"\*.dat\"" track.log
@@ -495,7 +539,6 @@ begin_test "clone with submodules"
   git add sub2 sub1.dat .gitattributes
   git commit -m "Nested submodule level 1"
   git push origin master
-
 
   clone_repo "$reponame" rootrepo
   git lfs track "*.dat" 2>&1 | tee track.log
@@ -530,10 +573,7 @@ begin_test "clone with submodules"
   assert_local_object "$contents_sub2_oid" "${#contents_sub2}"
   [ $(wc -c < "sub2.dat") -eq ${#contents_sub2} ]
 
-
   popd
-
-
 )
 end_test
 


### PR DESCRIPTION
This prevents LFS from replacing LFS pointers with the actual content if the `clean` filter is not configured. Otherwise, this leads to a dirty `git status`. Fixes #2472