### PR TITLE
progress: use git/githistory/log package for formatting

### DIFF
--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -2,9 +2,11 @@ package commands
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/git-lfs/git-lfs/filepathfilter"
 	"github.com/git-lfs/git-lfs/git"
+	"github.com/git-lfs/git-lfs/git/githistory/log"
 	"github.com/git-lfs/git-lfs/lfs"
 	"github.com/git-lfs/git-lfs/progress"
 	"github.com/spf13/cobra"
@@ -25,7 +27,9 @@ func checkoutCommand(cmd *cobra.Command, args []string) {
 
 	var totalBytes int64
 	var pointers []*lfs.WrappedPointer
+	logger := log.NewLogger(os.Stdout)
 	meter := progress.NewMeter(progress.WithOSEnv(cfg.Os))
+	logger.Enqueue(meter)
 	chgitscanner := lfs.NewGitScanner(func(p *lfs.WrappedPointer, err error) {
 		if err != nil {
 			LoggedError(err, "Scanner error: %s", err)

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -2,11 +2,13 @@ package commands
 
 import (
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
 	"github.com/git-lfs/git-lfs/filepathfilter"
 	"github.com/git-lfs/git-lfs/git"
+	"github.com/git-lfs/git-lfs/git/githistory/log"
 	"github.com/git-lfs/git-lfs/lfs"
 	"github.com/git-lfs/git-lfs/progress"
 	"github.com/git-lfs/git-lfs/tq"
@@ -37,7 +39,9 @@ func pull(filter *filepathfilter.Filter) {
 	}
 
 	pointers := newPointerMap()
+	logger := log.NewLogger(os.Stdout)
 	meter := progress.NewMeter(progress.WithOSEnv(cfg.Os))
+	logger.Enqueue(meter)
 	remote := cfg.Remote()
 	singleCheckout := newSingleCheckout(cfg.Git, remote)
 	q := newDownloadQueue(singleCheckout.Manifest(), remote, tq.WithProgress(meter))

--- a/git/githistory/log/log.go
+++ b/git/githistory/log/log.go
@@ -80,7 +80,7 @@ func (l *Logger) Close() {
 // Waitier creates and enqueues a new *WaitingTask.
 func (l *Logger) Waiter(msg string) *WaitingTask {
 	t := NewWaitingTask(msg)
-	l.enqueue(t)
+	l.Enqueue(t)
 
 	return t
 }
@@ -88,7 +88,7 @@ func (l *Logger) Waiter(msg string) *WaitingTask {
 // Percentage creates and enqueues a new *PercentageTask.
 func (l *Logger) Percentage(msg string, total uint64) *PercentageTask {
 	t := NewPercentageTask(msg, total)
-	l.enqueue(t)
+	l.Enqueue(t)
 
 	return t
 }
@@ -96,13 +96,13 @@ func (l *Logger) Percentage(msg string, total uint64) *PercentageTask {
 // List creates and enqueues a new *ListTask.
 func (l *Logger) List(msg string) *ListTask {
 	t := NewListTask(msg)
-	l.enqueue(t)
+	l.Enqueue(t)
 
 	return t
 }
 
-// enqueue enqueues the given Tasks "ts".
-func (l *Logger) enqueue(ts ...Task) {
+// Enqueue enqueues the given Tasks "ts".
+func (l *Logger) Enqueue(ts ...Task) {
 	if l == nil {
 		for _, t := range ts {
 			go func(t Task) {

--- a/git/githistory/log/log.go
+++ b/git/githistory/log/log.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/git-lfs/git-lfs/tools"
 	"github.com/olekukonko/ts"
 )
 
@@ -213,7 +212,7 @@ func (l *Logger) logTask(task Task) {
 // It returns the number of bytes "n" written to the sink and the error "err",
 // if one was encountered.
 func (l *Logger) logLine(str string) (n int, err error) {
-	padding := strings.Repeat(" ", tools.MaxInt(0, l.widthFn()-len(str)))
+	padding := strings.Repeat(" ", maxInt(0, l.widthFn()-len(str)))
 
 	return l.log(str + padding + "\r")
 }
@@ -224,4 +223,11 @@ func (l *Logger) logLine(str string) (n int, err error) {
 // if one was encountered.
 func (l *Logger) log(str string) (n int, err error) {
 	return fmt.Fprint(l.sink, str)
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }

--- a/git/githistory/log/log.go
+++ b/git/githistory/log/log.go
@@ -203,7 +203,12 @@ func (l *Logger) logTask(task Task) {
 		}
 	}
 
-	l.log(fmt.Sprintf("%s, done\n", update.S))
+	if update != nil {
+		// If a task sent no updates, the last recorded update will be
+		// nil. Given this, only log a message when there was at least
+		// (1) update.
+		l.log(fmt.Sprintf("%s, done\n", update.S))
+	}
 }
 
 // logLine writes a complete line and moves the cursor to the beginning of the

--- a/git/githistory/log/log_test.go
+++ b/git/githistory/log/log_test.go
@@ -175,3 +175,16 @@ func TestLoggerLogsAllDurableUpdates(t *testing.T) {
 		"second, done\n",
 	}, ""), buf.String())
 }
+
+func TestLoggerHandlesSilentTasks(t *testing.T) {
+	var buf bytes.Buffer
+
+	task := make(chan *Update)
+	close(task)
+
+	l := NewLogger(&buf)
+	l.Enqueue(ChanTask(task))
+	l.Close()
+
+	assert.Equal(t, "", buf.String())
+}

--- a/git/githistory/log/log_test.go
+++ b/git/githistory/log/log_test.go
@@ -34,7 +34,7 @@ func TestLoggerLogsTasks(t *testing.T) {
 	l := NewLogger(&buf)
 	l.throttle = 0
 	l.widthFn = func() int { return 0 }
-	l.enqueue(ChanTask(task))
+	l.Enqueue(ChanTask(task))
 	l.Close()
 
 	assert.Equal(t, "first\rsecond\rsecond, done\n", buf.String())
@@ -59,7 +59,7 @@ func TestLoggerLogsMultipleTasksInOrder(t *testing.T) {
 	l := NewLogger(&buf)
 	l.throttle = 0
 	l.widthFn = func() int { return 0 }
-	l.enqueue(ChanTask(t1), ChanTask(t2))
+	l.Enqueue(ChanTask(t1), ChanTask(t2))
 	l.Close()
 
 	assert.Equal(t, strings.Join([]string{
@@ -80,10 +80,10 @@ func TestLoggerLogsMultipleTasksWithoutBlocking(t *testing.T) {
 	t1, t2 := make(chan *Update), make(chan *Update)
 
 	l.widthFn = func() int { return 0 }
-	l.enqueue(ChanTask(t1))
+	l.Enqueue(ChanTask(t1))
 
 	t1 <- &Update{"first", time.Now(), false}
-	l.enqueue(ChanTask(t2))
+	l.Enqueue(ChanTask(t2))
 	close(t1)
 	t2 <- &Update{"second", time.Now(), false}
 	close(t2)
@@ -116,7 +116,7 @@ func TestLoggerThrottlesWrites(t *testing.T) {
 	l.widthFn = func() int { return 0 }
 	l.throttle = 15 * time.Millisecond
 
-	l.enqueue(ChanTask(t1))
+	l.Enqueue(ChanTask(t1))
 	l.Close()
 
 	assert.Equal(t, strings.Join([]string{
@@ -143,7 +143,7 @@ func TestLoggerThrottlesLastWrite(t *testing.T) {
 	l.widthFn = func() int { return 0 }
 	l.throttle = 15 * time.Millisecond
 
-	l.enqueue(ChanTask(t1))
+	l.Enqueue(ChanTask(t1))
 	l.Close()
 
 	assert.Equal(t, strings.Join([]string{
@@ -166,7 +166,7 @@ func TestLoggerLogsAllDurableUpdates(t *testing.T) {
 		close(t1)                                  // t = 0+3ε ms, throttle is closed
 	}()
 
-	l.enqueue(UnthrottledChanTask(t1))
+	l.Enqueue(UnthrottledChanTask(t1))
 	l.Close()
 
 	assert.Equal(t, strings.Join([]string{

--- a/progress/meter.go
+++ b/progress/meter.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
-	"github.com/olekukonko/ts"
+	"github.com/git-lfs/git-lfs/git/githistory/log"
+	"github.com/git-lfs/git-lfs/tools/humanize"
 )
 
 // ProgressMeter provides a progress bar type output for the TransferQueue. It
@@ -23,14 +23,13 @@ type ProgressMeter struct {
 	estimatedBytes    int64
 	currentBytes      int64
 	skippedBytes      int64
-	started           int32
 	estimatedFiles    int32
-	startTime         time.Time
-	finished          chan interface{}
+	paused            uint32
 	logger            *progressLogger
 	fileIndex         map[string]int64 // Maps a file name to its transfer number
 	fileIndexMutex    *sync.Mutex
 	dryRun            bool
+	updates           chan *log.Update
 }
 
 type env interface {
@@ -91,10 +90,9 @@ func WithOSEnv(os env) meterOption {
 func NewMeter(options ...meterOption) *ProgressMeter {
 	m := &ProgressMeter{
 		logger:         &progressLogger{},
-		startTime:      time.Now(),
 		fileIndex:      make(map[string]int64),
 		fileIndexMutex: &sync.Mutex{},
-		finished:       make(chan interface{}),
+		updates:        make(chan *log.Update),
 	}
 
 	for _, opt := range options {
@@ -106,22 +104,19 @@ func NewMeter(options ...meterOption) *ProgressMeter {
 
 // Start begins sending status updates to the optional log file, and stdout.
 func (p *ProgressMeter) Start() {
-	if atomic.CompareAndSwapInt32(&p.started, 0, 1) {
-		go p.writer()
-	}
+	atomic.StoreUint32(&p.paused, 0)
 }
 
 // Pause stops sending status updates temporarily, until Start() is called again.
 func (p *ProgressMeter) Pause() {
-	if atomic.CompareAndSwapInt32(&p.started, 1, 0) {
-		p.finished <- true
-	}
+	atomic.StoreUint32(&p.paused, 1)
 }
 
 // Add tells the progress meter that a single file of the given size will
 // possibly be transferred. If a file doesn't need to be transferred for some
 // reason, be sure to call Skip(int64) with the same size.
 func (p *ProgressMeter) Add(size int64) {
+	defer p.update()
 	atomic.AddInt32(&p.estimatedFiles, 1)
 	atomic.AddInt64(&p.estimatedBytes, size)
 }
@@ -129,6 +124,7 @@ func (p *ProgressMeter) Add(size int64) {
 // Skip tells the progress meter that a file of size `size` is being skipped
 // because the transfer is unnecessary.
 func (p *ProgressMeter) Skip(size int64) {
+	defer p.update()
 	atomic.AddInt64(&p.skippedFiles, 1)
 	atomic.AddInt64(&p.skippedBytes, size)
 	// Reduce bytes and files so progress easier to parse
@@ -139,6 +135,7 @@ func (p *ProgressMeter) Skip(size int64) {
 // StartTransfer tells the progress meter that a transferring file is being
 // added to the TransferQueue.
 func (p *ProgressMeter) StartTransfer(name string) {
+	defer p.update()
 	idx := atomic.AddInt64(&p.transferringFiles, 1)
 	p.fileIndexMutex.Lock()
 	p.fileIndex[name] = idx
@@ -147,12 +144,14 @@ func (p *ProgressMeter) StartTransfer(name string) {
 
 // TransferBytes increments the number of bytes transferred
 func (p *ProgressMeter) TransferBytes(direction, name string, read, total int64, current int) {
+	defer p.update()
 	atomic.AddInt64(&p.currentBytes, int64(current))
 	p.logBytes(direction, name, read, total)
 }
 
 // FinishTransfer increments the finished transfer count
 func (p *ProgressMeter) FinishTransfer(name string) {
+	defer p.update()
 	atomic.AddInt64(&p.finishedFiles, 1)
 	p.fileIndexMutex.Lock()
 	delete(p.fileIndex, name)
@@ -161,12 +160,54 @@ func (p *ProgressMeter) FinishTransfer(name string) {
 
 // Finish shuts down the ProgressMeter
 func (p *ProgressMeter) Finish() {
-	close(p.finished)
 	p.update()
-	p.logger.Close()
-	if !p.dryRun && p.estimatedBytes > 0 {
-		fmt.Fprintf(os.Stdout, "\n")
+	close(p.updates)
+}
+
+func (p *ProgressMeter) Updates() <-chan *log.Update {
+	return p.updates
+}
+
+func (p *ProgressMeter) Throttled() bool {
+	return true
+}
+
+func (p *ProgressMeter) update() {
+	if p.skipUpdate() {
+		return
 	}
+
+	p.updates <- &log.Update{
+		S:  p.str(),
+		At: time.Now(),
+	}
+}
+
+func (p *ProgressMeter) skipUpdate() bool {
+	return p.dryRun ||
+		(p.estimatedFiles == 0 && p.skippedFiles == 0) ||
+		atomic.LoadUint32(&p.paused) == 1
+}
+
+func (p *ProgressMeter) str() string {
+	// (%d of %d files, %d skipped) %f B / %f B, %f B skipped
+	// skipped counts only show when > 0
+
+	out := fmt.Sprintf("\rGit LFS: (%d of %d files",
+		p.finishedFiles,
+		p.estimatedFiles)
+	if p.skippedFiles > 0 {
+		out += fmt.Sprintf(", %d skipped", p.skippedFiles)
+	}
+	out += fmt.Sprintf(") %s / %s",
+		humanize.FormatBytes(uint64(p.currentBytes)),
+		humanize.FormatBytes(uint64(p.estimatedBytes)))
+	if p.skippedBytes > 0 {
+		out += fmt.Sprintf(", %s skipped",
+			humanize.FormatBytes(uint64(p.skippedBytes)))
+	}
+
+	return out
 }
 
 func (p *ProgressMeter) logBytes(direction, name string, read, total int64) {
@@ -177,86 +218,4 @@ func (p *ProgressMeter) logBytes(direction, name string, read, total int64) {
 	if err := p.logger.Write([]byte(line)); err != nil {
 		p.logger.Shutdown()
 	}
-}
-
-func (p *ProgressMeter) writer() {
-	p.update()
-	for {
-		select {
-		case <-p.finished:
-			return
-		case <-time.After(time.Millisecond * 200):
-			p.update()
-		}
-	}
-}
-
-func (p *ProgressMeter) update() {
-	if p.dryRun || (p.estimatedFiles == 0 && p.skippedFiles == 0) {
-		return
-	}
-
-	// (%d of %d files, %d skipped) %f B / %f B, %f B skipped
-	// skipped counts only show when > 0
-
-	out := fmt.Sprintf("\rGit LFS: (%d of %d files", p.finishedFiles, p.estimatedFiles)
-	if p.skippedFiles > 0 {
-		out += fmt.Sprintf(", %d skipped", p.skippedFiles)
-	}
-	out += fmt.Sprintf(") %s / %s", formatBytes(p.currentBytes), formatBytes(p.estimatedBytes))
-	if p.skippedBytes > 0 {
-		out += fmt.Sprintf(", %s skipped", formatBytes(p.skippedBytes))
-	}
-
-	fmt.Fprintf(os.Stdout, pad(out))
-}
-
-func formatBytes(i int64) string {
-	switch {
-	case i > 1099511627776:
-		return fmt.Sprintf("%#0.2f TB", float64(i)/1099511627776)
-	case i > 1073741824:
-		return fmt.Sprintf("%#0.2f GB", float64(i)/1073741824)
-	case i > 1048576:
-		return fmt.Sprintf("%#0.2f MB", float64(i)/1048576)
-	case i > 1024:
-		return fmt.Sprintf("%#0.2f KB", float64(i)/1024)
-	}
-
-	return fmt.Sprintf("%d B", i)
-}
-
-const defaultWidth = 80
-
-// pad pads the given message to occupy the entire maximum width of the terminal
-// LFS is attached to. In doing so, this safeguards subsequent prints of shorter
-// messages from leaving stray characters from the previous message on the
-// screen by writing over them with whitespace padding.
-func pad(msg string) string {
-	width := defaultWidth
-	size, err := ts.GetSize()
-	if err == nil {
-		// If `ts.GetSize()` was successful, set the width to the number
-		// of columns present in the terminal LFS is attached to.
-		// Otherwise, fall-back to `defaultWidth`.
-		width = size.Col()
-	}
-
-	// Pad the string with whitespace so that printing at the start of the
-	// line removes all traces from the last print.removes all traces from
-	// the last print.
-	padding := strings.Repeat(" ", maxInt(0, width-len(msg)))
-
-	return msg + padding
-}
-
-// maxInt returns the greater of two `int`s, "a", or "b". This function
-// originally comes from `github.com/git-lfs/git-lfs/tools#MaxInt`, but would
-// introduce an import cycle if depended on directly.
-func maxInt(a, b int) int {
-	if a > b {
-		return a
-	}
-
-	return b
 }

--- a/progress/noop.go
+++ b/progress/noop.go
@@ -1,10 +1,16 @@
 package progress
 
+import "github.com/git-lfs/git-lfs/git/githistory/log"
+
 func Noop() Meter {
-	return &nonMeter{}
+	return &nonMeter{
+		updates: make(chan *log.Update),
+	}
 }
 
-type nonMeter struct{}
+type nonMeter struct {
+	updates chan *log.Update
+}
 
 func (m *nonMeter) Start()                                                               {}
 func (m *nonMeter) Pause()                                                               {}
@@ -13,4 +19,9 @@ func (m *nonMeter) Skip(size int64)                                             
 func (m *nonMeter) StartTransfer(name string)                                            {}
 func (m *nonMeter) TransferBytes(direction, name string, read, total int64, current int) {}
 func (m *nonMeter) FinishTransfer(name string)                                           {}
-func (m *nonMeter) Finish()                                                              {}
+func (m *nonMeter) Finish() {
+	close(m.updates)
+}
+
+func (m *nonMeter) Updates() <-chan *log.Update { return m.updates }
+func (m *nonMeter) Throttled() bool             { return false }

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -2,7 +2,11 @@
 // NOTE: Subject to change, do not rely on this package from outside git-lfs source
 package progress
 
+import "github.com/git-lfs/git-lfs/git/githistory/log"
+
 type Meter interface {
+	log.Task
+
 	Start()
 	Pause()
 	Add(int64)

--- a/test/git-lfs-test-server-api/main.go
+++ b/test/git-lfs-test-server-api/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/fs"
+	"github.com/git-lfs/git-lfs/git/githistory/log"
 	"github.com/git-lfs/git-lfs/lfsapi"
 	"github.com/git-lfs/git-lfs/progress"
 	"github.com/git-lfs/git-lfs/test"
@@ -179,7 +180,9 @@ func buildTestData(repo *test.Repo, manifest *tq.Manifest) (oidsExist, oidsMissi
 	oidsMissing = make([]TestObject, 0, oidCount)
 
 	// just one commit
+	logger := log.NewLogger(os.Stdout)
 	meter := progress.NewMeter(progress.WithOSEnv(repo.OSEnv()))
+	logger.Enqueue(meter)
 	commit := test.CommitInput{CommitterName: "A N Other", CommitterEmail: "noone@somewhere.com"}
 	for i := 0; i < oidCount; i++ {
 		filename := fmt.Sprintf("file%d.dat", i)


### PR DESCRIPTION
This pull request extends the `progress.Meter` interface to implement `git/githistory/log.Task` so that the `progress.Meter` can be driven from a `*git/githistory/log.Logger`.

Being able to use the various implementations of `progress.Meter` within the `git/githistory/log` sub-package has the following benefits:

- Separating the concept of generating a message and printing it.
- Eliminating IO-races, where two things want to log at the same time and the message is garbled, or out of order.
- Consistent use of the `git/githistory/log` package, which makes changing IO behavior in this context easier.

Since it's been awhile for me, I wanted to write down some of the ideas in the `git/githistory/log` package here:

1. The `*Logger` logs `Task`s, which provide a channel of updates, and a `Throttled()` method, telling the logger whether or not they should be throttled.
2. The `*Logger` logs a `Task` until completion, enqueuing and subsequently printing messages from other `Task`s only after the currently running Task is complete. It buffers further tasks in a pseudo-infinite buffer.

This pull request seeks to achieve the above benefits by implementing `log.Task` in `progress.Meter`, making it possible to `log.NewLogger(...).Enqueue(progress.NewMeter())`. The approach towards doing this was done in a minimal fashion, keeping the majority of the formatting code as-is, but adding a new `update()` method, which sends a new update after each time a method that would change the output of the progress meter is called.

For instance:

```go
func (p *ProgressMeter) Add(size int64) {
	defer p.update()
 	atomic.AddInt32(&p.estimatedFiles, 1)
 	atomic.AddInt64(&p.estimatedBytes, size)
}
```

will modify the `*ProgressMeter`'s state, then issue a deferred `p.update()` call, which will construct a new update, and send it. The `*log.Logger` will either accept it, or drop it on the floor if the `*ProgressMeter` is generating too many updates.

This had some other unexpected benefits like removing the `for _ = range time.NewTicker(...).C` idiom, and simplifying the `Start()` and `Pause()` implementations.

## 

/cc @git-lfs/core @technoweenie 