### PR TITLE
Use unique repo name for tests that require credentials.

### DIFF
--- a/test/cmd/lfstest-gitserver.go
+++ b/test/cmd/lfstest-gitserver.go
@@ -1246,7 +1246,7 @@ func locksHandler(w http.ResponseWriter, r *http.Request, repo string) {
 }
 
 func missingRequiredCreds(w http.ResponseWriter, r *http.Request, repo string) bool {
-	if repo != "requirecreds" {
+	if !strings.HasPrefix(repo, "requirecreds") {
 		return false
 	}
 

--- a/test/test-credentials.sh
+++ b/test/test-credentials.sh
@@ -294,9 +294,9 @@ begin_test "credentials from lfs.url"
 (
   set -e
 
-  reponame="requirecreds"
+  reponame="requirecreds-lfsurl"
   setup_remote_repo "$reponame"
-  clone_repo "$reponame" requirecreds-lfsurl
+  clone_repo "$reponame" "$reponame"
 
   git lfs track "*.dat"
   echo "push a" > a.dat
@@ -335,9 +335,9 @@ begin_test "credentials from remote.origin.url"
 (
   set -e
 
-  reponame="requirecreds"
+  reponame="requirecreds-remoteurl"
   setup_remote_repo "$reponame"
-  clone_repo "$reponame" requirecreds-remoteurl
+  clone_repo "$reponame" "$reponame"
 
   git lfs track "*.dat"
   echo "push b" > b.dat

--- a/test/test-extra-header.sh
+++ b/test/test-extra-header.sh
@@ -30,7 +30,7 @@ begin_test "http.<url>.extraHeader with authorization"
 (
   set -e
 
-  reponame="requirecreds"
+  reponame="requirecreds-extraHeader"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"
 


### PR DESCRIPTION
Otherwise, when running tests in parallel, they might conflict.
Fixes #2899.

I went through all the builds in the linked issues, and every one that fails runs `test-extra-header.sh` before `test-credentials.sh`, while every one that passes does the opposite.