### PR TITLE
git/git.go: pass --multiple to git-fetch(1) when appropriate

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -975,7 +975,13 @@ func Fetch(remotes ...string) error {
 		return nil
 	}
 
-	_, err := gitNoLFSSimple(append([]string{"fetch"}, remotes...)...)
+	var args []string
+	if len(remotes) > 1 {
+		args = []string{"--multiple", "--"}
+	}
+	args = append(args, remotes...)
+
+	_, err := gitNoLFSSimple(append([]string{"fetch"}, args...)...)
 	return err
 }
 

--- a/test/test-migrate-fixtures.sh
+++ b/test/test-migrate-fixtures.sh
@@ -308,6 +308,31 @@ setup_single_local_branch_with_annotated_tags() {
   git tag "v1.0.0" -m "v1.0.0"
 }
 
+setup_multiple_remotes() {
+  set -e
+
+  reponame="migrate-multiple-remotes"
+  remove_and_create_remote_repo "$reponame"
+
+  forkname="$(git remote -v \
+    | head -n1 \
+    | cut -d ' ' -f 1 \
+    | sed -e 's/^.*\///g')-fork"
+  ( setup_remote_repo "$forkname" )
+
+  git remote add fork "$GITSERVER/$forkname"
+
+  base64 < /dev/urandom | head -c 16 > a.txt
+  git add a.txt
+  git commit -m "initial commit"
+  git push origin master
+
+  base64 < /dev/urandom | head -c 16 > a.txt
+  git add a.txt
+  git commit -m "another commit"
+  git push fork master
+}
+
 # setup_single_local_branch_deep_trees creates a repository as follows:
 #
 #   A

--- a/test/test-migrate-import.sh
+++ b/test/test-migrate-import.sh
@@ -691,3 +691,19 @@ begin_test "migrate import (commit --allow-empty)"
   assert_ref_unmoved "HEAD" "$original_head" "$migrated_head"
 )
 end_test
+
+begin_test "migrate import (multiple remotes)"
+(
+  set -e
+
+  setup_multiple_remotes
+
+  original_master="$(git rev-parse master)"
+
+  git lfs migrate import
+
+  migrated_master="$(git rev-parse master)"
+
+  assert_ref_unmoved "master" "$original_master" "$migrated_master"
+)
+end_test


### PR DESCRIPTION
This pull request passes the `--multiple` flag to `git-fetch(1)` when appropriate, i.e., when calling `git.Fetch()` with more than one remote.

When calling `git lfs migrate` (and the `--skip-fetch` option is not given) we first fetch all remote references, to make sure that we have an up-to-date copy of what is and is not present on the remote. This is done so that we can ensure that we aren't performing a migration that will later be rejected by a remote thus requiring a `--force`.

When users have multiple remotes, we will attempt to flatten that list into a single slice, and then call `git.Fetch()` once with all of the remotes. This is a correct calling convention for 0- and 1-arity arguments (none or a single remote) but is incorrect for `>1` remotes.

Specifically, if we have remotes `origin`, and `fork`, we will call `git fetch origin fork`, which tries to fetch the reference `fork` from the remote `origin`, which is likely to fail. Instead, adopt @fedde-s's recommendation in https://github.com/git-lfs/git-lfs/commit/36f3c951717772d2d91b0c91449e49222126e1ef#r29345999:

> Does this line break when more than one remote is provided, given that the main synopsis for git-fetch looks like the line below?
> 
> ```ShellSession
> git fetch [<options>] [<repository> [<refspec>...]]
> ```
>
> If so, this is probably the intended usage here:
> 
> ```ShellSession
> git fetch --multiple [<options>] [(<repository> | <group>)...]
> ```

Closes: https://github.com/git-lfs/git-lfs/issues/3052.

##

/cc @git-lfs/core 
/cc @fedde-s https://github.com/git-lfs/git-lfs/issues/3052