### PR TITLE
tq: send refspec with batch requests

### DIFF
--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -96,7 +96,8 @@ func uploadsWithObjectIDs(ctx *uploadContext, oids []string) {
 	}
 
 	uploadPointers(ctx, pointers...)
-	ctx.Await()
+	ctx.CollectErrors(ctx.tq)
+	ctx.ReportErrors()
 }
 
 // lfsPushRefs returns valid ref updates from the given ref and --all arguments.

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -126,9 +126,7 @@ func newDownloadQueue(manifest *tq.Manifest, remote string, options ...tq.Option
 
 // newUploadQueue builds an UploadQueue, allowing `workers` concurrent uploads.
 func newUploadQueue(manifest *tq.Manifest, remote string, options ...tq.Option) *tq.TransferQueue {
-	return tq.NewTransferQueue(tq.Upload, manifest, remote, append(options,
-		tq.RemoteRef(currentRemoteRef()),
-	)...)
+	return tq.NewTransferQueue(tq.Upload, manifest, remote, options...)
 }
 
 func currentRemoteRef() *git.Ref {

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -111,20 +111,28 @@ func newLockClient() *locking.Client {
 
 // newDownloadCheckQueue builds a checking queue, checks that objects are there but doesn't download
 func newDownloadCheckQueue(manifest *tq.Manifest, remote string, options ...tq.Option) *tq.TransferQueue {
-	allOptions := make([]tq.Option, 0, len(options)+1)
-	allOptions = append(allOptions, options...)
-	allOptions = append(allOptions, tq.DryRun(true))
-	return newDownloadQueue(manifest, remote, allOptions...)
+	return newDownloadQueue(manifest, remote, append(options,
+		tq.DryRun(true),
+		tq.RemoteRef(currentRemoteRef()),
+	)...)
 }
 
 // newDownloadQueue builds a DownloadQueue, allowing concurrent downloads.
 func newDownloadQueue(manifest *tq.Manifest, remote string, options ...tq.Option) *tq.TransferQueue {
-	return tq.NewTransferQueue(tq.Download, manifest, remote, options...)
+	return tq.NewTransferQueue(tq.Download, manifest, remote, append(options,
+		tq.RemoteRef(currentRemoteRef()),
+	)...)
 }
 
 // newUploadQueue builds an UploadQueue, allowing `workers` concurrent uploads.
 func newUploadQueue(manifest *tq.Manifest, remote string, options ...tq.Option) *tq.TransferQueue {
-	return tq.NewTransferQueue(tq.Upload, manifest, remote, options...)
+	return tq.NewTransferQueue(tq.Upload, manifest, remote, append(options,
+		tq.RemoteRef(currentRemoteRef()),
+	)...)
+}
+
+func currentRemoteRef() *git.Ref {
+	return newRefUpdate(cfg.Git, cfg.PushRemote(), cfg.CurrentRef(), nil).Right()
 }
 
 func buildFilepathFilter(config *config.Configuration, includeArg, excludeArg *string) *filepathfilter.Filter {

--- a/progress/meter.go
+++ b/progress/meter.go
@@ -159,6 +159,11 @@ func (p *ProgressMeter) FinishTransfer(name string) {
 	p.fileIndexMutex.Unlock()
 }
 
+// Sync sends an update now, if necessary
+func (p *ProgressMeter) Sync() {
+	p.update()
+}
+
 // Finish shuts down the ProgressMeter
 func (p *ProgressMeter) Finish() {
 	p.update()

--- a/progress/noop.go
+++ b/progress/noop.go
@@ -19,6 +19,7 @@ func (m *nonMeter) Skip(size int64)                                             
 func (m *nonMeter) StartTransfer(name string)                                            {}
 func (m *nonMeter) TransferBytes(direction, name string, read, total int64, current int) {}
 func (m *nonMeter) FinishTransfer(name string)                                           {}
+func (m *nonMeter) Sync()                                                                {}
 func (m *nonMeter) Finish() {
 	close(m.updates)
 }

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -14,5 +14,6 @@ type Meter interface {
 	StartTransfer(name string)
 	TransferBytes(direction, name string, read, total int64, current int)
 	FinishTransfer(name string)
+	Sync()
 	Finish()
 }

--- a/test/git-lfs-test-server-api/main.go
+++ b/test/git-lfs-test-server-api/main.go
@@ -285,7 +285,7 @@ func callBatchApi(manifest *tq.Manifest, dir tq.Direction, objs []TestObject) ([
 		apiobjs = append(apiobjs, &tq.Transfer{Oid: o.Oid, Size: o.Size})
 	}
 
-	bres, err := tq.Batch(manifest, dir, "origin", apiobjs)
+	bres, err := tq.Batch(manifest, dir, "origin", nil, apiobjs)
 	if err != nil {
 		return nil, err
 	}

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -2,6 +2,85 @@
 
 . "test/testlib.sh"
 
+begin_test "pre-push with good ref"
+(
+  set -e
+  reponame="pre-push-master-branch-required"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git config "lfs.$(repo_endpoint "$GITSERVER" "$reponame").locksverify" false
+  git lfs track "*.dat"
+  echo "hi" > a.dat
+  git add .gitattributes a.dat
+  git commit -m "add a.dat"
+
+  refute_server_object "$reponame" 98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4 "refs/heads/master"
+
+  # for some reason, using 'tee' and $PIPESTATUS does not work here
+  echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
+    git lfs pre-push origin "$GITSERVER/$reponame" 2>&1 > push.log
+
+  assert_server_object "$reponame" 98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4 "refs/heads/master"
+)
+end_test
+
+begin_test "pre-push with tracked ref"
+(
+  set -e
+  reponame="pre-push-tracked-branch-required"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git config "lfs.$(repo_endpoint "$GITSERVER" "$reponame").locksverify" false
+  git lfs track "*.dat"
+  echo "hi" > a.dat
+  git add .gitattributes a.dat
+  git commit -m "add a.dat"
+
+  refute_server_object "$reponame" 98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4 "refs/heads/tracked"
+
+  # for some reason, using 'tee' and $PIPESTATUS does not work here
+  echo "refs/heads/master master refs/heads/tracked 0000000000000000000000000000000000000000" |
+    git lfs pre-push origin master 2>&1 > push.log
+
+  assert_server_object "$reponame" 98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4 "refs/heads/tracked"
+)
+end_test
+
+begin_test "pre-push with bad ref"
+(
+  set -e
+  reponame="pre-push-other-branch-required"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git config "lfs.$(repo_endpoint "$GITSERVER" "$reponame").locksverify" false
+  git lfs track "*.dat"
+  echo "hi" > a.dat
+  git add .gitattributes a.dat
+  git commit -m "add a.dat"
+
+  refute_server_object "$reponame" 98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4 "refs/heads/other"
+
+  # for some reason, using 'tee' and $PIPESTATUS does not work here
+  set +e
+  echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
+    git lfs pre-push origin "$GITSERVER/$reponame" 2>&1 > push.log
+  pushcode=$?
+  set -e
+
+  if [ "0" -eq "$pushcode" ]; then
+    echo "expected command to fail"
+    exit 1
+  fi
+
+  grep 'Expected ref "refs/heads/other", got "refs/heads/master"' push.log
+
+  refute_server_object "$reponame" 98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4 "refs/heads/other"
+)
+end_test
+
 begin_test "pre-push"
 (
   set -e

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -28,6 +28,7 @@ end_test
 begin_test "pre-push with tracked ref"
 (
   set -e
+  exit 0
   reponame="pre-push-tracked-branch-required"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"
@@ -66,7 +67,7 @@ begin_test "pre-push with bad ref"
   # for some reason, using 'tee' and $PIPESTATUS does not work here
   set +e
   echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
-    git lfs pre-push origin "$GITSERVER/$reponame" 2>&1 > push.log
+    git lfs pre-push origin "$GITSERVER/$reponame" 2> push.log
   pushcode=$?
   set -e
 
@@ -874,7 +875,7 @@ begin_test "pre-push locks verify 403 with good ref"
   git config "lfs.$GITSERVER/$reponame.git.locksverify" true
   git push origin master 2>&1 | tee push.log
 
-  assert_server_object "$reponame" "$contents_oid"
+  assert_server_object "$reponame" "$contents_oid" "refs/heads/master"
 )
 end_test
 
@@ -898,7 +899,7 @@ begin_test "pre-push locks verify 403 with good tracked ref"
   git config "lfs.$GITSERVER/$reponame.git.locksverify" true
   git push 2>&1 | tee push.log
 
-  assert_server_object "$reponame" "$contents_oid"
+  assert_server_object "$reponame" "$contents_oid" "refs/heads/tracked"
 )
 end_test
 
@@ -920,7 +921,7 @@ begin_test "pre-push locks verify 403 with explicit ref"
   git config "lfs.$GITSERVER/$reponame.git.locksverify" true
   git push origin master:explicit 2>&1 | tee push.log
 
-  assert_server_object "$reponame" "$contents_oid"
+  assert_server_object "$reponame" "$contents_oid" "refs/heads/explicit"
 )
 end_test
 
@@ -942,7 +943,7 @@ begin_test "pre-push locks verify 403 with bad ref"
   git config "lfs.$GITSERVER/$reponame.git.locksverify" true
   git push origin master 2>&1 | tee push.log
   grep "failed to push some refs" push.log
-  refute_server_object "$reponame" "$contents_oid"
+  refute_server_object "$reponame" "$contents_oid" "refs/heads/other"
 )
 end_test
 

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -28,7 +28,6 @@ end_test
 begin_test "pre-push with tracked ref"
 (
   set -e
-  exit 0
   reponame="pre-push-tracked-branch-required"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -126,10 +126,11 @@ delete_server_object() {
 assert_server_object() {
   local reponame="$1"
   local oid="$2"
+  local refspec="$3"
   curl -v "$GITSERVER/$reponame.git/info/lfs/objects/batch" \
     -u "user:pass" \
     -o http.json \
-    -d "{\"operation\":\"download\",\"objects\":[{\"oid\":\"$oid\"}]}" \
+    -d "{\"operation\":\"download\",\"objects\":[{\"oid\":\"$oid\"}],\"ref\":{\"name\":\"$refspec\"}}" \
     -H "Accept: application/vnd.git-lfs+json" \
     -H "X-Check-Object: 1" \
     -H "X-Ignore-Retries: true" 2>&1 |

--- a/tq/api.go
+++ b/tq/api.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/git-lfs/git-lfs/errors"
+	"github.com/git-lfs/git-lfs/git"
 	"github.com/git-lfs/git-lfs/lfsapi"
 	"github.com/rubyist/tracerx"
 )
@@ -13,10 +14,15 @@ type tqClient struct {
 	*lfsapi.Client
 }
 
+type batchRef struct {
+	Name string `json:"name,omitempty"`
+}
+
 type batchRequest struct {
 	Operation            string      `json:"operation"`
 	Objects              []*Transfer `json:"objects"`
 	TransferAdapterNames []string    `json:"transfers,omitempty"`
+	Ref                  *batchRef   `json:"ref"`
 }
 
 type BatchResponse struct {
@@ -25,7 +31,7 @@ type BatchResponse struct {
 	endpoint            lfsapi.Endpoint
 }
 
-func Batch(m *Manifest, dir Direction, remote string, objects []*Transfer) (*BatchResponse, error) {
+func Batch(m *Manifest, dir Direction, remote string, remoteRef *git.Ref, objects []*Transfer) (*BatchResponse, error) {
 	if len(objects) == 0 {
 		return &BatchResponse{}, nil
 	}
@@ -34,6 +40,7 @@ func Batch(m *Manifest, dir Direction, remote string, objects []*Transfer) (*Bat
 		Operation:            dir.String(),
 		Objects:              objects,
 		TransferAdapterNames: m.GetAdapterNames(dir),
+		Ref:                  &batchRef{Name: remoteRef.Refspec()},
 	})
 }
 

--- a/tq/api_test.go
+++ b/tq/api_test.go
@@ -27,7 +27,7 @@ func TestAPIBatch(t *testing.T) {
 		}
 
 		assert.Equal(t, "POST", r.Method)
-		assert.Equal(t, "80", r.Header.Get("Content-Length"))
+		assert.Equal(t, "91", r.Header.Get("Content-Length"))
 
 		bodyLoader, body := gojsonschema.NewReaderLoader(r.Body)
 		bReq := &batchRequest{}


### PR DESCRIPTION
Implements #2712 for Batch API calls.

There is a problem here though. Currently, Transfer Queues and Git Scanners are scoped for a single remote. The updated `newUploadQueue()` builds a new Transfer Queue with the current remote ref.

That's fine, except the `pre-push` hook is called with the correct remote ref, and it supports multiple refs.

```
echo "refs/heads/master master refs/heads/tracked 0000000000000000000000000000000000000000" \
 | git lfs pre-push origin master
```

This should be calling `objects/batch` at least once for each ref. I made some changes to `commands/uploader.go` to initialize a new Transfer Queue and Git Scanner, but ran into a deadlock issue deep in the Git Scanner.