### PR TITLE
"git clone" does not smudge all files

### DIFF
--- a/test/test-clone.sh
+++ b/test/test-clone.sh
@@ -4,13 +4,13 @@
 
 ensure_git_version_isnt $VERSION_LOWER "2.2.0"
 
-begin_test "clone"
+begin_test "lfs clone (deprecated)"
 (
   set -e
 
-  reponame="$(basename "$0" ".sh")"
+  reponame="lfs-clone-deprecated"
   setup_remote_repo "$reponame"
-  clone_repo "$reponame" repo
+  clone_repo "$reponame" "$reponame"
 
   git lfs track "*.dat" 2>&1 | tee track.log
   grep "Tracking \"\*.dat\"" track.log
@@ -45,7 +45,7 @@ begin_test "clone"
   # Now clone again, test specific clone dir
   cd "$TRASHDIR"
 
-  newclonedir="testclone1"
+  newclonedir="testlfs-clone-deprecated"
   git lfs clone "$GITSERVER/$reponame" "$newclonedir" 2>&1 | tee lfsclone.log
   grep "Cloning into" lfsclone.log
   grep "Downloading LFS objects:" lfsclone.log

--- a/test/test-clone.sh
+++ b/test/test-clone.sh
@@ -14,6 +14,8 @@ begin_test "clone"
 
   git lfs track "*.dat" 2>&1 | tee track.log
   grep "Tracking \"\*.dat\"" track.log
+  git add .gitattributes
+  git commit -m "setup Git LFS pattern"
 
   # generate some test data & commits with random LFS data
   echo "[
@@ -55,6 +57,7 @@ begin_test "clone"
 
   # check a few file sizes to make sure pulled
   pushd "$newclonedir"
+    [ -f .gitattributes ]
     [ $(wc -c < "file1.dat") -eq 110 ]
     [ $(wc -c < "file2.dat") -eq 75 ]
     [ $(wc -c < "file3.dat") -eq 66 ]
@@ -75,6 +78,7 @@ begin_test "clone"
   [ -d "$reponame" ]
 
   pushd "$reponame"
+    [ -f .gitattributes ]
     [ $(wc -c < "file1.dat") -eq 110 ]
     [ $(wc -c < "file2.dat") -eq 75 ]
     [ $(wc -c < "file3.dat") -eq 66 ]
@@ -100,6 +104,8 @@ begin_test "cloneSSL"
 
   git lfs track "*.dat" 2>&1 | tee track.log
   grep "Tracking \"\*.dat\"" track.log
+  git add .gitattributes
+  git commit -m "setup Git LFS pattern"
 
   # generate some test data & commits with random LFS data
   echo "[
@@ -160,6 +166,8 @@ begin_test "clone ClientCert"
 
   git lfs track "*.dat" 2>&1 | tee track.log
   grep "Tracking \"\*.dat\"" track.log
+  git add .gitattributes
+  git commit -m "setup Git LFS pattern"
 
   # generate some test data & commits with random LFS data
   echo "[
@@ -218,6 +226,8 @@ begin_test "clone with flags"
 
   git lfs track "*.dat" 2>&1 | tee track.log
   grep "Tracking \"\*.dat\"" track.log
+  git add .gitattributes
+  git commit -m "setup Git LFS pattern"
 
   # generate some test data & commits with random LFS data
   echo "[


### PR DESCRIPTION
Commit 1 and 2 are cleanup and preparation.

Commit 3 demonstrates a bug in `git clone`. Apparently files in folders with an extension that is tracked are not smudged. I haven't investigated further yet and therefore I don't know if the problem is in Git or Git LFS. 