### PR TITLE
commands/ls-files: add --include, --exclude

### DIFF
--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -69,6 +69,9 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 	})
 	defer gitscanner.Close()
 
+	includeArg, excludeArg := getIncludeExcludeArgs(cmd)
+	gitscanner.Filter = buildFilepathFilter(cfg, includeArg, excludeArg)
+
 	if err := gitscanner.ScanTree(ref); err != nil {
 		Exit("Could not scan for Git LFS tree: %s", err)
 	}
@@ -92,5 +95,7 @@ func init() {
 		cmd.Flags().BoolVarP(&longOIDs, "long", "l", false, "")
 		cmd.Flags().BoolVarP(&lsFilesShowSize, "size", "s", false, "")
 		cmd.Flags().BoolVarP(&debug, "debug", "d", false, "")
+		cmd.Flags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")
+		cmd.Flags().StringVarP(&excludeArg, "exclude", "X", "", "Exclude a list of paths")
 	})
 }

--- a/docs/man/git-lfs-ls-files.1.ronn
+++ b/docs/man/git-lfs-ls-files.1.ronn
@@ -23,8 +23,14 @@ An asterisk (*) after the OID indicates a LFS pointer, a minus (-) a full object
   Show as much information as possible about a LFS file. This is intended
   for manual inspection; the exact format may change at any time.
 
+* `-I` <paths> `--include=`<paths>:
+  Include paths matching only these patterns; see [FETCH SETTINGS].
+
+* `-X` <paths> `--exclude=`<paths>:
+  Exclude paths matching any of these patterns; see [FETCH SETTINGS].
+
 ## SEE ALSO
 
-git-lfs-status(1).
+git-lfs-status(1), git-lfs-config(5).
 
 Part of the git-lfs(1) suite.

--- a/test/test-ls-files.sh
+++ b/test/test-ls-files.sh
@@ -77,6 +77,52 @@ begin_test "ls-files: outside git repository"
 )
 end_test
 
+begin_test "ls-files: --include"
+(
+  set -e
+
+  git init ls-files-include
+  cd ls-files-include
+
+  git lfs track "*.dat" "*.bin"
+  echo "a" > a.dat
+  echo "b" > b.dat
+  echo "c" > c.bin
+
+  git add *.gitattributes a.dat b.dat c.bin
+  git commit -m "initial commit"
+
+  git lfs ls-files --include="*.dat" 2>&1 | tee ls-files.log
+
+  [ "0" -eq "$(grep -c "\.bin" ls-files.log)" ]
+  [ "2" -eq "$(grep -c "\.dat" ls-files.log)" ]
+)
+end_test
+
+begin_test "ls-files: --exclude"
+(
+  set -e
+
+  git init ls-files-exclude
+  cd ls-files-exclude
+
+  mkdir dir
+
+  git lfs track "*.dat"
+  echo "a" > a.dat
+  echo "b" > b.dat
+  echo "c" > dir/c.dat
+
+  git add *.gitattributes a.dat b.dat dir/c.dat
+  git commit -m "initial commit"
+
+  git lfs ls-files --exclude="dir/" 2>&1 | tee ls-files.log
+
+  [ "0" -eq "$(grep -c "dir" ls-files.log)" ]
+  [ "2" -eq "$(grep -c "\.dat" ls-files.log)" ]
+)
+end_test
+
 begin_test "ls-files: with zero files"
 (
   set -e


### PR DESCRIPTION
This pull request adds `--include`, `--exclude` flag arguments to the `git-lfs-ls-files(1)` command, as per discussion in https://github.com/git-lfs/git-lfs/issues/2761#issuecomment-347938964:

> > How about `--pattern`, which works with any pattern that `.gitignore` or `.gitattributes` supports?
> 
> @technoweenie I like this -- what about our standard `--include`, `--exclude` (which would allow searching for one or many files/directories)?

Support for this leverages upon the work done by @technoweenie's work in https://github.com/git-lfs/git-lfs/pull/1696, that one can assign a `filepathfilter.Filter` implementation to the `*lfs.GitScanner`'s `Filter` field, and it will emit only tree entires that match the filter's include and exclude rules, as:

```go
s := lfs.NewGitScanner()
s.Filter = filepathfilter.New(...)
```

Closes: https://github.com/git-lfs/git-lfs/issues/2761

##

/cc @git-lfs/core https://github.com/git-lfs/git-lfs/issues/2761