### PR TITLE
lfsapi: canonicalize extra HTTP headers

### DIFF
--- a/lfsapi/auth.go
+++ b/lfsapi/auth.go
@@ -270,6 +270,8 @@ func hasScheme(what string) bool {
 }
 
 func requestHasAuth(req *http.Request) bool {
+	// The "Authorization" string constant is safe, since we assume that all
+	// request headers have been canonicalized.
 	if len(req.Header.Get("Authorization")) > 0 {
 		return true
 	}

--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/textproto"
 	"net/url"
 	"os"
 	"regexp"
@@ -147,6 +148,13 @@ func (c *Client) extraHeaders(u *url.URL) map[string][]string {
 		}
 
 		k, v := parts[0], strings.TrimSpace(parts[1])
+		// If header keys are given in non-canonicalized form (e.g.,
+		// "AUTHORIZATION" as opposed to "Authorization") they will not
+		// be returned in calls to net/http.Header.Get().
+		//
+		// So, we avoid this problem by first canonicalizing header keys
+		// for extra headers.
+		k = textproto.CanonicalMIMEHeaderKey(k)
 
 		m[k] = append(m[k], v)
 	}

--- a/test/test-extra-header.sh
+++ b/test/test-extra-header.sh
@@ -73,10 +73,10 @@ begin_test "http.<url>.extraHeader with authorization (casing)"
   pass="pass"
   auth="Basic $(echo -n $user:$pass | base64)"
 
-  git config --add lfs.access basic
+  git config --local --add lfs.access basic
   # N.B.: "AUTHORIZATION" is not the correct casing, and is therefore the
   # subject of this test. See lfsapi.Client.extraHeaders() for more.
-  git config --add "http.extraHeader" "AUTHORIZATION: $auth"
+  git config --local --add "http.extraHeader" "AUTHORIZATION: $auth"
 
   git lfs track "*.dat"
   printf "contents" > a.dat

--- a/test/test-extra-header.sh
+++ b/test/test-extra-header.sh
@@ -34,12 +34,49 @@ begin_test "http.<url>.extraHeader with authorization"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"
 
-  # See: test/cmd/lfstest-gitserver.go:1176.
+  # See: test/cmd/lfstest-gitserver.go:missingRequiredCreds().
   user="requirecreds"
   pass="pass"
   auth="Basic $(echo -n $user:$pass | base64)"
 
   git config --add "http.extraHeader" "Authorization: $auth"
+
+  git lfs track "*.dat"
+  printf "contents" > a.dat
+  git add .gitattributes a.dat
+  git commit -m "initial commit"
+
+  git push origin master 2>&1 | tee curl.log
+  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
+    echo >&2 "expected \`git push origin master\` to succeed, didn't"
+    exit 1
+  fi
+
+  [ "0" -eq "$(grep -c "creds: filling with GIT_ASKPASS" curl.log)" ]
+  [ "0" -eq "$(grep -c "creds: git credential approve" curl.log)" ]
+  [ "0" -eq "$(grep -c "creds: git credential cache" curl.log)" ]
+  [ "0" -eq "$(grep -c "creds: git credential fill" curl.log)" ]
+  [ "0" -eq "$(grep -c "creds: git credential reject" curl.log)" ]
+)
+end_test
+
+begin_test "http.<url>.extraHeader with authorization (casing)"
+(
+  set -e
+
+  reponame="requirecreds-extraHeaderCasing"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  # See: test/cmd/lfstest-gitserver.go:missingRequiredCreds().
+  user="requirecreds"
+  pass="pass"
+  auth="Basic $(echo -n $user:$pass | base64)"
+
+  git config --add lfs.access basic
+  # N.B.: "AUTHORIZATION" is not the correct casing, and is therefore the
+  # subject of this test. See lfsapi.Client.extraHeaders() for more.
+  git config --add "http.extraHeader" "AUTHORIZATION: $auth"
 
   git lfs track "*.dat"
   printf "contents" > a.dat


### PR DESCRIPTION
This pull request ensures that extra HTTP headers given over `http.[url.]extraHeaders` are canonicalized as proper MIME header keys before being sent over the network.

Ordinarily, any server that handles a request with a malformed HTTP header should canonicalize it without issue, so there aren't any problems with existing configurations and outgoing web requests. The problem, however, occurs when we check if the `Authorization: ` header is present by checking for the hard-coded string `"Authorization"` in package `lfsapi`.

(As an aside, this particular use-case is for figuring out whether we can skip calling out to the credential helper for an already-authenticated request).

Here's an example demonstrating the problem \[[1](https://play.golang.org/p/owfI4qv5o0L)\]:

```go
package main

import (
	"fmt"
	"net/http"
	"net/textproto"
)

func main() {
	checkHeader("AUTHORIZATION")
	checkHeader(textproto.CanonicalMIMEHeaderKey("AUTHORIZATION"))
}

func checkHeader(key string) {
	fmt.Printf("Checking %q ...\n", key)
	h := http.Header(map[string][]string{
		key: []string{"X"},
	})

	fmt.Printf("\t%s\n", h.Get("Authorization"))
	fmt.Printf("\t%s\n", h.Get("AUTHORIZATION"))
}
```

To fix this, let's do two things:

1. Ensure that incoming HTTP headers (from `http.[url.]extraHeaders`) are properly sanitized, and,
2. Add a new integration test in the appropriate spot to check that this all works.

Closes: https://github.com/git-lfs/git-lfs/issues/3007

##

/cc @git-lfs/core @TingluoHuang