### PR TITLE
tq: standardized progress meter formatting

### DIFF
--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -325,7 +325,7 @@ func fetchAndReportToChan(allpointers []*lfs.WrappedPointer, filter *filepathfil
 
 func readyAndMissingPointers(allpointers []*lfs.WrappedPointer, filter *filepathfilter.Filter) ([]*lfs.WrappedPointer, []*lfs.WrappedPointer, *tq.Meter) {
 	logger := tasklog.NewLogger(os.Stdout)
-	meter := buildProgressMeter(false)
+	meter := buildProgressMeter(false, tq.Download)
 	logger.Enqueue(meter)
 
 	seen := make(map[string]bool, len(allpointers))

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -430,10 +430,11 @@ func determineIncludeExcludePaths(config *config.Configuration, includeArg, excl
 	return
 }
 
-func buildProgressMeter(dryRun bool) *tq.Meter {
+func buildProgressMeter(dryRun bool, d tq.Direction) *tq.Meter {
 	m := tq.NewMeter()
 	m.Logger = m.LoggerFromEnv(cfg.Os)
 	m.DryRun = dryRun
+	m.Direction = d
 	return m
 }
 

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -108,7 +108,7 @@ func newUploadContext(dryRun bool) *uploadContext {
 	}
 
 	ctx.logger = tasklog.NewLogger(sink)
-	ctx.meter = buildProgressMeter(ctx.DryRun)
+	ctx.meter = buildProgressMeter(ctx.DryRun, tq.Upload)
 	ctx.logger.Enqueue(ctx.meter)
 	ctx.committerName, ctx.committerEmail = cfg.CurrentCommitter()
 	return ctx

--- a/test/test-batch-transfer.sh
+++ b/test/test-batch-transfer.sh
@@ -49,7 +49,7 @@ begin_test "batch transfer"
 
   # This pushes to the remote repository set up at the top of the test.
   git push origin master 2>&1 | tee push.log
-  grep "(1 of 1 files)" push.log
+  grep "Uploading LFS objects: 100% (1/1), 1 B" push.log
   grep "master -> master" push.log
 
   assert_server_object "$reponame" "$contents_oid"

--- a/test/test-chunked-transfer-encoding.sh
+++ b/test/test-chunked-transfer-encoding.sh
@@ -48,7 +48,7 @@ begin_test "chunked transfer encoding"
 
   # This pushes to the remote repository set up at the top of the test.
   git push origin master 2>&1 | tee push.log
-  grep "(1 of 1 files)" push.log
+  grep "Uploading LFS objects: 100% (1/1), 1 B" push.log
   grep "master -> master" push.log
 
   assert_server_object "$reponame" "$contents_oid"

--- a/test/test-clone.sh
+++ b/test/test-clone.sh
@@ -46,7 +46,7 @@ begin_test "clone"
   newclonedir="testclone1"
   git lfs clone "$GITSERVER/$reponame" "$newclonedir" 2>&1 | tee lfsclone.log
   grep "Cloning into" lfsclone.log
-  grep "Git LFS:" lfsclone.log
+  grep "Downloading LFS objects:" lfsclone.log
   # should be no filter errors
   [ ! $(grep "filter" lfsclone.log) ]
   [ ! $(grep "error" lfsclone.log) ]
@@ -67,7 +67,7 @@ begin_test "clone"
   rm -rf "$reponame"
   git lfs clone "$GITSERVER/$reponame" 2>&1 | tee lfsclone.log
   grep "Cloning into" lfsclone.log
-  grep "Git LFS:" lfsclone.log
+  grep "Downloading LFS objects:" lfsclone.log
   # should be no filter errors
   [ ! $(grep "filter" lfsclone.log) ]
   [ ! $(grep "error" lfsclone.log) ]
@@ -328,7 +328,7 @@ begin_test "clone (with include/exclude args)"
 
   git push origin master 2>&1 | tee push.log
   grep "master -> master" push.log
-  grep "Git LFS: (2 of 2 files)" push.log
+  grep "Uploading LFS objects: 100% (2/2), 2 B" push.log
 
   cd "$TRASHDIR"
 
@@ -392,7 +392,7 @@ begin_test "clone (with .lfsconfig)"
 
   git push origin master 2>&1 | tee push.log
   grep "master -> master" push.log
-  grep "Git LFS: (2 of 2 files)" push.log
+  grep "Uploading LFS objects: 100% (2/2), 2 B" push.log
 
   pushd "$TRASHDIR"
 
@@ -482,7 +482,7 @@ begin_test "clone (without clean filter)"
 
   git push origin master 2>&1 | tee push.log
   grep "master -> master" push.log
-  grep "Git LFS: (1 of 1 files)" push.log
+  grep "Uploading LFS objects: 100% (1/1), 1 B" push.log
 
   cd "$TRASHDIR"
 
@@ -613,7 +613,7 @@ begin_test "clone in current directory"
     mkdir "$reponame-clone"
     cd "$reponame-clone"
 
-    git lfs clone $GITSERVER/$reponame "." 2>&1 | grep "Git LFS"
+    git lfs clone $GITSERVER/$reponame "." 2>&1 | grep "Downloading LFS objects: 100% (1/1), 8 B"
 
     assert_local_object "$contents_oid" 8
     assert_hooks "$(dot_git_dir)"

--- a/test/test-credentials.sh
+++ b/test/test-credentials.sh
@@ -51,7 +51,7 @@ begin_test "credentials without useHttpPath, with bad path password"
   git commit -m "add a.dat"
 
   GIT_TRACE=1 git push origin without-path 2>&1 | tee push.log
-  grep "(1 of 1 files)" push.log
+  grep "Uploading LFS objects: 100% (1/1), 1 B" push.log
 
   echo "approvals:"
   [ "1" -eq "$(cat push.log | grep "creds: git credential approve" | wc -l)" ]
@@ -88,7 +88,7 @@ begin_test "credentials with url-specific useHttpPath, with bad path password"
   git commit -m "add a.dat"
 
   GIT_TRACE=1 git push origin without-path 2>&1 | tee push.log
-  grep "(1 of 1 files)" push.log
+  grep "Uploading LFS objects: 100% (1/1), 1 B" push.log
 
   echo "approvals:"
   [ "1" -eq "$(cat push.log | grep "creds: git credential approve" | wc -l)" ]
@@ -121,7 +121,7 @@ begin_test "credentials with useHttpPath, with wrong password"
   git commit -m "add a.dat"
 
   GIT_TRACE=1 git push origin with-path-wrong-pass 2>&1 | tee push.log
-  [ "0" = "$(grep -c "(1 of 1 files)" push.log)" ]
+  [ "0" = "$(grep -c "Uploading LFS objects: 100% (1/1), 0 B" push.log)" ]
   echo "approvals:"
   [ "0" -eq "$(cat push.log | grep "creds: git credential approve" | wc -l)" ]
   echo "fills:"
@@ -155,7 +155,7 @@ begin_test "credentials with useHttpPath, with correct password"
   git commit -m "add b.dat"
 
   GIT_TRACE=1 git push origin with-path-correct-pass 2>&1 | tee push.log
-  grep "(1 of 1 files)" push.log
+  grep "Uploading LFS objects: 100% (1/1), 1 B" push.log
   echo "approvals:"
   [ "1" -eq "$(cat push.log | grep "creds: git credential approve" | wc -l)" ]
   echo "fills:"
@@ -253,7 +253,7 @@ begin_test "credentials from netrc"
   git commit -m "add a.dat"
 
   GIT_TRACE=1 git lfs push netrc master 2>&1 | tee push.log
-  grep "(1 of 1 files)" push.log
+  grep "Uploading LFS objects: 100% (1/1), 7 B" push.log
   echo "any git credential calls:"
   [ "0" -eq "$(cat push.log | grep "git credential" | wc -l)" ]
 )
@@ -286,7 +286,7 @@ begin_test "credentials from netrc with bad password"
   git commit -m "add a.dat"
 
   git push netrc master 2>&1 | tee push.log
-  [ "0" = "$(grep -c "(1 of 1 files)" push.log)" ]
+  [ "0" = "$(grep -c "Uploading LFS objects: 100% (1/1), 7 B" push.log)" ]
 )
 end_test
 
@@ -306,28 +306,28 @@ begin_test "credentials from lfs.url"
   echo "bad push"
   git lfs env
   git lfs push origin master 2>&1 | tee push.log
-  grep "(0 of 1 files)" push.log
+  grep "Uploading LFS objects:   0% (0/1), 0 B" push.log
 
   echo "good push"
   gitserverhost=$(echo "$GITSERVER" | cut -d'/' -f3)
   git config lfs.url http://requirecreds:pass@$gitserverhost/$reponame.git/info/lfs
   git lfs env
   git lfs push origin master 2>&1 | tee push.log
-  grep "(1 of 1 files)" push.log
+  grep "Uploading LFS objects:   0% (0/1), 0 B" push.log
 
   echo "bad fetch"
   rm -rf .git/lfs/objects
   git config lfs.url http://$gitserverhost/$reponame.git/info/lfs
   git lfs env
   git lfs fetch --all 2>&1 | tee fetch.log
-  grep "(0 of 1 files)" fetch.log
+  grep "Downloading LFS objects:   0% (0/1), 0 B" fetch.log
 
   echo "good fetch"
   rm -rf .git/lfs/objects
   git config lfs.url http://requirecreds:pass@$gitserverhost/$reponame.git/info/lfs
   git lfs env
   git lfs fetch --all 2>&1 | tee fetch.log
-  grep "(1 of 1 files)" fetch.log
+  grep "Downloading LFS objects: 100% (1/1), 7 B" fetch.log
 )
 end_test
 
