### PR TITLE
README.md: reorganize into Core Team, Alumni

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,32 @@ These are the humans that form the Git LFS core team, which runs the project.
 
 In alphabetical order:
 
-| [@andyneff](https://github.com/andyneff) | [@rubyist](https://github.com/rubyist) | [@sinbad](https://github.com/sinbad) | [@technoweenie](https://github.com/technoweenie) | [@ttaylorr](https://github.com/ttaylorr) |
-|---|---|---|---|---|
-| [![](https://avatars1.githubusercontent.com/u/7596961?v=3&s=100)](https://github.com/andyneff) | [![](https://avatars1.githubusercontent.com/u/143?v=3&s=100)](https://github.com/rubyist) | [![](https://avatars1.githubusercontent.com/u/142735?v=3&s=100)](https://github.com/sinbad) | [![](https://avatars3.githubusercontent.com/u/21?v=3&s=100)](https://github.com/technoweenie) | [![](https://avatars3.githubusercontent.com/u/443245?v=3&s=100)](https://github.com/ttaylorr) |
+| [@larsxschneider][larsxschneider-user] | [@ttaylorr][ttaylorr-user] |
+|---|---|
+| [![][larsxschneider-img]][larsxschneider-user] | [![][ttaylorr-img]][ttaylorr-user] |
+
+[larsxschneider-img]: https://avatars1.githubusercontent.com/u/477434?s=100&v=4
+[ttaylorr-img]: https://avatars2.githubusercontent.com/u/443245?s=100&v=4
+[larsxschneider-user]: https://github.com/larsxschneider
+[ttaylorr-user]: https://github.com/ttaylorr
+
+### Alumni
+
+These are the humans that have in the past formed the Git LFS core team, or
+have otherwise contributed a significant amount to the project. Git LFS would
+not be possible without them.
+
+In alphabetical order:
+
+| [@andyneff][andyneff-user] | [@rubyist][rubyist-user] | [@sinbad][sinbad-user] | [@technoweenie][technoweenie-user] |
+|---|---|---|---|
+| [![][andyneff-img]][andyneff-user] | [![][rubyist-img]][rubyist-user] | [![][sinbad-img]][sinbad-user] | [![][technoweenie-img]][technoweenie-user] |
+
+[andyneff-img]: https://avatars1.githubusercontent.com/u/7596961?v=3&s=100
+[rubyist-img]: https://avatars1.githubusercontent.com/u/143?v=3&s=100
+[sinbad-img]: https://avatars1.githubusercontent.com/u/142735?v=3&s=100
+[technoweenie-img]: https://avatars3.githubusercontent.com/u/21?v=3&s=100
+[andyneff-user]: https://github.com/andyneff
+[sinbad-user]: https://github.com/sinbad
+[rubyist-user]: https://github.com/rubyist
+[technoweenie-user]: https://github.com/technoweenie


### PR DESCRIPTION
This pull request changes the README.md by breaking the "Core Team" section into "Core Team" and "Alumni" to accurately reflect the current set of Git LFS maintainers.

This change is motivated by a few things:

1. **Usage of `@git-lfs/core`**. I mention this team anytime I introduce a change to Git LFS. As the team has grown and changed over time, I have grown worried that mentioning `@git-lfs/core` sends notifications to people who are uninterested in them.

    By introducing a `@git-lfs/alumni` team and reflecting that change in the README, notifications to core go to the people who will most care about them.

2. **Accurate indication of who will provide help with Git LFS**.  I am additionally concerned that people looking to open a new issue or comment on an existing one within this repository will ping people who have previously been on `@git-lfs/core` since the README indicates that they are maintainers of the project.

    Out of courtesy to people who have previously maintained Git LFS (and no longer wish to be pinged on existing issues), I hope that this change will make more clear who people can expect responses from.

Before opening this pull request, I have discussed this change with the people who have moved from `@git-lfs/core` to `@git-lfs/alumni`, in order to confirm that this was indeed correct. If I have made any incorrect assumptions, please do not hesitate to let me know here.

I would also like to mention the tremendous amount of effort that the @technoweenie, @rubyist, @sinbad, and @andyneff have contributed to Git LFS. As stated in the README, this project would certainly not be possible without them. Thank you.

##

/cc @git-lfs/core, @git-lfs/alumni 