### PR TITLE
Specify the embedded Windows icon as part of versioninfo.json

### DIFF
--- a/git-lfs.go
+++ b/git-lfs.go
@@ -1,4 +1,4 @@
-//go:generate goversioninfo -icon=script/windows-installer/git-lfs-logo.ico
+//go:generate goversioninfo
 
 package main
 

--- a/versioninfo.json
+++ b/versioninfo.json
@@ -14,5 +14,6 @@
 		"LegalCopyright": "GitHub, Inc. and Git LFS contributors",
 		"ProductName": "Git Large File Storage (LFS)",
 		"ProductVersion": "2.3.4"
-	}
+	},
+	"IconPath": "script/windows-installer/git-lfs-logo.ico"
 }


### PR DESCRIPTION
As of [1] goversioninfo supports specifying the icon to embed as part of
versioninfo.json. Use that new mechanism for consistency with specifying
other meta-data fields.

[1] https://github.com/josephspurrier/goversioninfo/pull/17