### PR TITLE
README.md: hotlink to the Limitations wiki page from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ To https://github.com/git-lfs/git-lfs-test
    67fcf6a..47b2002  master -> master
 ```
 
+## Limitations
+
+Git LFS maintains a list of currently known limitations, which you can find and
+edit [here](https://github.com/git-lfs/git-lfs/wiki/Limitations).
+
 ## Need Help?
 
 You can get help on specific commands directly:


### PR DESCRIPTION
This pull request adds a link to the 'Limitations' wiki page in the README, per the discussion in https://github.com/git-lfs/git-lfs/pull/2876, particularly https://github.com/git-lfs/git-lfs/pull/2876#issuecomment-368713449.

##

/cc @git-lfs/core 
/cc @de-code @mathstuf @larsxschneider 