### PR TITLE
lfsapi: prefer proxying from gitconfig before environment

### DIFF
--- a/lfsapi/proxy.go
+++ b/lfsapi/proxy.go
@@ -49,13 +49,6 @@ func proxyFromClient(c *Client) func(req *http.Request) (*url.URL, error) {
 }
 
 func getProxyServers(u *url.URL, urlCfg *config.URLConfig, osEnv config.Environment) (httpsProxy string, httpProxy string, noProxy string) {
-	if urlCfg != nil {
-		httpProxy, _ = urlCfg.Get("http", u.String(), "proxy")
-		if strings.HasPrefix(httpProxy, "https://") {
-			httpsProxy = httpProxy
-		}
-	}
-
 	if osEnv == nil {
 		return
 	}
@@ -74,6 +67,16 @@ func getProxyServers(u *url.URL, urlCfg *config.URLConfig, osEnv config.Environm
 
 	if len(httpProxy) == 0 {
 		httpProxy, _ = osEnv.Get("http_proxy")
+	}
+
+	if urlCfg != nil {
+		gitProxy, ok := urlCfg.Get("http", u.String(), "proxy")
+		if len(gitProxy) > 0 && ok {
+			if strings.HasPrefix(gitProxy, "https://") {
+				httpsProxy = gitProxy
+			}
+			httpProxy = gitProxy
+		}
 	}
 
 	noProxy, _ = osEnv.Get("NO_PROXY")

--- a/lfsapi/proxy_test.go
+++ b/lfsapi/proxy_test.go
@@ -20,7 +20,7 @@ func TestHttpsProxyFromGitConfig(t *testing.T) {
 	require.Nil(t, err)
 
 	proxyURL, err := proxyFromClient(c)(req)
-	assert.Equal(t, "proxy-from-git-config:8080", proxyURL.Host)
+	assert.Equal(t, "proxy-from-env:8080", proxyURL.Host)
 	assert.Nil(t, err)
 }
 


### PR DESCRIPTION
This pull request changes the behavior of package `lfsapi` to prefer the HTTP(s) proxy values originating from the environment, rather than the Git configuration.

As noted in https://github.com/git-lfs/git-lfs/issues/3060, this was originally the case when it was introduced in #1358, but was changed in #1787.

From the Git documentation \[[1](https://git-scm.com/docs/git-config#git-config-httpproxy)\]:

> __`http.proxy`__
>
> Override the HTTP proxy, normally configured using the http_proxy, https_proxy, and all_proxy environment variables (see curl(1)). [...]

This is technically a breaking change, but it's one that I would feel comfortable releasing along the v2.5.0 line, since holding back such a small patch until v3.0.0 feels unwise.

Closes: https://github.com/git-lfs/git-lfs/issues/3060.

##

/cc @git-lfs/core @larsxschneider 
/cc https://github.com/git-lfs/git-lfs/issues/3060 @kenyon