### PR TITLE
commands/migrate: allow for ambiguous references in migrations

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -95,6 +95,20 @@ type Ref struct {
 	Sha  string
 }
 
+// String implements fmt.Stringer.String and returns the fully-qualified
+// reference name (including remote), i.e., for a remote branch called
+// 'my-feature' on remote 'origin', this function will return:
+//
+//   refs/remotes/origin/my-feature
+func (r *Ref) String() string {
+	prefix, ok := r.Type.Prefix()
+	if ok {
+		return fmt.Sprintf("%s/%s", prefix, r.Name)
+	}
+
+	return r.Name
+}
+
 // Some top level information about a commit (only first line of message)
 type CommitSummary struct {
 	Sha            string

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -13,6 +13,44 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestRefString(t *testing.T) {
+	const sha = "0000000000000000000000000000000000000000"
+	for s, r := range map[string]*Ref{
+		"refs/heads/master": &Ref{
+			Name: "master",
+			Type: RefTypeLocalBranch,
+			Sha:  sha,
+		},
+		"refs/remotes/origin/master": &Ref{
+			Name: "origin/master",
+			Type: RefTypeRemoteBranch,
+			Sha:  sha,
+		},
+		"refs/remotes/tags/v1.0.0": &Ref{
+			Name: "v1.0.0",
+			Type: RefTypeRemoteTag,
+			Sha:  sha,
+		},
+		"refs/tags/v1.0.0": &Ref{
+			Name: "v1.0.0",
+			Type: RefTypeLocalTag,
+			Sha:  sha,
+		},
+		"HEAD": &Ref{
+			Name: "HEAD",
+			Type: RefTypeHEAD,
+			Sha:  sha,
+		},
+		"other": &Ref{
+			Name: "other",
+			Type: RefTypeOther,
+			Sha:  sha,
+		},
+	} {
+		assert.Equal(t, s, r.String())
+	}
+}
+
 func TestParseRefs(t *testing.T) {
 	tests := map[string]RefType{
 		"refs/heads":        RefTypeLocalBranch,

--- a/test/test-migrate-import.sh
+++ b/test/test-migrate-import.sh
@@ -388,6 +388,7 @@ begin_test "migrate import (ambiguous reference)"
 
   # Create an ambiguously named reference sharing the name as the SHA-1 of
   # "HEAD".
+  sha="$(git rev-parse HEAD)"
   git tag "$sha"
 
   git lfs migrate import --everything

--- a/test/test-migrate-import.sh
+++ b/test/test-migrate-import.sh
@@ -403,8 +403,6 @@ begin_test "migrate import (--everything with --include-ref)"
 )
 end_test
 
-exit 0
-
 begin_test "migrate import (--everything with --exclude-ref)"
 (
   set -e

--- a/test/test-migrate-import.sh
+++ b/test/test-migrate-import.sh
@@ -380,6 +380,19 @@ begin_test "migrate import (--everything)"
 )
 end_test
 
+begin_test "migrate import (ambiguous reference)"
+(
+  set -e
+
+  setup_multiple_local_branches
+
+  # Create an ambiguously named reference sharing the name as the SHA-1 of
+  # "HEAD".
+  git tag "$sha"
+
+  git lfs migrate import --everything
+)
+end_test
 
 begin_test "migrate import (--everything with args)"
 (

--- a/test/test-migrate-info.sh
+++ b/test/test-migrate-info.sh
@@ -307,6 +307,20 @@ begin_test "migrate info (--everything)"
 )
 end_test
 
+begin_test "migrate info (ambiguous reference)"
+(
+  set -e
+
+  setup_multiple_local_branches
+
+  # Create an ambiguously named reference sharing the name as the SHA-1 of
+  # "HEAD".
+  git tag "$sha"
+
+  git lfs migrate info --everything
+)
+end_test
+
 begin_test "migrate info (--everything with args)"
 (
   set -e

--- a/test/test-migrate-info.sh
+++ b/test/test-migrate-info.sh
@@ -315,6 +315,7 @@ begin_test "migrate info (ambiguous reference)"
 
   # Create an ambiguously named reference sharing the name as the SHA-1 of
   # "HEAD".
+  sha="$(git rev-parse HEAD)"
   git tag "$sha"
 
   git lfs migrate info --everything


### PR DESCRIPTION
This pull request fixes a bug pointed out by @phord in https://github.com/git-lfs/git-lfs/issues/2654 where the `git lfs migrate` suite would refuse to disambiguate confusing reference names when asked to perform migrations.

@technoweenie points out a fix that I implemented in this pull request via https://github.com/git-lfs/git-lfs/issues/2654#issuecomment-335191900:

> Ah, I think this would be solved by including the ref prefixes, disambiguating the ref names.

To accomplish this, I taught the `*git.Ref` type to `String()` itself, returning a fully-qualified reference, and collect those instead of the local reference names. This allows for references to have existing SHA-1's as their local name, and migrate will still work correctly.

Closes: https://github.com/git-lfs/git-lfs/issues/2654.

##

/cc @git-lfs/core https://github.com/git-lfs/git-lfs/issues/2654