### PR TITLE
commands/migrate: do not migrate empty commits

### DIFF
--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -71,6 +71,18 @@ func migrateImportCommand(cmd *cobra.Command, args []string) {
 				// include set is the wildcard filepath
 				// extensions of files tracked.
 				ours = exts
+
+				if ours.Cardinality() == 0 {
+					// If it is still the case that we have
+					// no patterns to track, that means that
+					// we are in a tree that does not
+					// require .gitattributes changes.
+					//
+					// We can return early to avoid
+					// comparing and saving an identical
+					// tree.
+					return t, nil
+				}
 			}
 
 			theirs, err := trackedFromAttrs(db, t)

--- a/test/test-migrate-import.sh
+++ b/test/test-migrate-import.sh
@@ -673,3 +673,21 @@ begin_test "migrate import (handle symbolic link)"
   refute_local_object "$link_oid" "5"
 )
 end_test
+
+begin_test "migrate import (commit --allow-empty)"
+(
+  set -e
+
+  reponame="migrate---allow-empty"
+  git init "$reponame"
+  cd "$reponame"
+
+  git commit --allow-empty -m "initial commit"
+
+  original_head="$(git rev-parse HEAD)"
+  git lfs migrate import --everything
+  migrated_head="$(git rev-parse HEAD)"
+
+  assert_ref_unmoved "HEAD" "$original_head" "$migrated_head"
+)
+end_test


### PR DESCRIPTION
This pull request fixes a bug wherein `git lfs migrate import` issued over a commit containing no changes (i.e., one created with `--allow-empty`) would get a new SHA1.

This shouldn't happen, since initial commits created with `--allow-empty` should have an empty tree, and therefore no changes that are migrated.

However, in order to integrate with parallel changes being made to the `.gitattributes` file outside of a migration, `git lfs migrate` attempts to read the blob corresponding to `.gitattributes` in the root tree (`/`), and merge any changes from `--include`, `--exclude`, or file extensions that it has observed otherwise.

When all three of those sets are empty, Git LFS will create the singleton empty blob, and append it to the tree under the name `.gitattributes`. This would result in mysterious behavior like:

```ShellSession
$ git init example
Initialized empty Git repository in /Users/ttaylorr/Desktop/example/.git/
$ cd example

$ git commit -m "inital commit" --allow-empty
[master cb6ba23] inital commit

$ git rev-parse HEAD
cb6ba234d98b7e8e1dc8f4a787e398215433408c

$ git lfs migrate import
migrate: Fetching remote refs: ..., done
migrate: Sorting commits: ..., done
migrate: Rewriting commits: 100% (2/2), done
  master        cb6ba234d98b7e8e1dc8f4a787e398215433408c -> 25a94038ebf7a7b60a2a94de5e591fa6d1aa2c92
migrate: Updating refs: ..., done
migrate: checkout: ..., done

$ git rev-parse HEAD
25a94038ebf7a7b60a2a94de5e591fa6d1aa2c92
```

Instead, do a double-check to make sure that we never write the empty blob, hence making these types of migrations idempotent. While we're here, let's add a test in `test/test-migrate-import.sh` to ensure the same effect.

##

/cc @git-lfs/core 