### PR TITLE
release lfs for ubuntu/artful too

### DIFF
--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -60,6 +60,7 @@ $distro_name_map = {
     ubuntu/xenial
     ubuntu/yakkety
     ubuntu/zesty
+    ubuntu/artful
   ),
 }
 


### PR DESCRIPTION
This adds ubuntu/artful to the list of distros for future LFS releases.