### PR TITLE
add basic example in main manpage

### DIFF
--- a/docs/man/git-lfs-track.1.ronn
+++ b/docs/man/git-lfs-track.1.ronn
@@ -59,6 +59,6 @@ to match paths.
 
 ## SEE ALSO
 
-git-lfs-untrack(1), git-lfs-install(1), gitattributes(5).
+git-lfs-untrack(1), git-lfs-install(1), gitattributes(5), gitignore(5).
 
 Part of the git-lfs(1) suite.

--- a/docs/man/git-lfs.1.ronn
+++ b/docs/man/git-lfs.1.ronn
@@ -82,3 +82,28 @@ commands and low level ("plumbing") commands.
     Git pre-push hook implementation.
 * git-lfs-smudge(1):
     Git smudge filter that converts pointer in blobs to the actual content.
+
+## EXAMPLES
+
+To get started with Git LFS, the following commands can be used.
+
+ 1. Setup Git LFS on your system. You only have to do this once per
+    repository per machine:
+
+        git lfs install
+
+ 2. Choose the type of files you want to track, for examples all `ISO`
+    images, with git-lfs-track(1):
+
+        git lfs track "*.iso"
+
+ 3. The above stores this information in gitattributes(5) files, so
+    that file need to be added to the repository:
+
+        git add .gitattributes
+
+ 3. Commit, push and work with the files normally:
+
+        git add file.iso
+        git commit -m "Add disk image"
+        git push


### PR DESCRIPTION
Every time I go back to git LFS after a long break, I wonder how it
works and how to get started. The first manual page is currently a
reference to a fairly large number of other manual pages and, as the
core documentation of LFS, does not really help users in getting basic
things done.

In comparison, the LFS homepage has a good primer, so I have taken it
as an example for a basic example that would work in the manual page
to help users get out of the weeds quickly.