### PR TITLE
Filepathfilter wildcard

### DIFF
--- a/filepathfilter/filepathfilter.go
+++ b/filepathfilter/filepathfilter.go
@@ -355,6 +355,8 @@ func (n noOpMatcher) String() string {
 }
 
 var localDirSet = map[string]struct{}{
+	"*":   struct{}{},
+	"*.*": struct{}{},
 	".":   struct{}{},
 	"./":  struct{}{},
 	".\\": struct{}{},

--- a/filepathfilter/filepathfilter.go
+++ b/filepathfilter/filepathfilter.go
@@ -145,7 +145,7 @@ func NewPattern(rawpattern string) Pattern {
 
 	// Special case local dir, matches all (inc subpaths)
 	if _, local := localDirSet[cleanpattern]; local {
-		return noOpMatcher{}
+		return &noOpMatcher{pattern: cleanpattern}
 	}
 
 	hasPathSep := strings.Contains(cleanpattern, sep)
@@ -340,18 +340,22 @@ func (p *doubleWildcardPattern) String() string {
 }
 
 type noOpMatcher struct {
+	pattern string
 }
 
-func (n noOpMatcher) Match(name string) bool {
+func (n *noOpMatcher) Match(name string) bool {
 	return true
 }
 
-func (n noOpMatcher) HasPrefix(name string) bool {
+func (n *noOpMatcher) HasPrefix(name string) bool {
 	return true
 }
 
-func (n noOpMatcher) String() string {
-	return ""
+func (n *noOpMatcher) String() string {
+	if n == nil {
+		return ""
+	}
+	return n.pattern
 }
 
 var localDirSet = map[string]struct{}{

--- a/filepathfilter/filepathfilter_test.go
+++ b/filepathfilter/filepathfilter_test.go
@@ -112,14 +112,14 @@ func TestPatternMatch(t *testing.T) {
 
 func assertPatternMatch(t *testing.T, pattern string, filenames ...string) {
 	p := NewPattern(pattern)
-	for _, filename := range filenames {
+	for _, filename := range toWindowsPaths(filenames) {
 		assert.True(t, p.Match(filename), "%q should match pattern %q", filename, pattern)
 	}
 }
 
 func refutePatternMatch(t *testing.T, pattern string, filenames ...string) {
 	p := NewPattern(pattern)
-	for _, filename := range filenames {
+	for _, filename := range toWindowsPaths(filenames) {
 		assert.False(t, p.Match(filename), "%q should not match pattern %q", filename, pattern)
 	}
 }
@@ -154,23 +154,21 @@ func (c *filterPrefixTest) Assert(t *testing.T) {
 }
 
 func (c *filterPrefixTest) platformIncludes() []string {
-	if runtime.GOOS == "windows" {
-		return toWindowsPaths(c.includes)
-	}
-	return c.includes
+	return toWindowsPaths(c.includes)
 }
 
 func (c *filterPrefixTest) platformExcludes() []string {
-	if runtime.GOOS == "windows" {
-		return toWindowsPaths(c.excludes)
-	}
-	return c.excludes
+	return toWindowsPaths(c.excludes)
 }
 
 func toWindowsPaths(paths []string) []string {
-	var out []string
-	for _, path := range paths {
-		out = append(out, strings.Replace(path, "/", "\\", -1))
+	if runtime.GOOS != "windows" {
+		return paths
+	}
+
+	out := make([]string, len(paths))
+	for i, path := range paths {
+		out[i] = strings.Replace(path, "/", "\\", -1)
 	}
 
 	return out

--- a/filepathfilter/filepathfilter_test.go
+++ b/filepathfilter/filepathfilter_test.go
@@ -9,6 +9,20 @@ import (
 )
 
 func TestPatternMatch(t *testing.T) {
+	for _, wildcard := range []string{"*", "*.*"} {
+		assertPatternMatch(t, wildcard,
+			"a",
+			"a/",
+			"a.a",
+			"a/b",
+			"a/b/",
+			"a/b.b",
+			"a/b/c",
+			"a/b/c/",
+			"a/b/c.c",
+		)
+	}
+
 	assertPatternMatch(t, "filename.txt", "filename.txt")
 	assertPatternMatch(t, "*.txt", "filename.txt")
 	refutePatternMatch(t, "*.tx", "filename.txt")


### PR DESCRIPTION
This adds support for `--include="*.*"`, which should match everything:

```
$ git ls-files ':*.*'
.gitattributes
.gitignore
.mailmap
.travis.yml
CHANGELOG.md
CODE-OF-CONDUCT.md
CONTRIBUTING.md
INSTALLING.md
LICENSE.md
README.md
ROADMAP.md
appveyor.yml
circle.yml
commands/command_checkout.go
commands/command_clean.go
commands/command_clone.go
```

This also speeds up `*` matches too. It worked previously by calling `filepath.Match()` through a `*pathlessWildcardPattern`. 