### PR TITLE
Encoded characters in pathnames

### DIFF
--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -111,7 +111,8 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 
 // Returns true if a pointer appears to be properly smudge on checkout
 func fileExistsOfSize(p *lfs.WrappedPointer) bool {
-	info, err := os.Stat(p.Name)
+	path := cfg.Filesystem().DecodePathname(p.Name)
+	info, err := os.Stat(path)
 	return err == nil && info.Size() == p.Size
 }
 

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -3,24 +3,24 @@ package fs
 import "testing"
 
 func TestDecodeNone(t *testing.T) {
-    evaluate(t, "A:\\some\\regular\\windows\\path", "A:\\some\\regular\\windows\\path")
+	evaluate(t, "A:\\some\\regular\\windows\\path", "A:\\some\\regular\\windows\\path")
 }
 
 func TestDecodeSingle(t *testing.T) {
-    evaluate(t, "A:\\bl\\303\\204\\file.txt", "A:\\blÄ\\file.txt")
+	evaluate(t, "A:\\bl\\303\\204\\file.txt", "A:\\blÄ\\file.txt")
 }
 
 func TestDecodeMultiple(t *testing.T) {
-    evaluate(t, "A:\\fo\\130\\file\\303\\261.txt", "A:\\fo\130\\file\303\261.txt")
+	evaluate(t, "A:\\fo\\130\\file\\303\\261.txt", "A:\\fo\130\\file\303\261.txt")
 }
 
 func evaluate(t *testing.T, input string, expected string) {
-	
-	fs := Filesystem {}
+
+	fs := Filesystem{}
 	output := fs.DecodePathname(input)
-	
+
 	if output != expected {
-       t.Errorf("Expecting same path, got: %s, want: %s.", output, expected)
-    }
-	
+		t.Errorf("Expecting same path, got: %s, want: %s.", output, expected)
+	}
+
 }

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -1,0 +1,26 @@
+package fs
+
+import "testing"
+
+func TestDecodeNone(t *testing.T) {
+    evaluate(t, "A:\\some\\regular\\windows\\path", "A:\\some\\regular\\windows\\path")
+}
+
+func TestDecodeSingle(t *testing.T) {
+    evaluate(t, "A:\\bl\\303\\204\\file.txt", "A:\\blÄ\\file.txt")
+}
+
+func TestDecodeMultiple(t *testing.T) {
+    evaluate(t, "A:\\fo\\130\\file\\303\\261.txt", "A:\\fo\130\\file\303\261.txt")
+}
+
+func evaluate(t *testing.T, input string, expected string) {
+	
+	fs := Filesystem {}
+	output := fs.DecodePathname(input)
+	
+	if output != expected {
+       t.Errorf("Expecting same path, got: %s, want: %s.", output, expected)
+    }
+	
+}

--- a/test/test-ls-files.sh
+++ b/test/test-ls-files.sh
@@ -329,3 +329,36 @@ begin_test "ls-files: invalid --all ordering"
   grep "Could not scan for Git LFS tree" ls-files.out
 )
 end_test
+
+begin_test "ls-files: list/stat files with escaped runes in path before commit"
+(
+  set -e
+
+  reponame=runes-in-path
+  content="zero"
+  checksum="d3eb539a55"
+  pathWithGermanRunes="german/äöü"
+  fileWithGermanRunes="schüüch.bin"
+  
+  mkdir $reponame
+  git init "$reponame"
+  cd $reponame
+  git lfs track "**/*"
+
+  echo "$content" > regular
+  echo "$content" > "$fileWithGermanRunes"
+
+  mkdir -p "$pathWithGermanRunes"
+  echo "$content" > "$pathWithGermanRunes/regular"
+  echo "$content" > "$pathWithGermanRunes/$fileWithGermanRunes"
+  
+  git add *
+
+  # check short form
+  [ 4 -eq "$(git lfs ls-files | grep -c '*')" ]
+
+  # also check long format
+  [ 4 -eq "$(git lfs ls-files -l | grep -c '*')" ]
+   
+)
+end_test


### PR DESCRIPTION
### Symptom
`git lfs ls-files` lists uncommited files containing escaped runes in their pathname as **not added** even if they  will be added on commit.

````sh
git add "foo/*"
git status 
     new file:   "foo/Pr\303\244sentation.txt"
     new file:   foo/Regularname
git lfs ls-files
     70f78f04ee - "foo/Pr\303\244sentation.txt"   <-- Error! File should be marked with * like 'Regularname
     ae32d82ae1 * foo/Regularname
git commit
git lfs ls-files
     70f78f04ee * foo/Präsentation.pdf
     ae32d82ae1 * foo/Regularname
````

### Cause
`os.Stat(path)` in `commands/command_ls_files.go(114)` does not find files when the path contains escaped runes. For example: "foo/Pr\303\244sentation.txt"

### Fix
Parse escaped runes and replace with the corresponding byte value.

### Remaining Work
Check if needed in other places, where `lfs.WrappedPointer.Name` is used to access files.

