### PR TITLE
commands/{un,}track: perform "prefix-agnostic" comparisons

### DIFF
--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -67,7 +67,7 @@ func trackCommand(cmd *cobra.Command, args []string) {
 	var writeablePatterns []string
 ArgsLoop:
 	for _, unsanitizedPattern := range args {
-		pattern := cleanRootPath(unsanitizedPattern)
+		pattern := trimCurrentPrefix(cleanRootPath(unsanitizedPattern))
 		if !trackNoModifyAttrsFlag {
 			for _, known := range knownPatterns {
 				if known.Path == filepath.Join(relpath, pattern) &&

--- a/commands/command_untrack.go
+++ b/commands/command_untrack.go
@@ -63,8 +63,9 @@ func untrackCommand(cmd *cobra.Command, args []string) {
 }
 
 func removePath(path string, args []string) bool {
+	withoutCurrentDir := trimCurrentPrefix(path)
 	for _, t := range args {
-		if path == escapeAttrPattern(t) {
+		if withoutCurrentDir == escapeAttrPattern(trimCurrentPrefix(t)) {
 			return true
 		}
 	}

--- a/commands/path.go
+++ b/commands/path.go
@@ -12,6 +12,18 @@ func gitLineEnding(git env) string {
 	}
 }
 
+const (
+	windowsPrefix = `.\`
+	nixPrefix     = `./`
+)
+
+func trimCurrentPrefix(p string) string {
+	if strings.HasPrefix(p, windowsPrefix) {
+		return strings.TrimPrefix(p, windowsPrefix)
+	}
+	return strings.TrimPrefix(p, nixPrefix)
+}
+
 type env interface {
 	Get(string) (string, bool)
 }

--- a/test/test-track.sh
+++ b/test/test-track.sh
@@ -540,3 +540,21 @@ begin_test "track (with comments)"
   [ "0" -eq "$(grep -c "\.png" track.log)" ]
 )
 end_test
+
+begin_test "track (with current-directory prefix)"
+(
+  set -e
+
+  reponame="track-with-current-directory-prefix"
+  git init "$reponame"
+  cd "$reponame"
+
+  git lfs track "./a.dat"
+  printf "a" > a.dat
+
+  git add .gitattributes a.dat
+  git commit -m "initial commit"
+
+  grep -e "^a.dat" .gitattributes
+)
+end_test

--- a/test/test-untrack.sh
+++ b/test/test-untrack.sh
@@ -72,3 +72,65 @@ begin_test "untrack removes escape sequences"
   assert_attributes_count "\\#" "filter=lfs" 0
 )
 end_test
+
+begin_test "untrack removes prefixed patterns (legacy)"
+(
+  set -e
+
+  reponame="untrack-removes-prefix-patterns-legacy"
+  git init "$reponame"
+  cd "$reponame"
+
+  echo "./a.dat filter=lfs diff=lfs merge=lfs" > .gitattributes
+  printf "a" > a.dat
+  git add .gitattributes a.dat
+  git commit -m "initial commit"
+
+  git lfs untrack "./a.dat"
+
+  if [ ! -z "$(cat .gitattributes)" ]; then
+    echo &>2 "fatal: expected 'git lfs untrack' to clear .gitattributes"
+    exit 1
+  fi
+
+  git checkout -- .gitattributes
+
+  git lfs untrack "a.dat"
+
+  if [ ! -z "$(cat .gitattributes)" ]; then
+    echo &>2 "fatal: expected 'git lfs untrack' to clear .gitattributes"
+    exit 1
+  fi
+)
+end_test
+
+begin_test "untrack removes prefixed patterns (modern)"
+(
+  set -e
+
+  reponame="untrack-removes-prefix-patterns-modern"
+  git init "$reponame"
+  cd "$reponame"
+
+  echo "a.dat filter=lfs diff=lfs merge=lfs" > .gitattributes
+  printf "a" > a.dat
+  git add .gitattributes a.dat
+  git commit -m "initial commit"
+
+  git lfs untrack "./a.dat"
+
+  if [ ! -z "$(cat .gitattributes)" ]; then
+    echo &>2 "fatal: expected 'git lfs untrack' to clear .gitattributes"
+    exit 1
+  fi
+
+  git checkout -- .gitattributes
+
+  git lfs untrack "a.dat"
+
+  if [ ! -z "$(cat .gitattributes)" ]; then
+    echo &>2 "fatal: expected 'git lfs untrack' to clear .gitattributes"
+    exit 1
+  fi
+)
+end_test


### PR DESCRIPTION
This pull request teaches "git lfs track" and "git lfs untrack" to perform prefix-agnostic comparisons, meaning that "./a.dat" and "a.dat" are equivalent patterns. This writes a correct pattern to a user's .gitattribute file via translating "git lfs track ./a.dat" to "a.dat filter=lfs ...".

For more:

> 1c8209ba: commands/path.go: introduce trimCurrentPrefix to remove "./"
>
> There exist cases within Git LFS where we would like to perform a
> "pseudo-clean" on a given filepath. It should behave similarly to a call
> to filepath.Clean, but should only remove the beginning "./" (macOS,
> *nix) or ".\" (Windows, etc).
>
> This patch introduces trimCurrentPrefix, which removes such prefixes.
> It will be used in subsequent patches to perform prefix-independent
> comparison against arguments to "git lfs track" and "git lfs untrack"
> and the contents of a repository's .gitattributes file.
>
> Since we assume that the contents of ".gitattributes" are written on
> multiple platforms, each with their own platform-specific prefixes,
> trimCurrentPrefix is instructed to remove _all_ prefixes, not just the
> current platforms.

> 49bdc2b1: commands/{un,}track: local-prefix agnostic comparison
>
> This patch use the trimCurrentPrefix utility introduced in the previous
> patch to make all .gitattributes comparisons agnostic to the
> "current-prefix" of "./" or ".\".
>
> Since we treat both sides of the comparison as having passed through
> "trimCurrentPrefix", we harden ourselves against "legacy"-style
> .gitattributes patterns containing prefixes, and "modern"-style ones
> lacking prefixes.
>
> That means that both combinations of "git lfs untrack ./a.dat" and "git
> lfs untrack a.dat" will remove both of these lines from a .gittatributes
> file:
>
>   ./a.dat filter=lfs ...
>   a.dat filter=lfs ...

Closes: https://github.com/git-lfs/git-lfs/issues/825

##

/cc @git-lfs/core @zite