### PR TITLE
Install tweaks

### DIFF
--- a/commands/command_install.go
+++ b/commands/command_install.go
@@ -25,8 +25,9 @@ func installCommand(cmd *cobra.Command, args []string) {
 	}
 
 	if err := lfs.InstallFilters(opt, skipSmudgeInstall); err != nil {
-		Error(err.Error())
-		Exit("Run `git lfs install --force` to reset git config.")
+		Print("WARNING: %s", err.Error())
+		Print("Run `git lfs install --force` to reset git config.")
+		return
 	}
 
 	if !skipRepoInstall && (localInstall || lfs.InRepo()) {

--- a/lfs/attribute.go
+++ b/lfs/attribute.go
@@ -78,21 +78,15 @@ func (a *Attribute) set(key, value string, upgradeables []string, opt InstallOpt
 	if opt.Force || shouldReset(currentValue, upgradeables) {
 		var err error
 		if opt.Local {
-			// ignore error for unset, git returns non-zero if missing
-			git.Config.UnsetLocalKey("", key)
 			_, err = git.Config.SetLocal("", key, value)
 		} else if opt.System {
-			// ignore error for unset, git returns non-zero if missing
-			git.Config.UnsetSystem(key)
 			_, err = git.Config.SetSystem(key, value)
 		} else {
-			// ignore error for unset, git returns non-zero if missing
-			git.Config.UnsetGlobal(key)
 			_, err = git.Config.SetGlobal(key, value)
 		}
 		return err
 	} else if currentValue != value {
-		return fmt.Errorf("The %s attribute should be %q but is %q",
+		return fmt.Errorf("The %q attribute should be %q but is %q",
 			key, value, currentValue)
 	}
 

--- a/lfs/setup.go
+++ b/lfs/setup.go
@@ -28,6 +28,22 @@ var (
 		postMergeHook,
 	}
 
+	upgradeables = map[string][]string{
+		"clean": []string{"git-lfs clean %f"},
+		"smudge": []string{
+			"git-lfs smudge %f",
+			"git-lfs smudge --skip %f",
+			"git-lfs smudge -- %f",
+			"git-lfs smudge --skip -- %f",
+		},
+		"process": []string{
+			"git-lfs filter",
+			"git-lfs filter --skip",
+			"git-lfs filter-process",
+			"git-lfs filter-process --skip",
+		},
+	}
+
 	filters = &Attribute{
 		Section: "filter.lfs",
 		Properties: map[string]string{
@@ -36,11 +52,7 @@ var (
 			"process":  "git-lfs filter-process",
 			"required": "true",
 		},
-		Upgradeables: map[string][]string{
-			"clean":   []string{"git-lfs clean %f"},
-			"smudge":  []string{"git-lfs smudge %f"},
-			"process": []string{"git-lfs filter"},
-		},
+		Upgradeables: upgradeables,
 	}
 
 	passFilters = &Attribute{
@@ -51,11 +63,7 @@ var (
 			"process":  "git-lfs filter-process --skip",
 			"required": "true",
 		},
-		Upgradeables: map[string][]string{
-			"clean":   []string{"git-lfs clean %f"},
-			"smudge":  []string{"git-lfs smudge --skip %f"},
-			"process": []string{"git-lfs filter --skip"},
-		},
+		Upgradeables: upgradeables,
 	}
 )
 

--- a/test/test-install.sh
+++ b/test/test-install.sh
@@ -29,15 +29,10 @@ begin_test "install with old (non-upgradeable) settings"
   git config --global filter.lfs.smudge "git-lfs smudge --something %f"
   git config --global filter.lfs.clean "git-lfs clean --something %f"
 
-  set +e
-  git lfs install 2> install.log
-  res=$?
-  set -e
+  git lfs install | tee install.log
+  [ "${PIPESTATUS[0]}" = 0 ]
 
-  [ "$res" = 2 ]
-
-  cat install.log
-  grep -E "(clean|smudge) attribute should be" install.log
+  grep -E "(clean|smudge)\" attribute should be" install.log
   [ `grep -c "(MISSING)" install.log` = "0" ]
 
   [ "git-lfs smudge --something %f" = "$(git config --global filter.lfs.smudge)" ]

--- a/test/test-install.sh
+++ b/test/test-install.sh
@@ -194,7 +194,7 @@ begin_test "install --skip-smudge"
   [ "git-lfs smudge --skip -- %f" = "$(git config --global filter.lfs.smudge)" ]
   [ "git-lfs filter-process --skip" = "$(git config --global filter.lfs.process)" ]
 
-  git lfs install --force
+  git lfs install
   [ "git-lfs clean -- %f" = "$(git config --global filter.lfs.clean)" ]
   [ "git-lfs smudge -- %f" = "$(git config --global filter.lfs.smudge)" ]
   [ "git-lfs filter-process" = "$(git config --global filter.lfs.process)" ]


### PR DESCRIPTION
Fixes #2670. This PR fixes two common, but not fatal, problems that can arise when running `git lfs install`:

1. The values from `git lfs install --skip-smudge` can not be upgraded with `git lfs install`
2. An unexpected config value should not be overwritten. Instead, print a warning _without changing the exit code_. This way installations don't fail, but a user is told if their config values are unexpected.