### PR TITLE
verify locks against each ref being pushed

### DIFF
--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -51,13 +51,15 @@ func prePushCommand(cmd *cobra.Command, args []string) {
 		Exit("Invalid remote name %q: %s", args[0], err)
 	}
 
-	updates := prePushRefs(os.Stdin)
 	ctx := newUploadContext(prePushDryRun)
 	gitscanner, err := ctx.buildGitScanner()
 	if err != nil {
 		ExitWithError(err)
 	}
 	defer gitscanner.Close()
+
+	updates := prePushRefs(os.Stdin)
+	verifyLocksForUpdates(ctx.lockVerifier, updates)
 
 	for _, update := range updates {
 		if err := uploadLeftOrAll(gitscanner, ctx, update); err != nil {

--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -52,23 +52,10 @@ func prePushCommand(cmd *cobra.Command, args []string) {
 	}
 
 	ctx := newUploadContext(prePushDryRun)
-	gitscanner, err := ctx.buildGitScanner()
-	if err != nil {
+	updates := prePushRefs(os.Stdin)
+	if err := uploadForRefUpdates(ctx, updates, false); err != nil {
 		ExitWithError(err)
 	}
-	defer gitscanner.Close()
-
-	updates := prePushRefs(os.Stdin)
-	verifyLocksForUpdates(ctx.lockVerifier, updates)
-
-	for _, update := range updates {
-		if err := uploadLeftOrAll(gitscanner, ctx, update); err != nil {
-			Print("Error scanning for Git LFS files in %+v", update.Left())
-			ExitWithError(err)
-		}
-	}
-
-	ctx.Await()
 }
 
 // prePushRefs parses commit information that the pre-push git hook receives:

--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -96,7 +96,7 @@ func prePushRefs(r io.Reader) []*refUpdate {
 			continue
 		}
 
-		refs = append(refs, newRefUpdate(cfg.Git, left, right))
+		refs = append(refs, newRefUpdate(cfg.Git, cfg.Remote(), left, right))
 	}
 
 	return refs

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -122,7 +122,7 @@ func lfsPushRefs(refnames []string, pushAll bool) ([]*refUpdate, error) {
 	if pushAll && len(refnames) == 0 {
 		refs := make([]*refUpdate, len(localrefs))
 		for i, lr := range localrefs {
-			refs[i] = newRefUpdate(cfg.Git, lr, nil)
+			refs[i] = newRefUpdate(cfg.Git, cfg.Remote(), lr, nil)
 		}
 		return refs, nil
 	}
@@ -135,10 +135,10 @@ func lfsPushRefs(refnames []string, pushAll bool) ([]*refUpdate, error) {
 	refs := make([]*refUpdate, len(refnames))
 	for i, name := range refnames {
 		if left, ok := reflookup[name]; ok {
-			refs[i] = newRefUpdate(cfg.Git, left, nil)
+			refs[i] = newRefUpdate(cfg.Git, cfg.Remote(), left, nil)
 		} else {
 			left := &git.Ref{Name: name, Type: git.RefTypeOther, Sha: name}
-			refs[i] = newRefUpdate(cfg.Git, left, nil)
+			refs[i] = newRefUpdate(cfg.Git, cfg.Remote(), left, nil)
 		}
 	}
 

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -35,7 +35,7 @@ func uploadsBetweenRefAndRemote(ctx *uploadContext, refnames []string) {
 	}
 
 	for _, ref := range refs {
-		if err = uploadLeftOrAll(gitscanner, ctx, ref.Name); err != nil {
+		if err = uploadLeftOrAll(gitscanner, ctx, ref, nil); err != nil {
 			Print("Error scanning for Git LFS files in the %q ref", ref.Name)
 			ExitWithError(err)
 		}

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -74,6 +74,8 @@ func uploadsBetweenRefAndRemote(ctx *uploadContext, refnames []string) {
 		Exit("Error getting local refs.")
 	}
 
+	verifyLocksForUpdates(ctx.lockVerifier, updates)
+
 	for _, update := range updates {
 		if err = uploadLeftOrAll(gitscanner, ctx, update); err != nil {
 			Print("Error scanning for Git LFS files in the %q ref", update.Left().Name)

--- a/commands/lockverifier.go
+++ b/commands/lockverifier.go
@@ -1,0 +1,232 @@
+package commands
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/git-lfs/git-lfs/config"
+	"github.com/git-lfs/git-lfs/errors"
+	"github.com/git-lfs/git-lfs/lfsapi"
+	"github.com/git-lfs/git-lfs/locking"
+	"github.com/git-lfs/git-lfs/tq"
+)
+
+type verifyState byte
+
+const (
+	verifyStateUnknown verifyState = iota
+	verifyStateEnabled
+	verifyStateDisabled
+)
+
+// lockVerifier verifies locked files before updating one or more refs.
+type lockVerifier struct {
+	endpoint     lfsapi.Endpoint
+	verifyState  verifyState
+	verifiedRefs map[string]bool
+
+	// all existing locks
+	ourLocks   map[string]*refLock
+	theirLocks map[string]*refLock
+
+	// locks from ourLocks that have been modified
+	ownedLocks []*refLock
+
+	// locks from theirLocks that have been modified
+	unownedLocks []*refLock
+}
+
+func (lv *lockVerifier) Verify(ref string) {
+	if lv.verifyState == verifyStateDisabled || lv.verifiedRefs[ref] {
+		return
+	}
+
+	lockClient := newLockClient()
+	ours, theirs, err := lockClient.VerifiableLocks(ref, 0)
+	if err != nil {
+		if errors.IsNotImplementedError(err) {
+			disableFor(lv.endpoint.Url)
+		} else if lv.verifyState == verifyStateUnknown || lv.verifyState == verifyStateEnabled {
+			if errors.IsAuthError(err) {
+				if lv.verifyState == verifyStateUnknown {
+					Error("WARNING: Authentication error: %s", err)
+				} else if lv.verifyState == verifyStateEnabled {
+					Exit("ERROR: Authentication error: %s", err)
+				}
+			} else {
+				Print("Remote %q does not support the LFS locking API. Consider disabling it with:", cfg.Remote())
+				Print("  $ git config lfs.%s.locksverify false", lv.endpoint.Url)
+				if lv.verifyState == verifyStateEnabled {
+					ExitWithError(err)
+				}
+			}
+		}
+	} else if lv.verifyState == verifyStateUnknown {
+		Print("Locking support detected on remote %q. Consider enabling it with:", cfg.Remote())
+		Print("  $ git config lfs.%s.locksverify true", lv.endpoint.Url)
+	}
+
+	lv.addLocks(ref, ours, lv.ourLocks)
+	lv.addLocks(ref, theirs, lv.theirLocks)
+	lv.verifiedRefs[ref] = true
+}
+
+func (lv *lockVerifier) addLocks(ref string, locks []locking.Lock, set map[string]*refLock) {
+	for _, l := range locks {
+		if rl, ok := set[l.Path]; ok {
+			if err := rl.Add(ref, l); err != nil {
+				Error("WARNING: error adding %q lock for ref %q: %+v", l.Path, ref, err)
+			}
+		} else {
+			set[l.Path] = lv.newRefLocks(ref, l)
+		}
+	}
+}
+
+// Determines if a filename is lockable. Implements lfs.GitScannerSet
+func (lv *lockVerifier) Contains(name string) bool {
+	if lv == nil {
+		return false
+	}
+	_, ok := lv.theirLocks[name]
+	return ok
+}
+
+func (lv *lockVerifier) LockedByThem(name string) bool {
+	if lock, ok := lv.theirLocks[name]; ok {
+		lv.unownedLocks = append(lv.unownedLocks, lock)
+		return true
+	}
+	return false
+}
+
+func (lv *lockVerifier) LockedByUs(name string) bool {
+	if lock, ok := lv.ourLocks[name]; ok {
+		lv.ownedLocks = append(lv.ownedLocks, lock)
+		return true
+	}
+	return false
+}
+
+func (lv *lockVerifier) UnownedLocks() []*refLock {
+	return lv.unownedLocks
+}
+
+func (lv *lockVerifier) HasUnownedLocks() bool {
+	return len(lv.unownedLocks) > 0
+}
+
+func (lv *lockVerifier) OwnedLocks() []*refLock {
+	return lv.ownedLocks
+}
+
+func (lv *lockVerifier) HasOwnedLocks() bool {
+	return len(lv.ownedLocks) > 0
+}
+
+func (lv *lockVerifier) Enabled() bool {
+	return lv.verifyState == verifyStateEnabled
+}
+
+func (lv *lockVerifier) newRefLocks(ref string, l locking.Lock) *refLock {
+	return &refLock{
+		allRefs: lv.verifiedRefs,
+		path:    l.Path,
+		refs:    map[string]locking.Lock{ref: l},
+	}
+}
+
+func newLockVerifier(m *tq.Manifest) *lockVerifier {
+	lv := &lockVerifier{
+		endpoint:     getAPIClient().Endpoints.Endpoint("upload", cfg.Remote()),
+		verifiedRefs: make(map[string]bool),
+		ourLocks:     make(map[string]*refLock),
+		theirLocks:   make(map[string]*refLock),
+	}
+
+	// Do not check locks for standalone transfer, because there is no LFS
+	// server to ask.
+	if m.IsStandaloneTransfer() {
+		lv.verifyState = verifyStateDisabled
+	} else {
+		lv.verifyState = getVerifyStateFor(lv.endpoint.Url)
+	}
+
+	return lv
+}
+
+// refLock represents a unique locked file path, potentially across multiple
+// refs. It tracks each individual lock in case different users locked the
+// same path across multiple refs.
+type refLock struct {
+	path    string
+	allRefs map[string]bool
+	refs    map[string]locking.Lock
+}
+
+// Path returns the locked path.
+func (r *refLock) Path() string {
+	return r.path
+}
+
+// Owners returns the list of owners that locked this file, including what
+// specific refs the files were locked in. If a user locked a file on all refs,
+// don't bother listing them.
+//
+// Example: technoweenie, bob (refs: foo)
+func (r *refLock) Owners() string {
+	users := make(map[string][]string, len(r.refs))
+	for ref, lock := range r.refs {
+		u := lock.Owner.Name
+		if _, ok := users[u]; !ok {
+			users[u] = make([]string, 0, len(r.refs))
+		}
+		users[u] = append(users[u], ref)
+	}
+
+	owners := make([]string, 0, len(users))
+	for name, refs := range users {
+		seenRefCount := 0
+		for _, ref := range refs {
+			if r.allRefs[ref] {
+				seenRefCount++
+			}
+		}
+		if seenRefCount == len(r.allRefs) { // lock is included in all refs, so don't list them
+			owners = append(owners, name)
+			continue
+		}
+
+		sort.Strings(refs)
+		owners = append(owners, fmt.Sprintf("%s (refs: %s)", name, strings.Join(refs, ", ")))
+	}
+	sort.Strings(owners)
+	return strings.Join(owners, ", ")
+}
+
+func (r *refLock) Add(ref string, l locking.Lock) error {
+	r.refs[ref] = l
+	return nil
+}
+
+// getVerifyStateFor returns whether or not lock verification is enabled for the
+// given url. If no state has been explicitly set, an "unknown" state will be
+// returned instead.
+func getVerifyStateFor(rawurl string) verifyState {
+	uc := config.NewURLConfig(cfg.Git)
+
+	v, ok := uc.Get("lfs", rawurl, "locksverify")
+	if !ok {
+		if supportsLockingAPI(rawurl) {
+			return verifyStateEnabled
+		}
+		return verifyStateUnknown
+	}
+
+	if enabled, _ := strconv.ParseBool(v); enabled {
+		return verifyStateEnabled
+	}
+	return verifyStateDisabled
+}

--- a/commands/lockverifier.go
+++ b/commands/lockverifier.go
@@ -11,6 +11,7 @@ import (
 	"github.com/git-lfs/git-lfs/lfsapi"
 	"github.com/git-lfs/git-lfs/locking"
 	"github.com/git-lfs/git-lfs/tq"
+	"github.com/rubyist/tracerx"
 )
 
 type verifyState byte
@@ -20,6 +21,15 @@ const (
 	verifyStateEnabled
 	verifyStateDisabled
 )
+
+func verifyLocksForUpdates(lv *lockVerifier, updates []*refUpdate) {
+	lv.Verify(cfg.RemoteRefName())
+	/*
+		for _, update := range updates {
+			lv.Verify(update.Right().Name)
+		}
+		// */
+}
 
 // lockVerifier verifies locked files before updating one or more refs.
 type lockVerifier struct {
@@ -43,6 +53,7 @@ func (lv *lockVerifier) Verify(ref string) {
 		return
 	}
 
+	tracerx.Printf("LOCK VERIFY %q", ref)
 	lockClient := newLockClient()
 	ours, theirs, err := lockClient.VerifiableLocks(ref, 0)
 	if err != nil {

--- a/commands/lockverifier.go
+++ b/commands/lockverifier.go
@@ -11,7 +11,6 @@ import (
 	"github.com/git-lfs/git-lfs/lfsapi"
 	"github.com/git-lfs/git-lfs/locking"
 	"github.com/git-lfs/git-lfs/tq"
-	"github.com/rubyist/tracerx"
 )
 
 type verifyState byte
@@ -23,12 +22,9 @@ const (
 )
 
 func verifyLocksForUpdates(lv *lockVerifier, updates []*refUpdate) {
-	lv.Verify(cfg.RemoteRefName())
-	/*
-		for _, update := range updates {
-			lv.Verify(update.Right().Name)
-		}
-		// */
+	for _, update := range updates {
+		lv.Verify(update.Right().Name)
+	}
 }
 
 // lockVerifier verifies locked files before updating one or more refs.
@@ -53,7 +49,6 @@ func (lv *lockVerifier) Verify(ref string) {
 		return
 	}
 
-	tracerx.Printf("LOCK VERIFY %q", ref)
 	lockClient := newLockClient()
 	ours, theirs, err := lockClient.VerifiableLocks(ref, 0)
 	if err != nil {

--- a/commands/refs.go
+++ b/commands/refs.go
@@ -1,0 +1,53 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/git-lfs/git-lfs/config"
+	"github.com/git-lfs/git-lfs/git"
+)
+
+type refUpdate struct {
+	git   config.Environment
+	left  *git.Ref
+	right *git.Ref
+}
+
+func newRefUpdate(g config.Environment, l, r *git.Ref) *refUpdate {
+	return &refUpdate{
+		git:   g,
+		left:  l,
+		right: r,
+	}
+}
+
+func (u *refUpdate) Left() *git.Ref {
+	return u.left
+}
+
+func (u *refUpdate) LeftCommitish() string {
+	return refCommitish(u.Left())
+}
+
+func (u *refUpdate) Right() *git.Ref {
+	if u.right == nil {
+		l := u.Left()
+		if merge, ok := u.git.Get(fmt.Sprintf("branch.%s.merge", l.Name)); ok {
+			u.right = git.ParseRef(merge, "")
+		} else {
+			u.right = &git.Ref{Name: l.Name}
+		}
+	}
+	return u.right
+}
+
+func (u *refUpdate) RightCommitish() string {
+	return refCommitish(u.Right())
+}
+
+func refCommitish(r *git.Ref) string {
+	if len(r.Sha) > 0 {
+		return r.Sha
+	}
+	return r.Name
+}

--- a/commands/refs.go
+++ b/commands/refs.go
@@ -5,19 +5,22 @@ import (
 
 	"github.com/git-lfs/git-lfs/config"
 	"github.com/git-lfs/git-lfs/git"
+	"github.com/rubyist/tracerx"
 )
 
 type refUpdate struct {
-	git   config.Environment
-	left  *git.Ref
-	right *git.Ref
+	git    config.Environment
+	remote string
+	left   *git.Ref
+	right  *git.Ref
 }
 
-func newRefUpdate(g config.Environment, l, r *git.Ref) *refUpdate {
+func newRefUpdate(g config.Environment, remote string, l, r *git.Ref) *refUpdate {
 	return &refUpdate{
-		git:   g,
-		left:  l,
-		right: r,
+		git:    g,
+		remote: remote,
+		left:   l,
+		right:  r,
 	}
 }
 
@@ -31,14 +34,49 @@ func (u *refUpdate) LeftCommitish() string {
 
 func (u *refUpdate) Right() *git.Ref {
 	if u.right == nil {
-		l := u.Left()
-		if merge, ok := u.git.Get(fmt.Sprintf("branch.%s.merge", l.Name)); ok {
-			u.right = git.ParseRef(merge, "")
-		} else {
-			u.right = &git.Ref{Name: l.Name}
-		}
+		u.right = defaultRemoteRef(u.git, u.remote, u.Left())
 	}
 	return u.right
+}
+
+// defaultRemoteRef returns the remote ref receiving a push based on the current
+// repository config and local ref being pushed.
+//
+// See push.default rules in https://git-scm.com/docs/git-config
+func defaultRemoteRef(g config.Environment, remote string, left *git.Ref) *git.Ref {
+	pushMode, _ := g.Get("push.default")
+	switch pushMode {
+	case "", "simple":
+		brRemote, _ := g.Get(fmt.Sprintf("branch.%s.remote", left.Name))
+		if brRemote == remote {
+			// in centralized workflow, work like 'upstream' with an added safety to
+			// refuse to push if the upstream branch’s name is different from the
+			// local one.
+			return trackingRef(g, left)
+		}
+
+		// When pushing to a remote that is different from the remote you normally
+		// pull from, work as current.
+		return &git.Ref{Name: left.Name}
+	case "upstream", "tracking":
+		// push the current branch back to the branch whose changes are usually
+		// integrated into the current branch
+		return trackingRef(g, left)
+	case "current":
+		// push the current branch to update a branch with the same name on the
+		// receiving end.
+		return &git.Ref{Name: left.Name}
+	default:
+		tracerx.Printf("WARNING: %q push mode not supported", pushMode)
+		return &git.Ref{Name: left.Name}
+	}
+}
+
+func trackingRef(g config.Environment, left *git.Ref) *git.Ref {
+	if merge, ok := g.Get(fmt.Sprintf("branch.%s.merge", left.Name)); ok {
+		return git.ParseRef(merge, "")
+	}
+	return &git.Ref{Name: left.Name}
 }
 
 func (u *refUpdate) RightCommitish() string {

--- a/commands/refs_test.go
+++ b/commands/refs_test.go
@@ -1,0 +1,72 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/git-lfs/git-lfs/config"
+	"github.com/git-lfs/git-lfs/git"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRefUpdateDefault(t *testing.T) {
+	pushModes := []string{"simple", ""}
+	for _, pushMode := range pushModes {
+		cfg := config.NewFrom(config.Values{
+			Git: map[string][]string{
+				"push.default":       []string{pushMode},
+				"branch.left.remote": []string{"ignore"},
+				"branch.left.merge":  []string{"me"},
+			},
+		})
+
+		u := newRefUpdate(cfg.Git, "origin", git.ParseRef("left", ""), nil)
+		assert.Equal(t, "left", u.Right().Name, "pushmode=%q", pushMode)
+	}
+}
+
+func TestRefUpdateTrackedDefault(t *testing.T) {
+	pushModes := []string{"simple", "upstream", "tracking", ""}
+	for _, pushMode := range pushModes {
+		cfg := config.NewFrom(config.Values{
+			Git: map[string][]string{
+				"push.default":       []string{pushMode},
+				"branch.left.remote": []string{"origin"},
+				"branch.left.merge":  []string{"tracked"},
+			},
+		})
+
+		u := newRefUpdate(cfg.Git, "origin", git.ParseRef("left", ""), nil)
+		assert.Equal(t, "tracked", u.Right().Name, "pushmode=%s", pushMode)
+	}
+}
+
+func TestRefUpdateCurrentDefault(t *testing.T) {
+	cfg := config.NewFrom(config.Values{
+		Git: map[string][]string{
+			"push.default":       []string{"current"},
+			"branch.left.remote": []string{"origin"},
+			"branch.left.merge":  []string{"tracked"},
+		},
+	})
+
+	u := newRefUpdate(cfg.Git, "origin", git.ParseRef("left", ""), nil)
+	assert.Equal(t, "left", u.Right().Name)
+}
+
+func TestRefUpdateExplicitLeftAndRight(t *testing.T) {
+	u := newRefUpdate(nil, "", git.ParseRef("left", "abc123"), git.ParseRef("right", "def456"))
+	assert.Equal(t, "left", u.Left().Name)
+	assert.Equal(t, "abc123", u.Left().Sha)
+	assert.Equal(t, "abc123", u.LeftCommitish())
+	assert.Equal(t, "right", u.Right().Name)
+	assert.Equal(t, "def456", u.Right().Sha)
+	assert.Equal(t, "def456", u.RightCommitish())
+
+	u = newRefUpdate(nil, "", git.ParseRef("left", ""), git.ParseRef("right", ""))
+	assert.Equal(t, "left", u.Left().Name)
+	assert.Equal(t, "", u.Left().Sha)
+	assert.Equal(t, "left", u.LeftCommitish())
+	assert.Equal(t, "right", u.Right().Name)
+	assert.Equal(t, "", u.Right().Sha)
+	assert.Equal(t, "right", u.RightCommitish())
+}

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -135,7 +135,7 @@ func verifyLocks() (ours, theirs []locking.Lock, st verifyState) {
 
 	lockClient := newLockClient()
 
-	ours, theirs, err := lockClient.VerifiableLocks(0)
+	ours, theirs, err := lockClient.VerifiableLocks(cfg.RemoteRefName(), 0)
 	if err != nil {
 		if errors.IsNotImplementedError(err) {
 			disableFor(endpoint)

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -70,9 +70,6 @@ func newUploadContext(dryRun bool) *uploadContext {
 	ctx.meter = buildProgressMeter(ctx.DryRun)
 	ctx.tq = newUploadQueue(ctx.Manifest, ctx.Remote, tq.WithProgress(ctx.meter), tq.DryRun(ctx.DryRun))
 	ctx.committerName, ctx.committerEmail = cfg.CurrentCommitter()
-
-	ctx.lockVerifier.Verify(cfg.RemoteRefName())
-
 	return ctx
 }
 

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 
 	"github.com/git-lfs/git-lfs/errors"
-	"github.com/git-lfs/git-lfs/git"
 	"github.com/git-lfs/git-lfs/lfs"
 	"github.com/git-lfs/git-lfs/progress"
 	"github.com/git-lfs/git-lfs/tools"
@@ -17,26 +16,14 @@ import (
 	"github.com/rubyist/tracerx"
 )
 
-func uploadLeftOrAll(g *lfs.GitScanner, ctx *uploadContext, left, right *git.Ref) error {
-	leftName := left.Name
-	if len(left.Sha) > 0 {
-		leftName = left.Sha
-	}
-
+func uploadLeftOrAll(g *lfs.GitScanner, ctx *uploadContext, update *refUpdate) error {
 	if pushAll {
-		if err := g.ScanRefWithDeleted(leftName, nil); err != nil {
+		if err := g.ScanRefWithDeleted(update.LeftCommitish(), nil); err != nil {
 			return err
 		}
 	} else {
-		if right == nil {
-			if merge, ok := cfg.Git.Get(fmt.Sprintf("branch.%s.merge", left.Name)); ok {
-				right = git.ParseRef(merge, "")
-			} else {
-				right = &git.Ref{Name: left.Name}
-			}
-		}
-		tracerx.Printf("DEBUG LEFT to RIGHT: %+v => %+v", left, right)
-		if err := g.ScanLeftToRemote(leftName, nil); err != nil {
+		tracerx.Printf("DEBUG LEFT to RIGHT: %+v => %+v", update.Left(), update.Right())
+		if err := g.ScanLeftToRemote(update.LeftCommitish(), nil); err != nil {
 			return err
 		}
 	}

--- a/commands/uploader_test.go
+++ b/commands/uploader_test.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"testing"
 
-	"github.com/git-lfs/git-lfs/lfsapi"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -13,11 +12,7 @@ type LockingSupportTestCase struct {
 }
 
 func (l *LockingSupportTestCase) Assert(t *testing.T) {
-	ep := lfsapi.Endpoint{
-		Url: l.Given,
-	}
-
-	assert.Equal(t, l.ExpectedToMatch, supportsLockingAPI(ep))
+	assert.Equal(t, l.ExpectedToMatch, supportsLockingAPI(l.Given))
 }
 
 func TestSupportedLockingHosts(t *testing.T) {

--- a/config/config.go
+++ b/config/config.go
@@ -166,35 +166,6 @@ func (c *Configuration) CurrentRef() *git.Ref {
 	return c.ref
 }
 
-func (c *Configuration) RemoteRef() *git.Ref {
-	r := c.CurrentRef()
-
-	c.loading.Lock()
-	defer c.loading.Unlock()
-
-	if c.remoteRef != nil {
-		return c.remoteRef
-	}
-
-	if r != nil {
-		merge, _ := c.Git.Get(fmt.Sprintf("branch.%s.merge", r.Name))
-		if len(merge) > 0 {
-			c.remoteRef = git.ParseRef(merge, "")
-		} else {
-			c.remoteRef = r
-		}
-	}
-
-	return c.remoteRef
-}
-
-func (c *Configuration) RemoteRefName() string {
-	if r := c.RemoteRef(); r != nil {
-		return r.Name
-	}
-	return ""
-}
-
 func (c *Configuration) IsDefaultRemote() bool {
 	return c.Remote() == defaultRemote
 }

--- a/config/config.go
+++ b/config/config.go
@@ -178,11 +178,8 @@ func (c *Configuration) RemoteRef() *git.Ref {
 
 	if r != nil {
 		merge, _ := c.Git.Get(fmt.Sprintf("branch.%s.merge", r.Name))
-		if strings.HasPrefix(merge, "refs/heads/") {
-			c.remoteRef = &git.Ref{
-				Name: merge[11:],
-				Type: git.RefTypeRemoteBranch,
-			}
+		if len(merge) > 0 {
+			c.remoteRef = git.ParseRef(merge, "")
 		} else {
 			c.remoteRef = r
 		}

--- a/git/git.go
+++ b/git/git.go
@@ -63,6 +63,31 @@ func (t RefType) Prefix() (string, bool) {
 	}
 }
 
+func ParseRef(absRef, sha string) *Ref {
+	r := &Ref{Sha: sha}
+	if strings.HasPrefix(absRef, "refs/heads/") {
+		r.Name = absRef[11:]
+		r.Type = RefTypeLocalBranch
+	} else if strings.HasPrefix(absRef, "refs/tags/") {
+		r.Name = absRef[10:]
+		r.Type = RefTypeLocalTag
+	} else if strings.HasPrefix(absRef, "refs/remotes/tags/") {
+		r.Name = absRef[18:]
+		r.Type = RefTypeRemoteTag
+	} else if strings.HasPrefix(absRef, "refs/remotes/") {
+		r.Name = absRef[13:]
+		r.Type = RefTypeRemoteBranch
+	} else {
+		r.Name = absRef
+		if absRef == "HEAD" {
+			r.Type = RefTypeHEAD
+		} else {
+			r.Type = RefTypeOther
+		}
+	}
+	return r
+}
+
 // A git reference (branch, tag etc)
 type Ref struct {
 	Name string

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -13,6 +13,32 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestParseRefs(t *testing.T) {
+	tests := map[string]RefType{
+		"refs/heads":        RefTypeLocalBranch,
+		"refs/tags":         RefTypeLocalTag,
+		"refs/remotes/tags": RefTypeRemoteTag,
+		"refs/remotes":      RefTypeRemoteBranch,
+	}
+
+	for prefix, expectedType := range tests {
+		r := ParseRef(prefix+"/branch", "abc123")
+		assert.Equal(t, "abc123", r.Sha, "prefix: "+prefix)
+		assert.Equal(t, "branch", r.Name, "prefix: "+prefix)
+		assert.Equal(t, expectedType, r.Type, "prefix: "+prefix)
+	}
+
+	r := ParseRef("refs/foo/branch", "abc123")
+	assert.Equal(t, "abc123", r.Sha, "prefix: refs/foo")
+	assert.Equal(t, "refs/foo/branch", r.Name, "prefix: refs/foo")
+	assert.Equal(t, RefTypeOther, r.Type, "prefix: refs/foo")
+
+	r = ParseRef("HEAD", "abc123")
+	assert.Equal(t, "abc123", r.Sha, "prefix: HEAD")
+	assert.Equal(t, "HEAD", r.Name, "prefix: HEAD")
+	assert.Equal(t, RefTypeHEAD, r.Type, "prefix: HEAD")
+}
+
 func TestCurrentRefAndCurrentRemoteRef(t *testing.T) {
 	repo := test.NewRepo(t)
 	repo.Pushd()

--- a/locking/api.go
+++ b/locking/api.go
@@ -12,6 +12,10 @@ type lockClient struct {
 	*lfsapi.Client
 }
 
+type lockRef struct {
+	Name string `json:"name,omitempty"`
+}
+
 // LockRequest encapsulates the payload sent across the API when a client would
 // like to obtain a lock against a particular path on a given remote.
 type lockRequest struct {
@@ -192,7 +196,7 @@ func (c *lockClient) Search(remote string, searchReq *lockSearchRequest) (*lockL
 // lockVerifiableRequest encapsulates the request sent to the server when the
 // client would like a list of locks to verify a Git push.
 type lockVerifiableRequest struct {
-	Ref string `json:"ref"`
+	Ref *lockRef `json:"ref"`
 
 	// Cursor is an optional field used to tell the server which lock was
 	// seen last, if scanning through multiple pages of results.

--- a/locking/api.go
+++ b/locking/api.go
@@ -192,6 +192,8 @@ func (c *lockClient) Search(remote string, searchReq *lockSearchRequest) (*lockL
 // lockVerifiableRequest encapsulates the request sent to the server when the
 // client would like a list of locks to verify a Git push.
 type lockVerifiableRequest struct {
+	Ref string `json:"ref"`
+
 	// Cursor is an optional field used to tell the server which lock was
 	// seen last, if scanning through multiple pages of results.
 	//

--- a/locking/locks.go
+++ b/locking/locks.go
@@ -210,7 +210,7 @@ func (c *Client) VerifiableLocks(ref string, limit int) (ourLocks, theirLocks []
 	ourLocks = make([]Lock, 0, limit)
 	theirLocks = make([]Lock, 0, limit)
 	body := &lockVerifiableRequest{
-		Ref:   ref,
+		Ref:   &lockRef{Name: ref},
 		Limit: limit,
 	}
 

--- a/locking/locks.go
+++ b/locking/locks.go
@@ -206,12 +206,15 @@ func (c *Client) SearchLocks(filter map[string]string, limit int, localOnly bool
 	}
 }
 
-func (c *Client) VerifiableLocks(limit int) (ourLocks, theirLocks []Lock, err error) {
+func (c *Client) VerifiableLocks(ref string, limit int) (ourLocks, theirLocks []Lock, err error) {
 	ourLocks = make([]Lock, 0, limit)
 	theirLocks = make([]Lock, 0, limit)
 	body := &lockVerifiableRequest{
+		Ref:   ref,
 		Limit: limit,
 	}
+
+	c.cache.Clear()
 
 	for {
 		list, res, err := c.client.SearchVerifiable(c.Remote, body)
@@ -236,6 +239,7 @@ func (c *Client) VerifiableLocks(limit int) (ourLocks, theirLocks []Lock, err er
 		}
 
 		for _, l := range list.Ours {
+			c.cache.Add(l)
 			ourLocks = append(ourLocks, l)
 			if limit > 0 && (len(ourLocks)+len(theirLocks)) >= limit {
 				return ourLocks, theirLocks, nil
@@ -243,6 +247,7 @@ func (c *Client) VerifiableLocks(limit int) (ourLocks, theirLocks []Lock, err er
 		}
 
 		for _, l := range list.Theirs {
+			c.cache.Add(l)
 			theirLocks = append(theirLocks, l)
 			if limit > 0 && (len(ourLocks)+len(theirLocks)) >= limit {
 				return ourLocks, theirLocks, nil
@@ -347,23 +352,6 @@ func (c *Client) lockIdFromPath(path string) (string, error) {
 	default:
 		return "", ErrLockAmbiguous
 	}
-}
-
-// Fetch locked files for the current user and cache them locally
-// This can be used to sync up locked files when moving machines
-func (c *Client) refreshLockCache() error {
-	ourLocks, _, err := c.VerifiableLocks(0)
-	if err != nil {
-		return err
-	}
-
-	// We're going to overwrite the entire local cache
-	c.cache.Clear()
-	for _, l := range ourLocks {
-		c.cache.Add(l)
-	}
-
-	return nil
 }
 
 // IsFileLockedByCurrentCommitter returns whether a file is locked by the

--- a/locking/locks_test.go
+++ b/locking/locks_test.go
@@ -64,8 +64,7 @@ func TestRefreshCache(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Empty(t, locks)
 
-	// Should load from test data, just Fred's
-	err = client.refreshLockCache()
+	_, _, err = client.VerifiableLocks("", 100)
 	assert.Nil(t, err)
 
 	locks, err = client.SearchLocks(nil, 0, true)
@@ -79,6 +78,8 @@ func TestRefreshCache(t *testing.T) {
 		Lock{Path: "folder/test1.dat", Id: "101", Owner: &User{Name: "Fred"}, LockedAt: zeroTime},
 		Lock{Path: "folder/test2.dat", Id: "102", Owner: &User{Name: "Fred"}, LockedAt: zeroTime},
 		Lock{Path: "root.dat", Id: "103", Owner: &User{Name: "Fred"}, LockedAt: zeroTime},
+		Lock{Path: "other/test1.dat", Id: "199", Owner: &User{Name: "Charles"}, LockedAt: zeroTime},
+		Lock{Path: "folder/test3.dat", Id: "99", Owner: &User{Name: "Alice"}, LockedAt: zeroTime},
 	}, locks)
 }
 
@@ -129,7 +130,7 @@ func TestGetVerifiableLocks(t *testing.T) {
 	client, err := NewClient("", lfsclient)
 	assert.Nil(t, err)
 
-	ourLocks, theirLocks, err := client.VerifiableLocks(0)
+	ourLocks, theirLocks, err := client.VerifiableLocks("", 0)
 	assert.Nil(t, err)
 
 	// Need to include zero time in structure for equal to work

--- a/test/cmd/lfstest-gitserver.go
+++ b/test/cmd/lfstest-gitserver.go
@@ -882,6 +882,7 @@ type LockList struct {
 }
 
 type VerifiableLockRequest struct {
+	Ref    string `json:"ref,omitempty"`
 	Cursor string `json:"cursor,omitempty"`
 	Limit  int    `json:"limit,omitempty"`
 }
@@ -1087,6 +1088,18 @@ func locksHandler(w http.ResponseWriter, r *http.Request, repo string) {
 					Message string `json:"message"`
 				}{"json decode error: " + err.Error()})
 				return
+			}
+
+			if strings.HasSuffix(repo, "ref-required") {
+				parts := strings.Split(repo, "-")
+				lenParts := len(parts)
+				if lenParts > 3 && parts[lenParts-3] != reqBody.Ref {
+					w.WriteHeader(403)
+					enc.Encode(struct {
+						Message string `json:"message"`
+					}{fmt.Sprintf("Expected ref %q, got %q", parts[lenParts-3], reqBody.Ref)})
+					return
+				}
 			}
 
 			ll := &VerifiableLockList{}

--- a/test/cmd/lfstest-gitserver.go
+++ b/test/cmd/lfstest-gitserver.go
@@ -881,10 +881,21 @@ type LockList struct {
 	Message    string `json:"message,omitempty"`
 }
 
+type Ref struct {
+	Name string `json:"name,omitempty"`
+}
+
 type VerifiableLockRequest struct {
-	Ref    string `json:"ref,omitempty"`
+	Ref    *Ref   `json:"ref,omitempty"`
 	Cursor string `json:"cursor,omitempty"`
 	Limit  int    `json:"limit,omitempty"`
+}
+
+func (r *VerifiableLockRequest) RefName() string {
+	if r.Ref == nil {
+		return ""
+	}
+	return r.Ref.Name
 }
 
 type VerifiableLockList struct {
@@ -1093,11 +1104,11 @@ func locksHandler(w http.ResponseWriter, r *http.Request, repo string) {
 			if strings.HasSuffix(repo, "ref-required") {
 				parts := strings.Split(repo, "-")
 				lenParts := len(parts)
-				if lenParts > 3 && parts[lenParts-3] != reqBody.Ref {
+				if lenParts > 3 && parts[lenParts-3] != reqBody.RefName() {
 					w.WriteHeader(403)
 					enc.Encode(struct {
 						Message string `json:"message"`
-					}{fmt.Sprintf("Expected ref %q, got %q", parts[lenParts-3], reqBody.Ref)})
+					}{fmt.Sprintf("Expected ref %q, got %q", parts[lenParts-3], reqBody.RefName())})
 					return
 				}
 			}

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -583,7 +583,7 @@ begin_test "pre-push with our lock"
   git commit -m "add unauthorized changes"
 
   GIT_CURL_VERBOSE=1 git push origin master 2>&1 | tee push.log
-  grep "Consider unlocking your own locked file(s)" push.log
+  grep "Consider unlocking your own locked files" push.log
   grep "* locked.dat" push.log
 
   assert_server_lock "$id"
@@ -631,7 +631,7 @@ begin_test "pre-push with their lock on lfs file"
       exit 1
     fi
 
-    grep "Unable to push 1 locked file(s)" push.log
+    grep "Unable to push locked files" push.log
     grep "* locked_theirs.dat - Git LFS Tests" push.log
 
     grep "ERROR: Cannot update locked files." push.log
@@ -687,7 +687,7 @@ begin_test "pre-push with their lock on non-lfs lockable file"
       exit 1
     fi
 
-    grep "Unable to push 2 locked file(s)" push.log
+    grep "Unable to push locked files" push.log
     grep "* large_locked_theirs.dat - Git LFS Tests" push.log
     grep "* tiny_locked_theirs.dat - Git LFS Tests" push.log
     grep "ERROR: Cannot update locked files." push.log

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -823,6 +823,28 @@ begin_test "pre-push locks verify 403 with good tracked ref"
 )
 end_test
 
+begin_test "pre-push locks verify 403 with explicit ref"
+(
+  set -e
+
+  reponame="lock-verify-explicit-ref-required"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  contents="example"
+  contents_oid="$(calc_oid "$contents")"
+  printf "$contents" > a.dat
+  git lfs track "*.dat"
+  git add .gitattributes a.dat
+  git commit --message "initial commit"
+
+  git config "lfs.$GITSERVER/$reponame.git.locksverify" true
+  git push origin master:explicit 2>&1 | tee push.log
+
+  assert_server_object "$reponame" "$contents_oid"
+)
+end_test
+
 begin_test "pre-push locks verify 403 with bad ref"
 (
   set -e

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -814,9 +814,10 @@ begin_test "pre-push locks verify 403 with good tracked ref"
   git add .gitattributes a.dat
   git commit --message "initial commit"
 
+  git config push.default upstream
   git config branch.master.merge refs/heads/tracked
   git config "lfs.$GITSERVER/$reponame.git.locksverify" true
-  git push origin master 2>&1 | tee push.log
+  git push 2>&1 | tee push.log
 
   assert_server_object "$reponame" "$contents_oid"
 )

--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -485,15 +485,8 @@ begin_test "push ambiguous branch name"
   # lfs push master, should work
   git lfs push origin master
 
-  # push ambiguous, should fail
-  set +e
+  # push ambiguous, does not fail since lfs scans git with sha, not ref name
   git lfs push origin ambiguous
-  if [ $? -eq 0 ]
-  then
-    exit 1
-  fi
-  set -e
-
 )
 end_test
 


### PR DESCRIPTION
Implements 2 aspects of #2712:

* basic `push.default` support, which governs how Git chooses an implicit remote ref based on the remote and local ref being pushed.
* Verify locks on each ref being pushed.

Bonus: locks are not verified for `git lfs push --object-id` anymore. Since this push doesn't affect any Git code, there's no need to verify anything.

This also extracts a `*lockVerifier` and `*refUpdate`. There is still too much coupling, but it's better than everything being in `*uploadContext`. Baby steps....