### PR TITLE
README.md: mention note about `git lfs track` retroactively

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ $ git add my.psd
 $ git commit -m "add psd"
 ```
 
+> _Tip:_ if you have large files already in your repository's history, `git lfs
+> track` will _not_ track them retroactively. To migrate existing large files
+> in your history to use Git LFS, use `git lfs migrate`. For example:
+>
+> ```
+> $ git lfs migrate import --include="*.psd"
+> ```
+>
+> For more information, read [`git-lfs-migrate(1)`](https://github.com/git-lfs/git-lfs/blob/master/docs/man/git-lfs-migrate.1.ronn).
+
 You can confirm that Git LFS is managing your PSD file:
 
 ```bash


### PR DESCRIPTION
This pull request clarifies an issue when running `git lfs track` in a repository containing history which has already-large files in it.

The issue is that if a repository already contains `big.dat` in its history, and a user runs `git lfs track big.dat`, only future changes to that file will be tracked using Git LFS. In this case, the user would like to have already-existing `big.dat`'s migrated into Git LFS, but this is not how `git lfs track` works.

In order to accomplish this, a user must run `git lfs migrate import --include=/path/to/file`, which is the source of some confusion. In an attempt to mitigate this confusion and make the `track` command behave more ergonomically, I propose the following:

1. Mention that `git lfs migrate` is required when `track`-ing files that already exist in history. This is the contents of this pull request.
2. Modify `git lfs track` to search history by default in order to determine whether or not paths that match the given pattern already exist in history.

##

/cc @git-lfs/core 