### PR TITLE
ensure files are marked readonly after unlocking by ID

### DIFF
--- a/locking/lockable.go
+++ b/locking/lockable.go
@@ -39,7 +39,6 @@ func (c *Client) ensureLockablesLoaded() {
 // Internal function to repopulate lockable patterns
 // You must have locked the c.lockableMutex in the caller
 func (c *Client) refreshLockablePatterns() {
-
 	paths := git.GetAttributePaths(c.LocalWorkingDir, c.LocalGitDir)
 	// Always make non-nil even if empty
 	c.lockablePatterns = make([]string, 0, len(paths))

--- a/test/test-unlock.sh
+++ b/test/test-unlock.sh
@@ -34,7 +34,7 @@ begin_test "unlocking a file makes it readonly"
 )
 end_test
 
-begin_test "unlocking a file makes ignores readonly"
+begin_test "unlocking a file ignores readonly"
 (
   set -e
 
@@ -99,15 +99,16 @@ begin_test "unlocking a lock by id"
   set -e
 
   reponame="unlock_by_id"
-  setup_remote_repo_with_file "unlock_by_id" "d.dat"
+  setup_remote_repo_with_file "$reponame" "d.dat"
 
   git lfs lock --json "d.dat" | tee lock.log
+  assert_file_writeable d.dat
 
   id=$(assert_lock lock.log d.dat)
   assert_server_lock "$reponame" "$id"
 
   git lfs unlock --id="$id"
-  refute_server_lock "$reponame" "$id"
+  refute_file_writeable d.dat
 )
 end_test
 


### PR DESCRIPTION
Fixes #2640 by moving the file permission logic from `UnlockFile()` to `UnlockFileById()`. The path is taken from the `lock` property returned by the `/unlock` api endpoint.

```sh
$ GIT_CURL_VERBOSE=1 git lfs unlock --id=123
> POST /my-repo.git/info/lfs/locks/123/unlock HTTP/1.1
> Host: github.com
> Accept: application/vnd.git-lfs+json; charset=utf-8
> Authorization: Basic * * * * *
> Content-Length: 15
> Content-Type: application/vnd.git-lfs+json; charset=utf-8
> User-Agent: git-lfs/2.3.1 (GitHub; darwin amd64; go 1.9)
>
{"force":false}

< HTTP/1.1 200 OK
< Content-Length: 141
< Content-Type: application/vnd.git-lfs+json
< Date: Tue, 03 Oct 2017 17:11:25 GMT
< X-Frame-Options: DENY
< X-Github-Request-Id: FF7E:5D17:5AA5486:AB0C1BC:59D3C4BD
<
{"lock":{"id":"123","path":"my-file.zip","locked_at":"2017-10-03T17:11:09Z","unlocked_at":"2017-10-03T17:11:25.692648804Z"}}
Unlocked Lock 123
```