### PR TITLE
tools/humanize: add 'FormatByteRate' to format transfer speed

### DIFF
--- a/tools/humanize/humanize.go
+++ b/tools/humanize/humanize.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"strconv"
 	"strings"
+	"time"
 	"unicode"
 
 	"github.com/git-lfs/git-lfs/errors"
@@ -23,6 +24,10 @@ const (
 	Gigabyte = 1000 * Megabyte
 	Terabyte = 1000 * Gigabyte
 	Petabyte = 1000 * Terabyte
+
+	// eps is the machine epsilon, or a 64-bit floating point value
+	// reasonably close to zero.
+	eps float64 = 7.0/3 - 4.0/3 - 1.0
 )
 
 var bytesTable = map[string]uint64{
@@ -124,6 +129,38 @@ func FormatBytesUnit(s, u uint64) string {
 	}
 
 	return fmt.Sprintf(format, rounded)
+}
+
+// FormatByteRate outputs the given rate of transfer "r" as the quotient of "s"
+// (the number of bytes transferred) over "d" (the duration of time that those
+// bytes were transferred in).
+//
+// It displays the output as a quantity of a "per-unit-time" unit (i.e., B/s,
+// MiB/s) in the most representative fashion possible, as above.
+func FormatByteRate(s uint64, d time.Duration) string {
+	// e is the index of the most representative unit of storage.
+	var e float64
+
+	// f is the floating-point equivalent of "s", so as to avoid more
+	// conversions than necessary.
+	f := float64(s)
+
+	if f != 0 {
+		f = f / d.Seconds()
+		e = math.Floor(log(f, 1000))
+		if e <= eps {
+			// The result of math.Floor(log(r, 1000)) can be
+			// "close-enough" to zero that it should be effectively
+			// considered zero.
+			e = 0
+		}
+	}
+
+	unit := uint64(math.Pow(1000, e))
+	suffix := sizes[int(e)]
+
+	return fmt.Sprintf("%s %s/s",
+		FormatBytesUnit(uint64(math.Ceil(f)), unit), suffix)
 }
 
 // log takes the log base "b" of "n" (\log_b{n})

