### PR TITLE
commands/ls-files: behave correctly before initial commit

### DIFF
--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -26,9 +26,10 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 	} else {
 		fullref, err := git.CurrentRef()
 		if err != nil {
-			Exit(err.Error())
+			ref = git.RefBeforeFirstCommit
+		} else {
+			ref = fullref.Sha
 		}
-		ref = fullref.Sha
 	}
 
 	showOidLen := 10

--- a/test/test-ls-files.sh
+++ b/test/test-ls-files.sh
@@ -77,6 +77,21 @@ begin_test "ls-files: outside git repository"
 )
 end_test
 
+begin_test "ls-files: before first commit"
+(
+  set -e
+
+  reponame="ls-files-before-first-commit"
+  git init "$reponame"
+  cd "$reponame"
+
+  if [ 0 -ne $(git lfs ls-files | wc -l) ]; then
+    echo >&2 "fatal: expected \`git lfs ls-files\` to produce no output"
+    exit 1
+  fi
+)
+end_test
+
 begin_test "ls-files: show duplicate files"
 (
   set -e

--- a/test/test-ls-files.sh
+++ b/test/test-ls-files.sh
@@ -77,29 +77,6 @@ begin_test "ls-files: outside git repository"
 )
 end_test
 
-begin_test "ls-files: with zero files"
-(
-  set -e
-  mkdir empty
-  cd empty
-  git init
-  git lfs track "*.dat"
-  git add .gitattributes
-
-  set +e
-  git lfs ls-files 2> ls-files.log
-  res=$?
-  set -e
-
-  cat ls-files.log
-  [ "$res" = "2" ]
-  grep "Git can't resolve ref:" ls-files.log
-
-  git commit -m "initial commit"
-  [ "$(git lfs ls-files)" = "" ]
-)
-end_test
-
 begin_test "ls-files: show duplicate files"
 (
   set -e


### PR DESCRIPTION
This pull request teaches `git lfs ls-files` how to behave correctly when run in a repository before an initial commit has been made.

Previously, in a repository with no commits (and therefore, no `HEAD` reference), the behavior of `git lfs ls-files` was such:

```
~/D/new-repo $ git init
Initialized empty Git repository in /Users/ttaylorr/Desktop/new-repo/.git/
~/D/new-repo $ git lfs ls-files
Git can't resolve ref: "HEAD"
```

whereas now, it behaves as follows:

```
~/D/new-repo $ git init
Initialized empty Git repository in /Users/ttaylorr/Desktop/new-repo/.git/
~/D/new-repo $ git lfs ls-files
~/D/new-repo $ 
```

The above behavior was caused by the fact that `git.CurrentRef()` would try to resolve the `HEAD` reference, when it did not in fact exist. To resolve this, we compare the state of the repository against a SHA-1 constant representing the empty tree (see: git/git.go, `git.RefBeforeFirstCommit`).

We can safely fall back to this SHA-1, since the only error in trying to resolve `HEAD` would occur in bare repositories and repositories without any commits.

This change was introduced for two reasons:

1. Parity with Git's `git-ls-files(1)` builtin.
2. In anticipation of supporting https://github.com/git-lfs/git-lfs/issues/2705 (which will allow `git ls-files` to be run on a repository with objects cached, but absent from any tree).

##

/cc @git-lfs/core https://github.com/git-lfs/git-lfs/issues/2705