### PR TITLE
only use askpass if credential.helper is not configured

### DIFF
--- a/lfsapi/creds.go
+++ b/lfsapi/creds.go
@@ -22,6 +22,8 @@ type credsConfig struct {
 	// See: https://git-scm.com/docs/gitcredentials#_requesting_credentials
 	// for more.
 	AskPass string `os:"GIT_ASKPASS" git:"core.askpass" os:"SSH_ASKPASS"`
+	// Helper is a string defining the credential helper that Git should use.
+	Helper string `git:"credential.helper"`
 	// Cached is a boolean determining whether or not to enable the
 	// credential cacher.
 	Cached bool `git:"lfs.cachecredentials"`
@@ -42,7 +44,7 @@ func getCredentialHelper(cfg *config.Configuration) (CredentialHelper, error) {
 	}
 
 	var hs []CredentialHelper
-	if len(ccfg.AskPass) > 0 {
+	if len(ccfg.Helper) == 0 && len(ccfg.AskPass) > 0 {
 		hs = append(hs, &AskPassCredentialHelper{
 			Program: ccfg.AskPass,
 		})
@@ -118,7 +120,7 @@ func (h CredentialHelpers) Reject(what Creds) error {
 }
 
 // Approve implements CredentialHelper.Approve and approves the given Creds
-// "what" amongst all knonw CredentialHelpers. If any `CredentialHelper`s
+// "what" amongst all known CredentialHelpers. If any `CredentialHelper`s
 // returned a non-nil error, no further `CredentialHelper`s are notified, so as
 // to prevent inconsistent state.
 func (h CredentialHelpers) Approve(what Creds) error {

--- a/test/test-askpass.sh
+++ b/test/test-askpass.sh
@@ -19,6 +19,7 @@ begin_test "askpass: push with GIT_ASKPASS"
   # $password is defined from test/cmd/lfstest-gitserver.go (see: skipIfBadAuth)
   export LFS_ASKPASS_USERNAME="user"
   export LFS_ASKPASS_PASSWORD="pass"
+  git config "credential.helper" ""
   GIT_ASKPASS="lfs-askpass" SSH_ASKPASS="dont-call-me" GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push origin master 2>&1 | tee push.log
 
   GITSERVER_USER="$(printf $GITSERVER | sed -e 's/http:\/\//http:\/\/user@/')"
@@ -53,6 +54,7 @@ begin_test "askpass: push with core.askPass"
 
   # $password is defined from test/cmd/lfstest-gitserver.go (see: skipIfBadAuth)
   export LFS_ASKPASS_PASSWORD="pass"
+  git config "credential.helper" ""
   git config "core.askPass" "lfs-askpass"
   cat .git/config
   SSH_ASKPASS="dont-call-me" GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push origin master 2>&1 | tee push.log
@@ -90,6 +92,7 @@ begin_test "askpass: push with SSH_ASKPASS"
   # $password is defined from test/cmd/lfstest-gitserver.go (see: skipIfBadAuth)
   export LFS_ASKPASS_USERNAME="user"
   export LFS_ASKPASS_PASSWORD="pass"
+  git config "credential.helper" ""
   SSH_ASKPASS="lfs-askpass" GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push origin master 2>&1 | tee push.log
 
   GITSERVER_USER="$(printf $GITSERVER | sed -e 's/http:\/\//http:\/\/user@/')"


### PR DESCRIPTION
Fixes #2634. May change if the consensus reached in #2634 changes.