@@ -347,27 +347,28 @@ begin_test "credentials from remote.origin.url"
   echo "bad push"
   git lfs env
   git lfs push origin master 2>&1 | tee push.log
-  grep "(0 of 1 files)" push.log
+  grep "Uploading LFS objects:   0% (0/1), 0 B" push.log
 
   echo "good push"
   gitserverhost=$(echo "$GITSERVER" | cut -d'/' -f3)
   git config remote.origin.url http://requirecreds:pass@$gitserverhost/$reponame.git
   git lfs env
   git lfs push origin master 2>&1 | tee push.log
-  grep "(1 of 1 files)" push.log
+  grep "Uploading LFS objects: 100% (1/1), 7 B" push.log
 
   echo "bad fetch"
   rm -rf .git/lfs/objects
   git config remote.origin.url http://$gitserverhost/$reponame.git
   git lfs env
   git lfs fetch --all 2>&1 | tee fetch.log
-  grep "(0 of 1 files)" fetch.log
+  # Missing authentication causes `git lfs fetch` to fail before the progress
+  # meter is printed to the TTY.
 
   echo "good fetch"
   rm -rf .git/lfs/objects
   git config remote.origin.url http://requirecreds:pass@$gitserverhost/$reponame.git
   git lfs env
   git lfs fetch --all 2>&1 | tee fetch.log
