### PR TITLE
lfsapi/auth: teach DoWithAuth to respect http.extraHeaders

### DIFF
--- a/lfsapi/auth.go
+++ b/lfsapi/auth.go
@@ -61,7 +61,7 @@ func (c *Client) doWithCreds(req *http.Request, credHelper CredentialHelper, cre
 	if access == NTLMAccess {
 		return c.doWithNTLM(req, credHelper, creds, credsURL)
 	}
-	return c.Do(req)
+	return c.do(req)
 }
 
 // getCreds fills the authorization header for the given request if possible,

--- a/lfsapi/auth.go
+++ b/lfsapi/auth.go
@@ -25,17 +25,6 @@ var (
 // supporting basic and ntlm authentication.
 func (c *Client) DoWithAuth(remote string, req *http.Request) (*http.Response, error) {
 	req.Header = c.extraHeadersFor(req)
-	if len(req.Header.Get("Authorization")) > 0 {
-		// If the extra headers that were configured contained
-		// credentials, assume it is preferred to use those over
-		// contacting the credential helper. Fallback to c.Do.
-		res, err := c.doWithRedirects(c.httpClient(req.Host), req, nil)
-		if err != nil {
-			return res, err
-		}
-
-		return res, c.handleResponse(res)
-	}
 
 	apiEndpoint, access, credHelper, credsURL, creds, err := c.getCreds(remote, req)
 	if err != nil {

--- a/lfsapi/auth.go
+++ b/lfsapi/auth.go
@@ -24,6 +24,19 @@ var (
 // authentication from netrc or git's credential helpers if necessary,
 // supporting basic and ntlm authentication.
 func (c *Client) DoWithAuth(remote string, req *http.Request) (*http.Response, error) {
+	req.Header = c.extraHeadersFor(req)
+	if len(req.Header.Get("Authorization")) > 0 {
+		// If the extra headers that were configured contained
+		// credentials, assume it is preferred to use those over
+		// contacting the credential helper. Fallback to c.Do.
+		res, err := c.doWithRedirects(c.httpClient(req.Host), req, nil)
+		if err != nil {
+			return res, err
+		}
+
+		return res, c.handleResponse(res)
+	}
+
 	apiEndpoint, access, credHelper, credsURL, creds, err := c.getCreds(remote, req)
 	if err != nil {
 		return nil, err

--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -85,6 +85,13 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	req.Header = c.extraHeadersFor(req)
 	req.Header.Set("User-Agent", UserAgent)
 
+	return c.do(req)
+}
+
+// do performs an *http.Request respecting redirects, and handles the response
+// as defined in c.handleResponse. Notably, it does not alter the headers for
+// the request argument in any way.
+func (c *Client) do(req *http.Request) (*http.Response, error) {
 	res, err := c.doWithRedirects(c.httpClient(req.Host), req, nil)
 	if err != nil {
 		return res, err

--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -83,7 +83,6 @@ func joinURL(prefix, suffix string) string {
 // extra headers, redirection handling, and error reporting.
 func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	req.Header = c.extraHeadersFor(req)
-	req.Header.Set("User-Agent", UserAgent)
 
 	return c.do(req)
 }
@@ -92,6 +91,8 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 // as defined in c.handleResponse. Notably, it does not alter the headers for
 // the request argument in any way.
 func (c *Client) do(req *http.Request) (*http.Response, error) {
+	req.Header.Set("User-Agent", UserAgent)
+
 	res, err := c.doWithRedirects(c.httpClient(req.Host), req, nil)
 	if err != nil {
 		return res, err

--- a/lfsapi/ntlm.go
+++ b/lfsapi/ntlm.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (c *Client) doWithNTLM(req *http.Request, credHelper CredentialHelper, creds Creds, credsURL *url.URL) (*http.Response, error) {
-	res, err := c.Do(req)
+	res, err := c.do(req)
 	if err != nil && !errors.IsAuthError(err) {
 		return res, err
 	}
@@ -69,7 +69,7 @@ func (c *Client) ntlmReAuth(req *http.Request, credHelper CredentialHelper, cred
 
 func (c *Client) ntlmNegotiate(req *http.Request, message string) (*http.Response, []byte, error) {
 	req.Header.Add("Authorization", message)
-	res, err := c.Do(req)
+	res, err := c.do(req)
 	if err != nil && !errors.IsAuthError(err) {
 		return res, nil, err
 	}
@@ -100,7 +100,7 @@ func (c *Client) ntlmChallenge(req *http.Request, challengeBytes []byte, creds C
 
 	authMsg := base64.StdEncoding.EncodeToString(authenticate.Bytes())
 	req.Header.Set("Authorization", "NTLM "+authMsg)
-	return c.Do(req)
+	return c.do(req)
 }
 
 func (c *Client) ntlmClientSession(creds Creds) (ntlm.ClientSession, error) {

--- a/test/test-extra-header.sh
+++ b/test/test-extra-header.sh
@@ -25,3 +25,37 @@ begin_test "http.<url>.extraHeader"
   grep "> X-Foo: baz" curl.log
 )
 end_test
+
+begin_test "http.<url>.extraHeader with authorization"
+(
+  set -e
+
+  reponame="requirecreds"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  # See: test/cmd/lfstest-gitserver.go:1176.
+  user="requirecreds"
+  pass="pass"
+  auth="Basic $(echo -n $user:$pass | base64)"
+
+  git config --add "http.extraHeader" "Authorization: $auth"
+
+  git lfs track "*.dat"
+  printf "contents" > a.dat
+  git add .gitattributes a.dat
+  git commit -m "initial commit"
+
+  git push origin master 2>&1 | tee curl.log
+  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
+    echo >&2 "expected \`git push origin master\` to succeed, didn't"
+    exit 1
+  fi
+
+  [ "0" -eq "$(grep -c "creds: filling with GIT_ASKPASS" curl.log)" ]
+  [ "0" -eq "$(grep -c "creds: git credential approve" curl.log)" ]
+  [ "0" -eq "$(grep -c "creds: git credential cache" curl.log)" ]
+  [ "0" -eq "$(grep -c "creds: git credential fill" curl.log)" ]
+  [ "0" -eq "$(grep -c "creds: git credential reject" curl.log)" ]
+)
+end_test


### PR DESCRIPTION
This pull request fixes a bug pointed out in https://github.com/git-lfs/git-lfs/issues/2729 where @TingluoHuang noticed that setting `http.$url.extraHeader` in your Git config would still cause API requests needing authorization to contact your credential helper, even if the authorization header was set.

Introduced here is a mechanism to avoid contacting the credential helper if any matching `http.extraHeaders` entry contains a header with the key `Authorization: `. This intentionally does not fall back to the credential cache or other credential helpers, since we assume that if a user explicitly provided an `Authorization` header, they would like to use that.

Closes: https://github.com/git-lfs/git-lfs/issues/2729

##

/cc @git-lfs/core https://github.com/git-lfs/git-lfs/issues/2729