### PR TITLE
prune: always prune excluded paths

### DIFF
--- a/commands/command_prune.go
+++ b/commands/command_prune.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/git-lfs/git-lfs/filepathfilter"
 	"github.com/git-lfs/git-lfs/fs"
 	"github.com/git-lfs/git-lfs/git"
 	"github.com/git-lfs/git-lfs/lfs"
@@ -86,6 +87,8 @@ func prune(fetchPruneConfig lfs.FetchPruneConfig, verifyRemote, dryRun, verbose 
 	retainChan := make(chan string, 100)
 
 	gitscanner := lfs.NewGitScanner(nil)
+	gitscanner.Filter = filepathfilter.New(nil, cfg.FetchExcludePaths())
+
 	go pruneTaskGetRetainedCurrentAndRecentRefs(gitscanner, fetchPruneConfig, retainChan, errorChan, &taskwait)
 	go pruneTaskGetRetainedUnpushed(gitscanner, fetchPruneConfig, retainChan, errorChan, &taskwait)
 	go pruneTaskGetRetainedWorktree(gitscanner, retainChan, errorChan, &taskwait)

--- a/commands/command_prune.go
+++ b/commands/command_prune.go
@@ -347,10 +347,10 @@ func pruneTaskGetPreviousVersionsOfRef(gitscanner *lfs.GitScanner, ref string, s
 		if err != nil {
 			errorChan <- err
 			return
-		} else {
-			retainChan <- p.Oid
-			tracerx.Printf("RETAIN: %v via ref %v >= %v", p.Oid, ref, since)
 		}
+
+		retainChan <- p.Oid
+		tracerx.Printf("RETAIN: %v via ref %v >= %v", p.Oid, ref, since)
 	})
 
 	if err != nil {


### PR DESCRIPTION
People use 'lfs.fetchexclude' to limit the download of Git LFS content.
If a user excludes Git LFS files with 'lfs.fetchexclude' after a full 
clone, then Git LFS would not smudge the files in the working directory
but it would keep the LFS content in the LFS storage directory (usually 
.git/lfs/objects). Git LFS would keep the LFS content even after a
'git lfs prune' run. 

Change that behavior and prune all objects that match the 
'lfs.fetchexclude' pattern independent of their age.

---

⚠️  I am unfamiliar with these areas of the code. Please review carefully! All good ideas stolen from @ttaylorr 's great work in #2847 !