-  grep "(1 of 1 files)" fetch.log
+  grep "Downloading LFS objects: 100% (1/1), 7 B" fetch.log
 )
 end_test

--- a/test/test-custom-transfers.sh
+++ b/test/test-custom-transfers.sh
@@ -94,7 +94,7 @@ begin_test "custom-transfer-upload-download"
 
   grep "xfer: started custom adapter process" pushcustom.log
   grep "xfer\[lfstest-customadapter\]:" pushcustom.log
-  grep "12 of 12 files" pushcustom.log
+  grep "Uploading LFS objects: 100% (12/12)" pushcustom.log
 
   rm -rf .git/lfs/objects
   GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git lfs fetch --all  2>&1 | tee fetchcustom.log
@@ -102,7 +102,7 @@ begin_test "custom-transfer-upload-download"
 
   grep "xfer: started custom adapter process" fetchcustom.log
   grep "xfer\[lfstest-customadapter\]:" fetchcustom.log
-  grep "12 of 12 files" fetchcustom.log
+  grep "Downloading LFS objects: 100% (12/12)" fetchcustom.log
 
   grep "Terminating test custom adapter gracefully" fetchcustom.log
 
@@ -176,7 +176,7 @@ begin_test "custom-transfer-standalone"
 
   grep "xfer: started custom adapter process" pushcustom.log
   grep "xfer\[lfstest-standalonecustomadapter\]:" pushcustom.log
-  grep "12 of 12 files" pushcustom.log
+  grep "Uploading LFS objects: 100% (12/12)" pushcustom.log
 
   rm -rf .git/lfs/objects
   GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git lfs fetch --all  2>&1 | tee fetchcustom.log
@@ -184,7 +184,7 @@ begin_test "custom-transfer-standalone"
 
   grep "xfer: started custom adapter process" fetchcustom.log
   grep "xfer\[lfstest-standalonecustomadapter\]:" fetchcustom.log
-  grep "12 of 12 files" fetchcustom.log
+  grep "Downloading LFS objects: 100% (12/12)" fetchcustom.log
 
   grep "Terminating test custom adapter gracefully" fetchcustom.log
 
@@ -262,7 +262,7 @@ begin_test "custom-transfer-standalone-urlmatch"
 
   grep "xfer: started custom adapter process" pushcustom.log
   grep "xfer\[lfstest-standalonecustomadapter\]:" pushcustom.log
-  grep "12 of 12 files" pushcustom.log
+  grep "Uploading LFS objects: 100% (12/12)" pushcustom.log
 
   rm -rf .git/lfs/objects
   GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git lfs fetch --all  2>&1 | tee fetchcustom.log
@@ -270,7 +270,7 @@ begin_test "custom-transfer-standalone-urlmatch"
 
   grep "xfer: started custom adapter process" fetchcustom.log
   grep "xfer\[lfstest-standalonecustomadapter\]:" fetchcustom.log
-  grep "12 of 12 files" fetchcustom.log
+  grep "Downloading LFS objects: 100% (12/12)" fetchcustom.log
 
   grep "Terminating test custom adapter gracefully" fetchcustom.log
 

--- a/test/test-duplicate-oids.sh
+++ b/test/test-duplicate-oids.sh
@@ -43,7 +43,7 @@ begin_test "multiple revs with same OID get pushed once"
   # Delay the push until here, so the server doesn't have a copy of the OID that
   # we're trying to push.
   git push origin master 2>&1 | tee push.log
-  grep "Git LFS: (1 of 1 files)" push.log
+  grep "Uploading LFS objects: 100% (1/1), 8 B" push.log
 
   assert_server_object "$reponame" "$contents_oid"
 )

--- a/test/test-fetch-include.sh
+++ b/test/test-fetch-include.sh
@@ -36,7 +36,7 @@ begin_test "fetch: setup for include test"
   grep "create mode 100644 big/big3.big" commit.log
 
   git push origin master | tee push.log
-  grep "2 of 2 files" push.log
+  grep "Uploading LFS objects: 100% (2/2), 18 B" push.log
 
   assert_server_object "$reponame" "$contents_oid"
 )

--- a/test/test-fetch-paths.sh
+++ b/test/test-fetch-paths.sh
@@ -33,7 +33,7 @@ begin_test "init fetch unclean paths"
   refute_server_object "$contents_oid"
 
   git push origin master 2>&1 | tee push.log
-  grep "(1 of 1 files)" push.log
+  grep "Uploading LFS objects: 100% (1/1), 1 B" push.log
   grep "master -> master" push.log
 
   assert_server_object "$reponame" "$contents_oid"

