### PR TITLE
lfs: PointerScanner is nil after error, so don't close

### DIFF
--- a/lfs/gitscanner_catfilebatch.go
+++ b/lfs/gitscanner_catfilebatch.go
@@ -19,8 +19,6 @@ import (
 func runCatFileBatch(pointerCh chan *WrappedPointer, lockableCh chan string, lockableSet *lockableNameSet, revs *StringChannelWrapper, errCh chan error) error {
 	scanner, err := NewPointerScanner()
 	if err != nil {
-		scanner.Close()
-
 		return err
 	}
 


### PR DESCRIPTION
There's no need to close the scanner if `NewPointerScanner()` returns an error, since it returns a `nil` scanner:

https://github.com/git-lfs/git-lfs/blob/d039e3791aca6100a0e0944cc7f46d1f4d0f047b/lfs/gitscanner_catfilebatch.go#L69-L76

This also fits with common go conventions.