### PR TITLE
Issue #2879: Fix memory alignment issues on 32-bit systems.

### DIFF
--- a/tq/meter.go
+++ b/tq/meter.go
@@ -19,10 +19,6 @@ import (
 // files and bytes transferred as well as the number of files and bytes that
 // get skipped because the transfer is unnecessary.
 type Meter struct {
-	DryRun    bool
-	Logger    *tools.SyncWriter
-	Direction Direction
-
 	finishedFiles     int64 // int64s must come first for struct alignment
 	transferringFiles int64
 	estimatedBytes    int64
@@ -36,6 +32,10 @@ type Meter struct {
 	fileIndex         map[string]int64 // Maps a file name to its transfer number
 	fileIndexMutex    *sync.Mutex
 	updates           chan *tasklog.Update
+
+	DryRun    bool
+	Logger    *tools.SyncWriter
+	Direction Direction
 }
 
 type env interface {


### PR DESCRIPTION
Moved int64 declarations back to the top of the Meter struct for proper memory alignment.

See: https://github.com/git-lfs/git-lfs/issues/2879