### PR TITLE
commands/migrate: don't migrate remote references in bare repositories

### DIFF
--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -151,17 +151,24 @@ func includeExcludeRefs(l *tasklog.Logger, args []string) (include, exclude []st
 			include = append(include, ref.Refspec())
 		}
 	} else {
-		// Otherwise, if neither --include-ref=<ref> or
-		// --exclude-ref=<ref> were given, include no additional
-		// references, and exclude all remote references that are remote
-		// branches or remote tags.
-		remoteRefs, err := getRemoteRefs(l)
+		bare, err := git.IsBare()
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, errors.Wrap(err, "fatal: unable to determine bareness")
 		}
 
-		for _, rr := range remoteRefs {
-			exclude = append(exclude, rr.Refspec())
+		if !bare {
+			// Otherwise, if neither --include-ref=<ref> or
+			// --exclude-ref=<ref> were given, include no additional
+			// references, and exclude all remote references that
+			// are remote branches or remote tags.
+			remoteRefs, err := getRemoteRefs(l)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			for _, rr := range remoteRefs {
+				exclude = append(exclude, rr.Refspec())
+			}
 		}
 	}
 

--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -130,7 +130,7 @@ migrated.
 
 The migrate command's most common use case is to convert large git objects to
 LFS before pushing your commits. By default, it only scans commits that don't
-exist on any remote.
+exist on any remote, so long as the repository is non-bare.
 
 First, run `git lfs migrate info` to list the file types taking up the most
 space in your repository.

--- a/test/test-migrate-import.sh
+++ b/test/test-migrate-import.sh
@@ -33,6 +33,16 @@ begin_test "migrate import (default branch)"
 )
 end_test
 
+begin_test "migrate import (bare repository)"
+(
+  set -e
+
+  setup_multiple_remote_branches
+
+  git lfs migrate import --everything
+)
+end_test
+
 begin_test "migrate import (given branch)"
 (
   set -e

--- a/test/test-migrate-info.sh
+++ b/test/test-migrate-info.sh
@@ -22,6 +22,16 @@ begin_test "migrate info (default branch)"
 )
 end_test
 
+begin_test "migrate info (bare repository)"
+(
+  set -e
+
+  setup_multiple_remote_branches
+
+  git lfs migrate info --everything
+)
+end_test
+
 begin_test "migrate info (given branch)"
 (
   set -e


### PR DESCRIPTION
This pull request fixes a bug pointed out by @sgoo in https://github.com/git-lfs/git-lfs/issues/2688, where `git lfs migrate info --everything` would fail when run under a bare repository.

The issue occurred because `git-lfs-migrate(1)` assumed that remote references do always exist, which is not the case when operating in a bare repository. (Interestingly, this is not the first time that I have forgotten about bare repositories: c.f., https://github.com/git-lfs/git-lfs/pull/2389, https://github.com/git-lfs/git-lfs/pull/1310).

Normally, this assumption is not error-prone, when the user provides an explicit list of reference to include and not include in a migration. However, when this list is not provided, _and_ the migration is run in a bare repository, the migrator would previously (and incorrectly) include remote references that do not exist.

From the Git documentation<sup>[[1](https://git-scm.com/docs/git-clone#git-clone---bare)]</sup>: 

> `--bare` [...] Also the branch heads at the remote are copied directly to corresponding local branch heads, without mapping them to refs/remotes/origin/.

To fix this, we skip the exclusion of remote references when the repository is bare.

Closes https://github.com/git-lfs/git-lfs/issues/2688.

##

/cc @git-lfs/core @sgoo