--- a/test/test-fetch.sh
+++ b/test/test-fetch.sh
@@ -36,7 +36,7 @@ begin_test "init for fetch tests"
   refute_server_object "$reponame" "$contents_oid"
 
   git push origin master 2>&1 | tee push.log
-  grep "(1 of 1 files)" push.log
+  grep "Uploading LFS objects: 100% (1/1), 1 B" push.log
   grep "master -> master" push.log
 
   assert_server_object "$reponame" "$contents_oid"
@@ -62,7 +62,7 @@ begin_test "fetch"
   cd clone
   rm -rf .git/lfs/objects
 
-  git lfs fetch 2>&1 | grep "(1 of 1 files)"
+  git lfs fetch 2>&1 | grep "Downloading LFS objects: 100% (1/1), 1 B"
   assert_local_object "$contents_oid" 1
 )
 end_test
@@ -73,7 +73,7 @@ begin_test "fetch with remote"
   cd clone
   rm -rf .git/lfs/objects
 
-  git lfs fetch origin 2>&1 | grep "(1 of 1 files)"
+  git lfs fetch origin 2>&1 | grep "Downloading LFS objects: 100% (1/1), 1 B"
   assert_local_object "$contents_oid" 1
   refute_local_object "$b_oid" 1
 )
@@ -416,7 +416,7 @@ begin_test "fetch with no origin remote"
   refute_server_object "$reponame" "$contents_oid"
 
   git push origin master 2>&1 | tee push.log
-  grep "(1 of 1 files)" push.log
+  grep "Uploading LFS objects: 100% (1/1), 1 B" push.log
   grep "master -> master" push.log
 
 

--- a/test/test-happy-path.sh
+++ b/test/test-happy-path.sh
@@ -48,7 +48,7 @@ begin_test "happy path"
 
   # This pushes to the remote repository set up at the top of the test.
   git push origin master 2>&1 | tee push.log
-  grep "(1 of 1 files)" push.log
+  grep "Uploading LFS objects: 100% (1/1), 1 B" push.log
   grep "master -> master" push.log
 
   assert_server_object "$reponame" "$contents_oid"

--- a/test/test-pre-push.sh
+++ b/test/test-pre-push.sh
@@ -34,7 +34,7 @@ begin_test "pre-push"
   echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
     git lfs pre-push origin "$GITSERVER/$reponame" 2>&1 |
     tee push.log
-  grep "(1 of 1 files)" push.log
+  grep "Uploading LFS objects: 100% (1/1), 3 B" push.log
 
   assert_server_object "$reponame" 98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4
 )
@@ -104,7 +104,7 @@ begin_test "pre-push 307 redirects"
   echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
     git lfs pre-push origin "$GITSERVER/redirect307/rel/$reponame.git/info/lfs" 2>&1 |
     tee push.log
-  grep "(0 of 0 files, 1 skipped)" push.log
+  grep "Uploading LFS objects: 100% (1/1), 3 B" push.log
 
   assert_server_object "$reponame" 98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4
 
@@ -120,7 +120,7 @@ begin_test "pre-push 307 redirects"
   echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
     git lfs pre-push origin "$GITSERVER/redirect307/abs/$reponame.git/info/lfs" 2>&1 |
     tee push.log
-  grep "(0 of 0 files, 1 skipped)" push.log
+  grep "Uploading LFS objects: 100% (1/1), 3 B" push.log
 )
 end_test
 
@@ -146,7 +146,7 @@ begin_test "pre-push with existing file"
   echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
     git lfs pre-push origin "$GITSERVER/$reponame" 2>&1 |
     tee push.log
-  grep "(1 of 1 files)" push.log
+  grep "Uploading LFS objects: 100% (1/1), 4 B" push.log
 
   # now the file exists
   assert_server_object "$reponame" 7aa7a5359173d05b63cfd682e3c38487f3cb4f7f1d60659fe59fab1505977d4c
@@ -171,7 +171,7 @@ begin_test "pre-push with existing pointer"
   echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
     git lfs pre-push origin "$GITSERVER/$reponame" 2>&1 |
     tee push.log
-  grep "(1 of 1 files)" push.log
+  grep "Uploading LFS objects: 100% (1/1), 4 B" push.log
 )
 end_test
 
@@ -222,7 +222,7 @@ begin_test "pre-push with missing pointer which is on server"
   echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
     git lfs pre-push origin "$GITSERVER/$reponame" 2>&1 |
     tee push.log
-  grep "(1 of 1 files)" push.log
+  grep "Uploading LFS objects: 100% (1/1), 11 B" push.log
 
   # now the file exists
   assert_server_object "$reponame" "$contents_oid"

--- a/test/test-progress-meter.sh
+++ b/test/test-progress-meter.sh
@@ -24,6 +24,6 @@ begin_test "progress meter displays positive progress"
   git push origin master 2>&1 | tee push.log
   [ "0" -eq "${PIPESTATUS[0]}" ]
 
-  grep "Git LFS: (128 of 128 files) 276 B / 276 B" push.log
+  grep "Uploading LFS objects: 100% (128/128), 276 B" push.log
 )
 end_test

--- a/test/test-progress.sh
+++ b/test/test-progress.sh
@@ -19,7 +19,7 @@ begin_test "GIT_LFS_PROGRESS"
   git add .gitattributes *.dat
   git commit -m "add files"
   git push origin master 2>&1 | tee push.log
