### PR TITLE
Run `go generate` on commands in deb build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -32,6 +32,7 @@ override_dh_clean:
 	dh_clean
 
 override_dh_auto_build:
+	cd ${BUILD_DIR}/src/github.com/git-lfs/git-lfs && go generate ./commands
 	dh_auto_build
 	#dh_golang doesn't do anything here in deb 8, and it's needed in both
 	if [ "$(DEB_HOST_GNU_TYPE)" != "$(DEB_BUILD_GNU_TYPE)" ]; then\


### PR DESCRIPTION
The deb packages don't currently run `go generate` when building which
means commands like `git-lfs help` don't work properly.  This changes
the packaging script to run it.

Fixes #3043