### PR TITLE
add files to index with path relative to current dir

### DIFF
--- a/commands/pull.go
+++ b/commands/pull.go
@@ -38,8 +38,10 @@ type singleCheckout struct {
 }
 
 func (c *singleCheckout) Run(p *lfs.WrappedPointer) {
+	cwdfilepath := c.pathConverter.Convert(p.Name)
+
 	// Check the content - either missing or still this pointer (not exist is ok)
-	filepointer, err := lfs.DecodePointerFromFile(p.Name)
+	filepointer, err := lfs.DecodePointerFromFile(cwdfilepath)
 	if err != nil && !os.IsNotExist(err) {
 		if errors.IsNotAPointerError(err) {
 			// File has non-pointer content, leave it alone
@@ -55,8 +57,6 @@ func (c *singleCheckout) Run(p *lfs.WrappedPointer) {
 		// while leaving it a pointer; don't mess with this
 		return
 	}
-
-	cwdfilepath := c.pathConverter.Convert(p.Name)
 
 	err = lfs.PointerSmudgeToFile(cwdfilepath, p.Pointer, false, c.manifest, nil)
 	if err != nil {

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -238,6 +238,14 @@ assert_hooks() {
   [ -x "$git_root/hooks/pre-push" ]
 }
 
+assert_clean_status() {
+  status="$(git status)"
+  echo "$status" | grep "working tree clean" || {
+    echo $status
+    git lfs status
+  }
+}
+
 # pointer returns a string Git LFS pointer file.
 #
 #   $ pointer abc-some-oid 123 <version>
@@ -339,7 +347,6 @@ clone_repo_url() {
   echo "$out" > clone.log
   echo "$out"
 }
-
 
 # clone_repo_ssl clones a repository from the test Git server to the subdirectory
 # $dir under $TRASHDIR, using the SSL endpoint.


### PR DESCRIPTION
Fixes #2639 by ensuring files are added to the git index with a path relative to the current working directory.