### PR TITLE
tq: prevent uint64 underflow with invalid API response

### DIFF
--- a/test/test-push.sh
+++ b/test/test-push.sh
@@ -632,6 +632,7 @@ begin_test "push (with invalid object size)"
   set -e
 
   grep "invalid size (got: -1)" push.log
+  [ "0" -eq "$(grep -c "panic" push.log)" ]
   [ "0" -ne "$res" ]
 
   refute_server_object "$reponame" "$(calc_oid "$contents")"

--- a/tq/meter.go
+++ b/tq/meter.go
@@ -2,6 +2,7 @@ package tq
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -238,8 +239,30 @@ func (m *Meter) str() string {
 		direction,
 		percentage,
 		m.finishedFiles, m.estimatedFiles,
-		humanize.FormatBytes(uint64(m.currentBytes)),
-		humanize.FormatByteRate(uint64(m.avgBytes), time.Second))
+		humanize.FormatBytes(clamp(m.currentBytes)),
+		humanize.FormatByteRate(clampf(m.avgBytes), time.Second))
+}
+
+// clamp clamps the given "x" within the acceptable domain of the uint64 integer
+// type, so as to prevent over- and underflow.
+func clamp(x int64) uint64 {
+	if x < 0 {
+		return 0
+	}
+	if x > math.MaxInt64 {
+		return math.MaxUint64
+	}
+	return uint64(x)
+}
+
+func clampf(x float64) uint64 {
+	if x < 0 {
+		return 0
+	}
+	if x > math.MaxUint64 {
+		return math.MaxUint64
+	}
+	return uint64(x)
 }
 
 func (m *Meter) logBytes(direction, name string, read, total int64) {


### PR DESCRIPTION
This pull request prevents signed-to-unsigned conversion over- and underflows when using package `humanize`, thereby causing panics like in https://github.com/git-lfs/git-lfs/issues/2900.

As noted by @goodtune, the issue stems from a non-compliant implementation of the LFS API when it sends back a size that underflows the `uint64` type (see: https://github.com/git-lfs/git-lfs/issues/2900#issuecomment-370960857).

I think that it is worth being resilient to these failure modes, so let's add `clamp` and `clampf` to prevent overflow during these conversions.

To note, another way that we could fix this issue is by changing the internal representation of these fields such that they are unable to overflow in the first place. I pursued this implementation, but found it to be sub-par, since this approach simply pushes the problem further out through the code.

Closes: https://github.com/git-lfs/git-lfs/issues/2900.

##

/cc @git-lfs/core @goodtune https://github.com/git-lfs/git-lfs/issues/2900