### PR TITLE
Support default TTL for authentication tokens acquired via SSH

### DIFF
--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -303,6 +303,14 @@ be scoped inside the configuration for a remote.
   The default is `true`; you can disable this behaviour and have all files
   writeable by setting either variable to 0, 'no' or 'false'.
 
+* `lfs.defaulttokenttl`
+
+  This setting sets a default token TTL when git-lfs-authenticate does not
+  include the TTL in the JSON response but still enforces it.
+
+  Note that this is only necessary for larger repositories hosted on LFS
+  servers that don't include the TTL.
+
 ## LFSCONFIG
 
 The .lfsconfig file in a repository is read and interpreted in the same format

--- a/lfsapi/lfsapi.go
+++ b/lfsapi/lfsapi.go
@@ -72,7 +72,7 @@ func NewClient(ctx Context) (*Client, error) {
 	}
 
 	cacheCreds := gitEnv.Bool("lfs.cachecredentials", true)
-	var sshResolver SSHResolver = &sshAuthClient{os: osEnv}
+	var sshResolver SSHResolver = &sshAuthClient{os: osEnv, git: gitEnv}
 	if cacheCreds {
 		sshResolver = withSSHCache(sshResolver)
 	}

--- a/lfsapi/ssh.go
+++ b/lfsapi/ssh.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -71,7 +70,7 @@ func (r *sshAuthResponse) IsExpiredWithin(d time.Duration) (time.Time, bool) {
 }
 
 type sshAuthClient struct {
-	os config.Environment
+	os  config.Environment
 	git config.Environment
 }
 

--- a/lfsapi/ssh.go
+++ b/lfsapi/ssh.go
@@ -66,7 +66,7 @@ type sshAuthResponse struct {
 }
 
 func (r *sshAuthResponse) IsExpiredWithin(d time.Duration) (time.Time, bool) {
-	expiresAt := time.Now()
+	expiresAt := time.Time{}
 	if r.ExpiresAt != nil {
 		expiresAt = *r.ExpiresAt
 	}

--- a/lfsapi/ssh.go
+++ b/lfsapi/ssh.go
@@ -59,14 +59,22 @@ type sshAuthResponse struct {
 	Message   string            `json:"-"`
 	Href      string            `json:"href"`
 	Header    map[string]string `json:"header"`
-	ExpiresAt time.Time         `json:"expires_at"`
-	ExpiresIn int               `json:"expires_in"`
+	ExpiresAt *time.Time        `json:"expires_at"`
+	ExpiresIn *int              `json:"expires_in"`
 
 	createdAt time.Time
 }
 
 func (r *sshAuthResponse) IsExpiredWithin(d time.Duration) (time.Time, bool) {
-	return tools.IsExpiredAtOrIn(r.createdAt, d, r.ExpiresAt, time.Duration(r.ExpiresIn)*time.Second)
+	expiresAt := time.Now()
+	if r.ExpiresAt != nil {
+		expiresAt = *r.ExpiresAt
+	}
+	expiresIn := 0
+	if r.ExpiresIn != nil {
+		expiresIn = *r.ExpiresIn
+	}
+	return tools.IsExpiredAtOrIn(r.createdAt, d, expiresAt, time.Duration(expiresIn)*time.Second)
 }
 
 type sshAuthClient struct {
@@ -101,11 +109,12 @@ func (c *sshAuthClient) Resolve(e Endpoint, method string) (sshAuthResponse, err
 		res.Message = strings.TrimSpace(errbuf.String())
 	} else {
 		err = json.Unmarshal(outbuf.Bytes(), &res)
-		if res.ExpiresIn <= 0 {
+		if res.ExpiresIn == nil && res.ExpiresAt == nil {
 			ttl := c.git.Int("lfs.defaulttokenttl", 0)
-			if ttl > 0 {
-				res.ExpiresIn = ttl
+			if ttl < 0 {
+				ttl = 0
 			}
+			res.ExpiresIn = &ttl
 		}
 		res.createdAt = now
 	}


### PR DESCRIPTION
Certain LFS implementations do not return expires_in (or expires_in) from git-lfs-authenticate yet still enforce the TTL. This causes larger repositories to fail to download the LFS files if the transfer exceeds that TTL and it attempts to use the expired token. This workaround should not be necessary but I expect it's relatively common amongst implementations that support git-lfs-authenticate over SSH. The implementation that this workaround is targeting specifically is Bitbucket Server but likely affects Bitbucket Cloud as well as it is also missing the expires_in field. GitHub correctly includes the TTL which is expected as it is the reference implementation.

I understand it's not ideal to include workarounds for certain implementations but it does resolve it for Bitbucket and I cannot guarantee whether or not they will include the TTL in the near future as it is an optional field.