### PR TITLE
Add `lfs.locksverify` to safe keys.

### DIFF
--- a/config/git_fetcher.go
+++ b/config/git_fetcher.go
@@ -161,6 +161,7 @@ var safeKeys = []string{
 	"lfs.fetchexclude",
 	"lfs.fetchinclude",
 	"lfs.gitprotocol",
+	"lfs.locksverify",
 	"lfs.pushurl",
 	"lfs.url",
 }


### PR DESCRIPTION
LFS locking is currently only verified by the client. The server APIs just returned what paths are locked, while the client controls whether you can push or not. This change allows to set `lfs.locksverify` in a *./.lfsconfig* file which LFS will automatically pick up for all users of the repo.

Without defining `lfs.locksverify` as a safe key, the client will output a warning and simply ignore the setting.
