### PR TITLE
filepathfilter: use literal pattern when applicable

### DIFF
--- a/filepathfilter/filepathfilter.go
+++ b/filepathfilter/filepathfilter.go
@@ -151,7 +151,7 @@ func NewPattern(p string) Pattern {
 
 	msg := fmt.Sprintf("filepathfilter: rewrite %q as %q", p, pp)
 	if useLit {
-		msg = fmt.Sprintf("%s (or fallback)")
+		msg = fmt.Sprintf("%s (or fallback)", msg)
 	}
 	tracerx.Printf(msg)
 

--- a/filepathfilter/filepathfilter.go
+++ b/filepathfilter/filepathfilter.go
@@ -1,6 +1,7 @@
 package filepathfilter
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -78,13 +79,20 @@ func (f *Filter) Allows(filename string) bool {
 }
 
 type wm struct {
-	w    *wildmatch.Wildmatch
-	p    string
-	dirs bool
+	w, lit *wildmatch.Wildmatch
+	p      string
+	useLit bool
+	dirs   bool
 }
 
 func (w *wm) Match(filename string) bool {
-	return w.w.Match(w.chomp(filename))
+	filename = w.chomp(filename)
+	if w.useLit {
+		if w.lit.Match(filename) {
+			return true
+		}
+	}
+	return w.w.Match(filename)
 }
 
 func (w *wm) chomp(filename string) string {
@@ -109,6 +117,7 @@ func NewPattern(p string) Pattern {
 		pp = join("**", "*")
 	}
 
+	var useLit bool
 	dirs := strings.Contains(pp, string(sep))
 	rooted := strings.HasPrefix(pp, string(sep))
 	wild := strings.Contains(pp, "*")
@@ -117,6 +126,7 @@ func NewPattern(p string) Pattern {
 		// Special case: if pp is a literal string (optionally including
 		// a character class), rewrite it is a substring match.
 		pp = join("**", pp, "**")
+		useLit = true
 	} else {
 		if dirs && !rooted {
 			// Special case: if there are any directory separators,
@@ -138,15 +148,19 @@ func NewPattern(p string) Pattern {
 			}
 		}
 	}
-	tracerx.Printf("filepathfilter: rewrite %q as %q", p, pp)
+
+	msg := fmt.Sprintf("filepathfilter: rewrite %q as %q", p, pp)
+	if useLit {
+		msg = fmt.Sprintf("%s (or fallback)")
+	}
+	tracerx.Printf(msg)
 
 	return &wm{
-		p: p,
-		w: wildmatch.NewWildmatch(
-			pp,
-			wildmatch.SystemCase,
-		),
-		dirs: dirs,
+		p:      p,
+		useLit: useLit,
+		w:      wildmatch.NewWildmatch(pp, wildmatch.SystemCase),
+		lit:    wildmatch.NewWildmatch(p, wildmatch.SystemCase),
+		dirs:   dirs,
 	}
 }
 

--- a/test/test-pull.sh
+++ b/test/test-pull.sh
@@ -145,6 +145,39 @@ begin_test "pull"
 )
 end_test
 
+begin_test "pull (literal --include)"
+(
+  set -e
+
+  reponame="pull-include-literal"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  mkdir -p a/b/c
+  printf "d" > a/b/c/d.dat
+  printf "e" > a/b/c/e.dat
+
+  git lfs track 'a/b/c/*.dat'
+  git add .gitattributes
+  git add a/b/c/d.dat
+  git add a/b/c/e.dat
+
+  git commit -m "initial commit"
+  git push origin master
+
+  cd ..
+  rm -rf "$reponame"
+  GIT_LFS_SKIP_SMUDGE=1 git clone $GITSERVER/$reponame
+
+  cd "$reponame"
+
+  git lfs pull --include=a/b/c/d.dat
+
+  [ "d" = "$(cat a/b/c/d.dat)" ]
+  [ "e" != "$(cat a/b/c/e.dat)" ]
+)
+end_test
+
 begin_test "pull without clean filter"
 (
   set -e


### PR DESCRIPTION
This pull request teaches package `filepathfilter` to use the literal pattern given to `--include`, `--exclude` (or similar) when appropriate in order to retain backwards compatibility with versions earlier than v2.4.0.

In the v2.3.0 and earlier, a pattern like `a/b/c.dat` would be matched using the following code:

https://github.com/git-lfs/git-lfs/blob/4dd2bf73d7819733f7d8cc29a8e8404fc0552242/filepathfilter/filepathfilter.go#L248-L256

Which means that, in practice--on that version--files would be matched when they either are (1) in a directory called `a/b/c.dat`, (2) in a parent-directory and contain that name i.e., `d/e/a/b/c.dat`, or (3) are _equal_ (among other things, and using `filepath.Match`) to the given pattern.

In v2.4.0 and later, we rewrote patterns `P` of that form to `**/P/**`, retaining behaviors (1) and (2). However, this matches too much to be strictly equivalent to (3), so we tighten the restriction as follows:

If we have a pattern `P` that would be rewritten using the above rules, mark that we would like to fallback to the literal pattern given, and attempt to run that pattern first. This _won't_ match files with `[`-style character classes in its name, but this is consistent with the earlier behavior.

If there is a match, don't attempt to search further, i.e., don't include sibling or children files in the match.

Therefore, this change makes package `filepathfilter` behaviorally equivalent to what it previously was.

##

/cc @git-lfs/core 
/cc https://github.com/git-lfs/git-lfs/issues/3072, @goodtune