### PR TITLE
commands/lock: follow symlinks before locking

### DIFF
--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -79,6 +79,11 @@ func lockPath(file string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	wd, err = filepath.EvalSymlinks(wd)
+	if err != nil {
+		return "", errors.Wrapf(err,
+			"could not follow symlinks for %s", wd)
+	}
 
 	abs := filepath.Join(wd, file)
 	path := strings.TrimPrefix(abs, repo)

--- a/test/test-lock.sh
+++ b/test/test-lock.sh
@@ -12,7 +12,7 @@ begin_test "lock with good ref"
 
   git lfs lock "a.dat" --json 2>&1 | tee lock.json
   if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected 'git lfs lock \'a.dat\'' to succeed"
+    echo >&2 "fatal: expected \'git lfs lock \'a.dat\'\' to succeed"
     exit 1
   fi
 
@@ -40,7 +40,7 @@ begin_test "lock with good tracked ref"
 
   git lfs lock "a.dat" --json 2>&1 | tee lock.json
   if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected 'git lfs lock \'a.dat\'' to succeed"
+    echo >&2 "fatal: expected \'git lfs lock \'a.dat\'\' to succeed"
     exit 1
   fi
 
@@ -65,7 +65,7 @@ begin_test "lock with bad ref"
 
   GIT_CURL_VERBOSE=1 git lfs lock "a.dat" 2>&1 | tee lock.json
   if [ "0" -eq "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected 'git lfs lock \'a.dat\'' to fail"
+    echo >&2 "fatal: expected \'git lfs lock \'a.dat\'\' to fail"
     exit 1
   fi
 
@@ -187,7 +187,7 @@ begin_test "creating a lock (within subdirectory)"
 
   git lfs lock --json "a.dat" | tee lock.json
   if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected 'git lfs lock \'a.dat\'' to succeed"
+    echo >&2 "fatal: expected \'git lfs lock \'a.dat\'\' to succeed"
     exit 1
   fi
 

--- a/test/test-lock.sh
+++ b/test/test-lock.sh
@@ -195,3 +195,37 @@ begin_test "creating a lock (within subdirectory)"
   assert_server_lock "$reponame" "$id"
 )
 end_test
+
+begin_test "creating a lock (symlinked working directory)"
+(
+  set -eo pipefail
+
+  if [[ $(uname) == *"MINGW"* ]]; then
+    echo >&2 "info: skipped on Windows ..."
+    exit 0
+  fi
+
+  reponame="lock-in-symlinked-working-directory"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track -l "*.dat"
+  mkdir -p folder1 folder2
+  printf "hello" > folder2/a.dat
+  add_symlink "../folder2" "folder1/folder2"
+
+  git add --all .
+  git commit -m "initial commit"
+  git push origin master
+
+  pushd "$TRASHDIR" > /dev/null
+    ln -s "$reponame" "$reponame-symlink"
+    cd "$reponame-symlink"
+
+    git lfs lock --json folder1/folder2/a.dat 2>&1 | tee lock.json
+
+    id="$(assert_lock lock.json folder1/folder2/a.dat)"
+    assert_server_lock "$reponame" "$id" master
+  popd > /dev/null
+)
+end_test


### PR DESCRIPTION
This pull request teaches the `git lfs lock` command how to follow symlinks in the current working directory so that files in symlinks can be resolved, too.

Previously, a symlink-in-symlink would cause `git lfs lock` to fail: by avoiding following the symbolically linked current working directory, the symbolically linked target of `git lfs lock` would be appended to the path, and then `stat`'d, causing the stat to fail, for the path will likely not exist.

Instead, resolve the current working directory to be absolute, and _then_ append children relative to it.

Closes: https://github.com/git-lfs/git-lfs/issues/2990.

##

/cc @git-lfs/core @jbstewart