### PR TITLE
config/git_fetcher.go: mark 'lfs.allowincompletepush' as safe

### DIFF
--- a/config/git_fetcher.go
+++ b/config/git_fetcher.go
@@ -158,6 +158,7 @@ func keyIsUnsafe(key string) bool {
 }
 
 var safeKeys = []string{
+	"lfs.allowincompletepush",
 	"lfs.fetchexclude",
 	"lfs.fetchinclude",
 	"lfs.gitprotocol",


### PR DESCRIPTION
In config/git_fetcher.go, we have special rules to mark certain Git
configuration keys as safe or unsafe.

Particularly, we apply these rules strictly to all values fetched from
the repository-local .lfsconfig, since it is distributed to all fetchers
of a repository and provides a widely available attack-vector.
Therefore, we only allow a tiny subset of all keys via the keyIsUnsafe
function and safeKeys slice.

The 'lfs.allowincompletepush' configuration determines whether or not a
user should be allowed to push a repository that has missing LFS objects
to a remote.

Previously, it was ignored with the following message:

    $ git push repo_clone repo_orig_master
    WARNING: These unsafe lfsconfig keys were ignored:

      lfs.allowincompletepush

In [1], Lars changed the default from 'true' to 'false'. In order to
allow users or repository maintainers to retain the prior behavior,
let's let them distribute this configuration from the repository's
.lfsconfig and thusly mark it as safe.

[1]: https://github.com/git-lfs/git-lfs/pull/3109

##

/cc @git-lfs/core @larsxschneider 
/cc @jokram https://github.com/git-lfs/git-lfs/issues/3105#issuecomment-402950469