### PR TITLE
fix race conditions in upload progress meter

### DIFF
--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -39,7 +39,7 @@ func checkoutCommand(cmd *cobra.Command, args []string) {
 
 		totalBytes += p.Size
 		meter.Add(p.Size)
-		meter.StartTransfer(p.Name)
+		meter.StartTransfer(p.Name, p.Oid)
 		pointers = append(pointers, p)
 	})
 
@@ -56,7 +56,7 @@ func checkoutCommand(cmd *cobra.Command, args []string) {
 
 		// not strictly correct (parallel) but we don't have a callback & it's just local
 		// plus only 1 slot in channel so it'll block & be close
-		meter.TransferBytes("checkout", p.Name, p.Size, totalBytes, int(p.Size))
+		meter.TransferBytes("checkout", p.Name, p.Oid, p.Size, totalBytes, int(p.Size))
 		meter.FinishTransfer(p.Name)
 	}
 

--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -159,13 +159,13 @@ func (c *Client) doWithRedirects(cli *http.Client, req *http.Request, via []*htt
 
 	requests := tools.MaxInt(0, retries) + 1
 	for i := 0; i < requests; i++ {
+		if seek, ok := req.Body.(io.Seeker); ok {
+			seek.Seek(0, io.SeekStart)
+		}
+
 		res, err = cli.Do(req)
 		if err == nil {
 			break
-		}
-
-		if seek, ok := req.Body.(io.Seeker); ok {
-			seek.Seek(0, io.SeekStart)
 		}
 
 		c.traceResponse(req, tracedReq, nil)

--- a/lfsapi/errors.go
+++ b/lfsapi/errors.go
@@ -58,6 +58,10 @@ func (c *Client) handleResponse(res *http.Response) error {
 		return errors.NewAuthError(err)
 	}
 
+	if res.StatusCode == 503 {
+		return errors.NewRetriableError(err)
+	}
+
 	if res.StatusCode > 499 && res.StatusCode != 501 && res.StatusCode != 507 && res.StatusCode != 509 {
 		return errors.NewFatalError(err)
 	}
@@ -95,6 +99,7 @@ var (
 		429: "Rate limit exceeded: %s",
 		500: "Server error: %s",
 		501: "Not Implemented: %s",
+		503: "Service Unavailable: %s",
 		507: "Insufficient server storage: %s",
 		509: "Bandwidth limit exceeded: %s",
 	}

--- a/tq/adapterbase.go
+++ b/tq/adapterbase.go
@@ -225,10 +225,10 @@ func advanceCallbackProgress(cb ProgressCallback, t *Transfer, numBytes int64) {
 			remainder := numBytes - read
 			if remainder > int64(maxInt) {
 				read += int64(maxInt)
-				cb(t.Name, t.Size, read, maxInt)
+				cb(t.Name, t.Oid, t.Size, read, maxInt)
 			} else {
 				read += remainder
-				cb(t.Name, t.Size, read, int(remainder))
+				cb(t.Name, t.Oid, t.Size, read, int(remainder))
 			}
 
 		}

--- a/tq/basic_download.go
+++ b/tq/basic_download.go
@@ -198,7 +198,7 @@ func (a *basicDownloadAdapter) download(t *Transfer, cb ProgressCallback, authOk
 	// Wrap callback to give name context
 	ccb := func(totalSize int64, readSoFar int64, readSinceLast int) error {
 		if cb != nil {
-			return cb(t.Name, totalSize, readSoFar+fromByte, readSinceLast)
+			return cb(t.Name, t.Oid, totalSize, readSoFar+fromByte, readSinceLast)
 		}
 		return nil
 	}

--- a/tq/basic_upload.go
+++ b/tq/basic_upload.go
@@ -1,8 +1,10 @@
 package tq
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -66,12 +68,21 @@ func (a *basicUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb Progres
 		req.Header.Set("Content-Length", strconv.FormatInt(t.Size, 10))
 	}
 
-	req.ContentLength = t.Size
+	if err := a.fileHTTPUpload(req, t, 0, cb, authOkFunc); err != nil {
+		return err
+	}
+
+	return verifyUpload(a.apiClient, a.remote, t)
+}
+
+func (a *adapterBase) fileHTTPUpload(req *http.Request, t *Transfer, offset int64, cb ProgressCallback, authOkFunc func()) error {
+	req.ContentLength = t.Size - offset
 
 	f, err := os.OpenFile(t.Path, os.O_RDONLY, 0644)
 	if err != nil {
-		return errors.Wrap(err, "basic upload")
+		return errors.Wrap(err, "lfs upload")
 	}
+
 	defer f.Close()
 
 	// Ensure progress callbacks made while uploading
@@ -86,17 +97,24 @@ func (a *basicUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb Progres
 	cbr := tools.NewBodyWithCallback(f, t.Size, ccb)
 	var reader lfsapi.ReadSeekCloser = cbr
 
-	// Signal auth was ok on first read; this frees up other workers to start
-	if authOkFunc != nil {
+	if authOkFunc != nil || offset > 0 {
 		reader = newStartCallbackReader(reader, func() error {
 			authOkFunc()
+
+			if offset > 0 {
+				// seek to the offset since lfsapi.Client rewinds the body
+				if _, err := f.Seek(offset, os.SEEK_CUR); err != nil {
+					return err
+				}
+			}
+
 			return nil
 		})
 	}
 
 	req.Body = reader
-
 	req = a.apiClient.LogRequest(req, "lfs.data.upload")
+
 	res, err := a.doHTTP(t, req)
 	if err != nil {
 		// We're about to return a retriable error, meaning that this
@@ -112,11 +130,9 @@ func (a *basicUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb Progres
 		return errors.NewRetriableError(err)
 	}
 
-	// A status code of 403 likely means that an authentication token for the
-	// upload has expired. This can be safely retried.
-	if res.StatusCode == 403 {
-		err = errors.New("http: received status 403")
-		return errors.NewRetriableError(err)
+	switch res.StatusCode {
+	case 403: // likely an expired auth token
+		return errors.NewRetriableError(fmt.Errorf("http: received status %d", res.StatusCode))
 	}
 
 	if res.StatusCode > 299 {
@@ -128,9 +144,7 @@ func (a *basicUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb Progres
 	}
 
 	io.Copy(ioutil.Discard, res.Body)
-	res.Body.Close()
-
-	return verifyUpload(a.apiClient, a.remote, t)
+	return res.Body.Close()
 }
 
 // startCallbackReader is a reader wrapper which calls a function as soon as the
@@ -150,6 +164,7 @@ func (s *startCallbackReader) Read(p []byte) (n int, err error) {
 	}
 	return s.ReadSeekCloser.Read(p)
 }
+
 func newStartCallbackReader(r lfsapi.ReadSeekCloser, cb func() error) *startCallbackReader {
 	return &startCallbackReader{
 		ReadSeekCloser: r,

--- a/tq/basic_upload.go
+++ b/tq/basic_upload.go
@@ -88,13 +88,13 @@ func (a *adapterBase) fileHTTPUpload(req *http.Request, t *Transfer, offset int6
 	// Ensure progress callbacks made while uploading
 	// Wrap callback to give name context
 	if cb == nil {
-		cb = ProgressCallback(func(n string, t int64, r int64, rSince int) error {
+		cb = ProgressCallback(func(n, o string, t int64, r int64, rSince int) error {
 			return nil
 		})
 	}
 
 	ccb := func(totalSize int64, readSoFar int64, readSinceLast int) error {
-		return cb(t.Name, totalSize, readSoFar, readSinceLast)
+		return cb(t.Name, t.Oid, totalSize, readSoFar, readSinceLast)
 	}
 
 	cbr := tools.NewBodyWithCallback(f, t.Size, ccb)

--- a/tq/basic_upload.go
+++ b/tq/basic_upload.go
@@ -87,11 +87,14 @@ func (a *adapterBase) fileHTTPUpload(req *http.Request, t *Transfer, offset int6
 
 	// Ensure progress callbacks made while uploading
 	// Wrap callback to give name context
+	if cb == nil {
+		cb = ProgressCallback(func(n string, t int64, r int64, rSince int) error {
+			return nil
+		})
+	}
+
 	ccb := func(totalSize int64, readSoFar int64, readSinceLast int) error {
-		if cb != nil {
-			return cb(t.Name, totalSize, readSoFar, readSinceLast)
-		}
-		return nil
+		return cb(t.Name, totalSize, readSoFar, readSinceLast)
 	}
 
 	cbr := tools.NewBodyWithCallback(f, t.Size, ccb)

--- a/tq/basic_upload.go
+++ b/tq/basic_upload.go
@@ -131,7 +131,8 @@ func (a *adapterBase) fileHTTPUpload(req *http.Request, t *Transfer, offset int6
 	}
 
 	switch res.StatusCode {
-	case 403: // likely an expired auth token
+	case 403, // likely an expired auth token
+		503: // service unavailable
 		return errors.NewRetriableError(fmt.Errorf("http: received status %d", res.StatusCode))
 	}
 

--- a/tq/custom.go
+++ b/tq/custom.go
@@ -299,7 +299,7 @@ func (a *customAdapter) DoTransfer(ctx interface{}, t *Transfer, cb ProgressCall
 				return fmt.Errorf("Unexpected oid %q in response, expecting %q", resp.Oid, t.Oid)
 			}
 			if cb != nil {
-				cb(t.Name, t.Size, resp.BytesSoFar, resp.BytesSinceLast)
+				cb(t.Name, t.Oid, t.Size, resp.BytesSoFar, resp.BytesSinceLast)
 			}
 			wasAuthOk = resp.BytesSoFar > 0
 		case "complete":

--- a/tq/meter.go
+++ b/tq/meter.go
@@ -146,7 +146,7 @@ func (m *Meter) TransferBytes(direction, name string, read, total int64, current
 	}
 
 	defer m.update()
-	atomic.AddInt64(&m.currentBytes, int64(current))
+	atomic.StoreInt64(&m.currentBytes, read)
 	m.logBytes(direction, name, read, total)
 }
 

--- a/tq/meter.go
+++ b/tq/meter.go
@@ -21,17 +21,17 @@ type Meter struct {
 	DryRun bool
 	Logger *tools.SyncWriter
 
-	finishedFiles     int64 // int64s must come first for struct alignment
-	skippedFiles      int64
-	transferringFiles int64
-	estimatedBytes    int64
-	currentBytes      int64
-	skippedBytes      int64
-	estimatedFiles    int32
-	paused            uint32
-	fileIndex         map[string]int64 // Maps a file name to its transfer number
-	fileIndexMutex    *sync.Mutex
-	updates           chan *tasklog.Update
+	finishedFiles   int64 // int64s must come first for struct alignment
+	skippedFiles    int64
+	estimatedBytes  int64
+	currentBytes    int64
+	skippedBytes    int64
+	estimatedFiles  int32
+	paused          uint32
+	fileIndex       map[string]int64 // Maps a file name to its transfer number
+	oidCurrentBytes map[string]int64 // Mapos OID to its current transferred bytes
+	fileIndexMutex  *sync.Mutex
+	updates         chan *tasklog.Update
 }
 
 type env interface {
@@ -73,9 +73,10 @@ func (m *Meter) LoggerToFile(name string) *tools.SyncWriter {
 // NewMeter creates a new Meter.
 func NewMeter() *Meter {
 	m := &Meter{
-		fileIndex:      make(map[string]int64),
-		fileIndexMutex: &sync.Mutex{},
-		updates:        make(chan *tasklog.Update),
+		oidCurrentBytes: make(map[string]int64),
+		fileIndex:       make(map[string]int64),
+		fileIndexMutex:  &sync.Mutex{},
+		updates:         make(chan *tasklog.Update),
 	}
 
 	return m
@@ -127,26 +128,28 @@ func (m *Meter) Skip(size int64) {
 
 // StartTransfer tells the progress meter that a transferring file is being
 // added to the TransferQueue.
-func (m *Meter) StartTransfer(name string) {
+func (m *Meter) StartTransfer(name, oid string) {
 	if m == nil {
 		return
 	}
 
 	defer m.update()
-	idx := atomic.AddInt64(&m.transferringFiles, 1)
 	m.fileIndexMutex.Lock()
-	m.fileIndex[name] = idx
+	m.oidCurrentBytes[oid] = int64(0)
+	m.fileIndex[name] = int64(len(m.oidCurrentBytes))
 	m.fileIndexMutex.Unlock()
 }
 
 // TransferBytes increments the number of bytes transferred
-func (m *Meter) TransferBytes(direction, name string, read, total int64, current int) {
+func (m *Meter) TransferBytes(direction, name, oid string, read, total int64, current int) {
 	if m == nil {
 		return
 	}
 
 	defer m.update()
-	atomic.StoreInt64(&m.currentBytes, read)
+	m.fileIndexMutex.Lock()
+	m.oidCurrentBytes[oid] = read
+	m.fileIndexMutex.Unlock()
 	m.logBytes(direction, name, read, total)
 }
 
@@ -205,6 +208,13 @@ func (m *Meter) str() string {
 	// (%d of %d files, %d skipped) %f B / %f B, %f B skipped
 	// skipped counts only show when > 0
 
+	current := int64(0)
+	m.fileIndexMutex.Lock()
+	for _, read := range m.oidCurrentBytes {
+		current += read
+	}
+	m.fileIndexMutex.Unlock()
+
 	out := fmt.Sprintf("\rGit LFS: (%d of %d files",
 		m.finishedFiles,
 		m.estimatedFiles)
@@ -212,7 +222,7 @@ func (m *Meter) str() string {
 		out += fmt.Sprintf(", %d skipped", m.skippedFiles)
 	}
 	out += fmt.Sprintf(") %s / %s",
-		humanize.FormatBytes(uint64(m.currentBytes)),
+		humanize.FormatBytes(uint64(current)),
 		humanize.FormatBytes(uint64(m.estimatedBytes)))
 	if m.skippedBytes > 0 {
 		out += fmt.Sprintf(", %s skipped",

--- a/tq/transfer.go
+++ b/tq/transfer.go
@@ -169,7 +169,7 @@ func IsActionExpiredError(err error) bool {
 // name and dir are to provide context if one func implements many instances
 type NewAdapterFunc func(name string, dir Direction) Adapter
 
-type ProgressCallback func(name string, totalSize, readSoFar int64, readSinceLast int) error
+type ProgressCallback func(name, oid string, totalSize, readSoFar int64, readSinceLast int) error
 
 type AdapterConfig interface {
 	APIClient() *lfsapi.Client

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -491,7 +491,8 @@ func (q *TransferQueue) enqueueAndCollectRetriesFor(batch batch) (batch, error) 
 				q.Skip(o.Size)
 				q.wait.Done()
 			} else {
-				q.meter.StartTransfer(objects.First().Name)
+				obj := objects.First()
+				q.meter.StartTransfer(obj.Name, obj.Oid)
 				toTransfer = append(toTransfer, tr)
 			}
 		}
@@ -716,8 +717,8 @@ func (q *TransferQueue) ensureAdapterBegun(e lfsapi.Endpoint) error {
 	}
 
 	// Progress callback - receives byte updates
-	cb := func(name string, total, read int64, current int) error {
-		q.meter.TransferBytes(q.direction.String(), name, read, total, current)
+	cb := func(name, oid string, total, read int64, current int) error {
+		q.meter.TransferBytes(q.direction.String(), name, oid, read, total, current)
 		if q.cb != nil {
 			// NOTE: this is the mechanism by which the logpath
 			// specified by GIT_LFS_PROGRESS is written to.


### PR DESCRIPTION
This fixes 1 code duplication issue and 2 race conditions (plus 1 bonus fix!) causing the upload progress meter to report a higher current upload size than the estimated total size (reported in #2802).

> Git LFS: (22 of 22 files, 7 skipped) 227.26 MB / 203.26 MB, 750.98 KB skipped 

1. The `basic` and `tus` upload adapters have a lot of extremely similar logic for making and handling an HTTP request. This lead to some discrepancies with how `basic` and `tus` uploads handle failures. Introduced an internal `fileHTTPUpload()` helper so they both work consistently.
2. The LFS API client now rewinds the request body _right before_ making an initial or retried request. It used to rewind the request body after an HTTP request returned an error, meaning `ResetProgress()` was essentially doing nothing. This meant any retry during uploads would count the same transferred bytes again.
3. Found another rare race condition where the `tools.BodyWithCallback` would report transfer progress after `ResetProgress()`. So sometimes the output would report an extra 4k (a single io Read() chunk) of uploaded data. I fixed it by teaching `tq.Meter` to trust that the incoming `read` value from `tools.BodyWithCallback` is correct instead of keeping its own count. This means I had to track the value in a `map[string]int64`. Each `tools.BodyWithCallback` corresponds to an entry in the map according to the object OID. It works, but there's probably a better way to handle this.
4. BONUS: LFS now treats HTTP 503 statuses as a retriable request.

I tested this with the server at https://github.com/git-lfs/bench, on the `next` branch, with this [diff](https://gist.github.com/technoweenie/14b99ff2be13ad9a4a901b94bd683c49). Instead of randomly returning 503 errors, it now randomly closes the HTTP connection after reading a random number of bytes. That helped replicate the bug.