### PR TITLE
tasklog: introduce `*SimpleTask`

### DIFF
--- a/tasklog/percentage_task.go
+++ b/tasklog/percentage_task.go
@@ -51,17 +51,10 @@ func (c *PercentageTask) Count(n uint64) (new uint64) {
 		percentage = 100 * float64(new) / float64(c.total)
 	}
 
-	u := &Update{
+	c.ch <- &Update{
 		S: fmt.Sprintf("%s: %3.f%% (%d/%d)",
 			c.msg, math.Floor(percentage), new, c.total),
 		At: time.Now(),
-	}
-
-	select {
-	case c.ch <- u:
-	default:
-		// Use a non-blocking write, since it's unimportant that callers
-		// receive all updates.
 	}
 
 	if new >= c.total {

--- a/tasklog/simple_task.go
+++ b/tasklog/simple_task.go
@@ -1,0 +1,50 @@
+package tasklog
+
+import (
+	"fmt"
+	"time"
+)
+
+// SimpleTask is in an implementation of tasklog.Task which prints out messages
+// verbatim.
+type SimpleTask struct {
+	// ch is used to transmit task updates.
+	ch chan *Update
+}
+
+// NewSimpleTask returns a new *SimpleTask instance.
+func NewSimpleTask() *SimpleTask {
+	return &SimpleTask{
+		ch: make(chan *Update),
+	}
+}
+
+// Log logs a string with no formatting verbs.
+func (s *SimpleTask) Log(str string) {
+	s.Logf(str)
+}
+
+// Logf logs some formatted string, which is interpreted according to the rules
+// defined in package "fmt".
+func (s *SimpleTask) Logf(str string, vals ...interface{}) {
+	s.ch <- &Update{
+		S:  fmt.Sprintf(str, vals...),
+		At: time.Now(),
+	}
+}
+
+// Complete notes that the task is completed by closing the Updates channel and
+// yields the logger to the next Task.
+func (s *SimpleTask) Complete() {
+	close(s.ch)
+}
+
+// Updates implements Task.Updates and returns a channel of updates which is
+// closed when Complete() is called.
+func (s *SimpleTask) Updates() <-chan *Update {
+	return s.ch
+}
+
+// Throttled implements Task.Throttled and returns false, indicating that this
+// task is not throttled.
+func (s *SimpleTask) Throttled() bool { return false }

--- a/tasklog/simple_task_test.go
+++ b/tasklog/simple_task_test.go
@@ -1,0 +1,76 @@
+package tasklog
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSimpleTaskLogLogsUpdates(t *testing.T) {
+	task := NewSimpleTask()
+
+	var updates []*Update
+
+	wait := new(sync.WaitGroup)
+	wait.Add(1)
+	go func() {
+		for update := range task.Updates() {
+			updates = append(updates, update)
+		}
+		wait.Done()
+	}()
+
+	task.Log("Hello, world")
+	task.Complete()
+
+	require.Len(t, updates, 1)
+	assert.Equal(t, "Hello, world", updates[0].S)
+}
+
+func TestSimpleTaskLogfLogsFormattedUpdates(t *testing.T) {
+	task := NewSimpleTask()
+
+	var updates []*Update
+
+	wait := new(sync.WaitGroup)
+	wait.Add(1)
+	go func() {
+		for update := range task.Updates() {
+			updates = append(updates, update)
+		}
+		wait.Done()
+	}()
+
+	task.Logf("Hello, world (%d)", 3+4)
+	task.Complete()
+
+	require.Len(t, updates, 1)
+	assert.Equal(t, "Hello, world (7)", updates[0].S)
+}
+
+func TestSimpleTaskCompleteClosesUpdates(t *testing.T) {
+	task := NewSimpleTask()
+
+	select {
+	case <-task.Updates():
+		t.Fatalf("tasklog: unexpected update from *SimpleTask")
+	default:
+	}
+
+	task.Complete()
+
+	if _, ok := <-task.Updates(); ok {
+		t.Fatalf("tasklog: expected (*SimpleTask).Updates() to be closed")
+	}
+}
+
+func TestSimpleTaskIsNotThrottled(t *testing.T) {
+	task := NewSimpleTask()
+
+	throttled := task.Throttled()
+
+	assert.False(t, throttled,
+		"tasklog: expected *SimpleTask not to be Throttle()-d")
+}


### PR DESCRIPTION
This pull request introduces a new `Task` implementation, `*tasklog.SimpleTask`, for logging unrelated messages.

This functionality is required in replacing the usage of `*progress.Spinner` from within the `git-lfs-prune(1)` command. Instead of building domain-specific Task implementations, this pull request proposes the introduction of a string-based Task implementation that logs (and formats) strings without formatting guidelines.

This allows for quick prototyping of new Logger use-cases without the need to build out domain-specific loggers, and is a good fit for use within the `git-lfs-prune(1)` command.

##

/cc @git-lfs/core 