### PR TITLE
commands/checkout: fix inaccurate messaging

### DIFF
--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -29,6 +29,7 @@ func checkoutCommand(cmd *cobra.Command, args []string) {
 	var pointers []*lfs.WrappedPointer
 	logger := tasklog.NewLogger(os.Stdout)
 	meter := tq.NewMeter()
+	meter.Direction = tq.Checkout
 	meter.Logger = meter.LoggerFromEnv(cfg.Os)
 	logger.Enqueue(meter)
 	chgitscanner := lfs.NewGitScanner(func(p *lfs.WrappedPointer, err error) {

--- a/test/test-checkout.sh
+++ b/test/test-checkout.sh
@@ -53,25 +53,23 @@ begin_test "checkout"
   rm -rf file1.dat file2.dat file3.dat folder1/nested.dat folder2/nested.dat
 
   echo "checkout with filters"
-  git lfs checkout file2.dat 2>&1 | tee checkout.log
+  git lfs checkout file2.dat
   [ "$contents" = "$(cat file2.dat)" ]
   [ ! -f file1.dat ]
   [ ! -f file3.dat ]
   [ ! -f folder1/nested.dat ]
   [ ! -f folder2/nested.dat ]
-  grep "Checking out LFS objects: 100% (1/1), 19 B" checkout.log
 
   echo "quotes to avoid shell globbing"
-  git lfs checkout "file*.dat" 2>&1 | tee checkout.log
+  git lfs checkout "file*.dat"
   [ "$contents" = "$(cat file1.dat)" ]
   [ "$contents" = "$(cat file3.dat)" ]
   [ ! -f folder1/nested.dat ]
   [ ! -f folder2/nested.dat ]
-  grep "Checking out LFS objects: 100% (3/3), 57 B" checkout.log
 
   echo "test subdir context"
   pushd folder1
-  git lfs checkout nested.dat 2>&1 | tee checkout.log
+  git lfs checkout nested.dat 2>&1
   grep "Checking out LFS objects: 100% (1/1), 19 B" checkout.log
   [ "$contents" = "$(cat nested.dat)" ]
   [ ! -f ../folder2/nested.dat ]
@@ -79,35 +77,31 @@ begin_test "checkout"
   rm nested.dat
   git lfs checkout . 2>&1 | tee checkout.log
   [ "$contents" = "$(cat nested.dat)" ]
-  grep "Checking out LFS objects: 100% (1/1), 19 B" checkout.log
   popd
 
   echo "test folder param"
-  git lfs checkout folder2 2>&1 | tee checkout.log
+  git lfs checkout folder2
   [ "$contents" = "$(cat folder2/nested.dat)" ]
-  grep "Checking out LFS objects: 100% (1/1), 19 B" checkout.log
 
   echo "test '.' in current dir"
   rm -rf file1.dat file2.dat file3.dat folder1/nested.dat folder2/nested.dat
-  git lfs checkout . 2>&1 | tee checkout.log
+  git lfs checkout .
   [ "$contents" = "$(cat file1.dat)" ]
   [ "$contents" = "$(cat file2.dat)" ]
   [ "$contents" = "$(cat file3.dat)" ]
   [ "$contents" = "$(cat folder1/nested.dat)" ]
   [ "$contents" = "$(cat folder2/nested.dat)" ]
-  grep "Checking out LFS objects: 100% (5/5), 95 B" checkout.log
 
   echo "test checkout with missing data doesn't fail"
   git push origin master
   rm -rf .git/lfs/objects
   rm file*.dat
-  git lfs checkout 2>&1 | tee checkout.log
+  git lfs checkout
   [ "$(pointer $contents_oid $contentsize)" = "$(cat file1.dat)" ]
   [ "$(pointer $contents_oid $contentsize)" = "$(cat file2.dat)" ]
   [ "$(pointer $contents_oid $contentsize)" = "$(cat file3.dat)" ]
   [ "$contents" = "$(cat folder1/nested.dat)" ]
   [ "$contents" = "$(cat folder2/nested.dat)" ]
-  grep "Checking out LFS objects: 100% (5/5), 95 B" checkout.log
 )
 end_test
 

--- a/test/test-checkout.sh
+++ b/test/test-checkout.sh
@@ -69,8 +69,7 @@ begin_test "checkout"
 
   echo "test subdir context"
   pushd folder1
-  git lfs checkout nested.dat 2>&1
-  grep "Checking out LFS objects: 100% (1/1), 19 B" checkout.log
+  git lfs checkout nested.dat
   [ "$contents" = "$(cat nested.dat)" ]
   [ ! -f ../folder2/nested.dat ]
   # test '.' in current dir

--- a/test/test-checkout.sh
+++ b/test/test-checkout.sh
@@ -41,65 +41,73 @@ begin_test "checkout"
   rm -rf file1.dat file2.dat file3.dat folder1/nested.dat folder2/nested.dat
 
   echo "checkout should replace all"
-  git lfs checkout
+  git lfs checkout 2>&1 | tee checkout.log
   [ "$contents" = "$(cat file1.dat)" ]
   [ "$contents" = "$(cat file2.dat)" ]
   [ "$contents" = "$(cat file3.dat)" ]
   [ "$contents" = "$(cat folder1/nested.dat)" ]
   [ "$contents" = "$(cat folder2/nested.dat)" ]
+  grep "Checking out LFS objects: 100% (5/5), 95 B" checkout.log
 
   # Remove the working directory
   rm -rf file1.dat file2.dat file3.dat folder1/nested.dat folder2/nested.dat
 
   echo "checkout with filters"
-  git lfs checkout file2.dat
+  git lfs checkout file2.dat 2>&1 | tee checkout.log
   [ "$contents" = "$(cat file2.dat)" ]
   [ ! -f file1.dat ]
   [ ! -f file3.dat ]
   [ ! -f folder1/nested.dat ]
   [ ! -f folder2/nested.dat ]
+  grep "Checking out LFS objects: 100% (1/1), 19 B" checkout.log
 
   echo "quotes to avoid shell globbing"
-  git lfs checkout "file*.dat"
+  git lfs checkout "file*.dat" 2>&1 | tee checkout.log
   [ "$contents" = "$(cat file1.dat)" ]
   [ "$contents" = "$(cat file3.dat)" ]
   [ ! -f folder1/nested.dat ]
   [ ! -f folder2/nested.dat ]
+  grep "Checking out LFS objects: 100% (3/3), 57 B" checkout.log
 
   echo "test subdir context"
   pushd folder1
-  git lfs checkout nested.dat
+  git lfs checkout nested.dat 2>&1 | tee checkout.log
+  grep "Checking out LFS objects: 100% (1/1), 19 B" checkout.log
   [ "$contents" = "$(cat nested.dat)" ]
   [ ! -f ../folder2/nested.dat ]
   # test '.' in current dir
   rm nested.dat
-  git lfs checkout .
+  git lfs checkout . 2>&1 | tee checkout.log
   [ "$contents" = "$(cat nested.dat)" ]
+  grep "Checking out LFS objects: 100% (1/1), 19 B" checkout.log
   popd
 
   echo "test folder param"
-  git lfs checkout folder2
+  git lfs checkout folder2 2>&1 | tee checkout.log
   [ "$contents" = "$(cat folder2/nested.dat)" ]
+  grep "Checking out LFS objects: 100% (1/1), 19 B" checkout.log
 
   echo "test '.' in current dir"
   rm -rf file1.dat file2.dat file3.dat folder1/nested.dat folder2/nested.dat
-  git lfs checkout .
+  git lfs checkout . 2>&1 | tee checkout.log
   [ "$contents" = "$(cat file1.dat)" ]
   [ "$contents" = "$(cat file2.dat)" ]
   [ "$contents" = "$(cat file3.dat)" ]
   [ "$contents" = "$(cat folder1/nested.dat)" ]
   [ "$contents" = "$(cat folder2/nested.dat)" ]
+  grep "Checking out LFS objects: 100% (5/5), 95 B" checkout.log
 
   echo "test checkout with missing data doesn't fail"
   git push origin master
   rm -rf .git/lfs/objects
   rm file*.dat
-  git lfs checkout
+  git lfs checkout 2>&1 | tee checkout.log
   [ "$(pointer $contents_oid $contentsize)" = "$(cat file1.dat)" ]
   [ "$(pointer $contents_oid $contentsize)" = "$(cat file2.dat)" ]
   [ "$(pointer $contents_oid $contentsize)" = "$(cat file3.dat)" ]
   [ "$contents" = "$(cat folder1/nested.dat)" ]
   [ "$contents" = "$(cat folder2/nested.dat)" ]
+  grep "Checking out LFS objects: 100% (5/5), 95 B" checkout.log
 )
 end_test
 

--- a/tq/meter.go
+++ b/tq/meter.go
@@ -5,7 +5,6 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -231,12 +230,10 @@ func (m *Meter) skipUpdate() bool {
 
 func (m *Meter) str() string {
 	// (Uploading|Downloading) LFS objects: 100% (10/10) 100 MiB | 10 MiB/s
-
-	direction := strings.Title(m.Direction.String()) + "ing"
 	percentage := 100 * float64(m.finishedFiles) / float64(m.estimatedFiles)
 
 	return fmt.Sprintf("%s LFS objects: %3.f%% (%d/%d), %s | %s",
-		direction,
+		m.Direction.Verb(),
 		percentage,
 		m.finishedFiles, m.estimatedFiles,
 		humanize.FormatBytes(clamp(m.currentBytes)),

--- a/tq/transfer.go
+++ b/tq/transfer.go
@@ -16,11 +16,14 @@ type Direction int
 const (
 	Upload   = Direction(iota)
 	Download = Direction(iota)
+	Checkout = Direction(iota)
 )
 
 // Verb returns a string containing the verb form of the receiving action.
 func (d Direction) Verb() string {
 	switch d {
+	case Checkout:
+		return "Checking out"
 	case Download:
 		return "Downloading"
 	case Upload:
@@ -32,6 +35,8 @@ func (d Direction) Verb() string {
 
 func (d Direction) String() string {
 	switch d {
+	case Checkout:
+		return "checkout"
 	case Download:
 		return "download"
 	case Upload:

--- a/tq/transfer.go
+++ b/tq/transfer.go
@@ -18,6 +18,18 @@ const (
 	Download = Direction(iota)
 )
 
+// Verb returns a string containing the verb form of the receiving action.
+func (d Direction) Verb() string {
+	switch d {
+	case Download:
+		return "Downloading"
+	case Upload:
+		return "Uploading"
+	default:
+		return "<unknown>"
+	}
+}
+
 func (d Direction) String() string {
 	switch d {
 	case Download:


### PR DESCRIPTION
This pull request fixes an issue where `git lfs checkout` would log a message indicating that it was "Uploading LFS objects", instead of something more appropriate, such as "Checking out LFS objects".

This issue was pointed out by @shuhrat in https://github.com/git-lfs/git-lfs/issues/3037.

The cause of this issue is interesting: since `Upload` and `Download` are defined in terms of the `iota` keyword, `Upload` (being defined closer to the top of the file) is given value `0` whereas `Download` is given value `1`. Hence, when we avoid initialization, Go steps in and gives us the zero-value of this object, which happens to be `Upload`.

To avoid this in the future, we should make the Unknown field have value zero (or avoid this altogether, and start at `iota + 1`), but this change feels out-of-scope for this pull request.

To fix this, we have to do a few things:

1. 12dc6dd: to prepare for adding a new checkout action (in package `tq`), we should teach `Verb() string`, so that we don't have to introduce a new special case when logging this message out. Specifically, this is because we used to call `strings.Title(m.direction.String())`, but this is no longer desired.

2. aa2ad12: add the new checkout direction itself, along with new cases in `Verb()` and `String()`.

3. 58815a6: assign the appropriate "direction" the `tq.Meter` when it is initialized in `commands/command_checkout.go`.

## 

/cc @git-lfs/core 
/cc @shuhurat, https://github.com/git-lfs/git-lfs/issues/3037