### PR TITLE
Tracked remote

### DIFF
--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -86,7 +86,7 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 		filter := buildFilepathFilter(cfg, includeArg, excludeArg)
 		if cloneFlags.NoCheckout || cloneFlags.Bare {
 			// If --no-checkout or --bare then we shouldn't check out, just fetch instead
-			cfg.CurrentRemote = remote
+			cfg.SetRemote(remote)
 			fetchRef(ref.Name, filter)
 		} else {
 			pull(remote, filter)

--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -72,13 +72,9 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 
 	requireInRepo()
 
-	// Now just call pull with default args
 	// Support --origin option to clone
-	var remote string
 	if len(cloneFlags.Origin) > 0 {
-		remote = cloneFlags.Origin
-	} else {
-		remote = "origin"
+		cfg.SetRemote(cloneFlags.Origin)
 	}
 
 	if ref, err := git.CurrentRef(); err == nil {
@@ -86,10 +82,9 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 		filter := buildFilepathFilter(cfg, includeArg, excludeArg)
 		if cloneFlags.NoCheckout || cloneFlags.Bare {
 			// If --no-checkout or --bare then we shouldn't check out, just fetch instead
-			cfg.SetRemote(remote)
 			fetchRef(ref.Name, filter)
 		} else {
-			pull(remote, filter)
+			pull(filter)
 			err := postCloneSubmodules(args)
 			if err != nil {
 				Exit("Error performing 'git lfs pull' for submodules: %v", err)

--- a/commands/command_env.go
+++ b/commands/command_env.go
@@ -9,7 +9,7 @@ import (
 
 func envCommand(cmd *cobra.Command, args []string) {
 	config.ShowConfigWarnings = true
-	endpoint := getAPIClient().Endpoints.Endpoint("download", cfg.CurrentRemote)
+	endpoint := getAPIClient().Endpoints.Endpoint("download", cfg.Remote())
 
 	gitV, err := git.Version()
 	if err != nil {

--- a/commands/command_env.go
+++ b/commands/command_env.go
@@ -9,7 +9,6 @@ import (
 
 func envCommand(cmd *cobra.Command, args []string) {
 	config.ShowConfigWarnings = true
-	endpoint := getAPIClient().Endpoints.Endpoint("download", cfg.Remote())
 
 	gitV, err := git.Version()
 	if err != nil {
@@ -20,11 +19,14 @@ func envCommand(cmd *cobra.Command, args []string) {
 	Print(gitV)
 	Print("")
 
-	if len(endpoint.Url) > 0 {
-		access := getAPIClient().Endpoints.AccessFor(endpoint.Url)
-		Print("Endpoint=%s (auth=%s)", endpoint.Url, access)
-		if len(endpoint.SshUserAndHost) > 0 {
-			Print("  SSH=%s:%s", endpoint.SshUserAndHost, endpoint.SshPath)
+	if cfg.IsDefaultRemote() {
+		endpoint := getAPIClient().Endpoints.Endpoint("download", cfg.Remote())
+		if len(endpoint.Url) > 0 {
+			access := getAPIClient().Endpoints.AccessFor(endpoint.Url)
+			Print("Endpoint=%s (auth=%s)", endpoint.Url, access)
+			if len(endpoint.SshUserAndHost) > 0 {
+				Print("  SSH=%s:%s", endpoint.SshUserAndHost, endpoint.SshPath)
+			}
 		}
 	}
 

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -43,8 +43,6 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 			Exit("Invalid remote name %q", args[0])
 		}
 		cfg.SetRemote(args[0])
-	} else {
-		cfg.SetRemote("")
 	}
 
 	if len(args) > 1 {
@@ -268,16 +266,6 @@ func scanAll() []*lfs.WrappedPointer {
 // Fetch and report completion of each OID to a channel (optional, pass nil to skip)
 // Returns true if all completed with no errors, false if errors were written to stderr/log
 func fetchAndReportToChan(allpointers []*lfs.WrappedPointer, filter *filepathfilter.Filter, out chan<- *lfs.WrappedPointer) bool {
-	// Lazily initialize the current remote.
-	if len(cfg.Remote()) == 0 {
-		// Actively find the default remote, don't just assume origin
-		defaultRemote, err := cfg.GitConfig().DefaultRemote()
-		if err != nil {
-			Exit("No default remote")
-		}
-		cfg.SetRemote(defaultRemote)
-	}
-
 	ready, pointers, meter := readyAndMissingPointers(allpointers, filter)
 	q := newDownloadQueue(
 		getTransferManifestOperationRemote("download", cfg.Remote()),

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -39,10 +39,9 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 
 	if len(args) > 0 {
 		// Remote is first arg
-		if err := git.ValidateRemote(args[0]); err != nil {
-			Exit("Invalid remote name %q", args[0])
+		if err := cfg.SetValidRemote(args[0]); err != nil {
+			Exit("Invalid remote name %q: %s", args[0], err)
 		}
-		cfg.SetRemote(args[0])
 	}
 
 	if len(args) > 1 {

--- a/commands/command_filter_process.go
+++ b/commands/command_filter_process.go
@@ -69,8 +69,8 @@ func filterCommand(cmd *cobra.Command, args []string) {
 	if supportsDelay {
 		q = tq.NewTransferQueue(
 			tq.Download,
-			getTransferManifestOperationRemote("download", cfg.CurrentRemote),
-			cfg.CurrentRemote,
+			getTransferManifestOperationRemote("download", cfg.Remote()),
+			cfg.Remote(),
 		)
 		go infiniteTransferBuffer(q, available)
 	}

--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -28,7 +28,11 @@ func lockCommand(cmd *cobra.Command, args []string) {
 		Exit(err.Error())
 	}
 
-	lockClient := newLockClient(lockRemote)
+	if len(lockRemote) > 0 {
+		cfg.SetRemote(lockRemote)
+	}
+
+	lockClient := newLockClient()
 	defer lockClient.Close()
 
 	lock, err := lockClient.LockFile(path)
@@ -90,7 +94,7 @@ func lockPath(file string) (string, error) {
 
 func init() {
 	RegisterCommand("lock", lockCommand, func(cmd *cobra.Command) {
-		cmd.Flags().StringVarP(&lockRemote, "remote", "r", cfg.Remote(), lockRemoteHelp)
+		cmd.Flags().StringVarP(&lockRemote, "remote", "r", "", lockRemoteHelp)
 		cmd.Flags().BoolVarP(&locksCmdFlags.JSON, "json", "", false, "print output in json")
 	})
 }

--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -90,7 +90,7 @@ func lockPath(file string) (string, error) {
 
 func init() {
 	RegisterCommand("lock", lockCommand, func(cmd *cobra.Command) {
-		cmd.Flags().StringVarP(&lockRemote, "remote", "r", cfg.CurrentRemote, lockRemoteHelp)
+		cmd.Flags().StringVarP(&lockRemote, "remote", "r", cfg.Remote(), lockRemoteHelp)
 		cmd.Flags().BoolVarP(&locksCmdFlags.JSON, "json", "", false, "print output in json")
 	})
 }

--- a/commands/command_locks.go
+++ b/commands/command_locks.go
@@ -109,7 +109,7 @@ func (l *locksFlags) Filters() (map[string]string, error) {
 
 func init() {
 	RegisterCommand("locks", locksCommand, func(cmd *cobra.Command) {
-		cmd.Flags().StringVarP(&lockRemote, "remote", "r", cfg.CurrentRemote, lockRemoteHelp)
+		cmd.Flags().StringVarP(&lockRemote, "remote", "r", cfg.Remote(), lockRemoteHelp)
 		cmd.Flags().StringVarP(&locksCmdFlags.Path, "path", "p", "", "filter locks results matching a particular path")
 		cmd.Flags().StringVarP(&locksCmdFlags.Id, "id", "i", "", "filter locks results matching a particular ID")
 		cmd.Flags().IntVarP(&locksCmdFlags.Limit, "limit", "l", 0, "optional limit for number of results to return")

--- a/commands/command_locks.go
+++ b/commands/command_locks.go
@@ -22,7 +22,11 @@ func locksCommand(cmd *cobra.Command, args []string) {
 		Exit("Error building filters: %v", err)
 	}
 
-	lockClient := newLockClient(lockRemote)
+	if len(lockRemote) > 0 {
+		cfg.SetRemote(lockRemote)
+	}
+
+	lockClient := newLockClient()
 	defer lockClient.Close()
 
 	locks, err := lockClient.SearchLocks(filters, locksCmdFlags.Limit, locksCmdFlags.Local)
@@ -109,7 +113,7 @@ func (l *locksFlags) Filters() (map[string]string, error) {
 
 func init() {
 	RegisterCommand("locks", locksCommand, func(cmd *cobra.Command) {
-		cmd.Flags().StringVarP(&lockRemote, "remote", "r", cfg.Remote(), lockRemoteHelp)
+		cmd.Flags().StringVarP(&lockRemote, "remote", "r", "", lockRemoteHelp)
 		cmd.Flags().StringVarP(&locksCmdFlags.Path, "path", "p", "", "filter locks results matching a particular path")
 		cmd.Flags().StringVarP(&locksCmdFlags.Id, "id", "i", "", "filter locks results matching a particular ID")
 		cmd.Flags().IntVarP(&locksCmdFlags.Limit, "limit", "l", 0, "optional limit for number of results to return")

--- a/commands/command_post_checkout.go
+++ b/commands/command_post_checkout.go
@@ -32,7 +32,7 @@ func postCheckoutCommand(cmd *cobra.Command, args []string) {
 
 	requireGitVersion()
 
-	lockClient := newLockClient(cfg.CurrentRemote)
+	lockClient := newLockClient(cfg.Remote())
 
 	// Skip this hook if no lockable patterns have been configured
 	if len(lockClient.GetLockablePatterns()) == 0 {

--- a/commands/command_post_checkout.go
+++ b/commands/command_post_checkout.go
@@ -32,7 +32,7 @@ func postCheckoutCommand(cmd *cobra.Command, args []string) {
 
 	requireGitVersion()
 
-	lockClient := newLockClient(cfg.Remote())
+	lockClient := newLockClient()
 
 	// Skip this hook if no lockable patterns have been configured
 	if len(lockClient.GetLockablePatterns()) == 0 {

--- a/commands/command_post_commit.go
+++ b/commands/command_post_commit.go
@@ -24,7 +24,7 @@ func postCommitCommand(cmd *cobra.Command, args []string) {
 
 	requireGitVersion()
 
-	lockClient := newLockClient(cfg.Remote())
+	lockClient := newLockClient()
 
 	// Skip this hook if no lockable patterns have been configured
 	if len(lockClient.GetLockablePatterns()) == 0 {

--- a/commands/command_post_commit.go
+++ b/commands/command_post_commit.go
@@ -24,7 +24,7 @@ func postCommitCommand(cmd *cobra.Command, args []string) {
 
 	requireGitVersion()
 
-	lockClient := newLockClient(cfg.CurrentRemote)
+	lockClient := newLockClient(cfg.Remote())
 
 	// Skip this hook if no lockable patterns have been configured
 	if len(lockClient.GetLockablePatterns()) == 0 {

--- a/commands/command_post_merge.go
+++ b/commands/command_post_merge.go
@@ -24,7 +24,7 @@ func postMergeCommand(cmd *cobra.Command, args []string) {
 
 	requireGitVersion()
 
-	lockClient := newLockClient(cfg.CurrentRemote)
+	lockClient := newLockClient(cfg.Remote())
 
 	// Skip this hook if no lockable patterns have been configured
 	if len(lockClient.GetLockablePatterns()) == 0 {

--- a/commands/command_post_merge.go
+++ b/commands/command_post_merge.go
@@ -24,7 +24,7 @@ func postMergeCommand(cmd *cobra.Command, args []string) {
 
 	requireGitVersion()
 
-	lockClient := newLockClient(cfg.Remote())
+	lockClient := newLockClient()
 
 	// Skip this hook if no lockable patterns have been configured
 	if len(lockClient.GetLockablePatterns()) == 0 {

--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/git-lfs/git-lfs/git"
 	"github.com/rubyist/tracerx"
 	"github.com/spf13/cobra"
 )
@@ -46,10 +45,9 @@ func prePushCommand(cmd *cobra.Command, args []string) {
 	requireGitVersion()
 
 	// Remote is first arg
-	if err := git.ValidateRemote(args[0]); err != nil {
-		Exit("Invalid remote name %q", args[0])
+	if err := cfg.SetValidRemote(args[0]); err != nil {
+		Exit("Invalid remote name %q: %s", args[0], err)
 	}
-	cfg.SetRemote(args[0])
 
 	ctx := newUploadContext(prePushDryRun)
 

--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -49,8 +49,9 @@ func prePushCommand(cmd *cobra.Command, args []string) {
 	if err := git.ValidateRemote(args[0]); err != nil {
 		Exit("Invalid remote name %q", args[0])
 	}
+	cfg.SetRemote(args[0])
 
-	ctx := newUploadContext(args[0], prePushDryRun)
+	ctx := newUploadContext(prePushDryRun)
 
 	gitscanner, err := ctx.buildGitScanner()
 	if err != nil {

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -20,10 +20,9 @@ func pullCommand(cmd *cobra.Command, args []string) {
 
 	if len(args) > 0 {
 		// Remote is first arg
-		if err := git.ValidateRemote(args[0]); err != nil {
-			Panic(err, fmt.Sprintf("Invalid remote name '%v'", args[0]))
+		if err := cfg.SetValidRemote(args[0]); err != nil {
+			Exit("Invalid remote name %q: %s", args[0], err)
 		}
-		cfg.SetRemote(args[0])
 	}
 
 	includeArg, excludeArg := getIncludeExcludeArgs(cmd)

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -40,7 +40,7 @@ func pullCommand(cmd *cobra.Command, args []string) {
 }
 
 func pull(remote string, filter *filepathfilter.Filter) {
-	cfg.CurrentRemote = remote
+	cfg.SetRemote(remote)
 	ref, err := git.CurrentRef()
 	if err != nil {
 		Panic(err, "Could not pull")

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -113,11 +113,9 @@ func pushCommand(cmd *cobra.Command, args []string) {
 	requireGitVersion()
 
 	// Remote is first arg
-	if err := git.ValidateRemote(args[0]); err != nil {
-		Exit("Invalid remote name %q", args[0])
+	if err := cfg.SetValidRemote(args[0]); err != nil {
+		Exit("Invalid remote name %q: %s", args[0], err)
 	}
-
-	cfg.SetRemote(args[0])
 
 	ctx := newUploadContext(pushDryRun)
 

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -117,7 +117,9 @@ func pushCommand(cmd *cobra.Command, args []string) {
 		Exit("Invalid remote name %q", args[0])
 	}
 
-	ctx := newUploadContext(args[0], pushDryRun)
+	cfg.SetRemote(args[0])
+
+	ctx := newUploadContext(pushDryRun)
 
 	if pushObjectIDs {
 		if len(args) < 2 {

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -205,7 +205,7 @@ ArgsLoop:
 	}
 
 	// now flip read-only mode based on lockable / not lockable changes
-	lockClient := newLockClient(cfg.CurrentRemote)
+	lockClient := newLockClient(cfg.Remote())
 	err = lockClient.FixFileWriteFlagsInDir(relpath, readOnlyPatterns, writeablePatterns)
 	if err != nil {
 		LoggedError(err, "Error changing lockable file permissions: %s", err)

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -205,7 +205,7 @@ ArgsLoop:
 	}
 
 	// now flip read-only mode based on lockable / not lockable changes
-	lockClient := newLockClient(cfg.Remote())
+	lockClient := newLockClient()
 	err = lockClient.FixFileWriteFlagsInDir(relpath, readOnlyPatterns, writeablePatterns)
 	if err != nil {
 		LoggedError(err, "Error changing lockable file permissions: %s", err)

--- a/commands/command_unlock.go
+++ b/commands/command_unlock.go
@@ -35,7 +35,11 @@ func unlockCommand(cmd *cobra.Command, args []string) {
 		Exit(unlockUsage)
 	}
 
-	lockClient := newLockClient(lockRemote)
+	if len(lockRemote) > 0 {
+		cfg.SetRemote(lockRemote)
+	}
+
+	lockClient := newLockClient()
 	defer lockClient.Close()
 
 	if hasPath {
@@ -131,7 +135,7 @@ func unlockAbortIfFileModifiedById(id string, lockClient *locking.Client) {
 
 func init() {
 	RegisterCommand("unlock", unlockCommand, func(cmd *cobra.Command) {
-		cmd.Flags().StringVarP(&lockRemote, "remote", "r", cfg.Remote(), lockRemoteHelp)
+		cmd.Flags().StringVarP(&lockRemote, "remote", "r", "", lockRemoteHelp)
 		cmd.Flags().StringVarP(&unlockCmdFlags.Id, "id", "i", "", "unlock a lock by its ID")
 		cmd.Flags().BoolVarP(&unlockCmdFlags.Force, "force", "f", false, "forcibly break another user's lock(s)")
 		cmd.Flags().BoolVarP(&locksCmdFlags.JSON, "json", "", false, "print output in json")

--- a/commands/command_unlock.go
+++ b/commands/command_unlock.go
@@ -131,7 +131,7 @@ func unlockAbortIfFileModifiedById(id string, lockClient *locking.Client) {
 
 func init() {
 	RegisterCommand("unlock", unlockCommand, func(cmd *cobra.Command) {
-		cmd.Flags().StringVarP(&lockRemote, "remote", "r", cfg.CurrentRemote, lockRemoteHelp)
+		cmd.Flags().StringVarP(&lockRemote, "remote", "r", cfg.Remote(), lockRemoteHelp)
 		cmd.Flags().StringVarP(&unlockCmdFlags.Id, "id", "i", "", "unlock a lock by its ID")
 		cmd.Flags().BoolVarP(&unlockCmdFlags.Force, "force", "f", false, "forcibly break another user's lock(s)")
 		cmd.Flags().BoolVarP(&locksCmdFlags.JSON, "json", "", false, "print output in json")

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -90,8 +90,8 @@ func closeAPIClient() error {
 	return apiClient.Close()
 }
 
-func newLockClient(remote string) *locking.Client {
-	lockClient, err := locking.NewClient(remote, getAPIClient())
+func newLockClient() *locking.Client {
+	lockClient, err := locking.NewClient(cfg.Remote(), getAPIClient())
 	if err == nil {
 		os.MkdirAll(cfg.LFSStorageDir(), 0755)
 		err = lockClient.SetupFileCache(cfg.LFSStorageDir())

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -116,7 +116,7 @@ func newUploadContext(remote string, dryRun bool) *uploadContext {
 		return ctx
 	}
 
-	ourLocks, theirLocks, verifyState := verifyLocks(remote)
+	ourLocks, theirLocks, verifyState := verifyLocks()
 	ctx.lockVerifyState = verifyState
 	for _, l := range theirLocks {
 		ctx.theirLocks[l.Path] = l
@@ -128,14 +128,14 @@ func newUploadContext(remote string, dryRun bool) *uploadContext {
 	return ctx
 }
 
-func verifyLocks(remote string) (ours, theirs []locking.Lock, st verifyState) {
-	endpoint := getAPIClient().Endpoints.Endpoint("upload", remote)
+func verifyLocks() (ours, theirs []locking.Lock, st verifyState) {
+	endpoint := getAPIClient().Endpoints.Endpoint("upload", cfg.Remote())
 	state := getVerifyStateFor(endpoint)
 	if state == verifyStateDisabled {
 		return
 	}
 
-	lockClient := newLockClient(remote)
+	lockClient := newLockClient()
 
 	ours, theirs, err := lockClient.VerifiableLocks(0)
 	if err != nil {
@@ -149,7 +149,7 @@ func verifyLocks(remote string) (ours, theirs []locking.Lock, st verifyState) {
 					Exit("ERROR: Authentication error: %s", err)
 				}
 			} else {
-				Print("Remote %q does not support the LFS locking API. Consider disabling it with:", remote)
+				Print("Remote %q does not support the LFS locking API. Consider disabling it with:", cfg.Remote())
 				Print("  $ git config lfs.%s.locksverify false", endpoint.Url)
 				if state == verifyStateEnabled {
 					ExitWithError(err)
@@ -157,7 +157,7 @@ func verifyLocks(remote string) (ours, theirs []locking.Lock, st verifyState) {
 			}
 		}
 	} else if state == verifyStateUnknown {
-		Print("Locking support detected on remote %q. Consider enabling it with:", remote)
+		Print("Locking support detected on remote %q. Consider enabling it with:", cfg.Remote())
 		Print("  $ git config lfs.%s.locksverify true", endpoint.Url)
 	}
 

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -90,12 +90,9 @@ const (
 	verifyStateDisabled
 )
 
-func newUploadContext(remote string, dryRun bool) *uploadContext {
-	cfg.SetRemote(remote)
-
+func newUploadContext(dryRun bool) *uploadContext {
 	ctx := &uploadContext{
-		Remote:         remote,
-		Manifest:       getTransferManifestOperationRemote("upload", remote),
+		Remote:         cfg.Remote(),
 		DryRun:         dryRun,
 		uploadedOids:   tools.NewStringSet(),
 		gitfilter:      lfs.NewGitFilter(cfg),
@@ -105,6 +102,7 @@ func newUploadContext(remote string, dryRun bool) *uploadContext {
 		allowMissing:   cfg.Git.Bool("lfs.allowincompletepush", true),
 	}
 
+	ctx.Manifest = getTransferManifestOperationRemote("upload", ctx.Remote)
 	ctx.meter = buildProgressMeter(ctx.DryRun)
 	ctx.tq = newUploadQueue(ctx.Manifest, ctx.Remote, tq.WithProgress(ctx.meter), tq.DryRun(ctx.DryRun))
 	ctx.committerName, ctx.committerEmail = cfg.CurrentCommitter()

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -91,7 +91,7 @@ const (
 )
 
 func newUploadContext(remote string, dryRun bool) *uploadContext {
-	cfg.CurrentRemote = remote
+	cfg.SetRemote(remote)
 
 	ctx := &uploadContext{
 		Remote:         remote,

--- a/config/config.go
+++ b/config/config.go
@@ -169,6 +169,11 @@ func (c *Configuration) IsDefaultRemote() bool {
 	return c.Remote() == defaultRemote
 }
 
+// Remote returns the default remote based on:
+// 1. The currently tracked remote branch, if present
+// 2. Any other SINGLE remote defined in .git/config
+// 3. Use "origin" as a fallback.
+// Results are cached after the first hit.
 func (c *Configuration) Remote() string {
 	ref := c.CurrentRef()
 

--- a/config/config.go
+++ b/config/config.go
@@ -181,19 +181,24 @@ func (c *Configuration) Remote() string {
 	defer c.loading.Unlock()
 
 	if c.currentRemote == nil {
+		tracerx.Printf("REMOTE: %+v", ref)
 		if len(ref.Name) == 0 {
+			tracerx.Printf("REMOTE: empty")
 			c.currentRemote = &defaultRemote
 			return defaultRemote
 		}
 
 		if remote, ok := c.Git.Get(fmt.Sprintf("branch.%s.remote", ref.Name)); ok {
+			tracerx.Printf("REMOTE: branch.*.remote")
 			// try tracking remote
 			c.currentRemote = &remote
 		} else if remotes := c.Remotes(); len(remotes) == 1 {
+			tracerx.Printf("REMOTE: first remote: %+v", remotes)
 			// use only remote if there is only 1
 			c.currentRemote = &remotes[0]
 		} else {
 			// fall back to default :(
+			tracerx.Printf("REMOTE: default")
 			c.currentRemote = &defaultRemote
 		}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -170,6 +170,14 @@ func (c *Configuration) Remote() string {
 	return *c.currentRemote
 }
 
+func (c *Configuration) SetValidRemote(name string) error {
+	if err := git.ValidateRemote(name); err != nil {
+		return err
+	}
+	c.SetRemote(name)
+	return nil
+}
+
 func (c *Configuration) SetRemote(name string) {
 	c.currentRemote = &name
 }

--- a/config/config.go
+++ b/config/config.go
@@ -189,7 +189,7 @@ func (c *Configuration) Remote() string {
 		}
 
 		if remote, ok := c.Git.Get(fmt.Sprintf("branch.%s.remote", ref.Name)); ok {
-			tracerx.Printf("REMOTE: branch.*.remote")
+			tracerx.Printf("REMOTE: branch.*.remote %q (%v)", remote, ok)
 			// try tracking remote
 			c.currentRemote = &remote
 		} else if remotes := c.Remotes(); len(remotes) == 1 {

--- a/config/config.go
+++ b/config/config.go
@@ -157,7 +157,15 @@ func (c *Configuration) Remote() string {
 	c.loadingGit.Lock()
 	defer c.loadingGit.Unlock()
 	if c.currentRemote == nil {
-		c.currentRemote = &defaultRemote
+		r, err := c.GitConfig().DefaultRemote()
+		if err == nil && len(r) > 0 {
+			c.currentRemote = &r
+		} else {
+			if err != nil {
+				tracerx.Printf("Error getting default remote: %+v", err)
+			}
+			c.currentRemote = &defaultRemote
+		}
 	}
 	return *c.currentRemote
 }

--- a/config/config.go
+++ b/config/config.go
@@ -181,24 +181,19 @@ func (c *Configuration) Remote() string {
 	defer c.loading.Unlock()
 
 	if c.currentRemote == nil {
-		tracerx.Printf("REMOTE: %+v", ref)
 		if len(ref.Name) == 0 {
-			tracerx.Printf("REMOTE: empty")
 			c.currentRemote = &defaultRemote
 			return defaultRemote
 		}
 
 		if remote, ok := c.Git.Get(fmt.Sprintf("branch.%s.remote", ref.Name)); ok {
-			tracerx.Printf("REMOTE: branch.*.remote %q (%v)", remote, ok)
 			// try tracking remote
 			c.currentRemote = &remote
 		} else if remotes := c.Remotes(); len(remotes) == 1 {
-			tracerx.Printf("REMOTE: first remote: %+v", remotes)
 			// use only remote if there is only 1
 			c.currentRemote = &remotes[0]
 		} else {
 			// fall back to default :(
-			tracerx.Printf("REMOTE: default")
 			c.currentRemote = &defaultRemote
 		}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -149,6 +149,10 @@ func (c *Configuration) FetchExcludePaths() []string {
 	return tools.CleanPaths(patterns, ",")
 }
 
+func (c *Configuration) IsDefaultRemote() bool {
+	return c.Remote() == defaultRemote
+}
+
 func (c *Configuration) Remote() string {
 	c.loadingGit.Lock()
 	defer c.loadingGit.Unlock()

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ type Configuration struct {
 	// configuration.
 	Git Environment
 
-	CurrentRemote string
+	currentRemote string
 
 	// gitConfig can fetch or modify the current Git config and track the Git
 	// version.
@@ -54,7 +54,7 @@ func New() *Configuration {
 func NewIn(workdir, gitdir string) *Configuration {
 	gitConf := git.NewConfig(workdir, gitdir)
 	c := &Configuration{
-		CurrentRemote: defaultRemote,
+		currentRemote: defaultRemote,
 		Os:            EnvironmentOf(NewOsFetcher()),
 		gitConfig:     gitConf,
 	}
@@ -106,7 +106,7 @@ type Values struct {
 // This method should only be used during testing.
 func NewFrom(v Values) *Configuration {
 	c := &Configuration{
-		CurrentRemote: defaultRemote,
+		currentRemote: defaultRemote,
 		Os:            EnvironmentOf(mapFetcher(v.Os)),
 		gitConfig:     git.NewConfig("", ""),
 	}
@@ -149,6 +149,14 @@ func (c *Configuration) FetchIncludePaths() []string {
 func (c *Configuration) FetchExcludePaths() []string {
 	patterns, _ := c.Git.Get("lfs.fetchexclude")
 	return tools.CleanPaths(patterns, ",")
+}
+
+func (c *Configuration) Remote() string {
+	return c.currentRemote
+}
+
+func (c *Configuration) SetRemote(name string) {
+	c.currentRemote = name
 }
 
 func (c *Configuration) Remotes() []string {

--- a/git/git.go
+++ b/git/git.go
@@ -242,19 +242,6 @@ func (c *Configuration) CurrentRemoteRef() (*Ref, error) {
 	return ResolveRef(remoteref)
 }
 
-// RemoteForCurrentBranch returns the name of the remote that the current branch is tracking
-func (c *Configuration) RemoteForCurrentBranch() (string, error) {
-	ref, err := CurrentRef()
-	if err != nil {
-		return "", err
-	}
-	remote := c.RemoteForBranch(ref.Name)
-	if remote == "" {
-		return "", fmt.Errorf("remote not found for branch %q", ref.Name)
-	}
-	return remote, nil
-}
-
 // RemoteRefForCurrentBranch returns the full remote ref (refs/remotes/{remote}/{remotebranch})
 // that the current branch is tracking.
 func (c *Configuration) RemoteRefNameForCurrentBranch() (string, error) {
@@ -421,39 +408,6 @@ func ValidateRemoteURL(remote string) error {
 	default:
 		return fmt.Errorf("Invalid remote url protocol %q in %q", u.Scheme, remote)
 	}
-}
-
-// DefaultRemote returns the default remote based on:
-// 1. The currently tracked remote branch, if present
-// 2. "origin", if defined
-// 3. Any other SINGLE remote defined in .git/config
-// Returns an error if all of these fail, i.e. no tracked remote branch, no
-// "origin", and either no remotes defined or 2+ non-"origin" remotes
-func (c *Configuration) DefaultRemote() (string, error) {
-	tracked, err := c.RemoteForCurrentBranch()
-	if err == nil {
-		return tracked, nil
-	}
-
-	// Otherwise, check what remotes are defined
-	remotes, err := RemoteList()
-	if err != nil {
-		return "", err
-	}
-	switch len(remotes) {
-	case 0:
-		return "", errors.New("No remotes defined")
-	case 1: // always use a single remote whether it's origin or otherwise
-		return remotes[0], nil
-	default:
-		for _, remote := range remotes {
-			// Use origin if present
-			if remote == "origin" {
-				return remote, nil
-			}
-		}
-	}
-	return "", errors.New("Unable to pick default remote, too ambiguous")
 }
 
 func UpdateIndexFromStdin() *subprocess.Cmd {

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -71,10 +71,6 @@ func TestCurrentRefAndCurrentRemoteRef(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "refs/remotes/origin/someremotebranch", refname)
 
-	remote, err := gitConf.RemoteForCurrentBranch()
-	assert.Nil(t, err)
-	assert.Equal(t, "origin", remote)
-
 	ref, err = ResolveRef(outputs[2].Sha)
 	assert.Nil(t, err)
 	assert.Equal(t, &Ref{outputs[2].Sha, RefTypeOther, outputs[2].Sha}, ref)

--- a/lfs/gitfilter_smudge.go
+++ b/lfs/gitfilter_smudge.go
@@ -81,7 +81,8 @@ func (f *GitFilter) downloadFile(writer io.Writer, ptr *Pointer, workingfile, me
 	//
 	// Either way, forward it into the *tq.TransferQueue so that updates are
 	// sent over correctly.
-	q := tq.NewTransferQueue(tq.Download, manifest, "", tq.WithProgressCallback(cb))
+
+	q := tq.NewTransferQueue(tq.Download, manifest, f.cfg.Remote(), tq.WithProgressCallback(cb))
 	q.Add(filepath.Base(workingfile), mediafile, ptr.Oid, ptr.Size)
 	q.Wait()
 

--- a/lfs/lfs.go
+++ b/lfs/lfs.go
@@ -25,8 +25,8 @@ func Environ(cfg *config.Configuration, manifest *tq.Manifest) []string {
 		panic(err.Error())
 	}
 
-	download := api.Endpoints.AccessFor(api.Endpoints.Endpoint("download", cfg.CurrentRemote).Url)
-	upload := api.Endpoints.AccessFor(api.Endpoints.Endpoint("upload", cfg.CurrentRemote).Url)
+	download := api.Endpoints.AccessFor(api.Endpoints.Endpoint("download", cfg.Remote()).Url)
+	upload := api.Endpoints.AccessFor(api.Endpoints.Endpoint("upload", cfg.Remote()).Url)
 
 	dltransfers := manifest.GetDownloadAdapterNames()
 	sort.Strings(dltransfers)

--- a/test/test-fetch.sh
+++ b/test/test-fetch.sh
@@ -440,12 +440,6 @@ begin_test "fetch with no origin remote"
   # and no origin, but only 1 remote, should pick the only one as default
   git lfs fetch
   assert_local_object "$contents_oid" 1
-
-  # delete again, now add a second remote, also non-origin
-  rm -rf .git/lfs
-  git remote add something2 "$GITSERVER/$reponame"
-  git lfs fetch 2>&1 | grep "No default remote"
-  refute_local_object "$contents_oid"
 )
 end_test
 

--- a/test/test-happy-path.sh
+++ b/test/test-happy-path.sh
@@ -64,6 +64,35 @@ begin_test "happy path"
 )
 end_test
 
+begin_test "happy path on non-origin remote"
+(
+  set -e
+
+  reponame="happy-without-origin"
+  setup_remote_repo "$reponame"
+
+  clone_repo "$reponame" repo-without-origin
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "track"
+  git push origin master
+
+  clone_repo "$reponame" clone-without-origin
+  git remote rename origin happy-path
+
+  cd ../repo-without-origin
+  echo "a" > a.dat
+  git add a.dat
+  git commit -m "boom"
+  git push origin master
+
+  cd ../clone-without-origin
+  echo "remotes:"
+  git remote
+  git pull happy-path master
+)
+end_test
+
 begin_test "clears local temp objects"
 (
   set -e


### PR DESCRIPTION
This teaches `*config.Configuration` how to get the default remote.

1. The `CurrentRemote` property was replaced with `Remote() string` and `SetRemote(string)`
2. Behavior from `git.DefaultRemote()` was replicated in `Remote()`.
3. All traces of `git.DefaultRemote()` were removed.

Fixes #2169.

EDIT: 1 caveat: this does not work with an empty repository, since `git rev-parse` blows up:

https://github.com/git-lfs/git-lfs/blob/bee3e755e1cc2206c342344ea98bd29bb51c3235/git/git.go#L195-L200

Not sure if this should assume any default branch name. Maybe it could look for any `branch.*.remote` config keys? Or this could just require a repository with at least 1 commit.