### PR TITLE
script/test: run 'go tool vet' during testing

### DIFF
--- a/commands/command_filter_process.go
+++ b/commands/command_filter_process.go
@@ -329,8 +329,6 @@ func readAvailable(ch <-chan *tq.Transfer, cap int) []*tq.Transfer {
 			return append(ts, t)
 		}
 	}
-
-	return ts
 }
 
 // pathnames formats a list of *tq.Transfers as a valid response to the

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -16,32 +16,32 @@ import (
 func TestRefString(t *testing.T) {
 	const sha = "0000000000000000000000000000000000000000"
 	for s, r := range map[string]*Ref{
-		"refs/heads/master": &Ref{
+		"refs/heads/master": {
 			Name: "master",
 			Type: RefTypeLocalBranch,
 			Sha:  sha,
 		},
-		"refs/remotes/origin/master": &Ref{
+		"refs/remotes/origin/master": {
 			Name: "origin/master",
 			Type: RefTypeRemoteBranch,
 			Sha:  sha,
 		},
-		"refs/remotes/tags/v1.0.0": &Ref{
+		"refs/remotes/tags/v1.0.0": {
 			Name: "v1.0.0",
 			Type: RefTypeRemoteTag,
 			Sha:  sha,
 		},
-		"refs/tags/v1.0.0": &Ref{
+		"refs/tags/v1.0.0": {
 			Name: "v1.0.0",
 			Type: RefTypeLocalTag,
 			Sha:  sha,
 		},
-		"HEAD": &Ref{
+		"HEAD": {
 			Name: "HEAD",
 			Type: RefTypeHEAD,
 			Sha:  sha,
 		},
-		"other": &Ref{
+		"other": {
 			Name: "other",
 			Type: RefTypeOther,
 			Sha:  sha,
@@ -119,17 +119,29 @@ func TestCurrentRefAndCurrentRemoteRef(t *testing.T) {
 	gitConf := repo.GitConfig()
 	ref, err := CurrentRef()
 	assert.Nil(t, err)
-	assert.Equal(t, &Ref{"branch3", RefTypeLocalBranch, outputs[3].Sha}, ref)
+	assert.Equal(t, &Ref{
+		Name: "branch3",
+		Type: RefTypeLocalBranch,
+		Sha:  outputs[3].Sha,
+	}, ref)
 	test.RunGitCommand(t, true, "checkout", "master")
 	ref, err = CurrentRef()
 	assert.Nil(t, err)
-	assert.Equal(t, &Ref{"master", RefTypeLocalBranch, outputs[2].Sha}, ref)
+	assert.Equal(t, &Ref{
+		Name: "master",
+		Type: RefTypeLocalBranch,
+		Sha:  outputs[2].Sha,
+	}, ref)
 	// Check remote
 	repo.AddRemote("origin")
 	test.RunGitCommand(t, true, "push", "-u", "origin", "master:someremotebranch")
 	ref, err = gitConf.CurrentRemoteRef()
 	assert.Nil(t, err)
-	assert.Equal(t, &Ref{"origin/someremotebranch", RefTypeRemoteBranch, outputs[2].Sha}, ref)
+	assert.Equal(t, &Ref{
+		Name: "origin/someremotebranch",
+		Type: RefTypeRemoteBranch,
+		Sha:  outputs[2].Sha,
+	}, ref)
 
 	refname, err := gitConf.RemoteRefNameForCurrentBranch()
 	assert.Nil(t, err)
@@ -137,7 +149,11 @@ func TestCurrentRefAndCurrentRemoteRef(t *testing.T) {
 
 	ref, err = ResolveRef(outputs[2].Sha)
 	assert.Nil(t, err)
-	assert.Equal(t, &Ref{outputs[2].Sha, RefTypeOther, outputs[2].Sha}, ref)
+	assert.Equal(t, &Ref{
+		Name: outputs[2].Sha,
+		Type: RefTypeOther,
+		Sha:  outputs[2].Sha,
+	}, ref)
 }
 
 func TestRecentBranches(t *testing.T) {
@@ -211,9 +227,21 @@ func TestRecentBranches(t *testing.T) {
 	refs, err := RecentBranches(now.AddDate(0, 0, -7), false, "")
 	assert.Equal(t, nil, err)
 	expectedRefs := []*Ref{
-		&Ref{"master", RefTypeLocalBranch, outputs[5].Sha},
-		&Ref{"included_branch_2", RefTypeLocalBranch, outputs[4].Sha},
-		&Ref{"included_branch", RefTypeLocalBranch, outputs[3].Sha},
+		{
+			Name: "master",
+			Type: RefTypeLocalBranch,
+			Sha:  outputs[5].Sha,
+		},
+		{
+			Name: "included_branch_2",
+			Type: RefTypeLocalBranch,
+			Sha:  outputs[4].Sha,
+		},
+		{
+			Name: "included_branch",
+			Type: RefTypeLocalBranch,
+			Sha:  outputs[3].Sha,
+		},
 	}
 	assert.Equal(t, expectedRefs, refs, "Refs should be correct")
 
@@ -221,13 +249,41 @@ func TestRecentBranches(t *testing.T) {
 	refs, err = RecentBranches(now.AddDate(0, 0, -7), true, "")
 	assert.Equal(t, nil, err)
 	expectedRefs = []*Ref{
-		&Ref{"master", RefTypeLocalBranch, outputs[5].Sha},
-		&Ref{"included_branch_2", RefTypeLocalBranch, outputs[4].Sha},
-		&Ref{"included_branch", RefTypeLocalBranch, outputs[3].Sha},
-		&Ref{"upstream/master", RefTypeRemoteBranch, outputs[5].Sha},
-		&Ref{"upstream/included_branch_2", RefTypeRemoteBranch, outputs[4].Sha},
-		&Ref{"origin/master", RefTypeRemoteBranch, outputs[5].Sha},
-		&Ref{"origin/included_branch", RefTypeRemoteBranch, outputs[3].Sha},
+		{
+			Name: "master",
+			Type: RefTypeLocalBranch,
+			Sha:  outputs[5].Sha,
+		},
+		{
+			Name: "included_branch_2",
+			Type: RefTypeLocalBranch,
+			Sha:  outputs[4].Sha,
+		},
+		{
+			Name: "included_branch",
+			Type: RefTypeLocalBranch,
+			Sha:  outputs[3].Sha,
+		},
+		{
+			Name: "upstream/master",
+			Type: RefTypeRemoteBranch,
+			Sha:  outputs[5].Sha,
+		},
+		{
+			Name: "upstream/included_branch_2",
+			Type: RefTypeRemoteBranch,
+			Sha:  outputs[4].Sha,
+		},
+		{
+			Name: "origin/master",
+			Type: RefTypeRemoteBranch,
+			Sha:  outputs[5].Sha,
+		},
+		{
+			Name: "origin/included_branch",
+			Type: RefTypeRemoteBranch,
+			Sha:  outputs[3].Sha,
+		},
 	}
 	// Need to sort for consistent comparison
 	sort.Sort(test.RefsByName(expectedRefs))
@@ -238,11 +294,31 @@ func TestRecentBranches(t *testing.T) {
 	refs, err = RecentBranches(now.AddDate(0, 0, -7), true, "origin")
 	assert.Equal(t, nil, err)
 	expectedRefs = []*Ref{
-		&Ref{"master", RefTypeLocalBranch, outputs[5].Sha},
-		&Ref{"origin/master", RefTypeRemoteBranch, outputs[5].Sha},
-		&Ref{"included_branch_2", RefTypeLocalBranch, outputs[4].Sha},
-		&Ref{"included_branch", RefTypeLocalBranch, outputs[3].Sha},
-		&Ref{"origin/included_branch", RefTypeRemoteBranch, outputs[3].Sha},
+		{
+			Name: "master",
+			Type: RefTypeLocalBranch,
+			Sha:  outputs[5].Sha,
+		},
+		{
+			Name: "origin/master",
+			Type: RefTypeRemoteBranch,
+			Sha:  outputs[5].Sha,
+		},
+		{
+			Name: "included_branch_2",
+			Type: RefTypeLocalBranch,
+			Sha:  outputs[4].Sha,
+		},
+		{
+			Name: "included_branch",
+			Type: RefTypeLocalBranch,
+			Sha:  outputs[3].Sha,
+		},
+		{
+			Name: "origin/included_branch",
+			Type: RefTypeRemoteBranch,
+			Sha:  outputs[3].Sha,
+		},
 	}
 	// Need to sort for consistent comparison
 	sort.Sort(test.RefsByName(expectedRefs))
@@ -317,9 +393,21 @@ func TestWorkTrees(t *testing.T) {
 	refs, err := GetAllWorkTreeHEADs(filepath.Join(repo.Path, ".git"))
 	assert.Equal(t, nil, err)
 	expectedRefs := []*Ref{
-		&Ref{"master", RefTypeLocalBranch, outputs[0].Sha},
-		&Ref{"branch2", RefTypeLocalBranch, outputs[1].Sha},
-		&Ref{"branch4", RefTypeLocalBranch, outputs[3].Sha},
+		{
+			Name: "master",
+			Type: RefTypeLocalBranch,
+			Sha:  outputs[0].Sha,
+		},
+		{
+			Name: "branch2",
+			Type: RefTypeLocalBranch,
+			Sha:  outputs[1].Sha,
+		},
+		{
+			Name: "branch4",
+			Type: RefTypeLocalBranch,
+			Sha:  outputs[3].Sha,
+		},
 	}
 	// Need to sort for consistent comparison
 	sort.Sort(test.RefsByName(expectedRefs))

--- a/git/odb/pack/chain_delta_test.go
+++ b/git/odb/pack/chain_delta_test.go
@@ -73,7 +73,7 @@ func TestChainDeltaWithMultipleInstructions(t *testing.T) {
 	assert.Equal(t, []byte("Hello, world!\n"), data)
 }
 
-func TestchainDeltaWithInvalidDeltaInstruction(t *testing.T) {
+func TestChainDeltaWithInvalidDeltaInstruction(t *testing.T) {
 	c := &ChainDelta{
 		base: &ChainSimple{
 			X: make([]byte, 0),

--- a/script/test
+++ b/script/test
@@ -1,21 +1,35 @@
 #!/usr/bin/env bash
-#/ Usage: script/test          # run all non-vendored tests
-#/        script/test <subdir> # run just a package's tests
+#
+# Usage: script/test          # run all non-vendored tests
+#        script/test <subpkg> # run just a package's tests
+
+PACKAGES="$@"
+if [ $# -eq 0 ]; then
+  # The following vendor test-exclusion grep-s typically need to match the same
+  # set in debian/rules variable DH_GOLANG_EXCLUDES, so update those when adding
+  # here.
+  PACKAGES="$(go list ./... \
+                | grep -v "github.com/kr/pty" \
+                | grep -v "github.com/kr/text" \
+                | grep -v "github.com/olekukonko/ts" \
+                | grep -v "github.com/pkg/errors" \
+                | grep -v "github.com/stretchr/testify" \
+                | grep -v "github.com/xeipuuv/gojsonreference" \
+                | grep -v "github.com/xeipuuv/gojsonschema" \
+  )"
+else
+  PACKAGES="$(echo "$PACKAGES" \
+                | sed -e 's/ / .\//g' \
+                | sed -e 's/^\([^\.]\)/.\/\1/g')"
+fi
 
 script/fmt
-if [ $# -gt 0 ]; then
-    GO15VENDOREXPERIMENT=1 go test "./$@"
-else
-    # The following vendor test-exclusion grep-s typically need to match the same set in
-    # debian/rules variable DH_GOLANG_EXCLUDES, so update those when adding here.
-    GO15VENDOREXPERIMENT=1 go test \
-      $(GO15VENDOREXPERIMENT=1 go list ./... \
-          | grep -v "github.com/kr/pty" \
-          | grep -v "github.com/kr/text" \
-          | grep -v "github.com/olekukonko/ts" \
-          | grep -v "github.com/pkg/errors" \
-          | grep -v "github.com/stretchr/testify" \
-          | grep -v "github.com/xeipuuv/gojsonreference" \
-          | grep -v "github.com/xeipuuv/gojsonschema" \
-      )
-fi
+
+GO15VENDOREXPERIMENT=1 go test $PACKAGES
+GO15VENDOREXPERIMENT=1 go tool vet $(
+  echo "$PACKAGES" \
+    | grep -v vendor \
+    | sed -e 's/github\.com\/git-lfs\/git-lfs//g' \
+    | sed -e 's/^\///g' \
+    | xargs \
+)

--- a/script/test
+++ b/script/test
@@ -29,6 +29,7 @@ GO15VENDOREXPERIMENT=1 go test $PACKAGES
 GO15VENDOREXPERIMENT=1 go tool vet $(
   echo "$PACKAGES" \
     | grep -v vendor \
+    | grep -v git-source \
     | sed -e 's/github\.com\/git-lfs\/git-lfs//g' \
     | sed -e 's/^\///g' \
     | xargs \

--- a/test/git-lfs-test-server-api/testdownload.go
+++ b/test/git-lfs-test-server-api/testdownload.go
@@ -52,7 +52,7 @@ func downloadAllMissing(manifest *tq.Manifest, oidsExist, oidsMissing []TestObje
 	for _, o := range retobjs {
 		link, _ := o.Rel("download")
 		if link != nil {
-			errbuf.WriteString(fmt.Sprintf("Download link should not exist for %s, was %s\n", o.Oid, link))
+			errbuf.WriteString(fmt.Sprintf("Download link should not exist for %s, was %+v\n", o.Oid, link))
 		}
 		if o.Error == nil {
 			errbuf.WriteString(fmt.Sprintf("Download should include an error for missing object %s\n", o.Oid))
@@ -96,7 +96,7 @@ func downloadMixed(manifest *tq.Manifest, oidsExist, oidsMissing []TestObject) e
 		link, _ := o.Rel("download")
 		if missingSet.Contains(o.Oid) {
 			if link != nil {
-				errbuf.WriteString(fmt.Sprintf("Download link should not exist for %s, was %s\n", o.Oid, link))
+				errbuf.WriteString(fmt.Sprintf("Download link should not exist for %s, was %+v\n", o.Oid, link))
 			}
 			if o.Error == nil {
 				errbuf.WriteString(fmt.Sprintf("Download should include an error for missing object %s", o.Oid))

--- a/test/git-lfs-test-server-api/testupload.go
+++ b/test/git-lfs-test-server-api/testupload.go
@@ -53,7 +53,7 @@ func uploadAllExists(manifest *tq.Manifest, oidsExist, oidsMissing []TestObject)
 	for _, o := range retobjs {
 		link, _ := o.Rel("upload")
 		if link == nil {
-			errbuf.WriteString(fmt.Sprintf("Upload link should not exist for %s, was %s\n", o.Oid, link))
+			errbuf.WriteString(fmt.Sprintf("Upload link should not exist for %s, was %+v\n", o.Oid, link))
 		}
 	}
 
@@ -92,7 +92,7 @@ func uploadMixed(manifest *tq.Manifest, oidsExist, oidsMissing []TestObject) err
 		link, _ := o.Rel("upload")
 		if existSet.Contains(o.Oid) {
 			if link != nil {
-				errbuf.WriteString(fmt.Sprintf("Upload link should not exist for %s, was %s\n", o.Oid, link))
+				errbuf.WriteString(fmt.Sprintf("Upload link should not exist for %s, was %+v\n", o.Oid, link))
 			}
 		}
 		if missingSet.Contains(o.Oid) && link == nil {
@@ -166,7 +166,7 @@ func uploadEdgeCases(manifest *tq.Manifest, oidsExist, oidsMissing []TestObject)
 		if code, iserror := errorCodeMap[o.Oid]; iserror {
 			reason, _ := errorReasonMap[o.Oid]
 			if link != nil {
-				errbuf.WriteString(fmt.Sprintf("Upload link should not exist for %s, was %s, reason %s\n", o.Oid, link, reason))
+				errbuf.WriteString(fmt.Sprintf("Upload link should not exist for %s, was %+v, reason %s\n", o.Oid, link, reason))
 			}
 			if o.Error == nil {
 				errbuf.WriteString(fmt.Sprintf("Upload should include an error for invalid object %s, reason %s", o.Oid, reason))

--- a/tq/transfer.go
+++ b/tq/transfer.go
@@ -117,7 +117,7 @@ type Action struct {
 	ExpiresAt time.Time         `json:"expires_at,omitempty"`
 	ExpiresIn int               `json:"expires_in,omitempty"`
 
-	createdAt time.Time `json:"-"`
+	createdAt time.Time
 }
 
 func (a *Action) IsExpiredWithin(d time.Duration) (time.Time, bool) {


### PR DESCRIPTION
This pull request fixes `go tool vet` violations found in Git LFS, and runs `go tool vet` on the same list of packages being tested by any invocation of `script/test`.

@technoweenie's comment in https://github.com/git-lfs/git-lfs/issues/2743#issuecomment-346107557 got me thinking:

> [ ... ]
> 
> In fact, what do you think of adding `go vet` to `script/test`? I doubt it passes now, but I'd like to start nudging lfs towards a standard go codebase.

I think that this is a good idea. `go tool vet` provides useful insight on code _correctness_, not style as opposed to `golint`. I think that correctness of this sort is useful information to know about while testing, so let's do both at the same time.

In doing so, this pull request comes in two parts:

1. https://github.com/git-lfs/git-lfs/compare/7e4013d%5E1...a393bb1: fix current correctness violations found by `go tool vet`.
2. 49de92b: refactor `script/test` to:
  - Accept relative package names or subdirectories (`git`, `./git` respectively) as arguments.
  - Correctly run `go tool vet` over the same set of packages.

I think as a future point of discussion, adding `golint` ([source](https://github.com/golang/lint)) would be fruitful (as perhaps a part of `script/lint`, not `script/test`), but I believe that this discussion is out of the current scope.

## 

/cc @git-lfs/core 