### PR TITLE
git/githistory: copy entries from cache, elsewhere

### DIFF
--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -314,12 +314,12 @@ func (r *Rewriter) rewriteTree(commitOID []byte, treeOID []byte, path string, fn
 		path := filepath.Join(path, entry.Name)
 
 		if !r.allows(entry.Type(), path) {
-			entries = append(entries, entry)
+			entries = append(entries, copyEntry(entry))
 			continue
 		}
 
 		if cached := r.uncacheEntry(entry); cached != nil {
-			entries = append(entries, cached)
+			entries = append(entries, copyEntry(cached))
 			continue
 		}
 
@@ -354,6 +354,21 @@ func (r *Rewriter) rewriteTree(commitOID []byte, treeOID []byte, path string, fn
 		return treeOID, nil
 	}
 	return r.db.WriteTree(rewritten)
+}
+
+func copyEntry(e *odb.TreeEntry) *odb.TreeEntry {
+	if e == nil {
+		return nil
+	}
+
+	oid := make([]byte, len(e.Oid))
+	copy(oid, e.Oid)
+
+	return &odb.TreeEntry{
+		Filemode: e.Filemode,
+		Name:     e.Name,
+		Oid:      oid,
+	}
 }
 
 func (r *Rewriter) allows(typ odb.ObjectType, abs string) bool {


### PR DESCRIPTION
This pull request fixes an issue where the semantics of `range` would cause the resulting tree entries to be built incorrectly when the alias moved during the associated loop.

Since `range`'s second argument, when de-structured, is a pointer alias that moves through the array, appending it onto the end of a slice of other pointers is non-deterministic. If the memory layout changes, or the pointer changes into certain regions of the layout, the resulting tree will be built incorrectly.

To prevent this issue from occurring, introduce `copyEntry` which produces a new, heap-allocated `*odb.TreeEntry` not susceptible to the copying issue.

##

/cc @git-lfs/core @larsxschneider 