### PR TITLE
commands/track: respect global- and system-level gitattributes

### DIFF
--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -231,6 +231,7 @@ func listPatterns() {
 func getAllKnownPatterns() []git.AttributePath {
 	knownPatterns := git.GetAttributePaths(cfg.LocalWorkingDir(), cfg.LocalGitDir())
 	knownPatterns = append(knownPatterns, git.GetRootAttributePaths(cfg.Git)...)
+	knownPatterns = append(knownPatterns, git.GetSystemAttributePaths(cfg.Os)...)
 
 	return knownPatterns
 }

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -49,7 +49,7 @@ func trackCommand(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	knownPatterns := git.GetAttributePaths(cfg.LocalWorkingDir(), cfg.LocalGitDir())
+	knownPatterns := getAllKnownPatterns()
 	lineEnd := getAttributeLineEnding(knownPatterns)
 	if len(lineEnd) == 0 {
 		lineEnd = gitLineEnding(cfg.Git)
@@ -213,7 +213,7 @@ ArgsLoop:
 }
 
 func listPatterns() {
-	knownPatterns := git.GetAttributePaths(cfg.LocalWorkingDir(), cfg.LocalGitDir())
+	knownPatterns := getAllKnownPatterns()
 	if len(knownPatterns) < 1 {
 		return
 	}
@@ -226,6 +226,12 @@ func listPatterns() {
 			Print("    %s (%s)", t.Path, t.Source)
 		}
 	}
+}
+
+func getAllKnownPatterns() []git.AttributePath {
+	knownPatterns := git.GetAttributePaths(cfg.LocalWorkingDir(), cfg.LocalGitDir())
+
+	return knownPatterns
 }
 
 func getAttributeLineEnding(attribs []git.AttributePath) string {

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -230,6 +230,7 @@ func listPatterns() {
 
 func getAllKnownPatterns() []git.AttributePath {
 	knownPatterns := git.GetAttributePaths(cfg.LocalWorkingDir(), cfg.LocalGitDir())
+	knownPatterns = append(knownPatterns, git.GetRootAttributePaths(cfg.Git)...)
 
 	return knownPatterns
 }

--- a/git/attribs.go
+++ b/git/attribs.go
@@ -47,6 +47,24 @@ func GetRootAttributePaths(cfg Env) []AttributePath {
 	return attrPaths(af, "")
 }
 
+// GetSystemAttributePaths behaves as GetAttributePaths, and loads information
+// only from the system gitattributes file, respecting the $PREFIX environment
+// variable.
+func GetSystemAttributePaths(env Env) []AttributePath {
+	prefix, _ := env.Get("PREFIX")
+	if len(prefix) == 0 {
+		prefix = string(filepath.Separator)
+	}
+
+	path := filepath.Join(prefix, "etc", "gitattributes")
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil
+	}
+
+	return attrPaths(path, "")
+}
+
 // GetAttributePaths returns a list of entries in .gitattributes which are
 // configured with the filter=lfs attribute
 // workingDir is the root of the working copy

--- a/git/attribs.go
+++ b/git/attribs.go
@@ -35,6 +35,18 @@ func (s *AttributeSource) String() string {
 	return s.Path
 }
 
+// GetRootAttributePaths beahves as GetRootAttributePaths, and loads information
+// only from the global gitattributes file.
+func GetRootAttributePaths(cfg Env) []AttributePath {
+	af, ok := cfg.Get("core.attributesfile")
+	if !ok {
+		return nil
+	}
+
+	// The working directory for the root gitattributes file is blank.
+	return attrPaths(af, "")
+}
+
 // GetAttributePaths returns a list of entries in .gitattributes which are
 // configured with the filter=lfs attribute
 // workingDir is the root of the working copy

--- a/test/test-track.sh
+++ b/test/test-track.sh
@@ -576,3 +576,22 @@ begin_test "track (global gitattributes)"
   grep "*.dat" track.log
 )
 end_test
+
+begin_test "track (system gitattributes)"
+(
+  set -e
+
+  reponame="track-system-gitattributes"
+  git init "$reponame"
+  cd "$reponame"
+
+  pushd "$TRASHDIR" > /dev/null
+    mkdir -p "prefix/${reponame}/etc"
+    cd "prefix/${reponame}/etc"
+    echo "*.dat filter=lfs diff=lfs merge=lfs -text" > gitattributes
+  popd > /dev/null
+
+  PREFIX="${TRASHDIR}/prefix/${reponame}" git lfs track 2>&1 | tee track.log
+  grep "*.dat" track.log
+)
+end_test

--- a/test/test-track.sh
+++ b/test/test-track.sh
@@ -558,3 +558,21 @@ begin_test "track (with current-directory prefix)"
   grep -e "^a.dat" .gitattributes
 )
 end_test
+
+begin_test "track (global gitattributes)"
+(
+  set -e
+
+  reponame="track-global-gitattributes"
+  git init "$reponame"
+  cd "$reponame"
+
+  global="$(cd .. && pwd)/gitattributes-global"
+
+  echo "*.dat filter=lfs diff=lfs merge=lfs -text" > "$global"
+  git config --local core.attributesfile "$global"
+
+  git lfs track 2>&1 | tee track.log
+  grep "*.dat" track.log
+)
+end_test


### PR DESCRIPTION
This pull request teaches `git-lfs-track(1)` to examine both global- and system-level gitattributes files, though their use for Git LFS continues to remain discouraged.

The rationale for supporting the listing of such paths is as follows ([source](https://github.com/git-lfs/git-lfs/issues/3070)):

> I know tracking patterns in this way is discouraged because of the unintended consequences it can have with collaborators, but given that Git LFS will still end up tracking patterns that are matched in a global gitattributes file, wouldn't it be good to list them when running `git lfs track` (perhaps with a warning), rather than not listing them at all?

To accomplish this, let's do the following things:

- 44b7e44: in order to prepare for reading multiple gitattributes files from places other than the single extant loop, extract `attrPaths` to take the contents of an `io.Reader` and turn it into a list of matching attributes paths.
- f99790b: in order to prepare for calling multiple functions from package `git` in order to determine which paths are of interest, extract a wrapper function in order to add a location where we can call multiple functions as such.
- b0de5dc, 1f0214a: teach package `git` (specifically, `git/attribs.go`) how to read from the global- and system-level gitattributes locations, respectively.
- 7199215, 0cdbe90: add tests in `test/test-track.sh` in order to test this new behavior at the global- and system-level(s), respectively.

In the future, we might consider adding a denotation in the output of `git-lfs-track(1)` when listing a pattern that comes from outside the repository-local `.gitattributes` file, but we presently are unable to do this since it would involve a breaking change in the formatting of `git-lfs-track(1)`, so I am considering this a non-goal for now.

Closes: https://github.com/git-lfs/git-lfs/issues/3070.

##

/cc @git-lfs/core 
/cc https://github.com/git-lfs/git-lfs/issues/3070 @adamliter