### PR TITLE
tasklog: teach *Logger how to enqueue new `*SimpleTask`'s

### DIFF
--- a/tasklog/log.go
+++ b/tasklog/log.go
@@ -101,6 +101,14 @@ func (l *Logger) List(msg string) *ListTask {
 	return t
 }
 
+// List creates and enqueues a new *SimpleTask.
+func (l *Logger) Simple() *SimpleTask {
+	t := NewSimpleTask()
+	l.Enqueue(t)
+
+	return t
+}
+
 // Enqueue enqueues the given Tasks "ts".
 func (l *Logger) Enqueue(ts ...Task) {
 	if l == nil {


### PR DESCRIPTION
This pull request adds a `Simple()` method to the `*tasklog.Logger` API, which is consistent with other existing methods, and was pointed out by @technoweenie in https://github.com/git-lfs/git-lfs/pull/2757#discussion_r154760580.

##

/cc @git-lfs/core 