### PR TITLE
git: prefer sending revisions over STDIN than arguments

### DIFF
--- a/git/rev_list_scanner.go
+++ b/git/rev_list_scanner.go
@@ -225,7 +225,7 @@ func NewRevListScanner(include, excluded []string, opt *ScanRefsOptions) (*RevLi
 // occurred.
 func revListArgs(include, exclude []string, opt *ScanRefsOptions) (io.Reader, []string, error) {
 	var stdin io.Reader
-	args := []string{"rev-list"}
+	args := []string{"rev-list", "--stdin"}
 	if !opt.CommitsOnly {
 		args = append(args, "--objects")
 	}
@@ -246,15 +246,16 @@ func revListArgs(include, exclude []string, opt *ScanRefsOptions) (io.Reader, []
 			args = append(args, "--do-walk")
 		}
 
-		args = append(args, includeExcludeShas(include, exclude)...)
+		stdin = strings.NewReader(strings.Join(
+			includeExcludeShas(include, exclude), "\n"))
 	case ScanAllMode:
 		args = append(args, "--all")
 	case ScanLeftToRemoteMode:
 		if len(opt.SkippedRefs) == 0 {
-			args = append(args, includeExcludeShas(include, exclude)...)
 			args = append(args, "--not", "--remotes="+opt.Remote)
+			stdin = strings.NewReader(strings.Join(
+				includeExcludeShas(include, exclude), "\n"))
 		} else {
-			args = append(args, "--stdin")
 			stdin = strings.NewReader(strings.Join(
 				append(includeExcludeShas(include, exclude), opt.SkippedRefs...), "\n"),
 			)

--- a/git/rev_list_scanner_test.go
+++ b/git/rev_list_scanner_test.go
@@ -4,13 +4,13 @@ import (
 	"bufio"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"strings"
 	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type ArgsTestCase struct {
@@ -32,11 +32,7 @@ func (c *ArgsTestCase) Assert(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	require.Equal(t, len(c.ExpectedArgs), len(args))
-	for i := 0; i < len(c.ExpectedArgs); i++ {
-		assert.Equal(t, c.ExpectedArgs[i], args[i],
-			"element #%d not equal: wanted %q, got %q", i, c.ExpectedArgs[i], args[i])
-	}
+	assert.EqualValues(t, c.ExpectedArgs, args)
 
 	if stdin != nil {
 		b, err := ioutil.ReadAll(stdin)
@@ -60,34 +56,38 @@ func TestRevListArgs(t *testing.T) {
 				Mode:             ScanRefsMode,
 				SkipDeletedBlobs: false,
 			},
-			ExpectedArgs: []string{"rev-list", "--objects", "--do-walk", s1, "^" + s2, "--"},
+			ExpectedStdin: fmt.Sprintf("%s\n^%s", s1, s2),
+			ExpectedArgs:  []string{"rev-list", "--stdin", "--objects", "--do-walk", "--"},
 		},
 		"scan refs not deleted, left and right": {
 			Include: []string{s1}, Exclude: []string{s2}, Opt: &ScanRefsOptions{
 				Mode:             ScanRefsMode,
 				SkipDeletedBlobs: true,
 			},
-			ExpectedArgs: []string{"rev-list", "--objects", "--no-walk", s1, "^" + s2, "--"},
+			ExpectedStdin: fmt.Sprintf("%s\n^%s", s1, s2),
+			ExpectedArgs:  []string{"rev-list", "--stdin", "--objects", "--no-walk", "--"},
 		},
 		"scan refs deleted, left only": {
 			Include: []string{s1}, Opt: &ScanRefsOptions{
 				Mode:             ScanRefsMode,
 				SkipDeletedBlobs: false,
 			},
-			ExpectedArgs: []string{"rev-list", "--objects", "--do-walk", s1, "--"},
+			ExpectedStdin: s1,
+			ExpectedArgs:  []string{"rev-list", "--stdin", "--objects", "--do-walk", "--"},
 		},
 		"scan refs not deleted, left only": {
 			Include: []string{s1}, Opt: &ScanRefsOptions{
 				Mode:             ScanRefsMode,
 				SkipDeletedBlobs: true,
 			},
-			ExpectedArgs: []string{"rev-list", "--objects", "--no-walk", s1, "--"},
+			ExpectedStdin: s1,
+			ExpectedArgs:  []string{"rev-list", "--stdin", "--objects", "--no-walk", "--"},
 		},
 		"scan all": {
 			Include: []string{s1}, Exclude: []string{s2}, Opt: &ScanRefsOptions{
 				Mode: ScanAllMode,
 			},
-			ExpectedArgs: []string{"rev-list", "--objects", "--all", "--"},
+			ExpectedArgs: []string{"rev-list", "--stdin", "--objects", "--all", "--"},
 		},
 		"scan left to remote, no skipped refs": {
 			Include: []string{s1}, Opt: &ScanRefsOptions{
@@ -95,7 +95,8 @@ func TestRevListArgs(t *testing.T) {
 				Remote:      "origin",
 				SkippedRefs: []string{},
 			},
-			ExpectedArgs: []string{"rev-list", "--objects", s1, "--not", "--remotes=origin", "--"},
+			ExpectedStdin: s1,
+			ExpectedArgs:  []string{"rev-list", "--stdin", "--objects", "--not", "--remotes=origin", "--"},
 		},
 		"scan left to remote, skipped refs": {
 			Include: []string{s1}, Exclude: []string{s2}, Opt: &ScanRefsOptions{
@@ -103,7 +104,7 @@ func TestRevListArgs(t *testing.T) {
 				Remote:      "origin",
 				SkippedRefs: []string{"a", "b", "c"},
 			},
-			ExpectedArgs:  []string{"rev-list", "--objects", "--stdin", "--"},
+			ExpectedArgs:  []string{"rev-list", "--stdin", "--objects", "--"},
 			ExpectedStdin: s1 + "\n^" + s2 + "\na\nb\nc",
 		},
 		"scan unknown type": {
@@ -117,35 +118,40 @@ func TestRevListArgs(t *testing.T) {
 				Mode:  ScanRefsMode,
 				Order: DateRevListOrder,
 			},
-			ExpectedArgs: []string{"rev-list", "--objects", "--date-order", "--do-walk", s1, "^" + s2, "--"},
+			ExpectedStdin: fmt.Sprintf("%s\n^%s", s1, s2),
+			ExpectedArgs:  []string{"rev-list", "--stdin", "--objects", "--date-order", "--do-walk", "--"},
 		},
 		"scan author date order": {
 			Include: []string{s1}, Exclude: []string{s2}, Opt: &ScanRefsOptions{
 				Mode:  ScanRefsMode,
 				Order: AuthorDateRevListOrder,
 			},
-			ExpectedArgs: []string{"rev-list", "--objects", "--author-date-order", "--do-walk", s1, "^" + s2, "--"},
+			ExpectedStdin: fmt.Sprintf("%s\n^%s", s1, s2),
+			ExpectedArgs:  []string{"rev-list", "--stdin", "--objects", "--author-date-order", "--do-walk", "--"},
 		},
 		"scan topo order": {
 			Include: []string{s1}, Exclude: []string{s2}, Opt: &ScanRefsOptions{
 				Mode:  ScanRefsMode,
 				Order: TopoRevListOrder,
 			},
-			ExpectedArgs: []string{"rev-list", "--objects", "--topo-order", "--do-walk", s1, "^" + s2, "--"},
+			ExpectedStdin: fmt.Sprintf("%s\n^%s", s1, s2),
+			ExpectedArgs:  []string{"rev-list", "--stdin", "--objects", "--topo-order", "--do-walk", "--"},
 		},
 		"scan commits only": {
 			Include: []string{s1}, Exclude: []string{s2}, Opt: &ScanRefsOptions{
 				Mode:        ScanRefsMode,
 				CommitsOnly: true,
 			},
-			ExpectedArgs: []string{"rev-list", "--do-walk", s1, "^" + s2, "--"},
+			ExpectedStdin: fmt.Sprintf("%s\n^%s", s1, s2),
+			ExpectedArgs:  []string{"rev-list", "--stdin", "--do-walk", "--"},
 		},
 		"scan reverse": {
 			Include: []string{s1}, Exclude: []string{s2}, Opt: &ScanRefsOptions{
 				Mode:    ScanRefsMode,
 				Reverse: true,
 			},
-			ExpectedArgs: []string{"rev-list", "--objects", "--reverse", "--do-walk", s1, "^" + s2, "--"},
+			ExpectedStdin: fmt.Sprintf("%s\n^%s", s1, s2),
+			ExpectedArgs:  []string{"rev-list", "--stdin", "--objects", "--reverse", "--do-walk", "--"},
 		},
 	} {
 		t.Run(desc, c.Assert)


### PR DESCRIPTION
This pull request fixes an issue pointed out by @phord via https://github.com/git-lfs/git-lfs/issues/2655:

> I have a large repo with 45000 refs. When I first tried to run git lfs migrate info on it, it failed with  this error:
>
> ```
> $ git lfs migrate info
> migrate: Fetching remote refs: ..., done
> fork/exec /usr/libexec/git-core/git: argument list too long
> ```

The general problem is that when migrating a set of references who's combined string length is longer than the system argument list limit, the system will refuse to execute the `git-rev-list(1)` command because its arguments are too long.

One approach in fixing this is to process separate invocations of `git-rev-list` and merge the results back together, but this gets complicated fairly quickly when merging distinct topologically ordered sets.

Another approach (and one that was already used in a particular case of `git-rev-list(1)` invocation) is to use the `--stdin` flag, which<sup>[[1](https://git-scm.com/docs/git-rev-list#git-rev-list---stdin)]</sup>:

> In addition to the <commit> listed on the command line, read them from the standard input. If a `--` separator is seen, stop reading commits and start reading paths to limit the result.

And will, in effect, allow an arbitrarily long list of references to be read over stdin, mitigating the argument length problem. We already used this in certain cases of `git.ScanLeftToRemote`, but this change teaches the `git.RevListScanner` to use `--stdin` for _all_ modes. 

Closes: https://github.com/git-lfs/git-lfs/issues/2655.

##

/cc @git-lfs/core https://github.com/git-lfs/git-lfs/issues/2655