### PR TITLE
git/githistory: have *RefUpdater hold *odb.ObjectDatabase reference

### DIFF
--- a/git/githistory/ref_updater.go
+++ b/git/githistory/ref_updater.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/git"
+	"github.com/git-lfs/git-lfs/git/odb"
 	"github.com/git-lfs/git-lfs/tasklog"
 	"github.com/git-lfs/git-lfs/tools"
 )
@@ -25,6 +26,8 @@ type refUpdater struct {
 	// Root is the given directory on disk in which the repository is
 	// located.
 	Root string
+
+	db *odb.ObjectDatabase
 }
 
 // UpdateRefs performs the reference update(s) from existing locations (see:

--- a/git/githistory/ref_updater_test.go
+++ b/git/githistory/ref_updater_test.go
@@ -26,6 +26,7 @@ func TestRefUpdaterMovesRefs(t *testing.T) {
 			},
 		},
 		Root: root,
+		db:   db,
 	}
 
 	err := updater.UpdateRefs()
@@ -55,6 +56,7 @@ func TestRefUpdaterIgnoresUnovedRefs(t *testing.T) {
 			},
 		},
 		Root: root,
+		db:   db,
 	}
 
 	err := updater.UpdateRefs()

--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -280,6 +280,8 @@ func (r *Rewriter) Rewrite(opt *RewriteOptions) ([]byte, error) {
 			Logger:  r.l,
 			Refs:    refs,
 			Root:    root,
+
+			db: r.db,
 		}
 
 		if err := updater.UpdateRefs(); err != nil {


### PR DESCRIPTION
This pull request teaches the `*git/githistory.refUpdater` to hold a reference to a `*git/odb.ObjectDatabase` in anticipation of having to rewrite (and save new) annotated tags.

##

/cc @git-lfs/core 