### PR TITLE
Add `--no-rewrite` flag to `migrate import` command

### DIFF
--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -40,6 +40,9 @@ var (
 	// migrateNoRewrite is the flag indicating whether or not the
 	// command should rewrite git history
 	migrateNoRewrite bool
+	// migrateCommitMessage is the message to use with the commit generated
+	// by the migrate command
+	migrateCommitMessage string
 )
 
 // migrate takes the given command and arguments, *odb.ObjectDatabase, as well
@@ -292,6 +295,7 @@ func init() {
 	importCmd.Flags().BoolVar(&migrateVerbose, "verbose", false, "Verbose logging")
 	importCmd.Flags().StringVar(&objectMapFilePath, "object-map", "", "Object map file")
 	importCmd.Flags().BoolVar(&migrateNoRewrite, "no-rewrite", false, "Add new history without rewriting previous")
+	importCmd.Flags().StringVarP(&migrateCommitMessage, "message", "m", "", "With --no-rewrite, an optional commit message")
 
 	RegisterCommand("migrate", nil, func(cmd *cobra.Command) {
 		cmd.PersistentFlags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")

--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -36,6 +36,10 @@ var (
 	// objectMapFile is the path to the map of old sha1 to new sha1
 	// commits
 	objectMapFilePath string
+
+	// migrateNoRewrite is the flag indicating whether or not the
+	// command should rewrite git history
+	migrateNoRewrite bool
 )
 
 // migrate takes the given command and arguments, *odb.ObjectDatabase, as well
@@ -287,6 +291,7 @@ func init() {
 	importCmd := NewCommand("import", migrateImportCommand)
 	importCmd.Flags().BoolVar(&migrateVerbose, "verbose", false, "Verbose logging")
 	importCmd.Flags().StringVar(&objectMapFilePath, "object-map", "", "Object map file")
+	importCmd.Flags().BoolVar(&migrateNoRewrite, "no-rewrite", false, "Add new history without rewriting previous")
 
 	RegisterCommand("migrate", nil, func(cmd *cobra.Command) {
 		cmd.PersistentFlags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")

--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -49,7 +49,7 @@ func migrateImportCommand(cmd *cobra.Command, args []string) {
 		root := commit.TreeID
 
 		filter := git.GetAttributeFilter(cfg.LocalWorkingDir(), cfg.LocalGitDir())
-		if len(filter.Include()) == 0 && len(filter.Exclude()) == 0 {
+		if len(filter.Include()) == 0 {
 			ExitWithError(errors.Errorf("fatal: no Git LFS filters found in .gitattributes"))
 		}
 

--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -56,13 +56,15 @@ func migrateImportCommand(cmd *cobra.Command, args []string) {
 		gf := lfs.NewGitFilter(cfg)
 
 		for _, file := range args {
-			if filter.Allows(file) {
-				root, err = rewriteTree(gf, db, root, file)
-				if err != nil {
-					ExitWithError(errors.Wrapf(err, "fatal: could not rewrite %q", file))
-				}
-			} else {
+			if !filter.Allows(file) {
 				ExitWithError(errors.Errorf("fatal: file %s did not match any entries in .gitattributes", file))
+			}
+		}
+
+		for _, file := range args {
+			root, err = rewriteTree(gf, db, root, file)
+			if err != nil {
+				ExitWithError(errors.Wrapf(err, "fatal: could not rewrite %q", file))
 			}
 		}
 

--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -50,14 +50,14 @@ func migrateImportCommand(cmd *cobra.Command, args []string) {
 
 		filter := git.GetAttributeFilter(cfg.LocalWorkingDir(), cfg.LocalGitDir())
 		if len(filter.Include()) == 0 && len(filter.Exclude()) == 0 {
-			ExitWithError(errors.Errorf("fatal: no git lfs filters found in .gitattributes"))
+			ExitWithError(errors.Errorf("fatal: no Git LFS filters found in .gitattributes"))
 		}
 
 		gf := lfs.NewGitFilter(cfg)
 
 		for _, file := range args {
 			if !filter.Allows(file) {
-				ExitWithError(errors.Errorf("fatal: file %s did not match any entries in .gitattributes", file))
+				ExitWithError(errors.Errorf("fatal: file %s did not match any Git LFS filters in .gitattributes", file))
 			}
 		}
 

--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -85,37 +85,43 @@ options and these additional ones:
     format is CSV with this pattern: `OLD-SHA`,`NEW-SHA`
 
 * `--no-rewrite`
-    Migrate large objects to Git LFS in a new commit without rewriting git history.
-    Please note that when this option is used, the `migrate import` command will expect
-    a different argument list, specialized options will become available, and the core 
-    `migrate` options will be ignored. See [IMPORT (NO REWRITE)].
+    Migrate large objects to Git LFS in a new commit without rewriting git
+    history. Please note that when this option is used, the `migrate import`
+    command will expect a different argument list, specialized options will
+    become available, and the core `migrate` options will be ignored. See
+    [IMPORT (NO REWRITE)].
 
-If `--no-rewrite` is not provided and `--include` or `--exclude` (`-I`, `-X`, respectively) are given, the
-.gitattributes will be modified to include any new filepath patterns as given by
-those flags.
+If `--no-rewrite` is not provided and `--include` or `--exclude` (`-I`, `-X`,
+respectively) are given, the .gitattributes will be modified to include any new
+filepath patterns as given by those flags.
 
-If `--no-rewrite` is not provided and neither of those flags are given, the gitattributes will be incrementally
-modified to include new filepath extensions as they are rewritten in history.
+If `--no-rewrite` is not provided and neither of those flags are given, the
+gitattributes will be incrementally modified to include new filepath extensions
+as they are rewritten in history.
 
 ### IMPORT (NO REWRITE)
 
-The `import` mode has a special sub-mode enabled by the `--no-rewrite` flag. This sub-mode
-will migrate large objects to pointers as in the base `import` mode, but will do so in a new commit
-without rewriting Git history. When using this sub-mode, the base `migrate` options, 
-such as `--include-ref`, will be ignored, as will those for the base `import` mode. 
-The `migrate` command will also take a different argument list.
+The `import` mode has a special sub-mode enabled by the `--no-rewrite` flag.
+This sub-mode will migrate large objects to pointers as in the base `import`
+mode, but will do so in a new commit without rewriting Git history. When using
+this sub-mode, the base `migrate` options, such as `--include-ref`, will be
+ignored, as will those for the base `import` mode. The `migrate` command will
+also take a different argument list. As a result of these changes,
+`--no-rewrite` will only operate on the current branch - any other interested
+branches must have the generated commit merged in.
 
 The `--no-rewrite` sub-mode supports the following options and arguments:
 
-* `-m` <message> `--message`=<message>
+* `-m <message> --message=<message>`
     Specifies a commit message for the newly created commit.
 
 * [file ...]
-    The list of files to import. These files must be tracked by patterns specified in the
-    gitattributes.
+    The list of files to import. These files must be tracked by patterns
+    specified in the gitattributes.
 
-If `--message` is given, the new commit will be created with the provided message. If no message is given,
-a commit message will be generated based on the file arguments.
+If `--message` is given, the new commit will be created with the provided
+message. If no message is given, a commit message will be generated based on the
+file arguments.
 
 ## INCLUDE AND EXCLUDE
 
@@ -219,12 +225,14 @@ Note: This will require a force push to any existing Git remotes.
 
 You can also migrate files without modifying the existing history of your respoitory:
 
+Without a specified commit message: 
 ```
-# Without a specified commit message
-$ git lfs migrate import --no-rewrite test.zip *.mp3 *.psd
-
-# With a specified commit message
-$ git lfs migrate import --no-rewrite -m "Import .zip, .mp3, .psd files" test.zip *.mpd *.psd
+    git lfs migrate import --no-rewrite test.zip *.mp3 *.psd
+```
+With a specified commit message:
+```
+    git lfs migrate import --no-rewrite -m "Import .zip, .mp3, .psd files" \
+      test.zip *.mpd *.psd
 ```
 
 ## SEE ALSO

--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -84,12 +84,38 @@ options and these additional ones:
     Write to 'path' a file with the mapping of each rewritten commits. The file
     format is CSV with this pattern: `OLD-SHA`,`NEW-SHA`
 
-If `--include` or `--exclude` (`-I`, `-X`, respectively) are given, the
+* `--no-rewrite`
+    Migrate large objects to Git LFS in a new commit without rewriting git history.
+    Please note that when this option is used, the `migrate import` command will expect
+    a different argument list, specialized options will become available, and the core 
+    `migrate` options will be ignored. See [IMPORT (NO REWRITE)].
+
+If `--no-rewrite` is not provided and `--include` or `--exclude` (`-I`, `-X`, respectively) are given, the
 .gitattributes will be modified to include any new filepath patterns as given by
 those flags.
 
-If neither of those flags are given, the gitattributes will be incrementally
+If `--no-rewrite` is not provided and neither of those flags are given, the gitattributes will be incrementally
 modified to include new filepath extensions as they are rewritten in history.
+
+### IMPORT (NO REWRITE)
+
+The `import` mode has a special sub-mode enabled by the `--no-rewrite` flag. This sub-mode
+will migrate large objects to pointers as in the base `import` mode, but will do so in a new commit
+without rewriting Git history. When using this sub-mode, the base `migrate` options, 
+such as `--include-ref`, will be ignored, as will those for the base `import` mode. 
+The `migrate` command will also take a different argument list.
+
+The `--no-rewrite` sub-mode supports the following options and arguments:
+
+* `-m` <message> `--message`=<message>
+    Specifies a commit message for the newly created commit.
+
+* [file ...]
+    The list of files to import. These files must be tracked by patterns specified in the
+    gitattributes.
+
+If `--message` is given, the new commit will be created with the provided message. If no message is given,
+a commit message will be generated based on the file arguments.
 
 ## INCLUDE AND EXCLUDE
 
@@ -188,6 +214,18 @@ $ git lfs migrate import --everything --include="*.zip"
 ```
 
 Note: This will require a force push to any existing Git remotes.
+
+### Migrate without rewriting local history
+
+You can also migrate files without modifying the existing history of your respoitory:
+
+```
+# Without a specified commit message
+$ git lfs migrate import --no-rewrite test.zip *.mp3 *.psd
+
+# With a specified commit message
+$ git lfs migrate import --no-rewrite -m "Import .zip, .mp3, .psd files" test.zip *.mpd *.psd
+```
 
 ## SEE ALSO
 

--- a/git/attribs.go
+++ b/git/attribs.go
@@ -73,7 +73,7 @@ func GetAttributePaths(workingDir, gitDir string) []AttributePath {
 				fields := strings.Fields(line)
 				pattern := fields[0]
 				if len(reldir) > 0 {
-					pattern = filepath.ToSlash(filepath.Join(reldir, pattern))
+					pattern = filepath.Join(reldir, pattern)
 				}
 				// Find lockable flag in any position after pattern to avoid
 				// edge case of matching "lockable" to a file pattern
@@ -108,7 +108,9 @@ func GetAttributeFilter(workingDir, gitDir string) *filepathfilter.Filter {
 	patterns := make([]filepathfilter.Pattern, 0, len(paths))
 
 	for _, path := range paths {
-		patterns = append(patterns, filepathfilter.NewPattern(path.Path))
+		// Convert all separators to `/` before creating a pattern to
+		// avoid characters being escaped in situations like `subtree\*.md`
+		patterns = append(patterns, filepathfilter.NewPattern(filepath.ToSlash(path.Path)))
 	}
 
 	return filepathfilter.NewFromPatterns(patterns, nil)

--- a/git/attribs.go
+++ b/git/attribs.go
@@ -73,7 +73,7 @@ func GetAttributePaths(workingDir, gitDir string) []AttributePath {
 				fields := strings.Fields(line)
 				pattern := fields[0]
 				if len(reldir) > 0 {
-					pattern = filepath.Join(reldir, pattern)
+					pattern = filepath.ToSlash(filepath.Join(reldir, pattern))
 				}
 				// Find lockable flag in any position after pattern to avoid
 				// edge case of matching "lockable" to a file pattern

--- a/git/attribs.go
+++ b/git/attribs.go
@@ -105,10 +105,10 @@ func GetAttributePaths(workingDir, gitDir string) []AttributePath {
 // gitDir is the root of the git repo
 func GetAttributeFilter(workingDir, gitDir string) *filepathfilter.Filter {
 	paths := GetAttributePaths(workingDir, gitDir)
-	patterns := make([]filepathfilter.Pattern, len(paths))
+	patterns := make([]filepathfilter.Pattern, 0, len(paths))
 
-	for i, path := range paths {
-		patterns[i] = filepathfilter.NewPattern(path.Path)
+	for _, path := range paths {
+		patterns = append(patterns, filepathfilter.NewPattern(path.Path))
 	}
 
 	return filepathfilter.NewFromPatterns(patterns, nil)

--- a/git/attribs.go
+++ b/git/attribs.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/git-lfs/git-lfs/filepathfilter"
 	"github.com/git-lfs/git-lfs/tools"
 	"github.com/rubyist/tracerx"
 )
@@ -95,6 +96,22 @@ func GetAttributePaths(workingDir, gitDir string) []AttributePath {
 	}
 
 	return paths
+}
+
+// GetAttributeFilter returns a list of entries in .gitattributes which are
+// configured with the filter=lfs attribute as a file path filter which
+// file paths can be matched against
+// workingDir is the root of the working copy
+// gitDir is the root of the git repo
+func GetAttributeFilter(workingDir, gitDir string) *filepathfilter.Filter {
+	paths := GetAttributePaths(workingDir, gitDir)
+	patterns := make([]filepathfilter.Pattern, len(paths))
+
+	for i, path := range paths {
+		patterns[i] = filepathfilter.NewPattern(path.Path)
+	}
+
+	return filepathfilter.NewFromPatterns(patterns, nil)
 }
 
 // copies bufio.ScanLines(), counting LF vs CRLF in a file

--- a/test/test-migrate-fixtures.sh
+++ b/test/test-migrate-fixtures.sh
@@ -44,6 +44,46 @@ setup_local_branch_with_gitattrs() {
   git commit -m "add .gitattributes"
 }
 
+# setup_local_branch_with_nested_gitattrs creates a repository as follows:
+#
+#   A---B
+#        \
+#         refs/heads/master
+#
+# - Commit 'A' has 120, in a.txt, and a corresponding entry in .gitattributes. There is also
+#   140 in a.md, with no corresponding entry in .gitattributes.
+#   It also has 140 in subtree/a.md, and a corresponding entry in subtree/.gitattributes
+setup_local_branch_with_nested_gitattrs() {
+  set -e
+
+  reponame="migrate-single-remote-branch-with-nested-attrs"
+
+  remove_and_create_local_repo "$reponame"
+
+  mkdir subtree
+
+  base64 < /dev/urandom | head -c 120 > a.txt
+  base64 < /dev/urandom | head -c 140 > a.md
+  base64 < /dev/urandom | head -c 140 > subtree/a.md
+
+  git add a.txt a.md subtree/a.md
+  git commit -m "initial commit"
+
+  git lfs track "*.txt"
+
+  git add .gitattributes
+  git commit -m "add .gitattributes"
+
+  cd subtree
+
+  git lfs track "*.md"
+
+  cd ..
+
+  git add subtree/.gitattributes
+  git commit -m "add nested .gitattributes"
+}
+
 # setup_multiple_local_branches creates a repository as follows:
 #
 #     B
@@ -77,6 +117,21 @@ setup_multiple_local_branches() {
   git commit -m "add an additional 30 bytes to a.md"
 
   git checkout master
+}
+
+# setup_multiple_local_branches_with_gitattrs creates a repository in the same way
+# as setup_multiple_local_branches, but also adds relevant lfs filters to the
+# .gitattributes file in the master branch
+setup_multiple_local_branches_with_gitattrs() {
+  set -e
+
+  setup_multiple_local_branches
+
+  git lfs track *.txt
+  git lfs track *.md
+
+  git add .gitattributes
+  git commit -m "add .gitattributes"
 }
 
 # setup_local_branch_with_space creates a repository as follows:
@@ -132,6 +187,18 @@ setup_single_remote_branch() {
 
   git add a.md a.txt
   git commit -m "add an additional 30, 50 bytes to a.{txt,md}"
+}
+
+setup_single_remote_branch_with_gitattrs() {
+  set -e
+
+  setup_single_remote_branch
+
+  git lfs track *.txt
+  git lfs track *.md
+
+  git add .gitattributes
+  git commit -m "add .gitattributes"
 }
 
 # setup_multiple_remote_branches creates a repository as follows:

--- a/test/test-migrate-fixtures.sh
+++ b/test/test-migrate-fixtures.sh
@@ -56,17 +56,17 @@ setup_local_branch_with_gitattrs() {
 setup_local_branch_with_nested_gitattrs() {
   set -e
 
-  reponame="migrate-single-remote-branch-with-nested-attrs"
+  reponame="nested-attrs"
 
   remove_and_create_local_repo "$reponame"
 
-  mkdir subtree
+  mkdir b
 
   base64 < /dev/urandom | head -c 120 > a.txt
   base64 < /dev/urandom | head -c 140 > a.md
-  base64 < /dev/urandom | head -c 140 > subtree/a.md
+  base64 < /dev/urandom | head -c 140 > b/a.md
 
-  git add a.txt a.md subtree/a.md
+  git add a.txt a.md b/a.md
   git commit -m "initial commit"
 
   git lfs track "*.txt"
@@ -74,13 +74,13 @@ setup_local_branch_with_nested_gitattrs() {
   git add .gitattributes
   git commit -m "add .gitattributes"
 
-  cd subtree
+  cd b
 
   git lfs track "*.md"
 
   cd ..
 
-  git add subtree/.gitattributes
+  git add b/.gitattributes
   git commit -m "add nested .gitattributes"
 }
 

--- a/test/test-migrate-import-no-rewrite.sh
+++ b/test/test-migrate-import-no-rewrite.sh
@@ -111,7 +111,12 @@ begin_test "migrate import --no-rewrite (no .gitattributes)"
   setup_multiple_local_branches
 
   # Ensure command fails if no .gitattributes files are present
-  [ !"$(git lfs migrate import --no-rewrite *.txt *.md)" ]
+  git lfs migrate import --no-rewrite *.txt *.md 2>&1 | tee migrate.log
+  if [ ${PIPESTATUS[0]} -eq 0 ]; then
+    echo >&2 "fatal: expected git lfs migrate import --no-rewrite to fail, didn't"
+  fi
+
+  grep "no Git LFS filters found in .gitattributes" migrate.log
 )
 end_test
 
@@ -146,7 +151,12 @@ begin_test "migrate import --no-rewrite (nested .gitattributes)"
 
   # Failure should occur when trying to import a.md as no entry exists in
   # top-level .gitattributes file
-  [ !"$(git lfs migrate import --no-rewrite a.md)" ]
+  git lfs migrate import --no-rewrite a.md 2>&1 | tee migrate.log
+  if [ ${PIPESTATUS[0]} -eq 0 ]; then
+    echo >&2 "fatal: expected git lfs migrate import --no-rewrite to fail, didn't"
+  fi
+
+  grep "a.md did not match any Git LFS filters in .gitattributes" migrate.log
 )
 end_test
 

--- a/test/test-migrate-import-no-rewrite.sh
+++ b/test/test-migrate-import-no-rewrite.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+
+. "test/test-migrate-fixtures.sh"
+. "test/testlib.sh"
+
+begin_test "migrate import --no-rewrite (default branch)"
+(
+  set -e
+
+  setup_local_branch_with_gitattrs
+
+  txt_oid="$(calc_oid "$(git cat-file -p :a.txt)")"
+  prev_commit_oid="$(git rev-parse HEAD)"
+
+  git lfs migrate import --no-rewrite *.txt
+
+  # Ensure our desired files were imported into git-lfs
+  assert_pointer "refs/heads/master" "a.txt" "$txt_oid" "120"
+  assert_local_object "$txt_oid" "120"
+
+  # Ensure the git history remained the same
+  new_commit_oid="$(git rev-parse HEAD~1)"
+  if [ "$prev_commit_oid" != "$new_commit_oid" ]; then
+    exit 1
+  fi
+
+  # Ensure a new commit was made
+  new_head_oid="$(git rev-parse HEAD)"
+  if [ "$prev_commit_oid" == "$new_oid" ]; then
+    exit 1
+  fi
+
+  # Ensure a new commit message was generated based on the list of imported files
+  commit_msg="$(git log -1 --pretty=format:%s)"
+  echo "$commit_msg" | grep -q "a.txt: convert to Git LFS"
+)
+end_test
+
+begin_test "migrate import --no-rewrite (bare repository)"
+(
+  set -e
+
+  setup_single_remote_branch_with_gitattrs
+
+  prev_commit_oid="$(git rev-parse HEAD)"
+  txt_oid="$(calc_oid "$(git cat-file -p :a.txt)")"
+  md_oid="$(calc_oid "$(git cat-file -p :a.md)")"
+
+  git lfs migrate import --no-rewrite a.txt a.md
+
+  # Ensure our desired files were imported
+  assert_pointer "refs/heads/master" "a.txt" "$txt_oid" "30"
+  assert_pointer "refs/heads/master" "a.md" "$md_oid" "50"
+
+  # Ensure the git history remained the same
+  new_commit_oid="$(git rev-parse HEAD~1)"
+  if [ "$prev_commit_oid" != "$new_commit_oid" ]; then
+    exit 1
+  fi
+
+  # Ensure a new commit was made
+  new_head_oid="$(git rev-parse HEAD)"
+  if [ "$prev_commit_oid" == "$new_oid" ]; then
+    exit 1
+  fi
+)
+end_test
+
+begin_test "migrate import --no-rewrite (multiple branches)"
+(
+  set -e
+
+  setup_multiple_local_branches_with_gitattrs
+
+  prev_commit_oid="$(git rev-parse HEAD)"
+
+  md_oid="$(calc_oid "$(git cat-file -p :a.md)")"
+  txt_oid="$(calc_oid "$(git cat-file -p :a.txt)")"
+  md_feature_oid="$(calc_oid "$(git cat-file -p my-feature:a.md)")"
+
+  git lfs migrate import --no-rewrite *.txt *.md
+
+  # Ensure our desired files were imported
+  assert_pointer "refs/heads/master" "a.md" "$md_oid" "140"
+  assert_pointer "refs/heads/master" "a.txt" "$txt_oid" "120"
+
+  assert_local_object "$md_oid" "140"
+  assert_local_object "$txt_oid" "120"
+
+  # Ensure our other branch was unmodified
+  refute_local_object "$md_feature_oid" "30"
+
+  # Ensure the git history remained the same
+  new_commit_oid="$(git rev-parse HEAD~1)"
+  if [ "$prev_commit_oid" != "$new_commit_oid" ]; then
+    exit 1
+  fi
+
+  # Ensure a new commit was made
+  new_head_oid="$(git rev-parse HEAD)"
+  if [ "$prev_commit_oid" == "$new_oid" ]; then
+    exit 1
+  fi
+)
+end_test
+
+begin_test "migrate import --no-rewrite (no .gitattributes)"
+(
+  set -e
+
+  setup_multiple_local_branches
+
+  # Ensure command fails if no .gitattributes files are present
+  [ !"$(git lfs migrate import --no-rewrite *.txt *.md)" ]
+)
+end_test
+
+begin_test "migrate import --no-rewrite (nested .gitattributes)"
+(
+  set -e
+
+  setup_local_branch_with_nested_gitattrs
+
+  # Ensure a .md filter does not exist in the top-level .gitattributes
+  master_attrs="$(git cat-file -p "$master:.gitattributes")"
+  [ !"$(echo "$master_attrs" | grep -q ".md")" ]
+
+  # Ensure a .md filter exists in the nested .gitattributes
+  nested_attrs="$(git cat-file -p "$master:subtree/.gitattributes")"
+  echo "$nested_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
+
+  md_oid="$(calc_oid "$(git cat-file -p :a.md)")"
+  nested_md_oid="$(calc_oid "$(git cat-file -p :subtree/a.md)")"
+  txt_oid="$(calc_oid "$(git cat-file -p :a.txt)")"
+
+  git lfs migrate import --no-rewrite a.txt subtree/a.md
+
+  # Ensure a.txt and subtree/a.md were imported, even though *.md only exists in the
+  # nested subtree/.gitattributes file
+  assert_pointer "refs/heads/master" "subtree/a.md" "$nested_md_oid" "140"
+  assert_pointer "refs/heads/master" "a.txt" "$txt_oid" "120"
+
+  assert_local_object "$nested_md_oid" 140
+  assert_local_object "$txt_oid" 120
+  refute_local_object "$md_oid" 140
+
+  # Failure should occur when trying to import a.md as no entry exists in
+  # top-level .gitattributes file
+  [ !"$(git lfs migrate import --no-rewrite a.md)" ]
+)
+end_test
+
+begin_test "migrate import --no-rewrite (with commit message)"
+(
+  set -e
+
+  setup_local_branch_with_gitattrs
+
+  prev_commit_oid="$(git rev-parse HEAD)"
+  expected_commit_msg="run git-lfs migrate import --no-rewrite"
+
+  git lfs migrate import --message "$expected_commit_msg" --no-rewrite *.txt
+
+  # Ensure the git history remained the same
+  new_commit_oid="$(git rev-parse HEAD~1)"
+  if [ "$prev_commit_oid" != "$new_commit_oid" ]; then
+    exit 1
+  fi
+
+  # Ensure a new commit was made
+  new_head_oid="$(git rev-parse HEAD)"
+  if [ "$prev_commit_oid" == "$new_oid" ]; then
+    exit 1
+  fi
+
+  # Ensure the provided commit message was used
+  commit_msg="$(git log -1 --pretty=format:%s)"
+  if [ "$commit_msg" != "$expected_commit_msg" ]; then
+    exit 1
+  fi
+)
+end_test
+
+begin_test "migrate import --no-rewrite (with empty commit message)"
+(
+  set -e
+
+  setup_local_branch_with_gitattrs
+
+  prev_commit_oid="$(git rev-parse HEAD)"
+
+  git lfs migrate import -m "" --no-rewrite *.txt
+
+  # Ensure the git history remained the same
+  new_commit_oid="$(git rev-parse HEAD~1)"
+  if [ "$prev_commit_oid" != "$new_commit_oid" ]; then
+    exit 1
+  fi
+
+  # Ensure a new commit was made
+  new_head_oid="$(git rev-parse HEAD)"
+  if [ "$prev_commit_oid" == "$new_oid" ]; then
+    exit 1
+  fi
+
+  # Ensure the provided commit message was used
+  commit_msg="$(git log -1 --pretty=format:%s)"
+  if [ "$commit_msg" != "" ]; then
+    exit 1
+  fi
+)
+end_test

--- a/test/test-migrate-import-no-rewrite.sh
+++ b/test/test-migrate-import-no-rewrite.sh
@@ -132,18 +132,18 @@ begin_test "migrate import --no-rewrite (nested .gitattributes)"
   [ !"$(echo "$master_attrs" | grep -q ".md")" ]
 
   # Ensure a .md filter exists in the nested .gitattributes
-  nested_attrs="$(git cat-file -p "$master:subtree/.gitattributes")"
+  nested_attrs="$(git cat-file -p "$master:b/.gitattributes")"
   echo "$nested_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
 
   md_oid="$(calc_oid "$(git cat-file -p :a.md)")"
-  nested_md_oid="$(calc_oid "$(git cat-file -p :subtree/a.md)")"
+  nested_md_oid="$(calc_oid "$(git cat-file -p :b/a.md)")"
   txt_oid="$(calc_oid "$(git cat-file -p :a.txt)")"
 
-  git lfs migrate import --no-rewrite a.txt subtree/a.md
+  git lfs migrate import --no-rewrite a.txt b/a.md
 
   # Ensure a.txt and subtree/a.md were imported, even though *.md only exists in the
   # nested subtree/.gitattributes file
-  assert_pointer "refs/heads/master" "subtree/a.md" "$nested_md_oid" "140"
+  assert_pointer "refs/heads/master" "b/a.md" "$nested_md_oid" "140"
   assert_pointer "refs/heads/master" "a.txt" "$txt_oid" "120"
 
   assert_local_object "$nested_md_oid" 140

--- a/test/test-migrate-import-no-rewrite.sh
+++ b/test/test-migrate-import-no-rewrite.sh
@@ -114,6 +114,7 @@ begin_test "migrate import --no-rewrite (no .gitattributes)"
   git lfs migrate import --no-rewrite *.txt *.md 2>&1 | tee migrate.log
   if [ ${PIPESTATUS[0]} -eq 0 ]; then
     echo >&2 "fatal: expected git lfs migrate import --no-rewrite to fail, didn't"
+    exit 1
   fi
 
   grep "no Git LFS filters found in .gitattributes" migrate.log
@@ -154,6 +155,7 @@ begin_test "migrate import --no-rewrite (nested .gitattributes)"
   git lfs migrate import --no-rewrite a.md 2>&1 | tee migrate.log
   if [ ${PIPESTATUS[0]} -eq 0 ]; then
     echo >&2 "fatal: expected git lfs migrate import --no-rewrite to fail, didn't"
+    exit 1
   fi
 
   grep "a.md did not match any Git LFS filters in .gitattributes" migrate.log


### PR DESCRIPTION
This PR adds a new `--no-rewrite` flag to the `migrate import` command. When this flag is given, `migrate import` takes a list of files as arguments and imports these files into Git LFS. It does this by rewriting the git tree in a new commit, without modifying git history.

Some of the code in this PR was based off of code previously written by @ttaylorr. Also, a big thank you to @ttaylorr for pairing with me on parts of this PR!