### PR TITLE
README.md: add link to installation wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ setup and preferences.
 
 In addition, [binary packages](https://github.com/git-lfs/git-lfs/releases) are
 available for Linux, macOS, Windows, and FreeBSD. This repository can also be
-built-from-source using the latest version of [Go](https://golang.org).
+built from source using the latest version of [Go](https://golang.org), and the
+available instructions in our
+[Wiki](https://github.com/git-lfs/git-lfs/wiki/Installation#source).
 
 ### Usage
 


### PR DESCRIPTION
This pull request adopts a suggestion from https://github.com/git-lfs/git-lfs/issues/3069 to add a link to the installation wiki page in the relevant section in the README.md.

##

/cc @git-lfs/core
/cc https://github.com/git-lfs/git-lfs/issues/3069, @avilleret