### PR TITLE
Locks/verify: full refspec

### DIFF
--- a/commands/lockverifier.go
+++ b/commands/lockverifier.go
@@ -12,7 +12,6 @@ import (
 	"github.com/git-lfs/git-lfs/lfsapi"
 	"github.com/git-lfs/git-lfs/locking"
 	"github.com/git-lfs/git-lfs/tq"
-	"github.com/rubyist/tracerx"
 )
 
 type verifyState byte

--- a/commands/lockverifier.go
+++ b/commands/lockverifier.go
@@ -8,9 +8,11 @@ import (
 
 	"github.com/git-lfs/git-lfs/config"
 	"github.com/git-lfs/git-lfs/errors"
+	"github.com/git-lfs/git-lfs/git"
 	"github.com/git-lfs/git-lfs/lfsapi"
 	"github.com/git-lfs/git-lfs/locking"
 	"github.com/git-lfs/git-lfs/tq"
+	"github.com/rubyist/tracerx"
 )
 
 type verifyState byte
@@ -23,7 +25,7 @@ const (
 
 func verifyLocksForUpdates(lv *lockVerifier, updates []*refUpdate) {
 	for _, update := range updates {
-		lv.Verify(update.Right().Name)
+		lv.Verify(update.Right())
 	}
 }
 
@@ -44,8 +46,8 @@ type lockVerifier struct {
 	unownedLocks []*refLock
 }
 
-func (lv *lockVerifier) Verify(ref string) {
-	if lv.verifyState == verifyStateDisabled || lv.verifiedRefs[ref] {
+func (lv *lockVerifier) Verify(ref *git.Ref) {
+	if lv.verifyState == verifyStateDisabled || lv.verifiedRefs[ref.Refspec()] {
 		return
 	}
 
@@ -76,10 +78,10 @@ func (lv *lockVerifier) Verify(ref string) {
 
 	lv.addLocks(ref, ours, lv.ourLocks)
 	lv.addLocks(ref, theirs, lv.theirLocks)
-	lv.verifiedRefs[ref] = true
+	lv.verifiedRefs[ref.Refspec()] = true
 }
 
-func (lv *lockVerifier) addLocks(ref string, locks []locking.Lock, set map[string]*refLock) {
+func (lv *lockVerifier) addLocks(ref *git.Ref, locks []locking.Lock, set map[string]*refLock) {
 	for _, l := range locks {
 		if rl, ok := set[l.Path]; ok {
 			if err := rl.Add(ref, l); err != nil {
@@ -136,11 +138,11 @@ func (lv *lockVerifier) Enabled() bool {
 	return lv.verifyState == verifyStateEnabled
 }
 
-func (lv *lockVerifier) newRefLocks(ref string, l locking.Lock) *refLock {
+func (lv *lockVerifier) newRefLocks(ref *git.Ref, l locking.Lock) *refLock {
 	return &refLock{
 		allRefs: lv.verifiedRefs,
 		path:    l.Path,
-		refs:    map[string]locking.Lock{ref: l},
+		refs:    map[*git.Ref]locking.Lock{ref: l},
 	}
 }
 
@@ -169,7 +171,7 @@ func newLockVerifier(m *tq.Manifest) *lockVerifier {
 type refLock struct {
 	path    string
 	allRefs map[string]bool
-	refs    map[string]locking.Lock
+	refs    map[*git.Ref]locking.Lock
 }
 
 // Path returns the locked path.
@@ -189,7 +191,7 @@ func (r *refLock) Owners() string {
 		if _, ok := users[u]; !ok {
 			users[u] = make([]string, 0, len(r.refs))
 		}
-		users[u] = append(users[u], ref)
+		users[u] = append(users[u], ref.Name)
 	}
 
 	owners := make([]string, 0, len(users))
@@ -212,7 +214,7 @@ func (r *refLock) Owners() string {
 	return strings.Join(owners, ", ")
 }
 
-func (r *refLock) Add(ref string, l locking.Lock) error {
+func (r *refLock) Add(ref *git.Ref, l locking.Lock) error {
 	r.refs[ref] = l
 	return nil
 }

--- a/commands/refs.go
+++ b/commands/refs.go
@@ -57,7 +57,7 @@ func defaultRemoteRef(g config.Environment, remote string, left *git.Ref) *git.R
 
 		// When pushing to a remote that is different from the remote you normally
 		// pull from, work as current.
-		return &git.Ref{Name: left.Name}
+		return left
 	case "upstream", "tracking":
 		// push the current branch back to the branch whose changes are usually
 		// integrated into the current branch
@@ -65,10 +65,10 @@ func defaultRemoteRef(g config.Environment, remote string, left *git.Ref) *git.R
 	case "current":
 		// push the current branch to update a branch with the same name on the
 		// receiving end.
-		return &git.Ref{Name: left.Name}
+		return left
 	default:
 		tracerx.Printf("WARNING: %q push mode not supported", pushMode)
-		return &git.Ref{Name: left.Name}
+		return left
 	}
 }
 
@@ -76,7 +76,7 @@ func trackingRef(g config.Environment, left *git.Ref) *git.Ref {
 	if merge, ok := g.Get(fmt.Sprintf("branch.%s.merge", left.Name)); ok {
 		return git.ParseRef(merge, "")
 	}
-	return &git.Ref{Name: left.Name}
+	return left
 }
 
 func (u *refUpdate) RightCommitish() string {

--- a/commands/refs_test.go
+++ b/commands/refs_test.go
@@ -19,8 +19,9 @@ func TestRefUpdateDefault(t *testing.T) {
 			},
 		})
 
-		u := newRefUpdate(cfg.Git, "origin", git.ParseRef("left", ""), nil)
+		u := newRefUpdate(cfg.Git, "origin", git.ParseRef("refs/heads/left", ""), nil)
 		assert.Equal(t, "left", u.Right().Name, "pushmode=%q", pushMode)
+		assert.Equal(t, git.RefTypeLocalBranch, u.Right().Type, "pushmode=%q", pushMode)
 	}
 }
 
@@ -31,12 +32,13 @@ func TestRefUpdateTrackedDefault(t *testing.T) {
 			Git: map[string][]string{
 				"push.default":       []string{pushMode},
 				"branch.left.remote": []string{"origin"},
-				"branch.left.merge":  []string{"tracked"},
+				"branch.left.merge":  []string{"refs/heads/tracked"},
 			},
 		})
 
-		u := newRefUpdate(cfg.Git, "origin", git.ParseRef("left", ""), nil)
+		u := newRefUpdate(cfg.Git, "origin", git.ParseRef("refs/heads/left", ""), nil)
 		assert.Equal(t, "tracked", u.Right().Name, "pushmode=%s", pushMode)
+		assert.Equal(t, git.RefTypeLocalBranch, u.Right().Type, "pushmode=%q", pushMode)
 	}
 }
 
@@ -49,12 +51,13 @@ func TestRefUpdateCurrentDefault(t *testing.T) {
 		},
 	})
 
-	u := newRefUpdate(cfg.Git, "origin", git.ParseRef("left", ""), nil)
+	u := newRefUpdate(cfg.Git, "origin", git.ParseRef("refs/heads/left", ""), nil)
 	assert.Equal(t, "left", u.Right().Name)
+	assert.Equal(t, git.RefTypeLocalBranch, u.Right().Type)
 }
 
 func TestRefUpdateExplicitLeftAndRight(t *testing.T) {
-	u := newRefUpdate(nil, "", git.ParseRef("left", "abc123"), git.ParseRef("right", "def456"))
+	u := newRefUpdate(nil, "", git.ParseRef("refs/heads/left", "abc123"), git.ParseRef("refs/heads/right", "def456"))
 	assert.Equal(t, "left", u.Left().Name)
 	assert.Equal(t, "abc123", u.Left().Sha)
 	assert.Equal(t, "abc123", u.LeftCommitish())
@@ -62,7 +65,7 @@ func TestRefUpdateExplicitLeftAndRight(t *testing.T) {
 	assert.Equal(t, "def456", u.Right().Sha)
 	assert.Equal(t, "def456", u.RightCommitish())
 
-	u = newRefUpdate(nil, "", git.ParseRef("left", ""), git.ParseRef("right", ""))
+	u = newRefUpdate(nil, "", git.ParseRef("refs/heads/left", ""), git.ParseRef("refs/heads/right", ""))
 	assert.Equal(t, "left", u.Left().Name)
 	assert.Equal(t, "", u.Left().Sha)
 	assert.Equal(t, "left", u.LeftCommitish())

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -585,16 +585,3 @@ func TestRefTypeKnownPrefixes(t *testing.T) {
 		assert.Equal(t, expected.Ok, ok)
 	}
 }
-
-func TestRefTypeUnknownPrefix(t *testing.T) {
-	defer func() {
-		if err := recover(); err != nil {
-			assert.Equal(t, "git: unknown RefType -1", err)
-		} else {
-			t.Fatal("git: expected panic() from RefType.Prefix()")
-		}
-	}()
-
-	unknown := RefType(-1)
-	unknown.Prefix()
-}

--- a/locking/locks.go
+++ b/locking/locks.go
@@ -206,11 +206,11 @@ func (c *Client) SearchLocks(filter map[string]string, limit int, localOnly bool
 	}
 }
 
-func (c *Client) VerifiableLocks(ref string, limit int) (ourLocks, theirLocks []Lock, err error) {
+func (c *Client) VerifiableLocks(ref *git.Ref, limit int) (ourLocks, theirLocks []Lock, err error) {
 	ourLocks = make([]Lock, 0, limit)
 	theirLocks = make([]Lock, 0, limit)
 	body := &lockVerifiableRequest{
-		Ref:   &lockRef{Name: ref},
+		Ref:   &lockRef{Name: ref.Refspec()},
 		Limit: limit,
 	}
 

--- a/locking/locks_test.go
+++ b/locking/locks_test.go
@@ -64,7 +64,7 @@ func TestRefreshCache(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Empty(t, locks)
 
-	_, _, err = client.VerifiableLocks("", 100)
+	_, _, err = client.VerifiableLocks(nil, 100)
 	assert.Nil(t, err)
 
 	locks, err = client.SearchLocks(nil, 0, true)
@@ -130,7 +130,7 @@ func TestGetVerifiableLocks(t *testing.T) {
 	client, err := NewClient("", lfsclient)
 	assert.Nil(t, err)
 
-	ourLocks, theirLocks, err := client.VerifiableLocks("", 0)
+	ourLocks, theirLocks, err := client.VerifiableLocks(nil, 0)
 	assert.Nil(t, err)
 
 	// Need to include zero time in structure for equal to work

--- a/script/integration.go
+++ b/script/integration.go
@@ -50,17 +50,31 @@ func mainIntegration() {
 	for _, file := range files {
 		tests <- file
 	}
+	close(tests)
 
-	go printOutput(output)
+	outputDone := make(chan bool)
+	go func() {
+		for {
+			select {
+			case out, ok := <-output:
+				if !ok {
+					outputDone <- true
+					return
+				}
+
+				fmt.Println(out)
+			}
+		}
+	}()
+
 	for i := 0; i < maxprocs; i++ {
 		wg.Add(1)
 		go worker(tests, output, &wg)
 	}
 
-	close(tests)
 	wg.Wait()
 	close(output)
-	printOutput(output)
+	<-outputDone
 
 	if erroring {
 		os.Exit(1)
@@ -113,19 +127,6 @@ func sendTestOutput(output chan string, testname string, buf *bytes.Buffer, err 
 		}
 		erroring = true
 		output <- fmt.Sprintf("error: %s => %s\n%s", basetestname, err, cli)
-	}
-}
-
-func printOutput(output <-chan string) {
-	for {
-		select {
-		case out, ok := <-output:
-			if !ok {
-				return
-			}
-
-			fmt.Println(out)
-		}
 	}
 }
 

--- a/test/cmd/lfstest-gitserver.go
+++ b/test/cmd/lfstest-gitserver.go
@@ -1101,14 +1101,14 @@ func locksHandler(w http.ResponseWriter, r *http.Request, repo string) {
 				return
 			}
 
-			if strings.HasSuffix(repo, "ref-required") {
+			if strings.HasSuffix(repo, "branch-required") {
 				parts := strings.Split(repo, "-")
 				lenParts := len(parts)
-				if lenParts > 3 && parts[lenParts-3] != reqBody.RefName() {
+				if lenParts > 3 && "refs/heads/"+parts[lenParts-3] != reqBody.RefName() {
 					w.WriteHeader(403)
 					enc.Encode(struct {
 						Message string `json:"message"`
-					}{fmt.Sprintf("Expected ref %q, got %q", parts[lenParts-3], reqBody.RefName())})
+					}{fmt.Sprintf("Expected ref %q, got %q", "refs/heads/"+parts[lenParts-3], reqBody.RefName())})
 					return
 				}
 			}

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -781,7 +781,7 @@ begin_test "pre-push locks verify 403 with good ref"
 (
   set -e
 
-  reponame="lock-verify-master-ref-required"
+  reponame="lock-verify-master-branch-required"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"
 
@@ -803,7 +803,7 @@ begin_test "pre-push locks verify 403 with good tracked ref"
 (
   set -e
 
-  reponame="lock-verify-tracked-ref-required"
+  reponame="lock-verify-tracked-branch-required"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"
 
@@ -827,7 +827,7 @@ begin_test "pre-push locks verify 403 with explicit ref"
 (
   set -e
 
-  reponame="lock-verify-explicit-ref-required"
+  reponame="lock-verify-explicit-branch-required"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"
 
@@ -849,7 +849,7 @@ begin_test "pre-push locks verify 403 with bad ref"
 (
   set -e
 
-  reponame="lock-verify-other-ref-required"
+  reponame="lock-verify-other-branch-required"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"
 


### PR DESCRIPTION
Updates the `locks/verify` calls to send the full refspec. /cc #2712.