### PR TITLE
commands/migrate: support '^'-prefix refspec in arguments

### DIFF
--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -121,6 +121,12 @@ func includeExcludeRefs(l *tasklog.Logger, args []string) (include, exclude []st
 	}
 
 	for _, name := range args {
+		var excluded bool
+		if strings.HasPrefix("^", name) {
+			name = name[1:]
+			excluded = true
+		}
+
 		// Then, loop through each branch given, resolve that reference,
 		// and include it.
 		ref, err := git.ResolveRef(name)
@@ -128,7 +134,11 @@ func includeExcludeRefs(l *tasklog.Logger, args []string) (include, exclude []st
 			return nil, nil, err
 		}
 
-		include = append(include, ref.Refspec())
+		if excluded {
+			exclude = append(exclude, ref.Refspec())
+		} else {
+			include = append(include, ref.Refspec())
+		}
 	}
 
 	if hardcore {

--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -39,6 +39,9 @@ git-lfs-migrate(1) - Migrate history to or from git-lfs
     Migrate only the set of branches listed. If not given, `git-lfs-migrate(1)`
     will migrate the currently checked out branch.
 
+    References beginning with '^' will be excluded, whereas branches that do not
+    begin with '^' will be included.
+
     If any of `--include-ref` or `--exclude-ref` are given, the checked out
     branch will not be appended, but branches given explicitly will be appended.
 

--- a/test/test-migrate-import.sh
+++ b/test/test-migrate-import.sh
@@ -293,6 +293,44 @@ begin_test "migrate import (include/exclude ref)"
 )
 end_test
 
+begin_test "migrate import (include/exclude ref args)"
+(
+  set -e
+
+  setup_multiple_remote_branches
+
+  md_master_oid="$(calc_oid "$(git cat-file -p "refs/heads/master:a.md")")"
+  md_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/master:a.md")")"
+  md_feature_oid="$(calc_oid "$(git cat-file -p "refs/heads/my-feature:a.md")")"
+  txt_master_oid="$(calc_oid "$(git cat-file -p "refs/heads/master:a.txt")")"
+  txt_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/master:a.txt")")"
+  txt_feature_oid="$(calc_oid "$(git cat-file -p "refs/heads/my-feature:a.txt")")"
+
+  git lfs migrate import my-feature ^master
+
+  assert_pointer "refs/heads/my-feature" "a.md" "$md_feature_oid" "31"
+  assert_pointer "refs/heads/my-feature" "a.txt" "$txt_feature_oid" "30"
+
+  assert_local_object "$md_feature_oid" "31"
+  refute_local_object "$md_master_oid" "21"
+  assert_local_object "$txt_feature_oid" "30"
+  refute_local_object "$txt_master_oid" "20"
+  refute_local_object "$md_remote_oid" "11"
+  refute_local_object "$txt_remote_oid" "10"
+
+  master="$(git rev-parse refs/heads/master)"
+  feature="$(git rev-parse refs/heads/my-feature)"
+  remote="$(git rev-parse refs/remotes/origin/master)"
+
+  [ ! $(git cat-file -p "$master:.gitattributes") ]
+  [ ! $(git cat-file -p "$remote:.gitattributes") ]
+  feature_attrs="$(git cat-file -p "$feature:.gitattributes")"
+
+  echo "$feature_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
+  echo "$feature_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"
+)
+end_test
+
 begin_test "migrate import (include/exclude ref with filter)"
 (
   set -e

--- a/test/test-migrate-info.sh
+++ b/test/test-migrate-info.sh
@@ -193,6 +193,29 @@ begin_test "migrate info (include/exclude ref)"
 )
 end_test
 
+begin_test "migrate info (include/exclude ref args)"
+(
+  set -e
+
+  setup_multiple_remote_branches
+
+  original_master="$(git rev-parse refs/heads/master)"
+  original_feature="$(git rev-parse refs/heads/my-feature)"
+
+  diff -u <(git lfs migrate info \
+    my-feature ^master 2>&1 | tail -n 2) <(cat <<-EOF
+	*.md 	31 B	1/1 files(s)	100%
+	*.txt	30 B	1/1 files(s)	100%
+	EOF)
+
+  migrated_master="$(git rev-parse refs/heads/master)"
+  migrated_feature="$(git rev-parse refs/heads/my-feature)"
+
+  assert_ref_unmoved "refs/heads/master" "$original_master" "$migrated_master"
+  assert_ref_unmoved "refs/heads/my-feature" "$original_feature" "$migrated_feature"
+)
+end_test
+
 begin_test "migrate info (include/exclude ref with filter)"
 (
   set -e


### PR DESCRIPTION
This pull request supports `git-rev-list(1)`-style `^`-prefixed refspecs to be passed as arguments to the `git lfs migrate` command(s).

## 

/cc @git-lfs/core 