### PR TITLE
[WIP] git lfs status issue?

### DIFF
--- a/test/test-status.sh
+++ b/test/test-status.sh
@@ -2,6 +2,30 @@
 
 . "test/testlib.sh"
 
+begin_test "status with non LFS files"
+(
+  set -e
+
+  mkdir repo-0
+  cd repo-0
+  git init
+
+  echo "some text" > some.txt
+  git add some.txt
+  git commit -m "add text file"
+  echo "changed text" > some.txt
+
+  expected="On branch master
+
+Git LFS objects to be committed:
+
+
+Git LFS objects not staged for commit:"
+
+  [ "$expected" = "$(git lfs status)" ]
+)
+end_test
+
 begin_test "status"
 (
   set -e


### PR DESCRIPTION
We noticed that `git lfs status` reports changes in "non Git LFS tracked" files in the "Git LFS objects not staged for commit" section. Is this as it should be or is it a bug? 

If it is no bug, then I would argue it is at least confusing. 
If it is a bug, then you have a test case here.

--

PS: Are you OK with these kind of PR's to report "bugs"? Feel free to close the PRs if you don't want to tackle them. It won't hurt my feelings 😄 