-  grep "(5 of 5 files)" push.log
+  grep "Uploading LFS objects: 100% (5/5), 10 B" push.log
 
   cd ..
   GIT_LFS_PROGRESS="$TRASHDIR/progress.log" git lfs clone "$GITSERVER/$reponame" clone

--- a/test/test-pull.sh
+++ b/test/test-pull.sh
@@ -49,7 +49,7 @@ begin_test "pull"
 
   echo "initial push"
   git push origin master 2>&1 | tee push.log
-  grep "(3 of 3 files)" push.log
+  grep "Uploading LFS objects: 100% (3/3), 5 B" push.log
   grep "master -> master" push.log
 
   assert_server_object "$reponame" "$contents_oid"
@@ -72,7 +72,7 @@ begin_test "pull"
   echo "lfs pull"
   rm -r a.dat á.dat dir # removing files makes the status dirty
   rm -rf .git/lfs/objects
-  git lfs pull 2>&1 | grep "(3 of 3 files)"
+  git lfs pull 2>&1 | grep "Downloading LFS objects: 100% (3/3), 5 B"
   ls -al
   [ "a" = "$(cat a.dat)" ]
   [ "A" = "$(cat "á.dat")" ]
@@ -82,7 +82,7 @@ begin_test "pull"
   echo "lfs pull with remote"
   rm -r a.dat á.dat dir
   rm -rf .git/lfs/objects
-  git lfs pull origin 2>&1 | grep "(3 of 3 files)"
+  git lfs pull origin 2>&1 | grep "Downloading LFS objects: 100% (3/3), 5 B"
   [ "a" = "$(cat a.dat)" ]
   [ "A" = "$(cat "á.dat")" ]
   assert_local_object "$contents_oid" 1

--- a/test/test-push-file-with-branch-name.sh
+++ b/test/test-push-file-with-branch-name.sh
@@ -16,6 +16,6 @@ begin_test "push a file with the same name as a branch"
   git commit -m "add master"
 
   git lfs push --all origin master 2>&1 | tee push.log
-  grep "(1 of 1 files)" push.log
+  grep "Uploading LFS objects: 100% (1/1), 7 B" push.log
 )
 end_test

--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -22,7 +22,7 @@ begin_test "push"
   [ $(grep -c "push" push.log) -eq 1 ]
 
   git lfs push origin master 2>&1 | tee push.log
-  grep "(1 of 1 files)" push.log
+  grep "Uploading LFS objects: 100% (1/1), 7 B" push.log
 
   git checkout -b push-b
   echo "push b" > b.dat
@@ -44,7 +44,7 @@ begin_test "push"
   rm -rf .git/refs/remotes
 
   git lfs push origin push-b 2>&1 | tee push.log
-  grep "(1 of 1 files, 1 skipped)" push.log
+  grep "Uploading LFS objects: 100% (2/2), 14 B" push.log
 )
 end_test
 
@@ -136,7 +136,7 @@ begin_test "push --all (no ref args)"
   [ $(grep -c "push" < push.log) -eq 6 ]
 
   git push --all origin 2>&1 | tee push.log
-  [ $(grep -c "(6 of 6 files)" push.log) -eq 1 ]
+  [ $(grep -c "Uploading LFS objects: 100% (6/6), 36 B" push.log) -eq 1 ]
   assert_server_object "$reponame-$suffix" "$oid1"
   assert_server_object "$reponame-$suffix" "$oid2"
   assert_server_object "$reponame-$suffix" "$oid3"
@@ -168,9 +168,7 @@ begin_test "push --all (no ref args)"
   [ $(grep -c "push" push.log) -eq 6 ]
 
   git push --all origin 2>&1 | tee push.log
-  grep "(5 of 5 files, 1 skipped)" push.log
-  [ $(grep -c "files" push.log) -eq 1 ]
-  [ $(grep -c "skipped" push.log) -eq 1 ]
+  grep "Uploading LFS objects: 100% (6/6), 36 B" push.log
   assert_server_object "$reponame-$suffix-2" "$oid2"
   assert_server_object "$reponame-$suffix-2" "$oid3"
   assert_server_object "$reponame-$suffix-2" "$oid4"
@@ -353,7 +351,7 @@ begin_test "push object id(s)"
   git lfs push --object-id origin \
     4c48d2a6991c9895bcddcf027e1e4907280bcf21975492b1afbade396d6a3340 \
     2>&1 | tee push.log
-  grep "(0 of 0 files, 1 skipped)" push.log
+  grep "Uploading LFS objects: 100% (1/1), 7 B" push.log
 
   echo "push b" > b.dat
   git add b.dat
@@ -363,7 +361,7 @@ begin_test "push object id(s)"
     4c48d2a6991c9895bcddcf027e1e4907280bcf21975492b1afbade396d6a3340 \
     82be50ad35070a4ef3467a0a650c52d5b637035e7ad02c36652e59d01ba282b7 \
     2>&1 | tee push.log
-  grep "(0 of 0 files, 2 skipped)" push.log
+  grep "Uploading LFS objects: 100% (2/2), 14 B" push.log
 )
 end_test
 
