### PR TITLE
git/odb: implement parsing for annotated `*Tag`'s

### DIFF
--- a/git/odb/object_db.go
+++ b/git/odb/object_db.go
@@ -96,6 +96,17 @@ func (o *ObjectDatabase) Commit(sha []byte) (*Commit, error) {
 	return &c, nil
 }
 
+// Tag returns a *Tag as identified by the SHA given, or an error if one was
+// encountered.
+func (o *ObjectDatabase) Tag(sha []byte) (*Tag, error) {
+	var t Tag
+
+	if err := o.decode(sha, &t); err != nil {
+		return nil, err
+	}
+	return &t, nil
+}
+
 // WriteBlob stores a *Blob on disk and returns the SHA it is uniquely
 // identified by, or an error if one was encountered.
 func (o *ObjectDatabase) WriteBlob(b *Blob) ([]byte, error) {
@@ -131,6 +142,16 @@ func (o *ObjectDatabase) WriteTree(t *Tree) ([]byte, error) {
 // identified by, or an error if one was encountered.
 func (o *ObjectDatabase) WriteCommit(c *Commit) ([]byte, error) {
 	sha, _, err := o.encode(c)
+	if err != nil {
+		return nil, err
+	}
+	return sha, nil
+}
+
+// WriteTag stores a *Tag on disk and returns the SHA it is uniquely identified
+// by, or an error if one was encountered.
+func (o *ObjectDatabase) WriteTag(t *Tag) ([]byte, error) {
+	sha, _, err := o.encode(t)
 	if err != nil {
 		return nil, err
 	}

--- a/git/odb/object_db_test.go
+++ b/git/odb/object_db_test.go
@@ -166,6 +166,57 @@ func TestWriteCommit(t *testing.T) {
 	assert.NotNil(t, fs.fs[hex.EncodeToString(sha)])
 }
 
+func TestDecodeTag(t *testing.T) {
+	const sha = "7639ba293cd2c457070e8446ecdea56682af0f48"
+	tagShaHex, err := hex.DecodeString(sha)
+
+	var buf bytes.Buffer
+
+	zw := zlib.NewWriter(&buf)
+	fmt.Fprintf(zw, "tag 165\x00")
+	fmt.Fprintf(zw, "object 6161616161616161616161616161616161616161\n")
+	fmt.Fprintf(zw, "type commit\n")
+	fmt.Fprintf(zw, "tag v2.4.0\n")
+	fmt.Fprintf(zw, "tagger A U Thor <author@example.com>\n")
+	fmt.Fprintf(zw, "\n")
+	fmt.Fprintf(zw, "The quick brown fox jumps over the lazy dog.\n")
+	zw.Close()
+
+	odb := &ObjectDatabase{s: newMemoryStorer(map[string]io.ReadWriter{
+		sha: &buf,
+	})}
+
+	tag, err := odb.Tag(tagShaHex)
+
+	assert.Nil(t, err)
+
+	assert.Equal(t, []byte("aaaaaaaaaaaaaaaaaaaa"), tag.Object)
+	assert.Equal(t, CommitObjectType, tag.ObjectType)
+	assert.Equal(t, "v2.4.0", tag.Name)
+	assert.Equal(t, "A U Thor <author@example.com>", tag.Tagger)
+	assert.Equal(t, "The quick brown fox jumps over the lazy dog.", tag.Message)
+}
+
+func TestWriteTag(t *testing.T) {
+	fs := newMemoryStorer(make(map[string]io.ReadWriter))
+	odb := &ObjectDatabase{s: fs}
+
+	sha, err := odb.WriteTag(&Tag{
+		Object:     []byte("aaaaaaaaaaaaaaaaaaaa"),
+		ObjectType: CommitObjectType,
+		Name:       "v2.4.0",
+		Tagger:     "A U Thor <author@example.com>",
+
+		Message: "The quick brown fox jumps over the lazy dog.",
+	})
+
+	expected := "b0ea0039d536fb739dfa44e74e488b635bbb3a86"
+
+	assert.Nil(t, err)
+	assert.Equal(t, expected, hex.EncodeToString(sha))
+	assert.NotNil(t, fs.fs[hex.EncodeToString(sha)])
+}
+
 func TestReadingAMissingObjectAfterClose(t *testing.T) {
 	sha, _ := hex.DecodeString("af5626b4a114abcb82d63db7c8082c3c4756e51b")
 

--- a/git/odb/object_type.go
+++ b/git/odb/object_type.go
@@ -11,6 +11,7 @@ const (
 	BlobObjectType
 	TreeObjectType
 	CommitObjectType
+	TagObjectType
 )
 
 // ObjectTypeFromString converts from a given string to an ObjectType
@@ -23,6 +24,8 @@ func ObjectTypeFromString(s string) ObjectType {
 		return TreeObjectType
 	case "commit":
 		return CommitObjectType
+	case "tag":
+		return TagObjectType
 	default:
 		return UnknownObjectType
 	}
@@ -40,6 +43,8 @@ func (t ObjectType) String() string {
 		return "tree"
 	case CommitObjectType:
 		return "commit"
+	case TagObjectType:
+		return "tag"
 	}
 	return "<unknown>"
 }

--- a/git/odb/object_type_test.go
+++ b/git/odb/object_type_test.go
@@ -12,6 +12,7 @@ func TestObjectTypeFromString(t *testing.T) {
 		"blob":           BlobObjectType,
 		"tree":           TreeObjectType,
 		"commit":         CommitObjectType,
+		"tag":            TagObjectType,
 		"something else": UnknownObjectType,
 	} {
 		t.Run(str, func(t *testing.T) {
@@ -25,6 +26,7 @@ func TestObjectTypeToString(t *testing.T) {
 		BlobObjectType:            "blob",
 		TreeObjectType:            "tree",
 		CommitObjectType:          "commit",
+		TagObjectType:             "tag",
 		UnknownObjectType:         "unknown",
 		ObjectType(math.MaxUint8): "<unknown>",
 	} {

--- a/git/odb/tag.go
+++ b/git/odb/tag.go
@@ -1,0 +1,118 @@
+package odb
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/git-lfs/git-lfs/errors"
+)
+
+type Tag struct {
+	Object     []byte
+	ObjectType ObjectType
+	Name       string
+	Tagger     string
+
+	Message string
+}
+
+// Decode implements Object.Decode and decodes the uncompressed tag being
+// read. It returns the number of uncompressed bytes being consumed off of the
+// stream, which should be strictly equal to the size given.
+//
+// If any error was encountered along the way it will be returned, and the
+// receiving *Tag is considered invalid.
+func (t *Tag) Decode(r io.Reader, size int64) (int, error) {
+	scanner := bufio.NewScanner(io.LimitReader(r, size))
+
+	var (
+		finishedHeaders bool
+		message         []string
+	)
+
+	for scanner.Scan() {
+		if finishedHeaders {
+			message = append(message, scanner.Text())
+		} else {
+			if len(scanner.Bytes()) == 0 {
+				finishedHeaders = true
+				continue
+			}
+
+			parts := strings.SplitN(scanner.Text(), " ", 2)
+			if len(parts) < 2 {
+				return 0, errors.Errorf("git/odb: invalid tag header: %s", scanner.Text())
+			}
+
+			switch parts[0] {
+			case "object":
+				sha, err := hex.DecodeString(parts[1])
+				if err != nil {
+					return 0, errors.Wrap(err, "git/odb: unable to decode SHA-1")
+				}
+
+				t.Object = sha
+			case "type":
+				t.ObjectType = ObjectTypeFromString(parts[1])
+			case "tag":
+				t.Name = parts[1]
+			case "tagger":
+				t.Tagger = parts[1]
+			default:
+				return 0, errors.Errorf("git/odb: unknown tag header: %s", parts[0])
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return 0, err
+	}
+
+	t.Message = strings.Join(message, "\n")
+
+	return int(size), nil
+}
+
+// Encode encodes the Tag's contents to the given io.Writer, "w". If there was
+// any error copying the Tag's contents, that error will be returned.
+//
+// Otherwise, the number of bytes written will be returned.
+func (t *Tag) Encode(w io.Writer) (int, error) {
+	headers := []string{
+		fmt.Sprintf("object %s", hex.EncodeToString(t.Object)),
+		fmt.Sprintf("type %s", t.ObjectType),
+		fmt.Sprintf("tag %s", t.Name),
+		fmt.Sprintf("tagger %s", t.Tagger),
+	}
+
+	return fmt.Fprintf(w, "%s\n\n%s\n", strings.Join(headers, "\n"), t.Message)
+}
+
+// Equal returns whether the receiving and given Tags are equal, or in other
+// words, whether they are represented by the same SHA-1 when saved to the
+// object database.
+func (t *Tag) Equal(other *Tag) bool {
+	if (t == nil) != (other == nil) {
+		return false
+	}
+
+	if t != nil {
+		return bytes.Equal(t.Object, other.Object) &&
+			t.ObjectType == other.ObjectType &&
+			t.Name == other.Name &&
+			t.Tagger == other.Tagger &&
+			t.Message == other.Message
+	}
+
+	return true
+}
+
+// Type implements Object.ObjectType by returning the correct object type for
+// Tags, TagObjectType.
+func (t *Tag) Type() ObjectType {
+	return TagObjectType
+}

--- a/git/odb/tag_test.go
+++ b/git/odb/tag_test.go
@@ -1,0 +1,65 @@
+package odb
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTagTypeReturnsCorrectObjectType(t *testing.T) {
+	assert.Equal(t, TagObjectType, new(Tag).Type())
+}
+
+func TestTagEncode(t *testing.T) {
+	tag := &Tag{
+		Object:     []byte("aaaaaaaaaaaaaaaaaaaa"),
+		ObjectType: CommitObjectType,
+		Name:       "v2.4.0",
+		Tagger:     "A U Thor <author@example.com>",
+
+		Message: "The quick brown fox jumps over the lazy dog.",
+	}
+
+	buf := new(bytes.Buffer)
+
+	n, err := tag.Encode(buf)
+
+	assert.Nil(t, err)
+	assert.EqualValues(t, buf.Len(), n)
+
+	assertLine(t, buf, "object 6161616161616161616161616161616161616161")
+	assertLine(t, buf, "type commit")
+	assertLine(t, buf, "tag v2.4.0")
+	assertLine(t, buf, "tagger A U Thor <author@example.com>")
+	assertLine(t, buf, "")
+	assertLine(t, buf, "The quick brown fox jumps over the lazy dog.")
+
+	assert.Equal(t, 0, buf.Len())
+}
+
+func TestTagDecode(t *testing.T) {
+	from := new(bytes.Buffer)
+
+	fmt.Fprintf(from, "object 6161616161616161616161616161616161616161\n")
+	fmt.Fprintf(from, "type commit\n")
+	fmt.Fprintf(from, "tag v2.4.0\n")
+	fmt.Fprintf(from, "tagger A U Thor <author@example.com>\n")
+	fmt.Fprintf(from, "\n")
+	fmt.Fprintf(from, "The quick brown fox jumps over the lazy dog.\n")
+
+	flen := from.Len()
+
+	tag := new(Tag)
+	n, err := tag.Decode(from, int64(flen))
+
+	assert.Nil(t, err)
+	assert.Equal(t, n, flen)
+
+	assert.Equal(t, []byte("aaaaaaaaaaaaaaaaaaaa"), tag.Object)
+	assert.Equal(t, CommitObjectType, tag.ObjectType)
+	assert.Equal(t, "v2.4.0", tag.Name)
+	assert.Equal(t, "A U Thor <author@example.com>", tag.Tagger)
+	assert.Equal(t, "The quick brown fox jumps over the lazy dog.", tag.Message)
+}


### PR DESCRIPTION
This pull request implements support within the `git/odb` package for reading and writing loose and packed representations of annotated tags.

The process for adding a new object type to the `git/odb` package was as follows:

1. 1e239fe: add a new `ObjectType` constant for `Tag`'s, to be used as a return value for `(*Tag) Type() ObjectType`.
2. b78fa93: implement the `Object` interface on a new concrete type, in this case `*Tag`. By implementing this interface, the `git/odb/pack` sub-package can use it for free, and _automatically read packed representations of the same object type_.
3. 944eaf8: wire up the new implementation to the `*git/odb.ObjectDatabase` type to add convenience APIs for reading/writing the new object type.

##

/cc @git-lfs/core 