### PR TITLE
git/odb: extract identifiers from commits verbatim

### DIFF
--- a/git/odb/commit.go
+++ b/git/odb/commit.go
@@ -120,9 +120,17 @@ func (c *Commit) Decode(from io.Reader, size int64) (n int, err error) {
 				}
 				c.ParentIDs = append(c.ParentIDs, id)
 			case "author":
-				c.Author = strings.Join(fields[1:], " ")
+				if len(text) >= 7 {
+					c.Author = text[7:]
+				} else {
+					c.Author = ""
+				}
 			case "committer":
-				c.Committer = strings.Join(fields[1:], " ")
+				if len(text) >= 10 {
+					c.Committer = text[10:]
+				} else {
+					c.Committer = ""
+				}
 			default:
 				c.ExtraHeaders = append(c.ExtraHeaders, &ExtraHeader{
 					K: fields[0],

--- a/git/odb/commit_test.go
+++ b/git/odb/commit_test.go
@@ -83,6 +83,32 @@ func TestCommitDecoding(t *testing.T) {
 	assert.Equal(t, "initial commit", commit.Message)
 }
 
+func TestCommitDecodingWithEmptyName(t *testing.T) {
+	author := &Signature{Name: "", Email: "john@example.com", When: time.Now()}
+	committer := &Signature{Name: "", Email: "jane@example.com", When: time.Now()}
+
+	treeId := []byte("cccccccccccccccccccc")
+
+	from := new(bytes.Buffer)
+
+	fmt.Fprintf(from, "author %s\n", author)
+	fmt.Fprintf(from, "committer %s\n", committer)
+	fmt.Fprintf(from, "tree %s\n", hex.EncodeToString(treeId))
+	fmt.Fprintf(from, "\ninitial commit\n")
+
+	flen := from.Len()
+
+	commit := new(Commit)
+	n, err := commit.Decode(from, int64(flen))
+
+	assert.Nil(t, err)
+	assert.Equal(t, flen, n)
+
+	assert.Equal(t, author.String(), commit.Author)
+	assert.Equal(t, committer.String(), commit.Committer)
+	assert.Equal(t, "initial commit", commit.Message)
+}
+
 func TestCommitDecodingWithMessageKeywordPrefix(t *testing.T) {
 	author := &Signature{Name: "John Doe", Email: "john@example.com", When: time.Now()}
 	committer := &Signature{Name: "Jane Doe", Email: "jane@example.com", When: time.Now()}


### PR DESCRIPTION
Currently `git migrate import` corrupts commit objects which contain empty committer/author names by removing the leading space from the email 

(i.e. `author 'SP' 'SP' <my@email.com> --> author 'SP' <my@email.com>`).

This causes `git fsck` to fail with a 
`missingNameBeforeEmail: invalid author/committer line - missing space before email`
error. (And, I guess, would also mangle names containing consecutive whitespace... ;) )

This PR modifies `Commit.Decode` to grab the identifiers as is, retaining all whitespace.