@@ -516,7 +514,7 @@ begin_test "push (retry with expired actions)"
   expected="enqueue retry #1 for \"$contents_oid\" (size: $contents_size): LFS: tq: action \"upload\" expires at"
 
   grep "$expected" push.log
-  grep "(1 of 1 files)" push.log
+  grep "Uploading LFS objects: 100% (1/1), 21 B" push.log
 )
 end_test
 

--- a/test/test-smudge.sh
+++ b/test/test-smudge.sh
@@ -163,7 +163,7 @@ begin_test "smudge clone with include/exclude"
   assert_local_object "$contents_oid" 1
 
   git push origin master 2>&1 | tee push.log
-  grep "(1 of 1 files)" push.log
+  grep "Uploading LFS objects: 100% (1/1), 1 B" push.log
   grep "master -> master" push.log
 
   assert_server_object "$reponame" "$contents_oid"

--- a/test/test-unusual-filenames.sh
+++ b/test/test-unusual-filenames.sh
@@ -24,6 +24,6 @@ begin_test "push unusually named files"
   git commit -m "add files"
 
   git push origin master | tee push.log
-  grep "Git LFS: (1 of 1 files)" push.log
+  grep "Uploading LFS objects: 100% (1/1), 1 B" push.log
 )
 end_test

--- a/test/test-zero-len-file.sh
+++ b/test/test-zero-len-file.sh
@@ -39,7 +39,7 @@ begin_test "push zero len file"
   assert_pointer "master" "full.dat" "$contents_oid" 4
 
   git push origin master | tee push.log
-  grep "Git LFS: (1 of 1 files)" push.log
+  grep "Uploading LFS objects: 100% (1/1), 4 B" push.log
 )
 end_test
 

--- a/tools/humanize/humanize.go
+++ b/tools/humanize/humanize.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"strconv"
 	"strings"
+	"time"
 	"unicode"
 
 	"github.com/git-lfs/git-lfs/errors"
@@ -23,6 +24,10 @@ const (
 	Gigabyte = 1000 * Megabyte
 	Terabyte = 1000 * Gigabyte
 	Petabyte = 1000 * Terabyte
+
+	// eps is the machine epsilon, or a 64-bit floating point value
+	// reasonably close to zero.
+	eps float64 = 7.0/3 - 4.0/3 - 1.0
 )
 
 var bytesTable = map[string]uint64{
@@ -124,6 +129,38 @@ func FormatBytesUnit(s, u uint64) string {
 	}
 
 	return fmt.Sprintf(format, rounded)
+}
+
+// FormatByteRate outputs the given rate of transfer "r" as the quotient of "s"
+// (the number of bytes transferred) over "d" (the duration of time that those
+// bytes were transferred in).
+//
+// It displays the output as a quantity of a "per-unit-time" unit (i.e., B/s,
+// MiB/s) in the most representative fashion possible, as above.
+func FormatByteRate(s uint64, d time.Duration) string {
+	// e is the index of the most representative unit of storage.
+	var e float64
+
+	// f is the floating-point equivalent of "s", so as to avoid more
+	// conversions than necessary.
+	f := float64(s)
+
+	if f != 0 {
+		f = f / d.Seconds()
+		e = math.Floor(log(f, 1000))
+		if e <= eps {
+			// The result of math.Floor(log(r, 1000)) can be
+			// "close-enough" to zero that it should be effectively
+			// considered zero.
+			e = 0
+		}
+	}
+
+	unit := uint64(math.Pow(1000, e))
+	suffix := sizes[int(e)]
+
+	return fmt.Sprintf("%s %s/s",
+		FormatBytesUnit(uint64(math.Ceil(f)), unit), suffix)
 }
 
 // log takes the log base "b" of "n" (\log_b{n})

