### PR TITLE
test: ensure that git-mergetool(1) works with large files

### DIFF
--- a/test/test-mergetool.sh
+++ b/test/test-mergetool.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+. "test/testlib.sh"
+
+begin_test "mergetool works with large files"
+(
+  set -e
+
+  reponame="mergetool-works-with-large-files"
+  git init "$reponame"
+  cd "$reponame"
+
+  git lfs track "*.dat"
+  printf "base" > conflict.dat
+  git add .gitattributes conflict.dat
+  git commit -m "initial commit"
+
+  git checkout -b conflict
+  printf "b" > conflict.dat
+  git add conflict.dat
+  git commit -m "conflict.dat: b"
+
+  git checkout master
+
+  printf "a" > conflict.dat
+  git add conflict.dat
+  git commit -m "conflict.dat: a"
+
+  set +e
+  git merge conflict
+  set -e
+
+  git config mergetool.inspect.cmd '
+    for i in BASE LOCAL REMOTE; do
+      echo "\$$i=$(eval "cat \"\$$i\"")";
+    done;
+    exit 1
+  '
+  git config mergetool.inspect.trustExitCode true
+
+  yes | git mergetool \
+      --no-prompt \
+      --tool=inspect \
+      -- conflict.dat 2>&1 \
+    | tee mergetool.log
+
+  grep "\$BASE=base" mergetool.log
+  grep "\$LOCAL=a" mergetool.log
+  grep "\$REMOTE=b" mergetool.log
+)
+end_test


### PR DESCRIPTION
This pull request ensures that the `git-mergetool(1)` program works correctly with large files stored using Git LFS.

This is the result of spending some time doing research into and implementing a `git-lfs-mergetool(1)`, after thinking that `git-mergetool(1)` would not convert conflicts using their appropriate clean/smudge filters before sending to the designated mergetool.

(The result of that work can be viewed in [branch `mergetool`](https://github.com/git-lfs/git-lfs/compare/mergetool)).

While discussing with @peff, we noted that `git-mergetool(1)` uses `git-checkout-index(1)` to get the contents of a file before assigning it to a temporary location and attaching an environment variable to the mergetool program. For reference, that's:

- https://github.com/git/git/blob/90bbd502d54fe920356fa9278055dc9c9bfe9a56/git-mergetool.sh#L304-L306, and
- https://github.com/git/git/blob/90bbd502d54fe920356fa9278055dc9c9bfe9a56/git-mergetool.sh#L230-L241, and
- https://github.com/git/git/blob/90bbd502d54fe920356fa9278055dc9c9bfe9a56/git-mergetool.sh#L275-L278.

Since `git-checkout-index(1)` performs filter operations on files before returning them, `git-mergetool(1)` should do the same. This test ensures that this is the case. Thus, `git-mergetool(1)` is sufficient to work with conflicting large diff-able blobs stored in Git LFS.

##

/cc @git-lfs/core, esp. @larsxschneider 
/cc @shana 
/cc @git-lfs/core 