### PR TITLE
Update usage info for post-checkout

### DIFF
--- a/commands/command_post_checkout.go
+++ b/commands/command_post_checkout.go
@@ -21,7 +21,7 @@ import (
 // optimising that as best it can based on the available information.
 func postCheckoutCommand(cmd *cobra.Command, args []string) {
 	if len(args) != 3 {
-		Print("This should be run through Git's post-commit hook.  Run `git lfs update` to install it.")
+		Print("This should be run through Git's post-checkout hook.  Run `git lfs update` to install it.")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
I believe the usage documentation for `git lfs post-checkout` incorrectly states that this should be run as part of Git's `post-commit` hook, instead of the `post-checkout` hook.
