### PR TITLE
lfsapi: re-authenticate HTTP redirects when needed

### DIFF
--- a/lfsapi/auth.go
+++ b/lfsapi/auth.go
@@ -31,7 +31,7 @@ func (c *Client) DoWithAuth(remote string, req *http.Request) (*http.Response, e
 		return nil, err
 	}
 
-	res, err := c.doWithCreds(req, credHelper, creds, credsURL, access)
+	res, err := c.doWithCreds(req, credHelper, creds, credsURL, access, nil)
 	if err != nil {
 		if errors.IsAuthError(err) {
 			newAccess := getAuthAccess(res)
@@ -57,11 +57,11 @@ func (c *Client) DoWithAuth(remote string, req *http.Request) (*http.Response, e
 	return res, err
 }
 
-func (c *Client) doWithCreds(req *http.Request, credHelper CredentialHelper, creds Creds, credsURL *url.URL, access Access) (*http.Response, error) {
+func (c *Client) doWithCreds(req *http.Request, credHelper CredentialHelper, creds Creds, credsURL *url.URL, access Access, via []*http.Request) (*http.Response, error) {
 	if access == NTLMAccess {
 		return c.doWithNTLM(req, credHelper, creds, credsURL)
 	}
-	return c.do(req)
+	return c.do(req, via)
 }
 
 // getCreds fills the authorization header for the given request if possible,

--- a/lfsapi/auth.go
+++ b/lfsapi/auth.go
@@ -61,7 +61,7 @@ func (c *Client) doWithCreds(req *http.Request, credHelper CredentialHelper, cre
 	if access == NTLMAccess {
 		return c.doWithNTLM(req, credHelper, creds, credsURL)
 	}
-	return c.do(req, via)
+	return c.do(req, "", via)
 }
 
 // getCreds fills the authorization header for the given request if possible,

--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -231,6 +231,13 @@ func (c *Client) doWithRedirects(cli *http.Client, req *http.Request, remote str
 		return res, err
 	}
 
+	if len(req.Header.Get("Authorization")) > 0 {
+		// If the original request was authenticated (noted by the
+		// presence of the Authorization header), then recur through
+		// doWithAuth, retaining the requests via but only after
+		// authenticating the redirected request.
+		return c.doWithAuth(remote, redirectedReq, via)
+	}
 	return c.doWithRedirects(cli, redirectedReq, remote, via)
 }
 

--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -96,16 +96,16 @@ func joinURL(prefix, suffix string) string {
 func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	req.Header = c.extraHeadersFor(req)
 
-	return c.do(req, nil)
+	return c.do(req, "", nil)
 }
 
 // do performs an *http.Request respecting redirects, and handles the response
 // as defined in c.handleResponse. Notably, it does not alter the headers for
 // the request argument in any way.
-func (c *Client) do(req *http.Request, via []*http.Request) (*http.Response, error) {
+func (c *Client) do(req *http.Request, remote string, via []*http.Request) (*http.Response, error) {
 	req.Header.Set("User-Agent", UserAgent)
 
-	res, err := c.doWithRedirects(c.httpClient(req.Host), req, via)
+	res, err := c.doWithRedirects(c.httpClient(req.Host), req, remote, via)
 	if err != nil {
 		return res, err
 	}
@@ -161,7 +161,7 @@ func (c *Client) extraHeaders(u *url.URL) map[string][]string {
 	return m
 }
 
-func (c *Client) doWithRedirects(cli *http.Client, req *http.Request, via []*http.Request) (*http.Response, error) {
+func (c *Client) doWithRedirects(cli *http.Client, req *http.Request, remote string, via []*http.Request) (*http.Response, error) {
 	tracedReq, err := c.traceRequest(req)
 	if err != nil {
 		return nil, err
@@ -231,7 +231,7 @@ func (c *Client) doWithRedirects(cli *http.Client, req *http.Request, via []*htt
 		return res, err
 	}
 
-	return c.doWithRedirects(cli, redirectedReq, via)
+	return c.doWithRedirects(cli, redirectedReq, remote, via)
 }
 
 func (c *Client) httpClient(host string) *http.Client {

--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -96,16 +96,16 @@ func joinURL(prefix, suffix string) string {
 func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	req.Header = c.extraHeadersFor(req)
 
-	return c.do(req)
+	return c.do(req, nil)
 }
 
 // do performs an *http.Request respecting redirects, and handles the response
 // as defined in c.handleResponse. Notably, it does not alter the headers for
 // the request argument in any way.
-func (c *Client) do(req *http.Request) (*http.Response, error) {
+func (c *Client) do(req *http.Request, via []*http.Request) (*http.Response, error) {
 	req.Header.Set("User-Agent", UserAgent)
 
-	res, err := c.doWithRedirects(c.httpClient(req.Host), req, nil)
+	res, err := c.doWithRedirects(c.httpClient(req.Host), req, via)
 	if err != nil {
 		return res, err
 	}

--- a/lfsapi/ntlm.go
+++ b/lfsapi/ntlm.go
@@ -19,7 +19,7 @@ type ntmlCredentials struct {
 }
 
 func (c *Client) doWithNTLM(req *http.Request, credHelper CredentialHelper, creds Creds, credsURL *url.URL) (*http.Response, error) {
-	res, err := c.do(req)
+	res, err := c.do(req, nil)
 	if err != nil && !errors.IsAuthError(err) {
 		return res, err
 	}
@@ -86,7 +86,7 @@ func (c *Client) ntlmSendMessage(req *http.Request, message []byte) (*http.Respo
 
 	msg := base64.StdEncoding.EncodeToString(message)
 	req.Header.Set("Authorization", "NTLM "+msg)
-	return c.do(req)
+	return c.do(req, nil)
 }
 
 func parseChallengeResponse(res *http.Response) ([]byte, error) {

--- a/lfsapi/ntlm.go
+++ b/lfsapi/ntlm.go
@@ -19,7 +19,7 @@ type ntmlCredentials struct {
 }
 
 func (c *Client) doWithNTLM(req *http.Request, credHelper CredentialHelper, creds Creds, credsURL *url.URL) (*http.Response, error) {
-	res, err := c.do(req, nil)
+	res, err := c.do(req, "", nil)
 	if err != nil && !errors.IsAuthError(err) {
 		return res, err
 	}
@@ -86,7 +86,7 @@ func (c *Client) ntlmSendMessage(req *http.Request, message []byte) (*http.Respo
 
 	msg := base64.StdEncoding.EncodeToString(message)
 	req.Header.Set("Authorization", "NTLM "+msg)
-	return c.do(req, nil)
+	return c.do(req, "", nil)
 }
 
 func parseChallengeResponse(res *http.Response) ([]byte, error) {


### PR DESCRIPTION
This pull request teaches package `lfsapi` to re-authenticate HTTP requests when the response indicates a redirection.

When an HTTP request is sent through package `lfsapi`, there are a few paths that we can take down into `do()` and `doWithRedirects()`. The one that we're concerned with involves one of two outcomes:

1. We send an HTTP request that is responded to with a 301 or 302 code. If we're within our retry limit, we construct a new request sent to the new host/path, and copy over the headers from the old request \[[1](https://github.com/git-lfs/git-lfs/blob/v2.4.1/lfsapi/client.go#L360-L368)\]. Notably, we do _not_ copy the `Authorization` header iff the new host differs from the old one, as a security concern. We retry the request.

2. Same setup as (1), except we have exceeded our retry count. We complain and fail \[[2](https://github.com/git-lfs/git-lfs/blob/v2.4.1/lfsapi/client.go#L213-L216)\].

In case (1) this security measure has the opportunity to fail when _the redirected host differs from the requested host_ and _the redirected host requires authentication_. Because we recur early on `doWithRedirects()`, and _not_ `DoWithAuth()`, we don't re-authenticate the request, and instead devolve into a case like https://github.com/git-lfs/git-lfs/issues/3025.

But, recurring through `DoWithAuth()` would throw away our state `via`, allowing authenticated request to flow through different pairs of hosts infinitely. That's no good.

Instead, let's try this:

- 1a3a19c: set up `do()` to take `via []*http.Request`, the list of requests that have lead up to this one (redirects), or `nil` if there are no such requests.
- b1c2b42: keep track of the `remote` associated with a given request, or `""` if no remote matches, or we don't care which remote is associated.
- 5257e58: branch through `doWithAuth` and override the `via` list such that we can re-authenticate requests across different hosts.

One tricky thing in 5257e58 is that we don't actually know whether the original request was designated to be authenticated or not. An additional tricky thing is that we might _never_ authenticate the original request, and instead load from `http.[$url.]extraHeaders`, such that `Authorization` header is present, but Git LFS didn't put it there.

In all of those cases, we reduce the problem to checking whether the original request contained an `Authorization` header.

Closes: https://github.com/git-lfs/git-lfs/issues/3025.

##

/cc @git-lfs/core https://github.com/git-lfs/git-lfs/issues/3025