### PR TITLE
commands/migrate: add '--skip-fetch' for offline migrations

### DIFF
--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -20,6 +20,11 @@ var (
 	// in the migration.
 	migrateExcludeRefs []string
 
+	// migrateAssumeCurrentRemoteReferences assumes that the client has the
+	// latest copy of remote references, and thus should not contact the
+	// remote for a set of updated references.
+	migrateAssumeCurrentRemoteReferences bool
+
 	// migrateEverything indicates the presence of the --everything flag,
 	// and instructs 'git lfs migrate' to migrate all local references.
 	migrateEverything bool
@@ -171,14 +176,22 @@ func getRemoteRefs(l *log.Logger) ([]string, error) {
 		return nil, err
 	}
 
-	w := l.Waiter("migrate: Fetching remote refs")
-	if err := git.Fetch(remotes...); err != nil {
-		return nil, err
+	if !migrateAssumeCurrentRemoteReferences {
+		w := l.Waiter("migrate: Fetching remote refs")
+		if err := git.Fetch(remotes...); err != nil {
+			return nil, err
+		}
+		w.Complete()
 	}
-	w.Complete()
 
 	for _, remote := range remotes {
-		refsForRemote, err := git.RemoteRefs(remote)
+		var refsForRemote []*git.Ref
+		if migrateAssumeCurrentRemoteReferences {
+			refsForRemote, err = git.CachedRemoteRefs(remote)
+		} else {
+			refsForRemote, err = git.RemoteRefs(remote)
+		}
+
 		if err != nil {
 			return nil, err
 		}
@@ -252,6 +265,7 @@ func init() {
 		cmd.PersistentFlags().StringSliceVar(&migrateIncludeRefs, "include-ref", nil, "An explicit list of refs to include")
 		cmd.PersistentFlags().StringSliceVar(&migrateExcludeRefs, "exclude-ref", nil, "An explicit list of refs to exclude")
 		cmd.PersistentFlags().BoolVar(&migrateEverything, "everything", false, "Migrate all local references")
+		cmd.PersistentFlags().BoolVar(&migrateAssumeCurrentRemoteReferences, "assume-current-remote-refs", false, "Assume up-to-date remote references.")
 
 		cmd.AddCommand(importCmd, info)
 	})

--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -20,10 +20,10 @@ var (
 	// in the migration.
 	migrateExcludeRefs []string
 
-	// migrateAssumeCurrentRemoteReferences assumes that the client has the
-	// latest copy of remote references, and thus should not contact the
-	// remote for a set of updated references.
-	migrateAssumeCurrentRemoteReferences bool
+	// migrateSkipFetch assumes that the client has the latest copy of
+	// remote references, and thus should not contact the remote for a set
+	// of updated references.
+	migrateSkipFetch bool
 
 	// migrateEverything indicates the presence of the --everything flag,
 	// and instructs 'git lfs migrate' to migrate all local references.
@@ -176,7 +176,7 @@ func getRemoteRefs(l *log.Logger) ([]string, error) {
 		return nil, err
 	}
 
-	if !migrateAssumeCurrentRemoteReferences {
+	if !migrateSkipFetch {
 		w := l.Waiter("migrate: Fetching remote refs")
 		if err := git.Fetch(remotes...); err != nil {
 			return nil, err
@@ -186,7 +186,7 @@ func getRemoteRefs(l *log.Logger) ([]string, error) {
 
 	for _, remote := range remotes {
 		var refsForRemote []*git.Ref
-		if migrateAssumeCurrentRemoteReferences {
+		if migrateSkipFetch {
 			refsForRemote, err = git.CachedRemoteRefs(remote)
 		} else {
 			refsForRemote, err = git.RemoteRefs(remote)
@@ -265,7 +265,7 @@ func init() {
 		cmd.PersistentFlags().StringSliceVar(&migrateIncludeRefs, "include-ref", nil, "An explicit list of refs to include")
 		cmd.PersistentFlags().StringSliceVar(&migrateExcludeRefs, "exclude-ref", nil, "An explicit list of refs to exclude")
 		cmd.PersistentFlags().BoolVar(&migrateEverything, "everything", false, "Migrate all local references")
-		cmd.PersistentFlags().BoolVar(&migrateAssumeCurrentRemoteReferences, "assume-current-remote-refs", false, "Assume up-to-date remote references.")
+		cmd.PersistentFlags().BoolVar(&migrateSkipFetch, "skip-fetch", false, "Assume up-to-date remote references.")
 
 		cmd.AddCommand(importCmd, info)
 	})

--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -27,7 +27,7 @@ git-lfs-migrate(1) - Migrate history to or from git-lfs
 * `--exclude-ref`=<refname>:
     See [INCLUDE AND EXCLUDE (REFS)].
 
-* `--assume-current-remote-refs`:
+* `--skip-fetch`:
     Assumes that the known set of remote references is complete, and should not
     be refreshed when determining the set of "un-pushed" commits to migrate. Has
     no effect when combined with `--include-ref` or `--exclude-ref`.

--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -27,6 +27,11 @@ git-lfs-migrate(1) - Migrate history to or from git-lfs
 * `--exclude-ref`=<refname>:
     See [INCLUDE AND EXCLUDE (REFS)].
 
+* `--assume-current-remote-refs`:
+    Assumes that the known set of remote references is complete, and should not
+    be refreshed when determining the set of "un-pushed" commits to migrate. Has
+    no effect when combined with `--include-ref` or `--exclude-ref`.
+
 * `--everything`:
     See [INCLUDE AND EXCLUDE (REFS)].
 

--- a/test/test-migrate-import.sh
+++ b/test/test-migrate-import.sh
@@ -202,6 +202,47 @@ begin_test "migrate import (given branch, exclude remote refs)"
 )
 end_test
 
+begin_test "migrate import (given ref, --assume-current-remote-refs)"
+(
+  set -e
+
+  setup_single_remote_branch
+
+  md_master_oid="$(calc_oid "$(git cat-file -p "refs/heads/master:a.md")")"
+  md_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/master:a.md")")"
+  txt_master_oid="$(calc_oid "$(git cat-file -p "refs/heads/master:a.txt")")"
+  txt_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/master:a.txt")")"
+
+  git tag pseudo-remote "$(git rev-parse refs/remotes/origin/master)"
+  # Remove the refs/remotes/origin/master ref, and instruct 'git lfs migrate' to
+  # not fetch it.
+  git update-ref -d refs/remotes/origin/master
+
+  git lfs migrate import --assume-current-remote-refs
+
+  assert_pointer "refs/heads/master" "a.md" "$md_master_oid" "50"
+  assert_pointer "pseudo-remote" "a.md" "$md_remote_oid" "140"
+  assert_pointer "refs/heads/master" "a.txt" "$txt_master_oid" "30"
+  assert_pointer "pseudo-remote" "a.txt" "$txt_remote_oid" "120"
+
+  assert_local_object "$md_master_oid" "50"
+  assert_local_object "$txt_master_oid" "30"
+  assert_local_object "$md_remote_oid" "140"
+  assert_local_object "$txt_remote_oid" "120"
+
+  master="$(git rev-parse refs/heads/master)"
+  remote="$(git rev-parse pseudo-remote)"
+
+  master_attrs="$(git cat-file -p "$master:.gitattributes")"
+  remote_attrs="$(git cat-file -p "$remote:.gitattributes")"
+
+  echo "$master_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
+  echo "$master_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"
+  echo "$remote_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
+  echo "$remote_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"
+)
+end_test
+
 begin_test "migrate import (include/exclude ref)"
 (
   set -e

--- a/test/test-migrate-import.sh
+++ b/test/test-migrate-import.sh
@@ -202,7 +202,7 @@ begin_test "migrate import (given branch, exclude remote refs)"
 )
 end_test
 
-begin_test "migrate import (given ref, --assume-current-remote-refs)"
+begin_test "migrate import (given ref, --skip-fetch)"
 (
   set -e
 
@@ -218,7 +218,7 @@ begin_test "migrate import (given ref, --assume-current-remote-refs)"
   # not fetch it.
   git update-ref -d refs/remotes/origin/master
 
-  git lfs migrate import --assume-current-remote-refs
+  git lfs migrate import --skip-fetch
 
   assert_pointer "refs/heads/master" "a.md" "$md_master_oid" "50"
   assert_pointer "pseudo-remote" "a.md" "$md_remote_oid" "140"

--- a/test/test-migrate-info.sh
+++ b/test/test-migrate-info.sh
@@ -132,7 +132,7 @@ begin_test "migrate info (given branch, exclude remote refs)"
 )
 end_test
 
-begin_test "migrate info (given ref, --assume-current-remote-refs)"
+begin_test "migrate info (given ref, --skip-fetch)"
 (
   set -e
 
@@ -146,7 +146,7 @@ begin_test "migrate info (given ref, --assume-current-remote-refs)"
   # not fetch it.
   git update-ref -d refs/remotes/origin/master
 
-  diff -u <(git lfs migrate info --assume-current-remote-refs 2>&1 | tail -n 2) <(cat <<-EOF
+  diff -u <(git lfs migrate info --skip-fetch 2>&1 | tail -n 2) <(cat <<-EOF
 	*.md 	190 B	2/2 files(s)	100%
 	*.txt	150 B	2/2 files(s)	100%
 	EOF)

--- a/test/test-migrate-info.sh
+++ b/test/test-migrate-info.sh
@@ -132,6 +132,33 @@ begin_test "migrate info (given branch, exclude remote refs)"
 )
 end_test
 
+begin_test "migrate info (given ref, --assume-current-remote-refs)"
+(
+  set -e
+
+  setup_single_remote_branch
+
+  original_remote="$(git rev-parse refs/remotes/origin/master)"
+  original_master="$(git rev-parse refs/heads/master)"
+
+  git tag pseudo-remote "$original_remote"
+  # Remove the refs/remotes/origin/master ref, and instruct 'git lfs migrate' to
+  # not fetch it.
+  git update-ref -d refs/remotes/origin/master
+
+  diff -u <(git lfs migrate info --assume-current-remote-refs 2>&1 | tail -n 2) <(cat <<-EOF
+	*.md 	190 B	2/2 files(s)	100%
+	*.txt	150 B	2/2 files(s)	100%
+	EOF)
+
+  migrated_remote="$(git rev-parse pseudo-remote)"
+  migrated_master="$(git rev-parse refs/heads/master)"
+
+  assert_ref_unmoved "refs/remotes/origin/master" "$original_remote" "$migrated_remote"
+  assert_ref_unmoved "refs/heads/master" "$original_master" "$migrated_master"
+)
+end_test
+
 begin_test "migrate info (include/exclude ref)"
 (
   set -e


### PR DESCRIPTION
This pull request addresses an enhancement pointed out @phord in https://github.com/git-lfs/git-lfs/issues/2656 where the `git-lfs-migrate(1)` command's use of `git-fetch(1)` would make the command un-useable offline.

Since it's been a little while since I've thought about how this works, here's a refresher for my own edification. When determining what to migrate, the tool considers first explicitly given references, or, if none were provided, the unpushed changes on the current branch (i.e., `git log <branch>..<remote-tracking-branch>`). To ensure that we get an up-to-date result and don't accidentally require a force push when the user wasn't expecting one, we always `git fetch` to grab the latest remote refs, if any of them have moved.

Prior to this pull request, there was no way to explicitly disable that, meaning if you don't have an internet connection, you have to (at least) remove remotes, which means the migration won't update any remote refs (since they will be deleted when calling `git remote remove`).

This pull request addresses this problem by providing a `--assume-current-remote-refs` that explicitly tells Git LFS to _not_ contact the remote, and assume the copy of remote references it currently has is up-to-date.

I decided against the original issue title:

> [...] shouldn't fetch or reach out to the remote at all without permission

Since I think the default behavior is safe, if not at least good. I would prefer to explicitly opt-_out_ of the safe behavior rather than into it.

Closes: https://github.com/git-lfs/git-lfs/issues/2656.

##

/cc @git-lfs/core https://github.com/git-lfs/git-lfs/issues/2656