### PR TITLE
git/odb: retain trailing newlines in commit messages

### DIFF
--- a/git/githistory/rewriter_test.go
+++ b/git/githistory/rewriter_test.go
@@ -3,7 +3,6 @@ package githistory
 import (
 	"bytes"
 	"encoding/hex"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"reflect"
@@ -188,10 +187,6 @@ func TestRewriterVisitsUniqueEntriesWithIdenticalContents(t *testing.T) {
 	assert.Nil(t, err)
 
 	tree := "bbbe0a7676523ae02234bfe874784ca2380c2d4b"
-
-	fmt.Println(hex.EncodeToString(tip))
-	root, _ := db.Root()
-	fmt.Println(root)
 
 	AssertCommitTree(t, db, hex.EncodeToString(tip), tree)
 

--- a/git/githistory/rewriter_test.go
+++ b/git/githistory/rewriter_test.go
@@ -60,8 +60,8 @@ func TestRewriterRewritesHistory(t *testing.T) {
 	//
 	//   100644 blob e440e5c842586965a7fb77deda2eca68612b1f53   hello.txt
 
-	AssertCommitParent(t, db, hex.EncodeToString(tip), "911994ab82ce256433c1fa739dbbbc7142156289")
-	AssertCommitTree(t, db, "911994ab82ce256433c1fa739dbbbc7142156289", tree2)
+	AssertCommitParent(t, db, hex.EncodeToString(tip), "4aaa3f49ffeabbb874250fe13ffeb8c683aba650")
+	AssertCommitTree(t, db, "4aaa3f49ffeabbb874250fe13ffeb8c683aba650", tree2)
 
 	AssertBlobContents(t, db, tree2, "hello.txt", "3")
 
@@ -70,8 +70,8 @@ func TestRewriterRewritesHistory(t *testing.T) {
 	//
 	//   100644 blob d8263ee9860594d2806b0dfd1bfd17528b0ba2a4   hello.txt
 
-	AssertCommitParent(t, db, "911994ab82ce256433c1fa739dbbbc7142156289", "38679ebeba3403103196eb6272b326f96c928ace")
-	AssertCommitTree(t, db, "38679ebeba3403103196eb6272b326f96c928ace", tree3)
+	AssertCommitParent(t, db, "4aaa3f49ffeabbb874250fe13ffeb8c683aba650", "24a341e1ff75addc22e336a8d87f82ba56b86fcf")
+	AssertCommitTree(t, db, "24a341e1ff75addc22e336a8d87f82ba56b86fcf", tree3)
 
 	AssertBlobContents(t, db, tree3, "hello.txt", "2")
 }
@@ -111,14 +111,14 @@ func TestRewriterRewritesOctopusMerges(t *testing.T) {
 	//   parent 1fe2b9577d5610e8d8fb2c3030534036fb648393
 	//   parent ca447959bdcd20253d69b227bcc7c2e1d3126d5c
 
-	AssertCommitParent(t, db, hex.EncodeToString(tip), "89ab88fb7e11a439299aa2aa77a5d98f6629b750")
-	AssertCommitParent(t, db, hex.EncodeToString(tip), "adf1e9085f9dd263c1bec399b995ccfa5d994721")
+	AssertCommitParent(t, db, hex.EncodeToString(tip), "1fe2b9577d5610e8d8fb2c3030534036fb648393")
+	AssertCommitParent(t, db, hex.EncodeToString(tip), "ca447959bdcd20253d69b227bcc7c2e1d3126d5c")
 
 	// And each of those parents should contain the root commit as their own
 	// parent:
 
-	AssertCommitParent(t, db, "89ab88fb7e11a439299aa2aa77a5d98f6629b750", "52daca68bcf750bb86289fd95f92f5b3bd202328")
-	AssertCommitParent(t, db, "adf1e9085f9dd263c1bec399b995ccfa5d994721", "52daca68bcf750bb86289fd95f92f5b3bd202328")
+	AssertCommitParent(t, db, "1fe2b9577d5610e8d8fb2c3030534036fb648393", "9237567f379b3c83ddf53ad9a2ae3755afb62a09")
+	AssertCommitParent(t, db, "ca447959bdcd20253d69b227bcc7c2e1d3126d5c", "9237567f379b3c83ddf53ad9a2ae3755afb62a09")
 }
 
 func TestRewriterVisitsPackedObjects(t *testing.T) {
@@ -273,8 +273,8 @@ func TestRewriterAllowsAdditionalTreeEntries(t *testing.T) {
 	//   100644 blob d8263ee9860594d2806b0dfd1bfd17528b0ba2a4    hello.txt
 	//   100644 blob 0f2287157f7cb0dd40498c7a92f74b6975fa2d57    extra.txt
 
-	AssertCommitParent(t, db, hex.EncodeToString(tip), "54ca0fdd5ee455d872ce4b4e379abe1c4cdc39b3")
-	AssertCommitTree(t, db, "54ca0fdd5ee455d872ce4b4e379abe1c4cdc39b3", tree2)
+	AssertCommitParent(t, db, hex.EncodeToString(tip), "45af5deb9a25bc4069b15c1f5bdccb0340978707")
+	AssertCommitTree(t, db, "45af5deb9a25bc4069b15c1f5bdccb0340978707", tree2)
 
 	AssertBlobContents(t, db, tree2, "hello.txt", "2")
 	AssertBlobContents(t, db, tree2, "extra.txt", "extra\n")
@@ -285,8 +285,8 @@ func TestRewriterAllowsAdditionalTreeEntries(t *testing.T) {
 	//   100644 blob 56a6051ca2b02b04ef92d5150c9ef600403cb1de    hello.txt
 	//   100644 blob 0f2287157f7cb0dd40498c7a92f74b6975fa2d57    extra.txt
 
-	AssertCommitParent(t, db, "54ca0fdd5ee455d872ce4b4e379abe1c4cdc39b3", "4c52196256c611d18ad718b9b68b3d54d0a6686d")
-	AssertCommitTree(t, db, "4c52196256c611d18ad718b9b68b3d54d0a6686d", tree3)
+	AssertCommitParent(t, db, "45af5deb9a25bc4069b15c1f5bdccb0340978707", "99f6bd7cd69b45494afed95b026f3e450de8304f")
+	AssertCommitTree(t, db, "99f6bd7cd69b45494afed95b026f3e450de8304f", tree3)
 
 	AssertBlobContents(t, db, tree3, "hello.txt", "1")
 	AssertBlobContents(t, db, tree3, "extra.txt", "extra\n")
@@ -350,8 +350,8 @@ func TestHistoryRewriterUpdatesRefs(t *testing.T) {
 	assert.Nil(t, err)
 
 	c1 := hex.EncodeToString(tip)
-	c2 := "86f7ba8f02edaca4f980cdd584ea8899e18b840c"
-	c3 := "d73b8c1a294e2371b287d9b75dbed82328ad446e"
+	c2 := "66561fe3ae68651658e18e48053dcfe66a2e9da1"
+	c3 := "8268d8486c48024a871fa42fc487dbeabd6e3d86"
 
 	AssertRef(t, db, "refs/heads/master", tip)
 

--- a/git/githistory/rewriter_test.go
+++ b/git/githistory/rewriter_test.go
@@ -369,3 +369,18 @@ func TestHistoryRewriterReturnsFilter(t *testing.T) {
 	assert.Equal(t, expected, got,
 		"git/githistory: expected Rewriter.Filter() to return same *filepathfilter.Filter instance")
 }
+
+// debug is meant to be called from a defer statement to aide in debugging a
+// test failure among any in this file.
+//
+// Callers are expected to call it immediately after calling the Rewrite()
+// function.
+func debug(t *testing.T, db *odb.ObjectDatabase, tip []byte, err error) {
+	root, ok := db.Root()
+
+	t.Log(strings.Repeat("*", 80))
+	t.Logf("* root=%s, ok=%t\n", root, ok)
+	t.Logf("* tip=%x\n", tip)
+	t.Logf("* err=%s\n", err)
+	t.Log(strings.Repeat("*", 80))
+}

--- a/git/odb/commit.go
+++ b/git/odb/commit.go
@@ -185,7 +185,11 @@ func (c *Commit) Encode(to io.Writer) (n int, err error) {
 		n = n + n3
 	}
 
-	n4, err := fmt.Fprintf(to, "\n%s", c.Message)
+	// c.Message is built from messageParts in the Decode() function.
+	//
+	// Since each entry in messageParts _does not_ contain its trailing LF,
+	// append an empty string to capture the final newline.
+	n4, err := fmt.Fprintf(to, "\n%s\n", c.Message)
 	if err != nil {
 		return n, err
 	}

--- a/git/odb/object_db_test.go
+++ b/git/odb/object_db_test.go
@@ -159,7 +159,7 @@ func TestWriteCommit(t *testing.T) {
 		Message:   "initial commit",
 	})
 
-	expected := "77a746376fdb591a44a4848b5ba308b2d3e2a90c"
+	expected := "fee8a35c2890cd6e0e28d24cc457fcecbd460962"
 
 	assert.Nil(t, err)
 	assert.Equal(t, expected, hex.EncodeToString(sha))


### PR DESCRIPTION
This pull request fixes an issue where the final trailing newline in a commit message would be removed, thus making migrations that should have no effect change the SHA-1s of commits.

This was caused by #2784, wherein I misunderstood the lack of `LF` at the end of the specification to mean "there is no newline here". Instead, it means that there is no newline after the `<data>` field, which itself _does_ contain a newline.

Here's a demonstration of the problem prior to e35b429:

```ShellSession
$ git commit --allow-empty -m "initial commit"
[master (root-commit) 0feac72] initial commit

~/D/example (master) $ git cat-file -p HEAD
tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
author Taylor Blau <me@ttaylorr.com> 1528488020 -0500
committer Taylor Blau <me@ttaylorr.com> 1528488020 -0500

initial commit # <- note the newline

$ git lfs migrate import --everything
migrate: Sorting commits: ..., done
migrate: Rewriting commits: 100% (1/1), done
  master        0feac72dcdfe60a67ac35cb9b02a0abe1caa79b5 -> 00126865fe671c8fa035b602ec65ddcfa30679a7
migrate: Updating refs: ..., done
migrate: checkout: ..., done

$ git cat-file -p HEAD
tree f8614bda784833ac9ab9e82c4ca296948c6ddd60
author Taylor Blau <me@ttaylorr.com> 1528488020 -0500
committer Taylor Blau <me@ttaylorr.com> 1528488020 -0500

initial commit% # <- note the missing newline
```

and after:

```ShellSession
$ git commit --allow-empty -m "initial commit"
[master (root-commit) 0feac72] initial commit

~/D/example (master) $ git cat-file -p HEAD
tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
author Taylor Blau <me@ttaylorr.com> 1528488020 -0500
committer Taylor Blau <me@ttaylorr.com> 1528488020 -0500

initial commit # <- note the newline

$  git lfs migrate import --everything
migrate: Sorting commits: ..., done
migrate: Rewriting commits: 100% (1/1), done
  master        0feac72dcdfe60a67ac35cb9b02a0abe1caa79b5 -> 861ac1ff13abb0116f6f0437880768068ce5ee7c
migrate: Updating refs: ..., done
migrate: checkout: ..., done

$ git cat-file -p HEAD
tree f8614bda784833ac9ab9e82c4ca296948c6ddd60
author Taylor Blau <me@ttaylorr.com> 1528488020 -0500
committer Taylor Blau <me@ttaylorr.com> 1528488020 -0500

initial commit # <- note the newline
```

Closes: https://github.com/git-lfs/git-lfs/issues/3040.

##

/cc @git-lfs/core 
/cc @jcallen-gentoo https://github.com/git-lfs/git-lfs/issues/3040