### PR TITLE
git/odb: retain newlines when parsing commit messages

### DIFF
--- a/git/odb/commit.go
+++ b/git/odb/commit.go
@@ -100,7 +100,7 @@ func (c *Commit) Decode(from io.Reader, size int64) (n int, err error) {
 		text := s.Text()
 		n = n + len(text+"\n")
 
-		if len(s.Text()) == 0 {
+		if len(s.Text()) == 0 && !finishedHeaders {
 			finishedHeaders = true
 			continue
 		}

--- a/git/odb/commit_test.go
+++ b/git/odb/commit_test.go
@@ -120,6 +120,33 @@ func TestCommitDecodingWithMessageKeywordPrefix(t *testing.T) {
 	fmt.Fprintf(from, "author %s\n", author)
 	fmt.Fprintf(from, "committer %s\n", committer)
 	fmt.Fprintf(from, "tree %s\n", hex.EncodeToString(treeId))
+	fmt.Fprintf(from, "\nfirst line\n\nsecond line\n")
+
+	flen := from.Len()
+
+	commit := new(Commit)
+	n, err := commit.Decode(from, int64(flen))
+
+	assert.NoError(t, err)
+	assert.Equal(t, flen, n)
+
+	assert.Equal(t, author.String(), commit.Author)
+	assert.Equal(t, committer.String(), commit.Committer)
+	assert.Equal(t, treeIdAscii, hex.EncodeToString(commit.TreeID))
+	assert.Equal(t, "first line\n\nsecond line", commit.Message)
+}
+
+func TestCommitDecodingWithWhitespace(t *testing.T) {
+	author := &Signature{Name: "John Doe", Email: "john@example.com", When: time.Now()}
+	committer := &Signature{Name: "Jane Doe", Email: "jane@example.com", When: time.Now()}
+
+	treeId := []byte("aaaaaaaaaaaaaaaaaaaa")
+	treeIdAscii := hex.EncodeToString(treeId)
+
+	from := new(bytes.Buffer)
+	fmt.Fprintf(from, "author %s\n", author)
+	fmt.Fprintf(from, "committer %s\n", committer)
+	fmt.Fprintf(from, "tree %s\n", hex.EncodeToString(treeId))
 	fmt.Fprintf(from, "\ntree <- initial commit\n")
 
 	flen := from.Len()


### PR DESCRIPTION
This pull request fixes an issue pointed out by @hagami in https://github.com/git-lfs/git-lfs/issues/2772: 

> Before execute git lfs migrate import --everything --include="*.zip", git log shows below in my repository.
> 
> [ ... ]
> 
> After execute the command, empty line between "test" disappeared.

Here's some background: when parsing a commit, the stage of the encoded commit that we are currently parsing is kept track of. This is to differentiate a line beginning with `parent` when present in a header vs. when present in a commit message. To keep track of this, we use the fact that headers are separated from the commit message by a LF character.

Previously, something like this happened:

```go
for scan.Scan() {
	if len(s.Text()) == 0 {
                finishedHeaders = true
                continue
        }

        // ...
}
```

Which has the unfortunate side-effect of `continue`-ing over the parsing step if an empty newline is present in a commit _message.

To fix this, change `if len(s.Text()) == 0` to `if len(s.Text()) == 0 && !finishedHeaders`, such that the only `continue` happens once during the transition from parsing headers to parsing the commit message.

Closes: https://github.com/git-lfs/git-lfs/issues/2772.

##

/cc @git-lfs/core https://github.com/git-lfs/git-lfs/issues/2772