### PR TITLE
cache http credential helper output by default

### DIFF
--- a/lfsapi/creds.go
+++ b/lfsapi/creds.go
@@ -26,7 +26,7 @@ type credsConfig struct {
 	Helper string `git:"credential.helper"`
 	// Cached is a boolean determining whether or not to enable the
 	// credential cacher.
-	Cached bool `git:"lfs.cachecredentials"`
+	Cached bool
 	// SkipPrompt is a boolean determining whether or not to prompt the user
 	// for a password.
 	SkipPrompt bool `os:"GIT_TERMINAL_PROMPT"`
@@ -72,12 +72,15 @@ func getCredentialHelper(cfg *config.Configuration) (CredentialHelper, error) {
 // getCredentialConfig parses a *credsConfig given the OS and Git
 // configurations.
 func getCredentialConfig(cfg *config.Configuration) (*credsConfig, error) {
-	var what credsConfig
+	what := &credsConfig{
+		Cached: cfg.Git.Bool("lfs.cachecredentials", true),
+	}
 
-	if err := cfg.Unmarshal(&what); err != nil {
+	if err := cfg.Unmarshal(what); err != nil {
 		return nil, err
 	}
-	return &what, nil
+
+	return what, nil
 }
 
 // CredentialHelpers is a []CredentialHelper that iterates through each


### PR DESCRIPTION
#2508 enabled credential caching for SSH. This enables it for http requests that go through `git-credential` or GIT_ASKPASS.

The struct tag notation for git config values doesn't support setting a default value. So, this uses the `Bool()` method, which does accept a default.