### PR TITLE
add support for url-specific proxies

### DIFF
--- a/lfsapi/lfsapi.go
+++ b/lfsapi/lfsapi.go
@@ -30,9 +30,6 @@ type Client struct {
 	KeepaliveTimeout    int
 	TLSTimeout          int
 	ConcurrentTransfers int
-	HTTPSProxy          string
-	HTTPProxy           string
-	NoProxy             string
 	SkipSSLVerify       bool
 
 	Verbose          bool
@@ -69,8 +66,6 @@ func NewClient(osEnv Env, gitEnv Env) (*Client, error) {
 		return nil, errors.Wrap(err, fmt.Sprintf("bad netrc file %s", netrcfile))
 	}
 
-	httpsProxy, httpProxy, noProxy := getProxyServers(osEnv, gitEnv)
-
 	creds, err := getCredentialHelper(&config.Configuration{
 		Os: osEnv, Git: gitEnv})
 	if err != nil {
@@ -94,9 +89,6 @@ func NewClient(osEnv Env, gitEnv Env) (*Client, error) {
 		SkipSSLVerify:       !gitEnv.Bool("http.sslverify", true) || osEnv.Bool("GIT_SSL_NO_VERIFY", false),
 		Verbose:             osEnv.Bool("GIT_CURL_VERBOSE", false),
 		DebuggingVerbose:    osEnv.Bool("LFS_DEBUG_HTTP", false),
-		HTTPSProxy:          httpsProxy,
-		HTTPProxy:           httpProxy,
-		NoProxy:             noProxy,
 		gitEnv:              gitEnv,
 		osEnv:               osEnv,
 		uc:                  config.NewURLConfig(gitEnv),

--- a/lfsapi/proxy.go
+++ b/lfsapi/proxy.go
@@ -5,16 +5,16 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/git-lfs/git-lfs/config"
+
 	"fmt"
 )
 
 // Logic is copied, with small changes, from "net/http".ProxyFromEnvironment in the go std lib.
 func proxyFromClient(c *Client) func(req *http.Request) (*url.URL, error) {
-	httpProxy := c.HTTPProxy
-	httpsProxy := c.HTTPSProxy
-	noProxy := c.NoProxy
-
 	return func(req *http.Request) (*url.URL, error) {
+		httpsProxy, httpProxy, noProxy := getProxyServers(req.URL, c.uc, c.osEnv)
+
 		var proxy string
 		if req.URL.Scheme == "https" {
 			proxy = httpsProxy
@@ -48,11 +48,16 @@ func proxyFromClient(c *Client) func(req *http.Request) (*url.URL, error) {
 	}
 }
 
-func getProxyServers(osEnv Env, gitEnv Env) (string, string, string) {
-	var httpsProxy string
-	httpProxy, _ := gitEnv.Get("http.proxy")
-	if strings.HasPrefix(httpProxy, "https://") {
-		httpsProxy = httpProxy
+func getProxyServers(u *url.URL, urlCfg *config.URLConfig, osEnv Env) (httpsProxy string, httpProxy string, noProxy string) {
+	if urlCfg != nil {
+		httpProxy, _ = urlCfg.Get("http", u.String(), "proxy")
+		if strings.HasPrefix(httpProxy, "https://") {
+			httpsProxy = httpProxy
+		}
+	}
+
+	if osEnv == nil {
+		return
 	}
 
 	if len(httpsProxy) == 0 {
@@ -71,12 +76,12 @@ func getProxyServers(osEnv Env, gitEnv Env) (string, string, string) {
 		httpProxy, _ = osEnv.Get("http_proxy")
 	}
 
-	noProxy, _ := osEnv.Get("NO_PROXY")
+	noProxy, _ = osEnv.Get("NO_PROXY")
 	if len(noProxy) == 0 {
 		noProxy, _ = osEnv.Get("no_proxy")
 	}
 
-	return httpsProxy, httpProxy, noProxy
+	return
 }
 
 // canonicalAddr returns url.Host but always with a ":port" suffix


### PR DESCRIPTION
This uses `config.URLConfig` to get host-specific proxy settings like `http.{url}.proxy`. Fixes #2644.