### PR TITLE
fsck: attach a filter to exclude unfetched items from fsck

### DIFF
--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/git-lfs/git-lfs/filepathfilter"
 	"github.com/git-lfs/git-lfs/git"
 	"github.com/git-lfs/git-lfs/lfs"
 	"github.com/spf13/cobra"
@@ -45,6 +46,13 @@ func fsckCommand(cmd *cobra.Command, args []string) {
 			Panic(err, "Error checking Git LFS files")
 		}
 	})
+
+	// If 'lfs.fetchexclude' is set and 'git lfs fsck' is run after the
+	// initial fetch (i.e., has elected to fetch a subset of Git LFS
+	// objects), the "missing" ones will fail the fsck.
+	//
+	// Attach a filepathfilter to avoid _only_ the excluded paths.
+	gitscanner.Filter = filepathfilter.New(nil, cfg.FetchExcludePaths())
 
 	if err := gitscanner.ScanRef(ref.Sha, nil); err != nil {
 		ExitWithError(err)

--- a/lfs/gitscanner.go
+++ b/lfs/gitscanner.go
@@ -175,7 +175,7 @@ func (s *GitScanner) ScanIndex(ref string, cb GitScannerFoundPointer) error {
 	if err != nil {
 		return err
 	}
-	return scanIndex(callback, ref)
+	return scanIndex(callback, ref, s.Filter)
 }
 
 func (s *GitScanner) opts(mode ScanningMode) *ScanRefsOptions {

--- a/lfs/gitscanner_index.go
+++ b/lfs/gitscanner_index.go
@@ -3,6 +3,8 @@ package lfs
 import (
 	"strings"
 	"sync"
+
+	"github.com/git-lfs/git-lfs/filepathfilter"
 )
 
 // ScanIndex returns a slice of WrappedPointer objects for all Git LFS pointers
@@ -10,7 +12,7 @@ import (
 //
 // Ref is the ref at which to scan, which may be "HEAD" if there is at least one
 // commit.
-func scanIndex(cb GitScannerFoundPointer, ref string) error {
+func scanIndex(cb GitScannerFoundPointer, ref string, f *filepathfilter.Filter) error {
 	indexMap := &indexFileMap{
 		nameMap:      make(map[string][]*indexFile),
 		nameShaPairs: make(map[string]bool),
@@ -95,7 +97,9 @@ func scanIndex(cb GitScannerFoundPointer, ref string) error {
 	}()
 
 	for result := range ch {
-		cb(result.Pointer, result.Err)
+		if f.Allows(result.Pointer.Name) {
+			cb(result.Pointer, result.Err)
+		}
 	}
 
 	return nil

--- a/lfs/gitscanner_refs.go
+++ b/lfs/gitscanner_refs.go
@@ -72,11 +72,16 @@ func scanRefsToChan(scanner *GitScanner, pointerCb GitScannerFoundPointer, refLe
 		if name, ok := opt.GetName(p.Sha1); ok {
 			p.Name = name
 		}
-		pointerCb(p, nil)
+
+		if scanner.Filter.Allows(p.Name) {
+			pointerCb(p, nil)
+		}
 	}
 
 	for lockableName := range checkLockableCh {
-		lockableCb(lockableName)
+		if scanner.Filter.Allows(lockableName) {
+			lockableCb(lockableName)
+		}
 	}
 
 	if err := pointers.Wait(); err != nil {

--- a/test/test-fetch.sh
+++ b/test/test-fetch.sh
@@ -64,6 +64,9 @@ begin_test "fetch"
 
   git lfs fetch 2>&1 | grep "Downloading LFS objects: 100% (1/1), 1 B"
   assert_local_object "$contents_oid" 1
+
+  git lfs fsck 2>&1 | tee fsck.log
+  grep "Git LFS fsck OK" fsck.log
 )
 end_test
 
@@ -76,6 +79,9 @@ begin_test "fetch with remote"
   git lfs fetch origin 2>&1 | grep "Downloading LFS objects: 100% (1/1), 1 B"
   assert_local_object "$contents_oid" 1
   refute_local_object "$b_oid" 1
+
+  git lfs fsck 2>&1 | tee fsck.log
+  grep "Git LFS fsck OK" fsck.log
 )
 end_test
 
@@ -92,6 +98,9 @@ begin_test "fetch with remote and branches"
   git lfs fetch origin master newbranch
   assert_local_object "$contents_oid" 1
   assert_local_object "$b_oid" 1
+
+  git lfs fsck 2>&1 | tee fsck.log
+  grep "Git LFS fsck OK" fsck.log
 )
 end_test
 
@@ -105,6 +114,9 @@ begin_test "fetch with master commit sha1"
   git lfs fetch origin "$master_sha1"
   assert_local_object "$contents_oid" 1
   refute_local_object "$b_oid" 1
+
+  git lfs fsck 2>&1 | tee fsck.log
+  grep "Git LFS fsck OK" fsck.log
 )
 end_test
 
@@ -118,6 +130,9 @@ begin_test "fetch with newbranch commit sha1"
   git lfs fetch origin "$newbranch_sha1"
   assert_local_object "$contents_oid" 1
   assert_local_object "$b_oid" 1
+
+  git lfs fsck 2>&1 | tee fsck.log
+  grep "Git LFS fsck OK" fsck.log
 )
 end_test
 
@@ -131,6 +146,9 @@ begin_test "fetch with include filters in gitconfig"
   git lfs fetch origin master newbranch
   assert_local_object "$contents_oid" 1
   refute_local_object "$b_oid"
+
+  git lfs fsck 2>&1 | tee fsck.log
+  grep "Git LFS fsck OK" fsck.log
 )
 end_test
 
@@ -146,6 +164,9 @@ begin_test "fetch with exclude filters in gitconfig"
   git lfs fetch origin master newbranch
   refute_local_object "$contents_oid"
   assert_local_object "$b_oid" 1
+
+  git lfs fsck 2>&1 | tee fsck.log
+  grep "Git LFS fsck OK" fsck.log
 )
 end_test
 


### PR DESCRIPTION
If `lfs.fetchinclude` is used, then `git lfs fsck` reports errors. That might confuse users.