### PR TITLE
filepathfilter: test correct set of global wildcards

### DIFF
--- a/filepathfilter/filepathfilter_test.go
+++ b/filepathfilter/filepathfilter_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestPatternMatch(t *testing.T) {
-	for _, wildcard := range []string{"*", "*.*"} {
+	for _, wildcard := range []string{`*`, `.`, `./`, `.\`} {
 		assertPatternMatch(t, wildcard,
 			"a",
 			"a/",


### PR DESCRIPTION
This pull request fixes an error I introduced in https://github.com/git-lfs/git-lfs/commit/014fd601641cdea228b438895efb91237c12675a (see: https://github.com/git-lfs/git-lfs/pull/2875#discussion_r170778659) where the refined set of global wildcards was not being correctly tested against.

##

/cc @git-lfs/core @larsxschneider 