### PR TITLE
test: generate random repo names with fs-safe characters

### DIFF
--- a/test/test-migrate-fixtures.sh
+++ b/test/test-migrate-fixtures.sh
@@ -198,7 +198,7 @@ make_bare() {
 #
 #   remove_and_create_local_repo "$reponame"
 remove_and_create_local_repo() {
-  local reponame="$(base64 < /dev/urandom | head -c 8 | sed -e 's/\///')-$1"
+  local reponame="$(base64 < /dev/urandom | head -c 8 | $SHASUM | cut -f 1 -d ' ')-$1"
 
   git init "$reponame"
   cd "$reponame"
@@ -209,7 +209,7 @@ remove_and_create_local_repo() {
 #
 #   remove_and_create_remote_repo "$reponame"
 remove_and_create_remote_repo() {
-  local reponame="$(base64 < /dev/urandom | head -c 8 | sed -e 's/\///')-$1"
+  local reponame="$(base64 < /dev/urandom | head -c 8 | $SHASUM | cut -f 1 -d ' ')-$1"
 
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"


### PR DESCRIPTION
This should fix the rare intermittent test failures. Sometimes `base64` generates strings that some OS's won't allow as directory names. This PR runs the content through `shasum -a 256` to ensure the random filename only consists of hex characters.

[Sample failure](https://circleci.com/gh/git-lfs/git-lfs/2489?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link):

```
test: migrate info (--everything with --include-ref) ...           FAILED
-- stdout --
-- stderr --
    + set -e
    + setup_multiple_local_branches
    + set -e
    + reponame=migrate-info-multiple-local-branches
    + remove_and_create_local_repo migrate-info-multiple-local-branches
    ++ base64
    ++ head -c 8
    ++ sed -e 's/\///'
    + local reponame=/oxVeYF-migrate-info-multiple-local-branches
    + git init /oxVeYF-migrate-info-multiple-local-branches
    fatal: cannot mkdir /oxVeYF-migrate-info-multiple-local-branches: Permission denied
    + test_status=128
-- git trace --
   trace: built-in: git 'init' '/oxVeYF-migrate-info-multiple-local-branches'
```