### PR TITLE
potentially invoke lfs for 'git update-index'

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -459,7 +459,7 @@ func DefaultRemote() (string, error) {
 }
 
 func UpdateIndexFromStdin() *subprocess.Cmd {
-	return gitNoLFS("update-index", "-q", "--refresh", "--stdin")
+	return git("update-index", "-q", "--refresh", "--stdin")
 }
 
 type gitConfig struct {

--- a/test/test-clone.sh
+++ b/test/test-clone.sh
@@ -123,7 +123,7 @@ begin_test "cloneSSL"
 
   newclonedir="testcloneSSL1"
   git lfs clone "$SSLGITSERVER/$reponame" "$newclonedir" 2>&1 | tee lfsclone.log
-  #assert_clean_status
+  assert_clean_status
   grep "Cloning into" lfsclone.log
   grep "Git LFS:" lfsclone.log
   # should be no filter errors

--- a/test/test-clone.sh
+++ b/test/test-clone.sh
@@ -55,12 +55,14 @@ begin_test "clone"
 
   # check a few file sizes to make sure pulled
   pushd "$newclonedir"
-  [ $(wc -c < "file1.dat") -eq 110 ]
-  [ $(wc -c < "file2.dat") -eq 75 ]
-  [ $(wc -c < "file3.dat") -eq 66 ]
-  assert_hooks "$(dot_git_dir)"
-  [ ! -e "lfs" ]
+    [ $(wc -c < "file1.dat") -eq 110 ]
+    [ $(wc -c < "file2.dat") -eq 75 ]
+    [ $(wc -c < "file3.dat") -eq 66 ]
+    assert_hooks "$(dot_git_dir)"
+    [ ! -e "lfs" ]
+    assert_clean_status
   popd
+
   # Now check clone with implied dir
   rm -rf "$reponame"
   git lfs clone "$GITSERVER/$reponame" 2>&1 | tee lfsclone.log
@@ -71,12 +73,14 @@ begin_test "clone"
   [ ! $(grep "error" lfsclone.log) ]
   # clone location should be implied
   [ -d "$reponame" ]
+
   pushd "$reponame"
-  [ $(wc -c < "file1.dat") -eq 110 ]
-  [ $(wc -c < "file2.dat") -eq 75 ]
-  [ $(wc -c < "file3.dat") -eq 66 ]
-  assert_hooks "$(dot_git_dir)"
-  [ ! -e "lfs" ]
+    [ $(wc -c < "file1.dat") -eq 110 ]
+    [ $(wc -c < "file2.dat") -eq 75 ]
+    [ $(wc -c < "file3.dat") -eq 66 ]
+    assert_hooks "$(dot_git_dir)"
+    [ ! -e "lfs" ]
+    assert_clean_status
   popd
 
 )
@@ -119,6 +123,7 @@ begin_test "cloneSSL"
 
   newclonedir="testcloneSSL1"
   git lfs clone "$SSLGITSERVER/$reponame" "$newclonedir" 2>&1 | tee lfsclone.log
+  #assert_clean_status
   grep "Cloning into" lfsclone.log
   grep "Git LFS:" lfsclone.log
   # should be no filter errors
@@ -188,10 +193,11 @@ begin_test "clone ClientCert"
 
   # check a few file sizes to make sure pulled
   pushd "$newclonedir"
-  [ $(wc -c < "file1.dat") -eq 100 ]
-  [ $(wc -c < "file2.dat") -eq 75 ]
-  [ $(wc -c < "file3.dat") -eq 30 ]
-  assert_hooks "$(dot_git_dir)"
+    [ $(wc -c < "file1.dat") -eq 100 ]
+    [ $(wc -c < "file2.dat") -eq 75 ]
+    [ $(wc -c < "file3.dat") -eq 30 ]
+    assert_hooks "$(dot_git_dir)"
+    assert_clean_status
   popd
 
 

--- a/test/test-pull.sh
+++ b/test/test-pull.sh
@@ -87,34 +87,40 @@ begin_test "pull"
   [ "A" = "$(cat "á.dat")" ]
   assert_local_object "$contents_oid" 1
   assert_local_object "$contents2_oid" 1
+  assert_clean_status
 
   echo "lfs pull with local storage"
   rm a.dat á.dat
   git lfs pull
   [ "a" = "$(cat a.dat)" ]
   [ "A" = "$(cat "á.dat")" ]
+  assert_clean_status
 
   echo "lfs pull with include/exclude filters in gitconfig"
   rm -rf .git/lfs/objects
   git config "lfs.fetchinclude" "a*"
   git lfs pull
   assert_local_object "$contents_oid" 1
+  assert_clean_status
 
   rm -rf .git/lfs/objects
   git config --unset "lfs.fetchinclude"
   git config "lfs.fetchexclude" "a*"
   git lfs pull
   refute_local_object "$contents_oid"
+  assert_clean_status
 
   echo "lfs pull with include/exclude filters in command line"
   git config --unset "lfs.fetchexclude"
   rm -rf .git/lfs/objects
   git lfs pull --include="a*"
   assert_local_object "$contents_oid" 1
+  assert_clean_status
 
   rm -rf .git/lfs/objects
   git lfs pull --exclude="a*"
   refute_local_object "$contents_oid"
+  assert_clean_status
 
   echo "resetting to test status"
   git reset --hard


### PR DESCRIPTION
Brings LFS back for `git update-index` calls. This fixes issues where `git status` is unclean after a `git lfs pull` or `git lfs clone`.

/cc https://github.com/git-lfs/git-lfs/issues/2646#issuecomment-334204675