### PR TITLE
Map local abspath to file://<abspath> endpoint URL

### DIFF
--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -27,7 +27,18 @@ var (
 	httpRE    = regexp.MustCompile(`\Ahttps?://`)
 )
 
+var hintFileUrl = strings.TrimSpace(`
+hint: The remote resolves to a file:// URL, which can only work with a
+hint: standalone transfer agent.  See section "Using a Custom Transfer Type
+hint: without the API server" in custom-transfers.md for details.
+`)
+
 func (c *Client) NewRequest(method string, e Endpoint, suffix string, body interface{}) (*http.Request, error) {
+	if strings.HasPrefix(e.Url, "file://") {
+		// Initial `\n` to avoid overprinting `Downloading LFS...`.
+		fmt.Fprintf(os.Stderr, "\n%s\n", hintFileUrl)
+	}
+
 	sshRes, err := c.SSH.Resolve(e, method)
 	if err != nil {
 		tracerx.Printf("ssh: %s failed, error: %s, message: %s",

--- a/lfsapi/endpoint.go
+++ b/lfsapi/endpoint.go
@@ -106,3 +106,10 @@ func endpointFromGitUrl(u *url.URL, e *endpointGitFinder) Endpoint {
 	u.Scheme = e.gitProtocol
 	return Endpoint{Url: u.String()}
 }
+
+func endpointFromLocalPath(path string) Endpoint {
+	if !strings.HasSuffix(path, ".git") {
+		path = fmt.Sprintf("%s/.git", path)
+	}
+	return Endpoint{Url: fmt.Sprintf("file://%s", path)}
+}

--- a/lfsapi/endpoint_finder.go
+++ b/lfsapi/endpoint_finder.go
@@ -170,6 +170,9 @@ func (e *endpointGitFinder) NewEndpointFromCloneURL(rawurl string) Endpoint {
 
 func (e *endpointGitFinder) NewEndpoint(rawurl string) Endpoint {
 	rawurl = e.ReplaceUrlAlias(rawurl)
+	if strings.HasPrefix(rawurl, "/") {
+		return endpointFromLocalPath(rawurl)
+	}
 	u, err := url.Parse(rawurl)
 	if err != nil {
 		return endpointFromBareSshUrl(rawurl)

--- a/lfsapi/endpoint_finder_test.go
+++ b/lfsapi/endpoint_finder_test.go
@@ -250,6 +250,22 @@ func TestBareGitEndpointAddsLfsSuffix(t *testing.T) {
 	assert.Equal(t, "", e.SshPort)
 }
 
+func TestLocalPathEndpointAddsDotGitDir(t *testing.T) {
+	finder := NewEndpointFinder(NewContext(nil, nil, map[string]string{
+		"remote.origin.url": "/local/path",
+	}))
+	e := finder.Endpoint("download", "")
+	assert.Equal(t, "file:///local/path/.git/info/lfs", e.Url)
+}
+
+func TestLocalPathEndpointPreservesDotGit(t *testing.T) {
+	finder := NewEndpointFinder(NewContext(nil, nil, map[string]string{
+		"remote.origin.url": "/local/path.git",
+	}))
+	e := finder.Endpoint("download", "")
+	assert.Equal(t, "file:///local/path.git/info/lfs", e.Url)
+}
+
 func TestAccessConfig(t *testing.T) {
 	type accessTest struct {
 		Access        string


### PR DESCRIPTION
It can be used to configure a standalonetransferagent for local files,
like:

```
git config lfs.customtransfer.file.path git-lfs-standalonetransfer-file
git config lfs.file:///.standalonetransferagent file
```

Signed-off-by: Steffen Prohaska <prohaska@zib.de>