### PR TITLE
config/config.go: case-insensitive error search

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -295,7 +295,8 @@ func (c *Configuration) loadGitDirs() {
 	if err != nil {
 		errMsg := err.Error()
 		tracerx.Printf("Error running 'git rev-parse': %s", errMsg)
-		if !strings.Contains(errMsg, "Not a git repository") {
+		if !strings.Contains(strings.ToLower(errMsg),
+			"not a git repository") {
 			fmt.Fprintf(os.Stderr, "Error: %s\n", errMsg)
 		}
 		c.gitDir = &gitdir


### PR DESCRIPTION
In the internal function loadGitDirs, Git LFS will attempt to resolve
the working and dotgit directory by calling 'git rev-parse --git-dir
--show-top-level'.

This information is used in the output of 'git lfs env', which displays
information about the system- and repository-level configuration as it
pertains to Git LFS.

However, when 'git lfs env' is called outside of the repository, any
information that is repository-specific is left blank. For example,

    $ git lfs env
    git-lfs/2.4.0 (GitHub; darwin amd64; go 1.10.3)
    git version: 2.18.0

    LocalWorkingDir=

We ``silence'' the error coming from 'git-rev-parse(1)' in loadGitDirs
by looking for the string "Not a git repository". If we found that
string, we don't show the error message on STDERR (because it is OK not
to), but if we fail to find that string, we assume that the error is
legitimate and thusly forward it on to STDERR.

This string changed casing in [1], so we make a corresponding change
here in order to catch the casing on all versions of Git (by making the
comparison case-insensitive).

[1]: git/git@fc045fe7d4 (Mark messages for translations, 2018-02-13)

##

Closes: https://github.com/git-lfs/git-lfs/issues/3097

##

/cc @git-lfs/core 
/cc @zeyuanzhang https://github.com/git-lfs/git-lfs/issues/3097