### PR TITLE
commands: teach '--all' to `git lfs ls-files`

### DIFF
--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -85,8 +85,14 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 	if err := gitscanner.ScanIndex(ref, nil); err != nil {
 		Exit("Could not scan for Git LFS index: %s", err)
 	}
-	if err := gitscanner.ScanTree(ref); err != nil {
-		Exit("Could not scan for Git LFS tree: %s", err)
+	if lsFilesScanAll {
+		if err := gitscanner.ScanAll(nil); err != nil {
+			Exit("Could not scan for Git LFS history: %s", err)
+		}
+	} else {
+		if err := gitscanner.ScanTree(ref); err != nil {
+			Exit("Could not scan for Git LFS tree: %s", err)
+		}
 	}
 }
 

--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -23,6 +23,9 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 	var ref string
 
 	if len(args) == 1 {
+		if lsFilesScanAll {
+			Exit("fatal: cannot use --all with explicit reference")
+		}
 		ref = args[0]
 	} else {
 		fullref, err := git.CurrentRef()

--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -41,8 +41,10 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 	seen := make(map[string]struct{})
 
 	gitscanner := lfs.NewGitScanner(func(p *lfs.WrappedPointer, err error) {
-		if _, ok := seen[p.Name]; ok {
-			return
+		if !lsFilesScanAll {
+			if _, ok := seen[p.Name]; ok {
+				return
+			}
 		}
 
 		if err != nil {

--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -11,10 +11,11 @@ import (
 )
 
 var (
-	longOIDs        = false
-	lsFilesScanAll  = false
-	lsFilesShowSize = false
-	debug           = false
+	longOIDs           = false
+	lsFilesScanAll     = false
+	lsFilesScanDeleted = false
+	lsFilesShowSize    = false
+	debug              = false
 )
 
 func lsFilesCommand(cmd *cobra.Command, args []string) {
@@ -95,7 +96,14 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 			Exit("Could not scan for Git LFS history: %s", err)
 		}
 	} else {
-		if err := gitscanner.ScanTree(ref); err != nil {
+		var err error
+		if lsFilesScanDeleted {
+			err = gitscanner.ScanRefWithDeleted(ref, nil)
+		} else {
+			err = gitscanner.ScanTree(ref)
+		}
+
+		if err != nil {
 			Exit("Could not scan for Git LFS tree: %s", err)
 		}
 	}
@@ -120,6 +128,7 @@ func init() {
 		cmd.Flags().BoolVarP(&lsFilesShowSize, "size", "s", false, "")
 		cmd.Flags().BoolVarP(&debug, "debug", "d", false, "")
 		cmd.Flags().BoolVarP(&lsFilesScanAll, "all", "a", false, "")
+		cmd.Flags().BoolVar(&lsFilesScanDeleted, "deleted", false, "")
 		cmd.Flags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")
 		cmd.Flags().StringVarP(&excludeArg, "exclude", "X", "", "Exclude a list of paths")
 	})

--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -12,6 +12,7 @@ import (
 
 var (
 	longOIDs        = false
+	lsFilesScanAll  = false
 	lsFilesShowSize = false
 	debug           = false
 )
@@ -107,6 +108,7 @@ func init() {
 		cmd.Flags().BoolVarP(&longOIDs, "long", "l", false, "")
 		cmd.Flags().BoolVarP(&lsFilesShowSize, "size", "s", false, "")
 		cmd.Flags().BoolVarP(&debug, "debug", "d", false, "")
+		cmd.Flags().BoolVarP(&lsFilesScanAll, "all", "a", false, "")
 		cmd.Flags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")
 		cmd.Flags().StringVarP(&excludeArg, "exclude", "X", "", "Exclude a list of paths")
 	})

--- a/docs/man/git-lfs-ls-files.1.ronn
+++ b/docs/man/git-lfs-ls-files.1.ronn
@@ -27,6 +27,10 @@ An asterisk (*) after the OID indicates a LFS pointer, a minus (-) a full object
   Inspects the full history of the repository, not the current HEAD (or other
   provided reference).
 
+* `--deleted`:
+  Shows the full history of the given reference, including objects that have
+  been deleted.
+
 * `-I` <paths> `--include=`<paths>:
   Include paths matching only these patterns; see [FETCH SETTINGS].
 

--- a/docs/man/git-lfs-ls-files.1.ronn
+++ b/docs/man/git-lfs-ls-files.1.ronn
@@ -23,6 +23,10 @@ An asterisk (*) after the OID indicates a LFS pointer, a minus (-) a full object
   Show as much information as possible about a LFS file. This is intended
   for manual inspection; the exact format may change at any time.
 
+* -a --all:
+  Inspects the full history of the repository, not the current HEAD (or other
+  provided reference).
+
 * `-I` <paths> `--include=`<paths>:
   Include paths matching only these patterns; see [FETCH SETTINGS].
 

--- a/test/test-ls-files.sh
+++ b/test/test-ls-files.sh
@@ -233,3 +233,32 @@ a1fff0ffefb9eace7230c24e50731f0a91c62f9cefdfe77121c2f607125dffae * two.tgz")"
   [ "$expected" = "$(git lfs ls-files --long)" ]
 )
 end_test
+
+begin_test "ls-files: history with --all"
+(
+  set -e
+
+  reponame="ls-files-history-with-all"
+  git init "$reponame"
+  cd "$reponame"
+
+  git lfs track '*.dat'
+  printf "a" > a.dat
+  printf "b" > b.dat
+
+  git add .gitattributes a.dat b.dat
+  git commit -m "initial commit"
+
+  rm b.dat
+  git add b.dat
+  git commit -m "remove b.dat"
+
+  git lfs ls-files 2>&1 | tee ls-files.log
+  [ 1 -eq $(grep -c "a\.dat" ls-files.log) ]
+  [ 0 -eq $(grep -c "b\.dat" ls-files.log) ]
+
+  git lfs ls-files --all 2>&1 | tee ls-files-all.log
+  [ 1 -eq $(grep -c "a\.dat" ls-files-all.log) ]
+  [ 1 -eq $(grep -c "b\.dat" ls-files-all.log) ]
+)
+end_test

--- a/test/test-ls-files.sh
+++ b/test/test-ls-files.sh
@@ -262,3 +262,22 @@ begin_test "ls-files: history with --all"
   [ 1 -eq $(grep -c "b\.dat" ls-files-all.log) ]
 )
 end_test
+
+begin_test "ls-files: --all with argument(s)"
+(
+  set -e
+
+  reponame="ls-files-all-with-arguments"
+  git init "$reponame"
+  cd "$reponame"
+
+  git lfs ls-files --all master 2>&1 | tee ls-files.log
+
+  if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: \`git lfs ls-files --all master\` to fail"
+    exit 1
+  fi
+
+  [ "fatal: cannot use --all with explicit reference" = "$(cat ls-files.log)" ]
+)
+end_test

--- a/test/test-ls-files.sh
+++ b/test/test-ls-files.sh
@@ -281,3 +281,28 @@ begin_test "ls-files: --all with argument(s)"
   [ "fatal: cannot use --all with explicit reference" = "$(cat ls-files.log)" ]
 )
 end_test
+
+begin_test "ls-files: reference with --deleted"
+(
+  set -e
+
+  reponame="ls-files-reference-with-deleted"
+  git init "$reponame"
+  cd "$reponame"
+
+  git lfs track "*.dat"
+  printf "a" > a.dat
+  git add .gitattributes a.dat
+  git commit -m "initial commit"
+
+  rm a.dat
+  git add a.dat
+  git commit -m "a.dat: remove a.dat"
+
+  git lfs ls-files 2>&1 | tee ls-files.log
+  git lfs ls-files --deleted 2>&1 | tee ls-files-deleted.log
+
+  [ 0 -eq $(grep -c "a\.dat" ls-files.log) ]
+  [ 1 -eq $(grep -c "a\.dat" ls-files-deleted.log) ]
+)
+end_test


### PR DESCRIPTION
This pull request adds a new flag to the `git lfs ls-files` command, `--all` to scan for _all_ LFS objects in a repository, not just those at the given reference (or HEAD, by default).

This feature was requested by @emericv in https://github.com/git-lfs/git-lfs/issues/2575:

> There is a way to have the whole LFS object sha256 list from a git repo? (like a git-lfs ls-files, but including modified/deleted objects refs of all branchs/tags).

@technoweenie suggested in https://github.com/git-lfs/git-lfs/issues/2575#issuecomment-328909675 to use `ScanRefWithDeleted`, but I think that `--all` may be sufficient (ignoring reference arguments). That said, it might be worth expanding this to cover:

1. `--all`: the entire repository, ignoring the explicit reference argument.
2. `--deleted`: the entire reference space, showing deleted objects (via `ScanTreeWithDeleted()`). 

EDIT: I implemented the above in c4d5f495.

Closes: https://github.com/git-lfs/git-lfs/issues/2575.

##

/cc @git-lfs/core https://github.com/git-lfs/git-lfs/issues/2575