### PR TITLE
tasklog: don't drop updates in PercentageTask

### DIFF
--- a/tasklog/percentage_task.go
+++ b/tasklog/percentage_task.go
@@ -51,17 +51,10 @@ func (c *PercentageTask) Count(n uint64) (new uint64) {
 		percentage = 100 * float64(new) / float64(c.total)
 	}
 
-	u := &Update{
+	c.ch <- &Update{
 		S: fmt.Sprintf("%s: %3.f%% (%d/%d)",
 			c.msg, math.Floor(percentage), new, c.total),
 		At: time.Now(),
-	}
-
-	select {
-	case c.ch <- u:
-	default:
-		// Use a non-blocking write, since it's unimportant that callers
-		// receive all updates.
 	}
 
 	if new >= c.total {


### PR DESCRIPTION
This pull request changes the behavior of `*tasklog.ProgressTask` to no longer drop updates where the channel write to `ch` would block.

I discovered this issue while tweaking some of the output in the `git-lfs-prune(1)` command to use the new utilities provided by package `tasklog`. Sometimes, when using the `*PercentageTask` implementation provided, the final line would be:

```
<prefix>:   0% (0 of 1)
```

when it instead should have been:

```
<prefix>: 100% (1 of 1)
```

This is due to the non-blocking write that is removed in this pull-request. This is an artifact left over from before https://github.com/git-lfs/git-lfs/commit/fc1faca25aa1942aef8902bd6f1b1790ca6fdfed, when the `*log.Logger` implementation was taught how to discard too-frequent updates.

The old non-blocking write would cause some messages to be dropped in a race-y fashion when combined with this too-frequent filtering. To address this, write all updates, and expect instead that the `*tasklog.Logger` will drop them appropriately.

## 

/cc @git-lfs/core 