### PR TITLE
lfsapi/ssh.go: use zero-value sentinels

### DIFF
--- a/lfsapi/ssh.go
+++ b/lfsapi/ssh.go
@@ -59,22 +59,15 @@ type sshAuthResponse struct {
 	Message   string            `json:"-"`
 	Href      string            `json:"href"`
 	Header    map[string]string `json:"header"`
-	ExpiresAt *time.Time        `json:"expires_at"`
-	ExpiresIn *int              `json:"expires_in"`
+	ExpiresAt time.Time         `json:"expires_at"`
+	ExpiresIn int               `json:"expires_in"`
 
 	createdAt time.Time
 }
 
 func (r *sshAuthResponse) IsExpiredWithin(d time.Duration) (time.Time, bool) {
-	expiresAt := time.Time{}
-	if r.ExpiresAt != nil {
-		expiresAt = *r.ExpiresAt
-	}
-	expiresIn := 0
-	if r.ExpiresIn != nil {
-		expiresIn = *r.ExpiresIn
-	}
-	return tools.IsExpiredAtOrIn(r.createdAt, d, expiresAt, time.Duration(expiresIn)*time.Second)
+	return tools.IsExpiredAtOrIn(r.createdAt, d, r.ExpiresAt,
+		time.Duration(r.ExpiresIn)*time.Second)
 }
 
 type sshAuthClient struct {
@@ -109,12 +102,12 @@ func (c *sshAuthClient) Resolve(e Endpoint, method string) (sshAuthResponse, err
 		res.Message = strings.TrimSpace(errbuf.String())
 	} else {
 		err = json.Unmarshal(outbuf.Bytes(), &res)
-		if res.ExpiresIn == nil && res.ExpiresAt == nil {
+		if res.ExpiresIn == 0 && res.ExpiresAt.IsZero() {
 			ttl := c.git.Int("lfs.defaulttokenttl", 0)
 			if ttl < 0 {
 				ttl = 0
 			}
-			res.ExpiresIn = &ttl
+			res.ExpiresIn = ttl
 		}
 		res.createdAt = now
 	}


### PR DESCRIPTION
Instead of storing the ExpiresAt and ExpiresIn fields as a *time.Time,
and *int, respectively, use a time.Time and int instead.

Later, in the zero-value comparison, change from != nil to != 0 and
time.Time.IsZero(), respectively.

This has the effect of ridding the API of setting expires_in to zero,
and will fall-back to the default expiration offset, after which it will
retry, or fail the underlying request. We don't have precise
determinations on how many API requests this will affect, but it's
certainly not common usage of the specification, so the behavior change
is OK.

##

/cc @git-lfs/core 