### PR TITLE
vendor: update 'xeipuuv/gojsonpointer'

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: e19b925b9eaca9a10a7742b4a4b1dc8047bff437584538dda59f4f10e69fa6ca
-updated: 2017-09-27T12:34:48.032089491-04:00
+updated: 2018-01-29T17:36:52.158516-08:00
 imports:
 - name: github.com/bgentry/go-netrc
   version: 9fd32a8b3d3d3f9d43c341bfe098430e07609480
@@ -41,6 +41,6 @@ testImports:
   subpackages:
   - difflib
 - name: github.com/xeipuuv/gojsonpointer
-  version: 6fe8760cad3569743d51ddbb243b26f8456742dc
+  version: 4e3ac2762d5f479393488629ee9370b50873b3a6
 - name: github.com/xeipuuv/gojsonreference
-  version: e02fc20de94c78484cd5ffb007f8af96be030a45
+  version: bd5ef7bd5415a7ac448318e64f11a24cd21e594b

--- a/vendor/github.com/xeipuuv/gojsonpointer/README.md
+++ b/vendor/github.com/xeipuuv/gojsonpointer/README.md
@@ -1,6 +1,39 @@
 # gojsonpointer
 An implementation of JSON Pointer - Go language
 
+## Usage
+	jsonText := `{
+		"name": "Bobby B",
+		"occupation": {
+			"title" : "King",
+			"years" : 15,
+			"heir" : "Joffrey B"			
+		}
+	}`
+	
+    var jsonDocument map[string]interface{}
+    json.Unmarshal([]byte(jsonText), &jsonDocument)
+    
+    //create a JSON pointer
+    pointerString := "/occupation/title"
+    pointer, _ := NewJsonPointer(pointerString)
+    
+    //SET a new value for the "title" in the document     
+    pointer.Set(jsonDocument, "Supreme Leader of Westeros")
+    
+    //GET the new "title" from the document
+    title, _, _ := pointer.Get(jsonDocument)
+    fmt.Println(title) //outputs "Supreme Leader of Westeros"
+    
+    //DELETE the "heir" from the document
+    deletePointer := NewJsonPointer("/occupation/heir")
+    deletePointer.Delete(jsonDocument)
+    
+    b, _ := json.Marshal(jsonDocument)
+    fmt.Println(string(b))
+    //outputs `{"name":"Bobby B","occupation":{"title":"Supreme Leader of Westeros","years":15}}`
+
+
 ## References
 http://tools.ietf.org/html/draft-ietf-appsawg-json-pointer-07
 

--- a/vendor/github.com/xeipuuv/gojsonpointer/pointer_test.go
+++ b/vendor/github.com/xeipuuv/gojsonpointer/pointer_test.go
@@ -245,3 +245,103 @@ func TestSetNode(t *testing.T) {
 	}
 
 }
+
+func TestSetEmptyNode(t *testing.T) {
+
+	jsonText := `{}`
+
+	var jsonDocument interface{}
+	json.Unmarshal([]byte(jsonText), &jsonDocument)
+
+	in := "/a"
+
+	p, err := NewJsonPointer(in)
+	if err != nil {
+		t.Errorf("NewJsonPointer(%v) error %v", in, err.Error())
+	}
+
+	_, err = p.Set(jsonDocument, 999)
+	if err != nil {
+		t.Errorf("Set(%v) error %v", in, err.Error())
+	}
+
+	firstNode := jsonDocument.(map[string]interface{})
+	target := firstNode["a"].(int)
+	if target != 999 {
+		t.Errorf("Set(%s) failed", in)
+	}
+}
+
+func TestDelObject(t *testing.T) {
+	jsonText := `{
+		"a":["apple sauce", "ketchup", "soy sauce"],
+		"d": {
+			"z" : {
+				"v" : {
+					"name" : "donald mcbobble",
+					"occupation" : "corporate overlord"
+				}
+			}
+		}
+	}`
+
+	var jsonDocument map[string]interface{}
+	json.Unmarshal([]byte(jsonText), &jsonDocument)
+
+	//Deleting an object key
+	in := "/d/z/v/occupation"
+	p, err := NewJsonPointer(in)
+	if err != nil {
+		t.Errorf("NewJsonPointer(%v) error %v", in, err.Error())
+	}
+
+	_,  err = p.Delete(jsonDocument)
+	if err != nil {
+		t.Errorf("Delete(%v) error %v", in, err.Error())
+	}
+
+	var d map[string]interface{} = jsonDocument["d"].(map[string]interface{})
+	var z map[string]interface{} = d["z"].(map[string]interface{})
+	var v map[string]interface{} = z["v"].(map[string]interface{})
+
+	if _, present := v["occupation"]; present {
+		t.Errorf("Delete (%s) failed: key is still present in the map", in)
+	}
+}
+
+
+func TestDelArray(t *testing.T) {
+	jsonText := `{
+		"a":["applesauce", "ketchup", "soysauce", "oliveoil"],
+		"d": {
+			"z" : {
+				"v" : {
+					"name" : "donald mcbobble",
+					"occupation" : "corporate overlord",
+					"responsibilities" : ["managing", "hiring"]
+				}
+			}
+		}
+	}`
+
+	var jsonDocument map[string]interface{}
+	json.Unmarshal([]byte(jsonText), &jsonDocument)
+
+	//Deleting an array member
+	in := "/a/2"
+	p, err := NewJsonPointer(in)
+	if err != nil {
+		t.Errorf("NewJsonPointer(%v) error %v", in, err.Error())
+	}
+
+	_,  err = p.Delete(jsonDocument)
+	if err != nil {
+		t.Errorf("Delete(%v) error %v", in, err.Error())
+	}
+
+	a := jsonDocument["a"].([]interface{})
+	if len(a) != 3 || a[2] == "soysauce" {
+		t.Errorf("Delete(%v) error (%s)", in, a)
+	}
+
+}

