### PR TITLE
Bourne shell is enough for bootstrap

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 set -e
 
 if uname -s | grep -q "_NT-"; then


### PR DESCRIPTION
BSDs don't have bash installed by default, so this matters for them.