### PR TITLE
commands/run.go: exit 127 on unknown sub-command

### DIFF
--- a/commands/run.go
+++ b/commands/run.go
@@ -49,7 +49,9 @@ func RegisterCommand(name string, runFn func(cmd *cobra.Command, args []string),
 
 // Run initializes the 'git-lfs' command and runs it with the given stdin and
 // command line args.
-func Run() {
+//
+// It returns an exit code.
+func Run() int {
 	log.SetOutput(ErrorWriter)
 
 	root := NewCommand("git-lfs", gitlfsCommand)
@@ -70,6 +72,8 @@ func Run() {
 
 	root.Execute()
 	closeAPIClient()
+
+	return 0
 }
 
 func gitlfsCommand(cmd *cobra.Command, args []string) {

--- a/commands/run.go
+++ b/commands/run.go
@@ -70,9 +70,12 @@ func Run() int {
 		}
 	}
 
-	root.Execute()
+	err := root.Execute()
 	closeAPIClient()
 
+	if err != nil {
+		return 127
+	}
 	return 0
 }
 

--- a/git-lfs.go
+++ b/git-lfs.go
@@ -32,6 +32,7 @@ func main() {
 		}
 	}()
 
-	commands.Run()
+	code := commands.Run()
 	once.Do(commands.Cleanup)
+	os.Exit(code)
 }


### PR DESCRIPTION
This pull request teaches Git LFS to exit with code `127` when asked to invoke an unknown sub-command.

We accomplish this in two parts:

1. 3379c0c: teach `Run()` to become `Run() int`, and return the integer exit code of the status that it would like to exit with.
2. a4dfae7: teach `Run() int` to return `127` when cobra cannot invoke a sub-command.

Closes: https://github.com/git-lfs/git-lfs/issues/2253.

##

/cc @git-lfs/core 