### PR TITLE
Uninstall man page improvements

### DIFF
--- a/docs/man/git-lfs-uninstall.1.ronn
+++ b/docs/man/git-lfs-uninstall.1.ronn
@@ -12,6 +12,12 @@ Perform the following actions to remove the Git LFS configuration:
 * Remove the "lfs" clean and smudge filters from the global Git config.
 * Uninstall the Git LFS pre-push hook if run from inside a Git repository.
 
+## OPTIONS
+
+* --local:
+    Removes the "lfs" smudge and clean filters from the local repository's git
+    config, instead of the global git config (~/.gitconfig).
+
 ## SEE ALSO
 
 git-lfs-install(1).

--- a/docs/man/git-lfs.1.ronn
+++ b/docs/man/git-lfs.1.ronn
@@ -59,6 +59,8 @@ commands and low level ("plumbing") commands.
     Show the status of Git LFS files in the working tree.
 * git-lfs-track(1):
     View or add Git LFS paths to Git attributes.
+* git-lfs-uninstall(1):
+    Uninstall Git LFS by removing hooks and smudge/clean filter configuration.
 * git-lfs-unlock(1):
     Remove "locked" setting for a file on the Git LFS server.
 * git-lfs-untrack(1):


### PR DESCRIPTION
Includes fixes for #2713 and #2714 

- `uninstall` is added to the list of commands on the top level man page
- the `--local` option is added to the man page for `uninstall`