### PR TITLE
README.md: note the correct PackageCloud URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can install the Git LFS client in several different ways, depending on your
 setup and preferences.
 
 * **Linux users**. Debian and RPM packages are available from
-  [PackageCloud](https://packagecloud.io/git-lfs/install).
+  [PackageCloud](https://packagecloud.io/github/install).
 * **macOS users**. [Homebrew](https://brew.sh) bottles are distributed, and can
   be installed via `brew install git-lfs`.
 * **Windows users**. Chocolatey packages are distributed, and can be installed


### PR DESCRIPTION
This pull request updates the PackageCloud URL present in README.md to point at the correct organization URL, which is `github/`, not `git-lfs/`.

This is an artifact of when this repository used to live at `https://github.com/github/git-lfs`. The PackageCloud account was registered under the same namespace for consistency, but was not updated when the repository was moved.

I broke this in #2942, when I was updating the README to contain more new information.

To avoid breaking any scripts dependent on this location, and for historical purposes, let's leave the URL where it was and update the README to reflect that.

Closes: https://github.com/git-lfs/git-lfs/issues/2959.

##

/cc @git-lfs/core @necromuralist 