### PR TITLE
commands/migrate: escape paths before .gitattributes 

### DIFF
--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -123,11 +123,11 @@ func trackedFromFilter(filter *filepathfilter.Filter) *tools.OrderedSet {
 	tracked := tools.NewOrderedSet()
 
 	for _, include := range filter.Include() {
-		tracked.Add(fmt.Sprintf("%s filter=lfs diff=lfs merge=lfs -text", include))
+		tracked.Add(fmt.Sprintf("%s filter=lfs diff=lfs merge=lfs -text", escapeAttrPattern(include)))
 	}
 
 	for _, exclude := range filter.Exclude() {
-		tracked.Add(fmt.Sprintf("%s text -filter -merge -diff", exclude))
+		tracked.Add(fmt.Sprintf("%s text -filter -merge -diff", escapeAttrPattern(exclude)))
 	}
 
 	return tracked

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -81,7 +81,7 @@ ArgsLoop:
 		}
 
 		// Generate the new / changed attrib line for merging
-		encodedArg := escapeTrackPattern(pattern)
+		encodedArg := escapeAttrPattern(pattern)
 		lockableArg := ""
 		if trackLockableFlag { // no need to test trackNotLockableFlag, if we got here we're disabling
 			lockableArg = " " + git.LockableAttrib
@@ -95,7 +95,7 @@ ArgsLoop:
 			writeablePatterns = append(writeablePatterns, pattern)
 		}
 
-		Print("Tracking %q", unescapeTrackPattern(encodedArg))
+		Print("Tracking %q", unescapeAttrPattern(encodedArg))
 	}
 
 	// Now read the whole local attributes file and iterate over the contents,
@@ -258,7 +258,7 @@ var (
 	}
 )
 
-func escapeTrackPattern(unescaped string) string {
+func escapeAttrPattern(unescaped string) string {
 	var escaped string = strings.Replace(unescaped, `\`, "/", -1)
 
 	for from, to := range trackEscapePatterns {
@@ -268,7 +268,7 @@ func escapeTrackPattern(unescaped string) string {
 	return escaped
 }
 
-func unescapeTrackPattern(escaped string) string {
+func unescapeAttrPattern(escaped string) string {
 	var unescaped string = escaped
 
 	for to, from := range trackEscapePatterns {

--- a/commands/command_untrack.go
+++ b/commands/command_untrack.go
@@ -55,7 +55,7 @@ func untrackCommand(cmd *cobra.Command, args []string) {
 
 		path := strings.Fields(line)[0]
 		if removePath(path, args) {
-			Print("Untracking %q", unescapeTrackPattern(path))
+			Print("Untracking %q", unescapeAttrPattern(path))
 		} else {
 			attributesFile.WriteString(line + "\n")
 		}
@@ -64,7 +64,7 @@ func untrackCommand(cmd *cobra.Command, args []string) {
 
 func removePath(path string, args []string) bool {
 	for _, t := range args {
-		if path == escapeTrackPattern(t) {
+		if path == escapeAttrPattern(t) {
 			return true
 		}
 	}

--- a/test/test-migrate-fixtures.sh
+++ b/test/test-migrate-fixtures.sh
@@ -79,6 +79,27 @@ setup_multiple_local_branches() {
   git checkout master
 }
 
+# setup_local_branch_with_space creates a repository as follows:
+#
+#   A
+#    \
+#     refs/heads/master
+#
+# - Commit 'A' has 50 bytes in a file named "a file.txt".
+setup_local_branch_with_space() {
+  set -e
+
+  reponame="migrate-local-branch-with-space"
+  filename="a file.txt"
+
+  remove_and_create_local_repo "$reponame"
+
+  base64 < /dev/urandom | head -c 50 > "$filename"
+
+  git add "$filename"
+  git commit -m "initial commit"
+}
+
 # setup_single_remote_branch creates a repository as follows:
 #
 #   A---B

--- a/test/test-migrate-import.sh
+++ b/test/test-migrate-import.sh
@@ -616,3 +616,24 @@ begin_test "migrate import (handle copies of files)"
   [ "$oid_root" = "$oid_root_after_migration" ]
 )
 end_test
+
+begin_test "migrate import (--include with space)"
+(
+  set -e
+
+  setup_local_branch_with_space
+
+  oid="$(calc_oid "$(git cat-file -p :"a file.txt")")"
+
+  git lfs migrate import --include "a file.txt"
+
+  assert_pointer "refs/heads/master" "a file.txt" "$oid" 50
+  cat .gitattributes
+  if [ 1 -ne "$(grep -c "a\[\[:space:\]\]file.txt" .gitattributes)" ]; then
+    echo >&2 "fatal: expected \"a[[:space:]]file.txt\" to appear in .gitattributes"
+    echo >&2 "fatal: got"
+    sed -e 's/^/  /g' < .gitattributes >&2
+    exit 1
+  fi
+)
+end_test


### PR DESCRIPTION
This pull request fixes `git-lfs-migrate-import(1)` when given `--include` and/or `--exclude` filters that contain .gitattributes-unescaped sequences, such as whitespace.

When migrating, Git LFS will do either one of the following two things: (1) adopt filters from `--include`, `--exclude`, or (2) migrate all files that aren't named `.gitattributes`. When doing (1), Git LFS previously copied these filters verbatim as they were given on the command line.

This is problematic, as @mrackwitz points out in https://github.com/git-lfs/git-lfs/issues/2908:

> I passed in some quoted paths via --include, e.g. `"External/AWS iOS SDK/*"`.
> This resulted them being written to the `.gitattributes` as:
>
> ```
> External/AWS iOS SDK/* filter=lfs diff=lfs merge=lfs -text
> ```
>
> Which resulted in the following errors when checking out files:
>
> ``` 
> * is not a valid attribute name: .gitattributes:24
> ```

We already do a similar transformation in `git-lfs-track(1)` and `git-lfs-untrack(1)` via functions previously known as `escapeTrackPattern` and `unescapeTrackPattern`, respectively. Let's repurpose those functions here to avoid creating malformed `.gitattributes` file(s).

Here's how the change occurred:

1. 2409b3e: Rename the aforementioned functions to a more generally named `convertAttrPattern` (and its counterpart). "track" patterns are a misnomer for `.gitattribute` patterns, which is what they really are.
2. 89c5fa0: Now that those functions are named appropriately, use them in `git-lfs-migrate(1)`.
3. 11199f0, 5704057: add a fixture and test case to ensure that the above functionality works as expected.

This transformation is safe to apply, since it is done so once, and has a one-to-one correspondence.

Closes: https://github.com/git-lfs/git-lfs/issues/2908

##

/cc @git-lfs/core @mrackwitz