### PR TITLE
refspec docs

### DIFF
--- a/docs/api/batch.md
+++ b/docs/api/batch.md
@@ -31,6 +31,8 @@ some objects:
 * `transfers` - An optional Array of String identifiers for transfer adapters
 that the client has configured. If omitted, the `basic` transfer adapter MUST
 be assumed by the server.
+* `ref` - Optional object describing the server ref that the objects belong to. Note: Added in v2.4.
+  * `name` - Fully-qualified server refspec.
 * `objects` - An Array of objects to download.
   * `oid` - String OID of the LFS object.
   * `size` - Integer byte size of the LFS object. Must be at least zero.
@@ -48,6 +50,7 @@ transfer adapters.
 {
   "operation": "download",
   "transfers": [ "basic" ],
+  "ref": { "name": "refs/heads/master" },
   "objects": [
     {
       "oid": "12345678",
@@ -56,6 +59,62 @@ transfer adapters.
   ]
 }
 ```
+
+#### Ref Property
+
+The Batch API added the `ref` property in LFS v2.4 to support Git server authentication schemes that take the refspec into account. Since this is
+a new addition to the API, servers should be able to operate with a missing or null `ref` property.
+
+Some examples will illustrate how the `ref` property can be used.
+
+* User `owner` has full access to the repository.
+* User `contrib` has readonly access to the repository, and write access to `refs/heads/contrib`.
+
+```js
+{
+  "operation": "download",
+  "transfers": [ "basic" ],
+  "objects": [
+    {
+      "oid": "12345678",
+      "size": 123,
+    }
+  ]
+}
+```
+
+With this payload, both `owner` and `contrib` can download the requested object, since they both have read access.
+
+```js
+{
+  "operation": "upload",
+  "transfers": [ "basic" ],
+  "objects": [
+    {
+      "oid": "12345678",
+      "size": 123,
+    }
+  ]
+}
+```
+
+With this payload, only `owner` can upload the requested object.
+
+```js
+{
+  "operation": "upload",
+  "transfers": [ "basic" ],
+  "ref": { "name": "refs/heads/contrib" },
+  "objects": [
+    {
+      "oid": "12345678",
+      "size": 123,
+    }
+  ]
+}
+```
+
+Both `owner` and `contrib` can upload the request object.
 
 ### Successful Responses
 

--- a/docs/api/locking.md
+++ b/docs/api/locking.md
@@ -26,6 +26,8 @@ simplest use case: single branch locking. The API is designed to be extensible
 as we experiment with more advanced locking scenarios, as defined in the
 [original proposal](/docs/proposals/locking.md).
 
+The [Batch API's `ref` property docs](./batch.md#ref-property) describe how the `ref` property can be used to support auth schemes that include the server ref. Locking API implementations should also only use it for authentication, until advanced locking scenarios have been developed. 
+
 ## Create Lock
 
 The client sends the following to create a lock by sending a `POST` to `/locks`
@@ -35,9 +37,8 @@ to one user.
 
 * `path` - String path name of the file that is locked. This should be
 relative to the root of the repository working directory.
-* `ref` - The fully-qualified reference from which the client is locking the
-file. It is the responsibility of the server implementing this specification
-to decide on the semantic meaning of this.
+* `ref` - Optional object describing the server ref that the locks belong to. Note: Added in v2.4.
+  * `name` - Fully-qualified server refspec.
 
 ```js
 // POST https://lfs-server.com/locks
@@ -47,7 +48,7 @@ to decide on the semantic meaning of this.
 {
   "path": "foo/bar.zip",
   "ref": {
-    "name": "refs/heads/my-feature
+    "name": "refs/heads/my-feature"
   }
 }
 ```
@@ -157,8 +158,8 @@ The properties are sent as URI query values, instead of through a JSON body:
 should be the `next_cursor` from a previous request.
 * `limit` - The integer limit of the number of locks to return. The server
 should have its own upper and lower bounds on the supported limits.
-* `ref` - Optional reference representing the reference from which the client
-is searching for looks.
+* `ref` - Optional fully qualified server refspec
+from which to search for locks.
 
 ```js
 // GET https://lfs-server.com/locks?path=&id=&cursor=&limit=
@@ -251,8 +252,11 @@ LFS Servers should ensure that users have push access to the repository.
 Clients send the following to list locks for verification by sending a `POST`
 to `/locks/verify` (appended to the LFS server url, as described above):
 
-* `cursor`
-* `limit`
+* `ref` - Optional object describing the server ref that the locks belong to. Note: Added in v2.4.
+  * `name` - Fully-qualified server refspec.
+* `cursor` - Optional cursor to allow pagination. Servers can determine how cursors are formatted based on how they are stored internally.
+* `limit` - Optional limit to how many locks to
+return.
 
 ```js
 // POST https://lfs-server.com/locks/verify
@@ -385,9 +389,8 @@ Properties:
 
 * `force` - Optional boolean specifying that the user is deleting another user's
 lock.
-* `ref` - Optional reference object specifying the reference from which the
-client is deleting the lock. It is the responsibility of the server implementing
-this specification to decide upon the semantic meaning of this.
+* `ref` - Optional object describing the server ref that the locks belong to. Note: Added in v2.4.
+  * `name` - Fully-qualified server refspec.
 
 ```js
 // POST https://lfs-server.com/locks/:id/unlock
@@ -398,7 +401,7 @@ this specification to decide upon the semantic meaning of this.
 {
   "force": true,
   "ref": {
-    "name": "refs/heads/my-feature
+    "name": "refs/heads/my-feature"
   }
 }
 ```


### PR DESCRIPTION
Adds docs for the refspec api changes, as prophesized by #2712.

@ttaylorr I didn't realize you added some stuff at the end of #2773. Here's a chance to go through it all together :)

I changed some of the wording, with the intention of using Git terms, like "fully qualified refspec." Open to improvements here.