### PR TITLE
better Netrc errors

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -81,6 +81,15 @@ func getAPIClient() *lfsapi.Client {
 	return apiClient
 }
 
+func closeAPIClient() error {
+	global.Lock()
+	defer global.Unlock()
+	if apiClient == nil {
+		return nil
+	}
+	return apiClient.Close()
+}
+
 func newLockClient(remote string) *locking.Client {
 	storageConfig := config.Config.StorageConfig()
 	lockClient, err := locking.NewClient(remote, getAPIClient())

--- a/commands/run.go
+++ b/commands/run.go
@@ -66,7 +66,7 @@ func Run() {
 	}
 
 	root.Execute()
-	getAPIClient().Close()
+	closeAPIClient()
 }
 
 func gitlfsCommand(cmd *cobra.Command, args []string) {

--- a/lfsapi/lfsapi.go
+++ b/lfsapi/lfsapi.go
@@ -64,9 +64,9 @@ func NewClient(osEnv Env, gitEnv Env) (*Client, error) {
 		gitEnv = make(TestEnv)
 	}
 
-	netrc, err := ParseNetrc(osEnv)
+	netrc, netrcfile, err := ParseNetrc(osEnv)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, fmt.Sprintf("bad netrc file %s", netrcfile))
 	}
 
 	httpsProxy, httpProxy, noProxy := getProxyServers(osEnv, gitEnv)

--- a/lfsapi/netrc.go
+++ b/lfsapi/netrc.go
@@ -11,18 +11,19 @@ type NetrcFinder interface {
 	FindMachine(string) *netrc.Machine
 }
 
-func ParseNetrc(osEnv Env) (NetrcFinder, error) {
+func ParseNetrc(osEnv Env) (NetrcFinder, string, error) {
 	home, _ := osEnv.Get("HOME")
 	if len(home) == 0 {
-		return &noFinder{}, nil
+		return &noFinder{}, "", nil
 	}
 
 	nrcfilename := filepath.Join(home, netrcBasename)
 	if _, err := os.Stat(nrcfilename); err != nil {
-		return &noFinder{}, nil
+		return &noFinder{}, nrcfilename, nil
 	}
 
-	return netrc.ParseFile(nrcfilename)
+	f, err := netrc.ParseFile(nrcfilename)
+	return f, nrcfilename, err
 }
 
 type noFinder struct{}


### PR DESCRIPTION
Fixes #2624 

BEFORE:

```sh
$ git lfs fetch
line 1: keyword expected; got maachine
```

AFTER:

```sh
$ script/run fetch
bad netrc file /Users/rick/.netrc: line 1: keyword expected; got maachine
exit status 2
```

This includes a bonus tweak that doesn't initialize an api client unless it's needed. So `lfs version` won't trigger the error. You'll have to run something like `git lfs fetch`.