### PR TITLE
Wait longer for test lfs server to start.

### DIFF
--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -266,15 +266,20 @@ size %s
 wait_for_file() {
   local filename="$1"
   n=0
-  while [ $n -lt 10 ]; do
+  wait_time=1
+  while [ $n -lt 17 ]; do
     if [ -s $filename ]; then
       return 0
     fi
 
-    sleep 0.5
+    sleep $wait_time
     n=`expr $n + 1`
+    if [ $wait_time -lt 4 ]; then
+      wait_time=`expr $wait_time \* 2`
+    fi
   done
 
+  echo "$filename did not appear after 60 seconds."
   return 1
 }
 


### PR DESCRIPTION
Also, back off on polling a bit after the first check to reduce any I/O contention that might slow things down even more. Instead of 5 seconds, this will wait up to about 60 seconds for files created by the test server to appear. This allows very slow systems to be able to pass tests.

Finally, add a message if the file doesn't appear to make it clear what went wrong.

For example, slow builders like [aarch64](https://kojipkgs.fedoraproject.org//work/tasks/291/22880291/build.log) or [armv7hl](https://kojipkgs.fedoraproject.org//work/tasks/294/22880294/build.log) mysteriously fail right after printing git(lfs) versions without any indication why.