### PR TITLE
commands: make --version a synonym for 'version'

### DIFF
--- a/commands/run.go
+++ b/commands/run.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/git-lfs/git-lfs/config"
+	"github.com/git-lfs/git-lfs/lfsapi"
 	"github.com/spf13/cobra"
 )
 
@@ -54,6 +55,10 @@ func Run() {
 
 	root := NewCommand("git-lfs", gitlfsCommand)
 	root.PreRun = nil
+
+	// Set up --version flag to be a synonym of version sub-command.
+	root.SetVersionTemplate("{{ .Version }}\n")
+	root.Version = lfsapi.UserAgent
 
 	// Set up help/usage funcs based on manpage text
 	root.SetHelpTemplate("{{.UsageString}}")

--- a/test/test-version.sh
+++ b/test/test-version.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+. "test/testlib.sh"
+
+begin_test "git lfs --version is a synonym of git lfs version"
+(
+  set -e
+
+  reponame="git-lfs-version-synonymous"
+  mkdir "$reponame"
+  cd "$reponame"
+
+  git lfs version 2>&1 >version.log
+  git lfs --version 2>&1 >flag.log
+
+  if [ "$(cat version.log)" != "$(cat flag.log)" ]; then
+    echo >&2 "fatal: expected 'git lfs version' and 'git lfs --version' to"
+    echo >&2 "produce identical output ..."
+
+    diff -u {version,flag}.log
+  fi
+)
+end_test


### PR DESCRIPTION
This pull request builds on https://github.com/git-lfs/git-lfs/pull/2967 by using the newly available APIs on `*cobra.Command`, `.Version`, and `.SetVersionTemplate` to introduce `git lfs --version` as a synonym for `git lfs version`.

It is based off of cobra-pflag-update, but should be merged into `master`.

Closes: https://github.com/git-lfs/git-lfs/issues/2118.

##

/cc @git-lfs/core