### PR TITLE
commands/ls-files: show cached, tree-less LFS objects

### DIFF
--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -78,6 +78,9 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 	})
 	defer gitscanner.Close()
 
+	if err := gitscanner.ScanIndex(ref, nil); err != nil {
+		Exit("Could not scan for Git LFS tree: %s", err)
+	}
 	if err := gitscanner.ScanTree(ref); err != nil {
 		Exit("Could not scan for Git LFS tree: %s", err)
 	}

--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -37,7 +37,13 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 		showOidLen = 64
 	}
 
+	seen := make(map[string]struct{})
+
 	gitscanner := lfs.NewGitScanner(func(p *lfs.WrappedPointer, err error) {
+		if _, ok := seen[p.Name]; ok {
+			return
+		}
+
 		if err != nil {
 			Exit("Could not scan for Git LFS tree: %s", err)
 			return
@@ -67,6 +73,8 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 
 			Print(strings.Join(msg, " "))
 		}
+
+		seen[p.Name] = struct{}{}
 	})
 	defer gitscanner.Close()
 

--- a/lfs/gitscanner_index.go
+++ b/lfs/gitscanner_index.go
@@ -120,18 +120,13 @@ func revListIndex(atRef string, cache bool, indexMap *indexFileMap) (*StringChan
 				name = scanner.Entry().SrcName
 			}
 
-			var sha string = scanner.Entry().DstSha
-			if scanner.Entry().Status == StatusModification {
-				sha = scanner.Entry().SrcSha
-			}
-
-			indexMap.Add(sha, &indexFile{
+			indexMap.Add(scanner.Entry().DstSha, &indexFile{
 				Name:    name,
 				SrcName: scanner.Entry().SrcName,
 				Status:  string(scanner.Entry().Status),
 			})
 
-			revs <- sha
+			revs <- scanner.Entry().DstSha
 		}
 
 		if err := scanner.Err(); err != nil {

--- a/lfs/gitscanner_index.go
+++ b/lfs/gitscanner_index.go
@@ -33,17 +33,6 @@ func scanIndex(cb GitScannerFoundPointer, ref string) error {
 	go func() {
 		seenRevs := make(map[string]bool, 0)
 
-		for rev := range revs.Results {
-			if !seenRevs[rev] {
-				allRevsChan <- rev
-				seenRevs[rev] = true
-			}
-		}
-		err := revs.Wait()
-		if err != nil {
-			allRevsErr <- err
-		}
-
 		for rev := range cachedRevs.Results {
 			if !seenRevs[rev] {
 				allRevsChan <- rev
@@ -51,6 +40,17 @@ func scanIndex(cb GitScannerFoundPointer, ref string) error {
 			}
 		}
 		err = cachedRevs.Wait()
+		if err != nil {
+			allRevsErr <- err
+		}
+
+		for rev := range revs.Results {
+			if !seenRevs[rev] {
+				allRevsChan <- rev
+				seenRevs[rev] = true
+			}
+		}
+		err := revs.Wait()
 		if err != nil {
 			allRevsErr <- err
 		}

--- a/test/test-ls-files.sh
+++ b/test/test-ls-files.sh
@@ -61,6 +61,58 @@ begin_test "ls-files: --size"
 )
 end_test
 
+begin_test "ls-files: indexed files without tree"
+(
+  set -e
+
+  reponame="ls-files-indexed-files-without-tree"
+  git init "$reponame"
+  cd "$reponame"
+
+  git lfs track '*.dat'
+  git add .gitattributes
+
+  contents="a"
+  oid="$(calc_oid "$contents")"
+  printf "$contents" > a.dat
+
+  [ "" = "$(git lfs ls-files)" ]
+
+  git add a.dat
+
+  [ "${oid:0:10} * a.dat" = "$(git lfs ls-files)" ]
+)
+end_test
+
+begin_test "ls-files: indexed file with tree"
+(
+  set -e
+
+  reponame="ls-files-indexed-files-with-tree"
+  git init "$reponame"
+  cd "$reponame"
+
+  git lfs track '*.dat'
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  tree_contents="a"
+  tree_oid="$(calc_oid "$tree_contents")"
+
+  printf "$tree_contents" > a.dat
+  git add a.dat
+  git commit -m "add a.dat"
+
+  index_contents="b"
+  index_oid="$(calc_oid "$index_contents")"
+
+  printf "$index_contents" > a.dat
+  git add a.dat
+
+  [ "${index_oid:0:10} * a.dat" = "$(git lfs ls-files)" ]
+)
+end_test
+
 begin_test "ls-files: outside git repository"
 (
   set +e


### PR DESCRIPTION
⚠️ This pull request is based upon https://github.com/git-lfs/git-lfs/pull/2794, and an inter-diff is available [here][1].

##

This pull request teaches `git lfs ls-files` to show tracked LFS objects that are present in the index, which may or may not appear in a tree, as was suggested by @aleb in https://github.com/git-lfs/git-lfs/issues/2705:

> Currently `git lfs ls-files` by default lists the files at the current HEAD, but excluding the new files in the staging area. This is inconsistent with the behaviour of `git ls-files` which by default lists also the new files in the staging area.
> 
> It would be nice to fix this inconsistency:

To accomplish this, we print the set intersection of all LFS objects scanned from the tree (using the `gitscanner`'s `ScanTree()` method), and all LFS objects found in the index (using the `gitscanner`'s `ScanIndex()` method). The later adds an amount of computation proportional to the size of the index, with a constant factor of spawning the necessary `git-diff-index(1)` programs.

Making this work required a few other changes:

1. da94a63: always prefer the destination SHA-1 when scanning the results from `git-diff-index(1)`. This behavior was introduced in https://github.com/git-lfs/git-lfs/pull/137 (via: https://github.com/git-lfs/git-lfs/commit/aa8cea0f98ae4bd5c41c7eb2733a27bc78451468), but is unnecessary as far as I can tell (@rubyist, please correct me if I am wrong).
2. 7efde39: prefer results from the cache before taking the diff-index outside of the cache. This ordering makes more sense for both users of `ScanIndex()` (currently: `git lfs fsck`, `git lfs ls-files`).

Finally, we can apply e271768, and include the results from scanning the index as well as the tree to include _all_ LFS objects in the same manner as `git ls-files`.

Closes: https://github.com/git-lfs/git-lfs/issues/2705.

##

/cc @git-lfs/core https://github.com/git-lfs/git-lfs/issues/2705

[1]: https://github.com/git-lfs/git-lfs/compare/c3418c5...4abc433