### PR TITLE
Run 1 TransferQueue per uploaded ref

### DIFF
--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -95,8 +95,9 @@ func uploadsWithObjectIDs(ctx *uploadContext, oids []string) {
 		}
 	}
 
-	ctx.UploadPointers(ctx.tq, pointers...)
-	ctx.CollectErrors(ctx.tq)
+	q := ctx.NewQueue()
+	ctx.UploadPointers(q, pointers...)
+	ctx.CollectErrors(q)
 	ctx.ReportErrors()
 }
 

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -95,7 +95,7 @@ func uploadsWithObjectIDs(ctx *uploadContext, oids []string) {
 		}
 	}
 
-	uploadPointers(ctx, pointers...)
+	ctx.UploadPointers(ctx.tq, pointers...)
 	ctx.Await()
 }
 

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -96,7 +96,8 @@ func uploadsWithObjectIDs(ctx *uploadContext, oids []string) {
 	}
 
 	ctx.UploadPointers(ctx.tq, pointers...)
-	ctx.Await()
+	ctx.CollectErrors(ctx.tq)
+	ctx.ReportErrors()
 }
 
 // lfsPushRefs returns valid ref updates from the given ref and --all arguments.

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -121,11 +121,6 @@ func newDownloadQueue(manifest *tq.Manifest, remote string, options ...tq.Option
 	return tq.NewTransferQueue(tq.Download, manifest, remote, options...)
 }
 
