### PR TITLE
commands/status.go: relative paths outside of root

### DIFF
--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -53,19 +53,29 @@ func statusCommand(cmd *cobra.Command, args []string) {
 		ExitWithError(err)
 	}
 
+	wd, _ := os.Getwd()
+	repo := cfg.LocalWorkingDir()
+
 	Print("\nGit LFS objects to be committed:\n")
 	for _, entry := range staged {
+		// Find a path from the current working directory to the
+		// absolute path of each side of the entry.
+		src := relativize(wd, filepath.Join(repo, entry.SrcName))
+		dst := relativize(wd, filepath.Join(repo, entry.DstName))
+
 		switch entry.Status {
 		case lfs.StatusRename, lfs.StatusCopy:
-			Print("\t%s -> %s (%s)", entry.SrcName, entry.DstName, formatBlobInfo(scanner, entry))
+			Print("\t%s -> %s (%s)", src, dst, formatBlobInfo(scanner, entry))
 		default:
-			Print("\t%s (%s)", entry.SrcName, formatBlobInfo(scanner, entry))
+			Print("\t%s (%s)", src, formatBlobInfo(scanner, entry))
 		}
 	}
 
 	Print("\nGit LFS objects not staged for commit:\n")
 	for _, entry := range unstaged {
-		Print("\t%s (%s)", entry.SrcName, formatBlobInfo(scanner, entry))
+		src := relativize(wd, filepath.Join(repo, entry.SrcName))
+
+		Print("\t%s (%s)", src, formatBlobInfo(scanner, entry))
 	}
 
 	Print("")
@@ -310,6 +320,39 @@ func porcelainStatusLine(entry *lfs.DiffIndexEntry) string {
 	}
 
 	return fmt.Sprintf("%s  %s", entry.Status, entry.SrcName)
+}
+
+// relativize relatives a path from "from" to "to". For instance, note that, for
+// any paths "from" and "to", that:
+//
+//   to == filepath.Clean(filepath.Join(from, relativize(from, to)))
+func relativize(from, to string) string {
+	if len(from) == 0 {
+		return to
+	}
+
+	flist := strings.Split(filepath.ToSlash(from), "/")
+	tlist := strings.Split(filepath.ToSlash(to), "/")
+
+	var (
+		divergence int
+		min        int
+	)
+
+	if lf, lt := len(flist), len(tlist); lf < lt {
+		min = lf
+	} else {
+		min = lt
+	}
+
+	for ; divergence < min; divergence++ {
+		if flist[divergence] != tlist[divergence] {
+			break
+		}
+	}
+
+	return strings.Repeat("../", len(flist)-divergence) +
+		strings.Join(tlist[divergence:], "/")
 }
 
 func init() {

--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -134,7 +135,7 @@ func blobInfo(s *lfs.PointerScanner, blobSha, name string) (sha, from string, er
 		return s.ContentsSha()[:7], from, nil
 	}
 
-	f, err := os.Open(name)
+	f, err := os.Open(filepath.Join(cfg.LocalWorkingDir(), name))
 	if err != nil {
 		return "", "", err
 	}

--- a/test/test-status.sh
+++ b/test/test-status.sh
@@ -119,6 +119,34 @@ begin_test "status --json"
 )
 end_test
 
+begin_test "status in a sub-directory"
+(
+  set -e
+
+  reponame="status-sub-directory"
+  git init "$reponame"
+  cd "$reponame"
+
+  git lfs track "*.dat"
+  printf "asdf" > file.dat
+  mkdir -p dir
+  git add .gitattributes file.dat
+  git commit -m "initial commit"
+
+  printf "ASDF" > file.dat
+
+  expected="On branch master
+
+Git LFS objects to be committed:
+
+
+Git LFS objects not staged for commit:
+
+	../file.dat (LFS: f0e4c2f -> File: 99b3bcf)"
+
+	[ "$expected" = "$(cd dir && git lfs status)" ]
+)
+end_test
 
 begin_test "status: outside git repository"
 (


### PR DESCRIPTION
This pull request teaches `git lfs status` how to work properly when invoked from a working directory other than the root of the repository upon which it is operating.

When `git lfs status` is invoked, we use `git-diff-index(1)` underneath in order to determine what paths in the index have changed, and what the nature of each change is. Unbeknownst to us, `git-diff-index(1)` reports paths in its output from the root of the repository, not relative to the current working directory.

So, this has two downstream effects:

1. When we print the name of a file that has changed in the index, it will be incorrect if we're not in the root of the repository. For this, we use the changes in 3d879fe in order to calculate and display a relative path.

2. If the file is unstaged (i.e., we have to load it from disk in order to read the SHA256 hash of the file in order to determine the signature change) we will try and open a file that does not exist. For this, we use the changes in 5d645c2 in order to open an absolute path instead of a relative one.

Now, the output of `git lfs status` looks like the following:

```ShellSession
$ git lfs status
On branch master

Git LFS objects to be committed:


Git LFS objects not staged for commit:

  ../file.dat (LFS: f0e4c2f -> File: 99b3bcf)"
```

Since we denote the `--porcelain` and `--json` formats of `git-lfs-status(1)` as stable and machine-readable, this bug is not fixed at those sites, in case anyone is depending on the non-relative paths. This is a good candidate for a breaking bug-fix in v3.0.0.

##

/cc @git-lfs/core 
/cc https://github.com/git-lfs/git-lfs/issues/3071, @nuxi