### PR TITLE
*: fix 32-bit alignment issues with `sync/atomic`

### DIFF
--- a/git/odb/object_db.go
+++ b/git/odb/object_db.go
@@ -16,16 +16,19 @@ import (
 // ObjectDatabase enables the reading and writing of objects against a storage
 // backend.
 type ObjectDatabase struct {
-	// s is the storage backend which opens/creates/reads/writes.
-	s storer
-	// packs are the set of packfiles which contain all packed objects
-	// within this repository.
-	packs *pack.Set
+	// members managed via sync/atomic must be aligned at the top of this
+	// structure (see: https://github.com/git-lfs/git-lfs/pull/2880).
 
 	// closed is a uint32 managed by sync/atomic's <X>Uint32 methods. It
 	// yields a value of 0 if the *ObjectDatabase it is stored upon is open,
 	// and a value of 1 if it is closed.
 	closed uint32
+
+	// s is the storage backend which opens/creates/reads/writes.
+	s storer
+	// packs are the set of packfiles which contain all packed objects
+	// within this repository.
+	packs *pack.Set
 
 	// temp directory, defaults to os.TempDir
 	tmp string

--- a/git/odb/object_writer.go
+++ b/git/odb/object_writer.go
@@ -13,14 +13,17 @@ import (
 // writes data given to it, and keeps track of the SHA1 hash of the data as it
 // is written.
 type ObjectWriter struct {
-	// w is the underling writer that this ObjectWriter is writing to.
-	w io.Writer
-	// sum is the in-progress hash calculation.
-	sum hash.Hash
+	// members managed via sync/atomic must be aligned at the top of this
+	// structure (see: https://github.com/git-lfs/git-lfs/pull/2880).
 
 	// wroteHeader is a uint32 managed by the sync/atomic package. It is 1
 	// if the header was written, and 0 otherwise.
 	wroteHeader uint32
+
+	// w is the underling writer that this ObjectWriter is writing to.
+	w io.Writer
+	// sum is the in-progress hash calculation.
+	sum hash.Hash
 
 	// closeFn supplies an optional function that, when called, frees an
 	// resources (open files, memory, etc) held by this instance of the

--- a/lfsapi/stats.go
+++ b/lfsapi/stats.go
@@ -16,9 +16,9 @@ import (
 )
 
 type httpTransfer struct {
-	URL             string
-	Method          string
-	Key             string
+	// members managed via sync/atomic must be aligned at the top of this
+	// structure (see: https://github.com/git-lfs/git-lfs/pull/2880).
+
 	RequestBodySize int64
 	Start           int64
 	ResponseStart   int64
@@ -28,6 +28,9 @@ type httpTransfer struct {
 	DNSEnd          int64
 	TLSStart        int64
 	TLSEnd          int64
+	URL             string
+	Method          string
+	Key             string
 }
 
 type statsContextKey string

--- a/tasklog/percentage_task.go
+++ b/tasklog/percentage_task.go
@@ -10,13 +10,16 @@ import (
 // PercentageTask is a task that is performed against a known number of
 // elements.
 type PercentageTask struct {
-	// msg is the task message.
-	msg string
+	// members managed via sync/atomic must be aligned at the top of this
+	// structure (see: https://github.com/git-lfs/git-lfs/pull/2880).
+
 	// n is the number of elements whose work has been completed. It is
 	// managed sync/atomic.
 	n uint64
 	// total is the total number of elements to execute work upon.
 	total uint64
+	// msg is the task message.
+	msg string
 	// ch is a channel which is written to when the task state changes and
 	// is closed when the task is completed.
 	ch chan *Update


### PR DESCRIPTION
This pull request fixes an issue when using `sync/atomic` on 32-bit architectures when the structure alignment did not place numeric types at the top.

In the affected structures, we realign the fields and note that future fields should be placed at the top, if they are numeric.

I am indicating that this issue closes #2879, the remaining follow-up was to run CI on 32-bit architectures, but this is not something that TravisCI currently supports. I will follow up here if this feature is ever added upstream.

Closes: https://github.com/git-lfs/git-lfs/issues/2879.

##

/cc @git-lfs/core @jeffreydwalter
/cc https://github.com/git-lfs/git-lfs/issues/2879