### PR TITLE
status: fix incorrect formatting with unpushed objects

### DIFF
--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -221,7 +221,7 @@ func statusScanRefRange(ref *git.Ref) {
 			return
 		}
 
-		Print("\t%s (%s)", p.Name)
+		Print("\t%s (%s)", p.Name, p.Oid)
 	})
 	defer gitscanner.Close()
 

--- a/test/test-status.sh
+++ b/test/test-status.sh
@@ -385,3 +385,38 @@ begin_test "status (missing objects)"
     | grep "a.dat (?: <missing> -> LFS: $(calc_oid b | head -c 7))"
 )
 end_test
+
+begin_test "status (unpushed objects)"
+(
+  set -e
+
+  reponame="status-unpushed-objects"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  git push origin master
+
+  contents="a"
+  oid="$(calc_oid "$contents")"
+  printf "$contents" > a.dat
+
+  git add a.dat
+  git commit -m "add a large file"
+
+  expected="On branch master
+Git LFS objects to be pushed to origin/master:
+
+	a.dat ($oid)
+
+Git LFS objects to be committed:
+
+
+Git LFS objects not staged for commit:"
+
+  [ "$expected" = "$(git lfs status)" ]
+)
+end_test


### PR DESCRIPTION
This pull request fixes an issue pointed out by @fortytwoish in https://github.com/git-lfs/git-lfs/issues/2742, where `git lfs status` would not correctly format un-pushed objects, producing the following:

> git lfs status shows
> 
> ```
> $ git lfs status
> On branch master
> Git LFS objects to be pushed to origin/master:
>
>         [...]
>         Content/Maps/Prototypes/Autorunner.umap (%!s(MISSING))
>         [...]
> ```

I broke this in https://github.com/git-lfs/git-lfs/commit/6089d1931 (via: https://github.com/git-lfs/git-lfs/pull/2042), and this issue wasn't caught since we don't have any integration tests covering `git lfs status` running on un-pushed objects. In this pull request, such a test is added, along with a fix to remove the `(%!s(MISSING))` verb issue.

Closes: https://github.com/git-lfs/git-lfs/issues/2742

##

/cc @git-lfs/core @fortytwoish