--- a/vendor/github.com/xeipuuv/gojsonreference/reference.go
+++ b/vendor/github.com/xeipuuv/gojsonreference/reference.go
@@ -27,11 +27,12 @@ package gojsonreference
 
 import (
 	"errors"
-	"github.com/xeipuuv/gojsonpointer"
 	"net/url"
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/xeipuuv/gojsonpointer"
 )
 
 const (
@@ -124,16 +125,21 @@ func (r *JsonReference) parse(jsonReferenceString string) (err error) {
 // Creates a new reference from a parent and a child
 // If the child cannot inherit from the parent, an error is returned
 func (r *JsonReference) Inherits(child JsonReference) (*JsonReference, error) {
-	childUrl := child.GetUrl()
-	parentUrl := r.GetUrl()
-	if childUrl == nil {
+	if child.GetUrl() == nil {
 		return nil, errors.New("childUrl is nil!")
 	}
-	if parentUrl == nil {
+
+	if r.GetUrl() == nil {
 		return nil, errors.New("parentUrl is nil!")
 	}
 
-	ref, err := NewJsonReference(parentUrl.ResolveReference(childUrl).String())
+	// Get a copy of the parent url to make sure we do not modify the original.
+	// URL reference resolving fails if the fragment of the child is empty, but the parent's is not.
+	// The fragment of the child must be used, so the fragment of the parent is manually removed.
+	parentUrl := *r.GetUrl()
+	parentUrl.Fragment = ""
+
+	ref, err := NewJsonReference(parentUrl.ResolveReference(child.GetUrl()).String())
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/xeipuuv/gojsonreference/reference_test.go
+++ b/vendor/github.com/xeipuuv/gojsonreference/reference_test.go
@@ -245,6 +245,24 @@ func TestInheritsDifferentHost(t *testing.T) {
 	}
 }
 
+func TestInheritsEmptyFragment(t *testing.T) {
+	in1 := "#a"
+	in2 := ""
+
+	r1, _ := NewJsonReference(in1)
+	r2, _ := NewJsonReference(in2)
+
+	result, err := r1.Inherits(r2)
+
+	if err != nil {
+		t.Errorf("Inherits(%s,%s) should not fail. Error: %s", r1.String(), r2.String(), err.Error())
+	}
+
+	if result.String() != in2 {
+		t.Errorf("Inherits(%s,%s) should be empty but is %s", in1, in2, result)
+	}
+}
+
 func TestFileScheme(t *testing.T) {
 
 	in1 := "file:///Users/mac/1.json#a"
@@ -266,7 +284,7 @@ func TestFileScheme(t *testing.T) {
 	}
 
 	if r1.IsCanonical() != true {
-		t.Errorf("NewJsonReference(%v)::IsCanonical %v expect %v", in1, r1.IsCanonical, true)
+		t.Errorf("NewJsonReference(%v)::IsCanonical %v expect %v", in1, r1.IsCanonical(), true)
 	}
 
 	result, err := r1.Inherits(r2)


### PR DESCRIPTION
This pull request updates the vendored copy of `github.com/xeipuuv/gojsonpointer`.

Running `script/vendor` produces a diff in this tree without updating the hash of the lock file or the project itself.

##

/cc @git-lfs/core 