### PR TITLE
commands/uninstall: do not log about global hooks with --local

### DIFF
--- a/commands/command_uninstall.go
+++ b/commands/command_uninstall.go
@@ -14,7 +14,9 @@ func uninstallCommand(cmd *cobra.Command, args []string) {
 		uninstallHooksCommand(cmd, args)
 	}
 
-	Print("Global Git LFS configuration has been removed.")
+	if !localInstall {
+		Print("Global Git LFS configuration has been removed.")
+	}
 }
 
 // uninstallHooksCmd removes any hooks created by Git LFS.

--- a/test/test-uninstall.sh
+++ b/test/test-uninstall.sh
@@ -169,7 +169,12 @@ begin_test "uninstall --local"
   [ "global clean" = "$(git config --global filter.lfs.clean)" ]
   [ "global filter" = "$(git config --global filter.lfs.process)" ]
 
-  git lfs uninstall --local
+  git lfs uninstall --local 2>&1 | tee uninstall.log
+  if [ ${PIPESTATUS[0]} -ne 0 ]; then
+    echo >&2 "fatal: expected 'git lfs uninstall --local' to succeed"
+    exit 1
+  fi
+  grep -v "Global Git LFS configuration has been removed." uninstall.log
 
   # global configs
   [ "global smudge" = "$(git config --global filter.lfs.smudge)" ]


### PR DESCRIPTION
This pull request fixes a bug where `git lfs uninstall --local` would produce output suggesting that it had uninstall global hooks when in fact it had not.

For example (as pointed out by @hraban in https://github.com/git-lfs/git-lfs/issues/2975):

```ShellSession
$ git lfs uninstall --local
Hooks for this repository have been removed.
Global Git LFS configuration has been removed.
```

To fix this, ensure that we're not running in `--local` mode before logging about the global Git LFS configuration. We do not treat `--system` as a special-case here, since it is not used by this command. (A future pull request will remove this from `git lfs uninstall`).

Closes: https://github.com/git-lfs/git-lfs/issues/2975.

##

/cc @git-lfs/core 