-// newUploadQueue builds an UploadQueue, allowing `workers` concurrent uploads.
-func newUploadQueue(manifest *tq.Manifest, remote string, options ...tq.Option) *tq.TransferQueue {
-	return tq.NewTransferQueue(tq.Upload, manifest, remote, options...)
-}
-
 func buildFilepathFilter(config *config.Configuration, includeArg, excludeArg *string) *filepathfilter.Filter {
 	inc, exc := determineIncludeExcludePaths(config, includeArg, excludeArg)
 	return filepathfilter.New(inc, exc)

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -258,6 +258,7 @@ func (c *uploadContext) CollectErrors(tqueues ...*tq.TransferQueue) {
 }
 
 func (c *uploadContext) ReportErrors() {
+	c.meter.Finish()
 	for _, err := range c.otherErrs {
 		FullError(err)
 	}

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -243,20 +243,18 @@ func (c *uploadContext) UploadPointers(q *tq.TransferQueue, unfiltered ...*lfs.W
 	}
 }
 
-func (c *uploadContext) CollectErrors(tqueues ...*tq.TransferQueue) {
-	for _, tqueue := range tqueues {
-		tqueue.Wait()
+func (c *uploadContext) CollectErrors(tqueue *tq.TransferQueue) {
+	tqueue.Wait()
 
-		for _, err := range tqueue.Errors() {
-			if malformed, ok := err.(*tq.MalformedObjectError); ok {
-				if malformed.Missing() {
-					c.missing[malformed.Name] = malformed.Oid
-				} else if malformed.Corrupt() {
-					c.corrupt[malformed.Name] = malformed.Oid
-				}
-			} else {
-				c.otherErrs = append(c.otherErrs, err)
+	for _, err := range tqueue.Errors() {
+		if malformed, ok := err.(*tq.MalformedObjectError); ok {
+			if malformed.Missing() {
+				c.missing[malformed.Name] = malformed.Oid
+			} else if malformed.Corrupt() {
+				c.corrupt[malformed.Name] = malformed.Oid
 			}
+		} else {
+			c.otherErrs = append(c.otherErrs, err)
 		}
 	}
 }

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -72,6 +72,11 @@ type uploadContext struct {
 	// tracks errors from gitscanner callbacks
 	scannerErr error
 	errMu      sync.Mutex
+
+	// filename => oid
+	missing   map[string]string
+	corrupt   map[string]string
+	otherErrs []error
 }
 
 func newUploadContext(dryRun bool) *uploadContext {
@@ -85,6 +90,9 @@ func newUploadContext(dryRun bool) *uploadContext {
 		gitfilter:    lfs.NewGitFilter(cfg),
 		lockVerifier: newLockVerifier(manifest),
 		allowMissing: cfg.Git.Bool("lfs.allowincompletepush", true),
+		missing:      make(map[string]string),
+		corrupt:      make(map[string]string),
+		otherErrs:    make([]error, 0),
 	}
 
 	var sink io.Writer = os.Stdout
@@ -222,30 +230,30 @@ func uploadPointers(c *uploadContext, unfiltered ...*lfs.WrappedPointer) {
 	}
 }
 
-func (c *uploadContext) Await() {
-	c.tq.Wait()
+func (c *uploadContext) CollectErrors(tqueues ...*tq.TransferQueue) {
+	for _, tqueue := range tqueues {
+		tqueue.Wait()
 
-	var missing = make(map[string]string)
-	var corrupt = make(map[string]string)
-	var others = make([]error, 0, len(c.tq.Errors()))
-
-	for _, err := range c.tq.Errors() {
-		if malformed, ok := err.(*tq.MalformedObjectError); ok {
-			if malformed.Missing() {
-				missing[malformed.Name] = malformed.Oid
-			} else if malformed.Corrupt() {
-				corrupt[malformed.Name] = malformed.Oid
+		for _, err := range tqueue.Errors() {
+			if malformed, ok := err.(*tq.MalformedObjectError); ok {
+				if malformed.Missing() {
+					c.missing[malformed.Name] = malformed.Oid
+				} else if malformed.Corrupt() {
+					c.corrupt[malformed.Name] = malformed.Oid
+				}
+			} else {
+				c.otherErrs = append(c.otherErrs, err)
 			}
-		} else {
-			others = append(others, err)
 		}
 	}
+}
 
-	for _, err := range others {
+func (c *uploadContext) ReportErrors() {
+	for _, err := range c.otherErrs {
 		FullError(err)
 	}
 
-	if len(missing) > 0 || len(corrupt) > 0 {
+	if len(c.missing) > 0 || len(c.corrupt) > 0 {
 		var action string
 		if c.allowMissing {
 			action = "missing objects"
@@ -254,10 +262,10 @@ func (c *uploadContext) Await() {
 		}
 
 		Print("LFS upload %s:", action)
-		for name, oid := range missing {
+		for name, oid := range c.missing {
 			Print("  (missing) %s (%s)", name, oid)
 		}
-		for name, oid := range corrupt {
+		for name, oid := range c.corrupt {
 			Print("  (corrupt) %s (%s)", name, oid)
 		}
 
@@ -266,7 +274,7 @@ func (c *uploadContext) Await() {
 		}
 	}
 
-	if len(others) > 0 {
+	if len(c.otherErrs) > 0 {
 		os.Exit(2)
 	}
 
@@ -287,6 +295,11 @@ func (c *uploadContext) Await() {
 			Print("* %s", owned.Path())
 		}
 	}
+}
+
+func (c *uploadContext) Await() {
+	c.CollectErrors(c.tq)
+	c.ReportErrors()
 }
 
 var (

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -32,7 +32,8 @@ func uploadForRefUpdates(ctx *uploadContext, updates []*refUpdate, pushAll bool)
 		}
 	}
 
-	ctx.Await()
+	ctx.CollectErrors(ctx.tq)
+	ctx.ReportErrors()
 	return nil
 }
 
@@ -303,11 +304,6 @@ func (c *uploadContext) ReportErrors() {
 			Print("* %s", owned.Path())
 		}
 	}
-}
-
-func (c *uploadContext) Await() {
-	c.CollectErrors(c.tq)
-	c.ReportErrors()
 }
 
 var (

--- a/tq/meter.go
+++ b/tq/meter.go
@@ -169,7 +169,11 @@ func (m *Meter) Flush() {
 		return
 	}
 
-	m.update()
+	m.updates <- &tasklog.Update{
+		S:     m.str(),
+		At:    time.Now(),
+		Force: true,
+	}
 }
 
 // Finish shuts down the Meter.

--- a/tq/meter.go
+++ b/tq/meter.go
@@ -163,6 +163,15 @@ func (m *Meter) FinishTransfer(name string) {
 	m.fileIndexMutex.Unlock()
 }
 
+// Flush sends the latest progress update, while leaving the meter active.
+func (m *Meter) Flush() {
+	if m == nil {
+		return
+	}
+
+	m.update()
+}
+
 // Finish shuts down the Meter.
 func (m *Meter) Finish() {
 	if m == nil {

--- a/tq/meter.go
+++ b/tq/meter.go
@@ -165,7 +165,7 @@ func (m *Meter) FinishTransfer(name string) {
 
 // Flush sends the latest progress update, while leaving the meter active.
 func (m *Meter) Flush() {
-	if m == nil {
+	if m == nil || m.skipUpdate() {
 		return
 	}
 

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -768,7 +768,7 @@ func (q *TransferQueue) Wait() {
 		close(watcher)
 	}
 
-	q.meter.Finish()
+	q.meter.Flush()
 	q.errorwait.Wait()
 }
 


### PR DESCRIPTION
This started as a rewrite of #2774 against new master (due to lots of conflicts with the progress meter in #2762). However, I decided to keep it scoped to just running multiple transfer queues, leaving the actual refspec-sending stuff to a follow up PR. I think that'll make this easier to review.

* While `commands.uploadContext` is an internal type, I'm trying to use exported functions in `commands`, outside of the actual `uploadContext` type. Also, some functions were moved to the `uploadContext` type, instead of merely accepting one as an argument. There's certainly more to be done with `*uploadContext`, but I'd rather do that in a specific refactor PR.
* `*tq.TransferQueue` now flushes the latest update, but doesn't close the Meter's internal channel. This is so there's only 1 line in the output, instead of 1 per ref. I'm open to having a single meter line per ref, but I think that should come with the upload output changes instead.
* `(*uploadContext) Await()` has been broken up into `CollectErrors(*tq.TransferQueue)` and `ReportErrors()`. This is so `CollectErrors()` can be called after each uploaded ref.