### PR TITLE
commands/ls-files: do not accept '--all' after '--'

### DIFF
--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -45,15 +45,15 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 	seen := make(map[string]struct{})
 
 	gitscanner := lfs.NewGitScanner(func(p *lfs.WrappedPointer, err error) {
+		if err != nil {
+			Exit("Could not scan for Git LFS tree: %s", err)
+			return
+		}
+
 		if !lsFilesScanAll {
 			if _, ok := seen[p.Name]; ok {
 				return
 			}
-		}
-
-		if err != nil {
-			Exit("Could not scan for Git LFS tree: %s", err)
-			return
 		}
 
 		if debug {

--- a/test/test-ls-files.sh
+++ b/test/test-ls-files.sh
@@ -306,3 +306,26 @@ begin_test "ls-files: reference with --deleted"
   [ 1 -eq $(grep -c "a\.dat" ls-files-deleted.log) ]
 )
 end_test
+
+begin_test "ls-files: invalid --all ordering"
+(
+  set -e
+
+  reponame="ls-files-invalid---all-ordering"
+  git init "$reponame"
+  cd "$reponame"
+
+  git lfs track "*.dat"
+  echo "Hello world" > a.dat
+
+  git add .gitattributes a.dat
+  git commit -m "initial commit"
+
+  git lfs ls-files -- --all 2>&1 | tee ls-files.out
+  if [ ${PIPESTATUS[0]} = "0" ]; then
+    echo >&2 "fatal: expected \`git lfs ls-files -- --all\' to fail"
+    exit 1
+  fi
+  grep "Could not scan for Git LFS tree" ls-files.out
+)
+end_test


### PR DESCRIPTION
This pull request fixes a bug pointed out by @xerus in https://github.com/git-lfs/git-lfs/issues/2930, where the following command would crash Git LFS: `git lfs ls-files -- --all`.

The issue is that the `--` separator signals that the following arguments are to be treated as-such, and not parsed as flags, so `git ls-tree` attempts to scan an object with the SHA1 "--all", which is invalid.

This issue was introduced by me in https://github.com/git-lfs/git-lfs/pull/2795, and worsened in https://github.com/git-lfs/git-lfs/pull/2796, after adding the `--all` option to `git-lfs-ls-files(1)`. To avoid observing duplicate tree entries in the output, we maintain a cache `seen : map[string]struct{}`, keyed by the object's name.

However, should there be an `err` in the callback and a nil `*lfs.Pointer`, "p", we will eagerly attempt to dereference it resulting in a crash.

To avoid this, move the existing error check _above_ the dereference site, thus preventing nil pointers from being accessed.

##

/cc @git-lfs/core 