--- a/tools/humanize/humanize_test.go
+++ b/tools/humanize/humanize_test.go
@@ -3,6 +3,7 @@ package humanize_test
 import (
 	"math"
 	"testing"
+	"time"
 
 	"github.com/git-lfs/git-lfs/tools/humanize"
 	"github.com/stretchr/testify/assert"
@@ -57,6 +58,16 @@ type FormatBytesUnitTestCase struct {
 
 func (c *FormatBytesUnitTestCase) Assert(t *testing.T) {
 	assert.Equal(t, c.Expected, humanize.FormatBytesUnit(c.Given, c.Unit))
+}
+
+type FormatByteRateTestCase struct {
+	Given    uint64
+	Over     time.Duration
+	Expected string
+}
+
+func (c *FormatByteRateTestCase) Assert(t *testing.T) {
+	assert.Equal(t, c.Expected, humanize.FormatByteRate(c.Given, c.Over))
 }
 
 func TestParseBytes(t *testing.T) {
@@ -230,6 +241,39 @@ func TestFormatBytesUnit(t *testing.T) {
 		"format gigabytes over": {uint64(1.51 * math.Pow(10, 9)), humanize.Byte, "1510000000"},
 		"format petabytes over": {uint64(1.51 * math.Pow(10, 12)), humanize.Byte, "1510000000000"},
 		"format terabytes over": {uint64(1.51 * math.Pow(10, 15)), humanize.Byte, "1510000000000000"},
+	} {
+		t.Run(desc, c.Assert)
+	}
+}
+
+func TestFormateByteRate(t *testing.T) {
+	for desc, c := range map[string]*FormatByteRateTestCase{
+		"format bytes":     {uint64(1 * math.Pow(10, 0)), time.Second, "1 B/s"},
+		"format kilobytes": {uint64(1 * math.Pow(10, 3)), time.Second, "1.0 KB/s"},
+		"format megabytes": {uint64(1 * math.Pow(10, 6)), time.Second, "1.0 MB/s"},
+		"format gigabytes": {uint64(1 * math.Pow(10, 9)), time.Second, "1.0 GB/s"},
+		"format petabytes": {uint64(1 * math.Pow(10, 12)), time.Second, "1.0 TB/s"},
+		"format terabytes": {uint64(1 * math.Pow(10, 15)), time.Second, "1.0 PB/s"},
+
+		"format kilobytes under": {uint64(1.49 * math.Pow(10, 3)), time.Second, "1.5 KB/s"},
+		"format megabytes under": {uint64(1.49 * math.Pow(10, 6)), time.Second, "1.5 MB/s"},
+		"format gigabytes under": {uint64(1.49 * math.Pow(10, 9)), time.Second, "1.5 GB/s"},
+		"format petabytes under": {uint64(1.49 * math.Pow(10, 12)), time.Second, "1.5 TB/s"},
+		"format terabytes under": {uint64(1.49 * math.Pow(10, 15)), time.Second, "1.5 PB/s"},
+
+		"format kilobytes over": {uint64(1.51 * math.Pow(10, 3)), time.Second, "1.5 KB/s"},
+		"format megabytes over": {uint64(1.51 * math.Pow(10, 6)), time.Second, "1.5 MB/s"},
+		"format gigabytes over": {uint64(1.51 * math.Pow(10, 9)), time.Second, "1.5 GB/s"},
+		"format petabytes over": {uint64(1.51 * math.Pow(10, 12)), time.Second, "1.5 TB/s"},
+		"format terabytes over": {uint64(1.51 * math.Pow(10, 15)), time.Second, "1.5 PB/s"},
+
+		"format kilobytes exact": {uint64(1.3 * math.Pow(10, 3)), time.Second, "1.3 KB/s"},
+		"format megabytes exact": {uint64(1.3 * math.Pow(10, 6)), time.Second, "1.3 MB/s"},
+		"format gigabytes exact": {uint64(1.3 * math.Pow(10, 9)), time.Second, "1.3 GB/s"},
+		"format petabytes exact": {uint64(1.3 * math.Pow(10, 12)), time.Second, "1.3 TB/s"},
+		"format terabytes exact": {uint64(1.3 * math.Pow(10, 15)), time.Second, "1.3 PB/s"},
+
+		"format bytes (non-second)": {uint64(10 * math.Pow(10, 0)), 2 * time.Second, "5 B/s"},
 	} {
 		t.Run(desc, c.Assert)
 	}


### PR DESCRIPTION
This pull request adds `humanize.FormatByteRate` to the `tools/humanize` package, necessary for the progress meter changes described by @bitinn in #2802.

From @technoweenie's comment in https://github.com/git-lfs/git-lfs/issues/2802#issuecomment-355317842:

>Would it be possible to change the meter to `[Uploading | Downloading] LFS objects: 100% (63/63), 2.01 MiB | 280.00 KiB/s, done.` [...]

To format the `2.01 MiB`, we can use `humanize.FormatBytes` or `humanize.FormatBytesUnit`, but to format the `280.00 KiB/s`, we must either hack the output of one of the two former functions, or add a new one. This pull request opts for the later.

The premise of the function is as follows:

> ```go
> // FormatByteRate outputs the given rate of transfer "r" as the quotient of "s"
> // (the number of bytes transferred) over "d" (the duration of time that those
> // bytes were transferred in).
> //
> // It displays the output as a quantity of a "per-unit-time" unit (i.e., B/s,
> // MiB/s) in the most representative fashion possible, as above.
> func FormatByteRate(s uint64, d time.Duration) string { ... }
> ```

Accept an amount of bytes transferred "s", and a duration of time over which they were transferred, "d". Divide one by the other, and format a string in the existing conventions using an appropriately-representative unit, and appending `$UNIT/s`.

This approach has the following two benefits:

1. If the caller is calculating a changing rate over time (i.e., by continually updating a cumulative moving average or similar), allow them to display the rate as they wish by specifying the constant rate of time `1 * time.Second`.
2. If, on the other hand, the caller has only a single byte rate to display, and they have kept track of the two necessary pieces of information (the quantity and duration of transfer), but do _not_ wish to manage a changing rate over time themselves, this function will do the appropriate math to display the output correctly.

EDIT: There is some floating-point math going on here, which is a topic I often find myself in trouble with. I have done my best to do a reasonable amount of _safe_ integer conversions (`uint64 -> float64`) and documented my intentions. There is a case where some floating-point math produces a float that is within a margin of error of zero, but produces unintended side-effects when it is exponentiated. My best efforts to prevent this are documented in the const `eps`.

##

/cc @git-lfs/core https://github.com/git-lfs/git-lfs/issues/2802
  