### PR TITLE
lfs/attribute.go: remove default value from upgradeables

### DIFF
--- a/lfs/attribute.go
+++ b/lfs/attribute.go
@@ -56,7 +56,21 @@ func filterAttribute() *Attribute {
 			"process":  "git-lfs filter-process",
 			"required": "true",
 		},
-		Upgradeables: upgradeables(),
+		Upgradeables: map[string][]string{
+			"clean": []string{
+				"git-lfs clean %f",
+			},
+			"smudge": []string{
+				"git-lfs smudge %f",
+				"git-lfs smudge --skip %f",
+				"git-lfs smudge --skip -- %f",
+			},
+			"process": []string{
+				"git-lfs filter",
+				"git-lfs filter --skip",
+				"git-lfs filter-process --skip",
+			},
+		},
 	}
 }
 
@@ -69,24 +83,20 @@ func skipSmudgeFilterAttribute() *Attribute {
 			"process":  "git-lfs filter-process --skip",
 			"required": "true",
 		},
-		Upgradeables: upgradeables(),
-	}
-}
-
-func upgradeables() map[string][]string {
-	return map[string][]string{
-		"clean": []string{"git-lfs clean %f"},
-		"smudge": []string{
-			"git-lfs smudge %f",
-			"git-lfs smudge --skip %f",
-			"git-lfs smudge -- %f",
-			"git-lfs smudge --skip -- %f",
-		},
-		"process": []string{
-			"git-lfs filter",
-			"git-lfs filter --skip",
-			"git-lfs filter-process",
-			"git-lfs filter-process --skip",
+		Upgradeables: map[string][]string{
+			"clean": []string{
+				"git-lfs clean -- %f",
+			},
+			"smudge": []string{
+				"git-lfs smudge %f",
+				"git-lfs smudge --skip %f",
+				"git-lfs smudge -- %f",
+			},
+			"process": []string{
+				"git-lfs filter",
+				"git-lfs filter --skip",
+				"git-lfs filter-process",
+			},
 		},
 	}
 }


### PR DESCRIPTION
This pull request teaches `git lfs install` not to treat the current, installed values of an "attribute" as upgrade-able, and therefore avoids writing over a `.gitconfig` time at each invocation of `git lfs install`.

As @niik points out in https://github.com/git-lfs/git-lfs/issues/2993, users of GitHub Desktop were noticing that their `~/.gitconfig` files were being written to every time that GitHub Desktop launched, but the contents of the file was left unchanged.

> Running git lfs install --skip-repo with the GIT_TRACE=1 environment variable yields the following
> 
> ```ShellSession
> $ GIT_TRACE=1 ./git-lfs install --skip-repo
> 16:38:58.656296 trace git-lfs: exec: git 'version'
> 16:38:58.669961 trace git-lfs: exec: git 'config' '--global' 'filter.lfs.process'
> 16:38:58.686455 trace git-lfs: exec: git 'config' '--global' '--replace-all' 'filter.lfs.process' 'git-lfs filter-process'
> 16:38:58.714318 trace git-lfs: exec: git 'config' '--global' 'filter.lfs.required'
> 16:38:58.735164 trace git-lfs: exec: git 'config' '--global' 'filter.lfs.clean'
> 16:38:58.755172 trace git-lfs: exec: git 'config' '--global' 'filter.lfs.smudge'
> 16:38:58.772220 trace git-lfs: exec: git 'config' '--global' '--replace-all' 'filter.lfs.smudge' 'git-lfs smudge -- %f'
> Git LFS initialized.
> ```
>
> Note that while it doesn't attempt to replace filter.lfs.required or filter.lfs.clean it does try to replace the filter.lfs.smudge and filter.lfs.process.
> 
> I think this (though I'm certainly not well-versed in the git-lfs code base) that this is because the default value of, filter.lfs.process (git-lfs filter-process) and filter.lfs.clean is listed as an 'upgradeable' value in
>
> [...]
>
> From my cursory reading of the code it's not obvious to me if there's a good reason for the default configuration value of a config key should also be listed as an upgradeable.

So, Git LFS treats the currently-installed (and up-to-date) value of both `filter.lfs.smudge` and `filter.lfs.process` as "upgradeable" and therefore needing to be upgraded to their same value.

This commit teaches Git LFS to no longer treat the current value of an attribute as upgradeable. If in the future, any of these values need to be changed, they may simply be added to the list of upgradeables without issue.

While I was here, I gave the `install again` test some ❤️. There were a few things I noticed:

1. The `printf | grep` anti-pattern. This breaks for strings that contain format verbs (`like %f`), and can be substituted for `[ "expected" = "$ACTUAL" ]`.
2. `git lfs install` does not work outside of a repository without `--skip-repo`. This is desireable, but was behind a `|`, (without `set -o pipefail`, or checking `${PIPESTATUS[0]}`) so wasn't being caught.
3. Ensure that `--replace-all` doesn't show up in the `GIT_TRACE=1`'d output of `git lfs install`. 

Closes: https://github.com/git-lfs/git-lfs/issues/2993.

##

/cc @git-lfs/core @niik