--- a/tools/humanize/humanize_test.go
+++ b/tools/humanize/humanize_test.go
@@ -3,6 +3,7 @@ package humanize_test
 import (
 	"math"
 	"testing"
+	"time"
 
 	"github.com/git-lfs/git-lfs/tools/humanize"
 	"github.com/stretchr/testify/assert"
@@ -57,6 +58,16 @@ type FormatBytesUnitTestCase struct {
 
 func (c *FormatBytesUnitTestCase) Assert(t *testing.T) {
 	assert.Equal(t, c.Expected, humanize.FormatBytesUnit(c.Given, c.Unit))
+}
+
+type FormatByteRateTestCase struct {
+	Given    uint64
+	Over     time.Duration
+	Expected string
+}
+
+func (c *FormatByteRateTestCase) Assert(t *testing.T) {
+	assert.Equal(t, c.Expected, humanize.FormatByteRate(c.Given, c.Over))
 }
 
 func TestParseBytes(t *testing.T) {
@@ -230,6 +241,39 @@ func TestFormatBytesUnit(t *testing.T) {
 		"format gigabytes over": {uint64(1.51 * math.Pow(10, 9)), humanize.Byte, "1510000000"},
 		"format petabytes over": {uint64(1.51 * math.Pow(10, 12)), humanize.Byte, "1510000000000"},
 		"format terabytes over": {uint64(1.51 * math.Pow(10, 15)), humanize.Byte, "1510000000000000"},
+	} {
+		t.Run(desc, c.Assert)
+	}
+}
+
+func TestFormateByteRate(t *testing.T) {
+	for desc, c := range map[string]*FormatByteRateTestCase{
+		"format bytes":     {uint64(1 * math.Pow(10, 0)), time.Second, "1 B/s"},
+		"format kilobytes": {uint64(1 * math.Pow(10, 3)), time.Second, "1.0 KB/s"},
+		"format megabytes": {uint64(1 * math.Pow(10, 6)), time.Second, "1.0 MB/s"},
+		"format gigabytes": {uint64(1 * math.Pow(10, 9)), time.Second, "1.0 GB/s"},
+		"format petabytes": {uint64(1 * math.Pow(10, 12)), time.Second, "1.0 TB/s"},
+		"format terabytes": {uint64(1 * math.Pow(10, 15)), time.Second, "1.0 PB/s"},
+
+		"format kilobytes under": {uint64(1.49 * math.Pow(10, 3)), time.Second, "1.5 KB/s"},
+		"format megabytes under": {uint64(1.49 * math.Pow(10, 6)), time.Second, "1.5 MB/s"},
+		"format gigabytes under": {uint64(1.49 * math.Pow(10, 9)), time.Second, "1.5 GB/s"},
+		"format petabytes under": {uint64(1.49 * math.Pow(10, 12)), time.Second, "1.5 TB/s"},
+		"format terabytes under": {uint64(1.49 * math.Pow(10, 15)), time.Second, "1.5 PB/s"},
+
+		"format kilobytes over": {uint64(1.51 * math.Pow(10, 3)), time.Second, "1.5 KB/s"},
+		"format megabytes over": {uint64(1.51 * math.Pow(10, 6)), time.Second, "1.5 MB/s"},
+		"format gigabytes over": {uint64(1.51 * math.Pow(10, 9)), time.Second, "1.5 GB/s"},
+		"format petabytes over": {uint64(1.51 * math.Pow(10, 12)), time.Second, "1.5 TB/s"},
+		"format terabytes over": {uint64(1.51 * math.Pow(10, 15)), time.Second, "1.5 PB/s"},
+
+		"format kilobytes exact": {uint64(1.3 * math.Pow(10, 3)), time.Second, "1.3 KB/s"},
+		"format megabytes exact": {uint64(1.3 * math.Pow(10, 6)), time.Second, "1.3 MB/s"},
+		"format gigabytes exact": {uint64(1.3 * math.Pow(10, 9)), time.Second, "1.3 GB/s"},
+		"format petabytes exact": {uint64(1.3 * math.Pow(10, 12)), time.Second, "1.3 TB/s"},
+		"format terabytes exact": {uint64(1.3 * math.Pow(10, 15)), time.Second, "1.3 PB/s"},
+
+		"format bytes (non-second)": {uint64(10 * math.Pow(10, 0)), 2 * time.Second, "5 B/s"},
 	} {
 		t.Run(desc, c.Assert)
 	}

--- a/tq/meter.go
+++ b/tq/meter.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -18,11 +19,11 @@ import (
 // files and bytes transferred as well as the number of files and bytes that
 // get skipped because the transfer is unnecessary.
 type Meter struct {
-	DryRun bool
-	Logger *tools.SyncWriter
+	DryRun    bool
+	Logger    *tools.SyncWriter
+	Direction Direction
 
 	finishedFiles     int64 // int64s must come first for struct alignment
-	skippedFiles      int64
 	transferringFiles int64
 	estimatedBytes    int64
 	lastBytes         int64
@@ -30,13 +31,11 @@ type Meter struct {
 	sampleCount       uint64
 	avgBytes          float64
 	lastAvg           time.Time
-	skippedBytes      int64
 	estimatedFiles    int32
 	paused            uint32
 	fileIndex         map[string]int64 // Maps a file name to its transfer number
 	fileIndexMutex    *sync.Mutex
 	updates           chan *tasklog.Update
-	direction         Direction
 }
 
 type env interface {
@@ -123,11 +122,8 @@ func (m *Meter) Skip(size int64) {
 	}
 
 	defer m.update(false)
-	atomic.AddInt64(&m.skippedFiles, 1)
-	atomic.AddInt64(&m.skippedBytes, size)
-	// Reduce bytes and files so progress easier to parse
-	atomic.AddInt32(&m.estimatedFiles, -1)
-	atomic.AddInt64(&m.estimatedBytes, -size)
+	atomic.AddInt64(&m.finishedFiles, 1)
+	atomic.AddInt64(&m.currentBytes, size)
 }
 
 // StartTransfer tells the progress meter that a transferring file is being
@@ -229,29 +225,22 @@ func (m *Meter) update(force bool) {
 
 func (m *Meter) skipUpdate() bool {
 	return m.DryRun ||
-		(m.estimatedFiles == 0 && m.skippedFiles == 0) ||
+		m.estimatedFiles == 0 ||
 		atomic.LoadUint32(&m.paused) == 1
 }
 
 func (m *Meter) str() string {
-	// (%d of %d files, %d skipped) %f B / %f B, %f B skipped
-	// skipped counts only show when > 0
+	// (Uploading|Downloading) LFS objects: 100% (10/10) 100 MiB | 10 MiB/s
 
-	out := fmt.Sprintf("\rGit LFS: (%d of %d files",
-		m.finishedFiles,
-		m.estimatedFiles)
-	if m.skippedFiles > 0 {
-		out += fmt.Sprintf(", %d skipped", m.skippedFiles)
-	}
-	out += fmt.Sprintf(") %s / %s",
+	direction := strings.Title(m.Direction.String()) + "ing"
+	percentage := 100 * float64(m.finishedFiles) / float64(m.estimatedFiles)
+
+	return fmt.Sprintf("%s LFS objects: %3.f%% (%d/%d), %s | %s",
+		direction,
+		percentage,
+		m.finishedFiles, m.estimatedFiles,
 		humanize.FormatBytes(uint64(m.currentBytes)),
-		humanize.FormatBytes(uint64(m.estimatedBytes)))
-	if m.skippedBytes > 0 {
-		out += fmt.Sprintf(", %s skipped",
-			humanize.FormatBytes(uint64(m.skippedBytes)))
-	}
-
-	return out
+		humanize.FormatByteRate(uint64(m.avgBytes), time.Second))
 }
 
 func (m *Meter) logBytes(direction, name string, read, total int64) {

--- a/tq/meter.go
+++ b/tq/meter.go
@@ -36,6 +36,7 @@ type Meter struct {
 	fileIndex         map[string]int64 // Maps a file name to its transfer number
 	fileIndexMutex    *sync.Mutex
 	updates           chan *tasklog.Update
+	direction         Direction
 }
 
 type env interface {

--- a/tq/meter.go
+++ b/tq/meter.go
@@ -142,14 +142,13 @@ func (m *Meter) StartTransfer(name string) {
 
 // TransferBytes increments the number of bytes transferred
 func (m *Meter) TransferBytes(direction, name string, read, total int64, current int) {
-	now := time.Now()
-
 	if m == nil {
 		return
 	}
 
 	defer m.update(false)
 
+	now := time.Now()
 	since := now.Sub(m.lastAvg)
 	atomic.AddInt64(&m.currentBytes, int64(current))
 	atomic.AddInt64(&m.lastBytes, int64(current))

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -223,6 +223,9 @@ func NewTransferQueue(dir Direction, manifest *Manifest, remote string, options 
 	if q.bufferDepth <= 0 {
 		q.bufferDepth = q.batchSize
 	}
+	if q.meter != nil {
+		q.meter.Direction = q.direction
+	}
 
 	q.incoming = make(chan *objectTuple, q.bufferDepth)
 	q.collectorWait.Add(1)


### PR DESCRIPTION
This pull request adopts the recommendation for a new style of progress meter proposed by @bitinn and @technoweenie in https://github.com/git-lfs/git-lfs/issues/2802, and https://github.com/git-lfs/git-lfs/issues/2802#issuecomment-355317842, respectively:

> Would it be possible to change the meter to `[Uploading | Downloading] LFS objects: 100% (63/63), 2.01 MiB | 280.00 KiB/s, done.` That matches the "Writing objects" message, retains the file counts, and even shows current speed.

The style that is implemented in this pull request is exactly as @technoweenie's recommendation above:

```
~/example-repository (master) $ git lfs pull
Downloading LFS objects: 100% (501/501), 1.9 KB | 210 B/s, done
```

Here's a large overview of the changes:

1. **Remove the notion of 'skipped' files.** This term has been used to indicate files that are unnecessary to re-transfer, for they are already present on either the client (in the case of a fetch) or the server (in the case of a push). This term has unfortunately also been the source of some confusion by users. To remove this source of confusion, let's instead treat "skipped" files as already having been transferred, and instead of incrementing a "skipped" count, simply increment the number of files and bytes as already having been transferred, without affecting the true transfer speed.

2. **Introduce a transfer rate indicator.** To match the style of progress meter used by Git to indicate push/pull operations, introduce to Git LFS's progress meter the average rate at which the transfer is occurring.<sup>[1]</sup> To keep track of this, each time we receive a read update, we first check if it has been sufficiently long enough since the last time we calculated an average (to avoid a false sense of precision) and, if so, recalculate the average rate of transfer by using a Cumulative Moving Average (C.M.A) function, so as to weight more heavily recent transfer speeds, so that they dominate the average.

The average is calculated as:

![mathtex](https://user-images.githubusercontent.com/443245/34635927-79f9aa42-f24b-11e7-804b-4e89c3a6f88c.gif)

Where:

- `avg` is the average rate of transfer (given as bytes/second)
- `n` is the number of samples taken
- `s` is the number of bytes transferred since the last sample was taken
- `d` is the duration of time that has passed since the last sample

I am hoping that this new formatting will clarify what is going on when LFS uploads and downloads objects. The majority of this pull request is changing outdated assertions in the integration suite to match the new formatting.

Closes: https://github.com/git-lfs/git-lfs/issues/2802.

<sup>[1]</sup>: This is actually something that I've been wanting to add to LFS for some time now, but haven't found the right time to do it. I have published [this][1] Gist around a year ago at the time of writing this pull request. That code was originally intended for something exactly like this.

##

/cc @git-lfs/core https://github.com/git-lfs/git-lfs/issues/2802

[1]: https://gist.github.com/ttaylorr/ffe27bae92ebfffe5d805b06766b2e03/