### PR TITLE
commands/checkout: mark 'git lfs checkout' as deprecated

### DIFF
--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/git-lfs/git-lfs/filepathfilter"
 	"github.com/git-lfs/git-lfs/git"
@@ -14,6 +15,15 @@ import (
 
 func checkoutCommand(cmd *cobra.Command, args []string) {
 	requireInRepo()
+
+	msg := []string{
+		"WARNING: 'git lfs checkout' is deprecated and will be removed in v3.0.0.",
+
+		"'git checkout' has been updated in upstream Git to have comparable speeds",
+		"to 'git lfs checkout'.",
+	}
+	fmt.Fprintln(os.Stderr, strings.Join(msg, "\n"))
+
 	ref, err := git.CurrentRef()
 	if err != nil {
 		Panic(err, "Could not checkout")

--- a/docs/man/git-lfs-checkout.1.ronn
+++ b/docs/man/git-lfs-checkout.1.ronn
@@ -7,6 +7,8 @@ git-lfs-checkout(1) -- Update working copy with file content if available
 
 ## DESCRIPTION
 
+This command is deprecated, and should be replaced with `git checkout`.
+
 Try to ensure that the working copy contains file content for Git LFS objects
 for the current ref, if the object data is available. Does not download any
 content, see git-lfs-fetch(1) for that. 


### PR DESCRIPTION
This pull request marks `git lfs checkout` as deprecated, indicating that it will be removed in v3.0.0.

`git checkout` benefits from the `delay=` capability introduced by @larsxschneider upstream, thus removing the need to retain this command in the future. Since we can't get rid of it between v2.4.0 and v2.5.0, let's mark that it is deprecated (similar to #2526) and schedule it for removal in v3.0.0.

One thing to consider is a feature such as `--include` or `--exclude`. `git lfs checkout` never supported these interestingly enough, so I suppose `git lfs checkout --include` was a fairly uncommon use-case. If someone so desired it, it could be accomplished by

    $ git -c lfs.fetchinclude=foo checkout -- 

##

/cc @git-lfs/core @larsxschneider 