### PR TITLE
commands/fetch: unify formatting

### DIFF
--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -229,6 +229,8 @@ func fetchAll() bool {
 func scanAll() []*lfs.WrappedPointer {
 	// This could be a long process so use the chan version & report progress
 	task := tasklog.NewSimpleTask()
+	defer task.Complete()
+
 	logger := tasklog.NewLogger(OutputWriter)
 	logger.Enqueue(task)
 	var numObjs int64
@@ -260,8 +262,6 @@ func scanAll() []*lfs.WrappedPointer {
 	if multiErr != nil {
 		Panic(multiErr, "Could not scan for Git LFS files")
 	}
-
-	task.Complete()
 	return pointers
 }
 

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -84,7 +84,7 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 
 		// Fetch refs sequentially per arg order; duplicates in later refs will be ignored
 		for _, ref := range refs {
-			Print("fetch: Fetching reference %s", ref.Name)
+			Print("fetch: Fetching reference %s", ref.Refspec())
 			s := fetchRef(ref.Sha, filter)
 			success = success && s
 		}

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -84,7 +84,7 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 
 		// Fetch refs sequentially per arg order; duplicates in later refs will be ignored
 		for _, ref := range refs {
-			Print("Fetching %v", ref.Name)
+			Print("fetch: Fetching reference %s", ref.Name)
 			s := fetchRef(ref.Sha, filter)
 			success = success && s
 		}
@@ -181,7 +181,7 @@ func fetchRecent(fetchconf lfs.FetchPruneConfig, alreadyFetchedRefs []*git.Ref, 
 	}
 	// First find any other recent refs
 	if fetchconf.FetchRecentRefsDays > 0 {
-		Print("Fetching recent branches within %v days", fetchconf.FetchRecentRefsDays)
+		Print("fetch: Fetching recent branches within %v days", fetchconf.FetchRecentRefsDays)
 		refsSince := time.Now().AddDate(0, 0, -fetchconf.FetchRecentRefsDays)
 		refs, err := git.RecentBranches(refsSince, fetchconf.FetchRecentRefsIncludeRemotes, cfg.Remote())
 		if err != nil {
@@ -195,7 +195,7 @@ func fetchRecent(fetchconf lfs.FetchPruneConfig, alreadyFetchedRefs []*git.Ref, 
 				}
 			} else {
 				uniqueRefShas[ref.Sha] = ref.Name
-				Print("Fetching %v", ref.Name)
+				Print("fetch: Fetching reference %s", ref.Name)
 				k := fetchRef(ref.Sha, filter)
 				ok = ok && k
 			}
@@ -210,7 +210,7 @@ func fetchRecent(fetchconf lfs.FetchPruneConfig, alreadyFetchedRefs []*git.Ref, 
 				Error("Couldn't scan commits at %v: %v", refName, err)
 				continue
 			}
-			Print("Fetching changes within %v days of %v", fetchconf.FetchRecentCommitsDays, refName)
+			Print("fetch: Fetching changes within %v days of %v", fetchconf.FetchRecentCommitsDays, refName)
 			commitsSince := summ.CommitDate.AddDate(0, 0, -fetchconf.FetchRecentCommitsDays)
 			k := fetchPreviousVersions(commit, commitsSince, filter)
 			ok = ok && k
@@ -222,16 +222,15 @@ func fetchRecent(fetchconf lfs.FetchPruneConfig, alreadyFetchedRefs []*git.Ref, 
 
 func fetchAll() bool {
 	pointers := scanAll()
-	Print("Fetching objects...")
+	Print("fetch: Fetching all references...")
 	return fetchAndReportToChan(pointers, nil, nil)
 }
 
 func scanAll() []*lfs.WrappedPointer {
 	// This could be a long process so use the chan version & report progress
-	Print("Scanning for all objects ever referenced...")
+	task := tasklog.NewSimpleTask()
 	logger := tasklog.NewLogger(OutputWriter)
-	spinner := progress.NewSpinner()
-	logger.Enqueue(spinner)
+	logger.Enqueue(task)
 	var numObjs int64
 
 	// use temp gitscanner to collect pointers
@@ -248,7 +247,7 @@ func scanAll() []*lfs.WrappedPointer {
 		}
 
 		numObjs++
-		spinner.Spinf("%d objects found", numObjs)
+		task.Logf("fetch: %d object(s) found", numObjs)
 		pointers = append(pointers, p)
 	})
 
@@ -262,7 +261,7 @@ func scanAll() []*lfs.WrappedPointer {
 		Panic(multiErr, "Could not scan for Git LFS files")
 	}
 
-	spinner.Finish("%d objects found", numObjs)
+	task.Complete()
 	return pointers
 }
 

--- a/tasklog/percentage_task.go
+++ b/tasklog/percentage_task.go
@@ -51,17 +51,10 @@ func (c *PercentageTask) Count(n uint64) (new uint64) {
 		percentage = 100 * float64(new) / float64(c.total)
 	}
 
-	u := &Update{
+	c.ch <- &Update{
 		S: fmt.Sprintf("%s: %3.f%% (%d/%d)",
 			c.msg, math.Floor(percentage), new, c.total),
 		At: time.Now(),
-	}
-
-	select {
-	case c.ch <- u:
-	default:
-		// Use a non-blocking write, since it's unimportant that callers
-		// receive all updates.
 	}
 
 	if new >= c.total {

--- a/tasklog/simple_task.go
+++ b/tasklog/simple_task.go
@@ -1,0 +1,50 @@
+package tasklog
+
+import (
+	"fmt"
+	"time"
+)
+
+// SimpleTask is in an implementation of tasklog.Task which prints out messages
+// verbatim.
+type SimpleTask struct {
+	// ch is used to transmit task updates.
+	ch chan *Update
+}
+
+// NewSimpleTask returns a new *SimpleTask instance.
+func NewSimpleTask() *SimpleTask {
+	return &SimpleTask{
+		ch: make(chan *Update),
+	}
+}
+
+// Log logs a string with no formatting verbs.
+func (s *SimpleTask) Log(str string) {
+	s.Logf(str)
+}
+
+// Logf logs some formatted string, which is interpreted according to the rules
+// defined in package "fmt".
+func (s *SimpleTask) Logf(str string, vals ...interface{}) {
+	s.ch <- &Update{
+		S:  fmt.Sprintf(str, vals...),
+		At: time.Now(),
+	}
+}
+
+// Complete notes that the task is completed by closing the Updates channel and
+// yields the logger to the next Task.
+func (s *SimpleTask) Complete() {
+	close(s.ch)
+}
+
+// Updates implements Task.Updates and returns a channel of updates which is
+// closed when Complete() is called.
+func (s *SimpleTask) Updates() <-chan *Update {
+	return s.ch
+}
+
+// Throttled implements Task.Throttled and returns false, indicating that this
+// task is not throttled.
+func (s *SimpleTask) Throttled() bool { return false }

--- a/tasklog/simple_task_test.go
+++ b/tasklog/simple_task_test.go
@@ -1,0 +1,76 @@
+package tasklog
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSimpleTaskLogLogsUpdates(t *testing.T) {
+	task := NewSimpleTask()
+
+	var updates []*Update
+
+	wait := new(sync.WaitGroup)
+	wait.Add(1)
+	go func() {
+		for update := range task.Updates() {
+			updates = append(updates, update)
+		}
+		wait.Done()
+	}()
+
+	task.Log("Hello, world")
+	task.Complete()
+
+	require.Len(t, updates, 1)
+	assert.Equal(t, "Hello, world", updates[0].S)
+}
+
+func TestSimpleTaskLogfLogsFormattedUpdates(t *testing.T) {
+	task := NewSimpleTask()
+
+	var updates []*Update
+
+	wait := new(sync.WaitGroup)
+	wait.Add(1)
+	go func() {
+		for update := range task.Updates() {
+			updates = append(updates, update)
+		}
+		wait.Done()
+	}()
+
+	task.Logf("Hello, world (%d)", 3+4)
+	task.Complete()
+
+	require.Len(t, updates, 1)
+	assert.Equal(t, "Hello, world (7)", updates[0].S)
+}
+
+func TestSimpleTaskCompleteClosesUpdates(t *testing.T) {
+	task := NewSimpleTask()
+
+	select {
+	case <-task.Updates():
+		t.Fatalf("tasklog: unexpected update from *SimpleTask")
+	default:
+	}
+
+	task.Complete()
+
+	if _, ok := <-task.Updates(); ok {
+		t.Fatalf("tasklog: expected (*SimpleTask).Updates() to be closed")
+	}
+}
+
+func TestSimpleTaskIsNotThrottled(t *testing.T) {
+	task := NewSimpleTask()
+
+	throttled := task.Throttled()
+
+	assert.False(t, throttled,
+		"tasklog: expected *SimpleTask not to be Throttle()-d")
+}


### PR DESCRIPTION
This pull request unifies the formatting of `git-lfs-fetch(1)`'s output, similarly to https://github.com/git-lfs/git-lfs/pull/2757.

Before:

```
~/repository (master) $ git lfs fetch --all
Scanning for all objects ever referenced...
Fetching objects...
✔ 501 objects found, done
Git LFS: (291 of 291 files) 1.1 KB / 1.1 KB, done
```

After:

```
~/repository (master) $ git lfs fetch --all
fetch: Fetching all references...
fetch: 501 object(s) found, done
Git LFS: (501 of 501 files) 1.9 KB / 1.9 KB, done
```

## 

This removes the later of the two remaining uses of the `*progress.Spinner` type, which will allow it to be removed entirely in a subsequent pull request.

Similar to https://github.com/git-lfs/git-lfs/pull/2757:

> Please let me know if you have any thoughts on the formatting of these messages. I tried to make them as similar as I would imagine Git writing them, with these thoughts in mind:
> 
> 1. Lowercase prefix of the command that is being run.
> 2. ", done\n" on the end (courtesy of `*tasklog.Logger`).
> 3. ~~Use percentages where appropriate, text where otherwise.~~

##

/cc @git-lfs/core 