### PR TITLE
commands/migrate: infer wildmatches with --fixup

### DIFF
--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -102,8 +102,9 @@ func rewriteOptions(args []string, opts *githistory.RewriteOptions, l *tasklog.L
 		Verbose:           opts.Verbose,
 		ObjectMapFilePath: opts.ObjectMapFilePath,
 
-		BlobFn:         opts.BlobFn,
-		TreeCallbackFn: opts.TreeCallbackFn,
+		BlobFn:            opts.BlobFn,
+		TreePreCallbackFn: opts.TreePreCallbackFn,
+		TreeCallbackFn:    opts.TreeCallbackFn,
 	}, nil
 }
 

--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -91,6 +91,13 @@ options and these additional ones:
     become available, and the core `migrate` options will be ignored. See
     [IMPORT (NO REWRITE)].
 
+* `--fixup`
+    Infer `--include` and `--exclude` filters on a per-commit basis based on the
+    .gitattributes files in a repository. In practice, this option ``fixes'' a
+    repository over the commit range specified without requiring guidance from
+    the user. This option is incompatible with explicitly given `--include`,
+    `--exclude` filters.
+
 If `--no-rewrite` is not provided and `--include` or `--exclude` (`-I`, `-X`,
 respectively) are given, the .gitattributes will be modified to include any new
 filepath patterns as given by those flags.
@@ -248,7 +255,7 @@ Note: This will require a force push to any existing Git remotes.
 
 You can also migrate files without modifying the existing history of your respoitory:
 
-Without a specified commit message: 
+Without a specified commit message:
 ```
     git lfs migrate import --no-rewrite test.zip *.mp3 *.psd
 ```

--- a/git/gitattr/attr.go
+++ b/git/gitattr/attr.go
@@ -1,0 +1,129 @@
+package gitattr
+
+import (
+	"bufio"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/git-lfs/git-lfs/errors"
+	"github.com/git-lfs/wildmatch"
+)
+
+// Line carries a single line from a repository's .gitattributes file, affecting
+// a single pattern and applying zero or more attributes.
+type Line struct {
+	// Pattern is a wildmatch pattern that, when matched, indicates that all
+	// of the below attributes (Attrs) should be applied to that tree entry.
+	//
+	// Pattern is relative to the tree in which the .gitattributes was read
+	// from. For example, /.gitattributes affects all blobs in the
+	// repository, while /path/to/.gitattributes affects all blobs that are
+	// direct or indirect children of /path/to.
+	Pattern *wildmatch.Wildmatch
+	// Attrs is the list of attributes to be applied when the above pattern
+	// matches a given filename.
+	//
+	// It is populated in-order as it was written in the .gitattributes file
+	// being read, from left to right.
+	Attrs []*Attr
+}
+
+// Attr is a single attribute that may be applied to a file.
+type Attr struct {
+	// K is the name of the attribute. It is commonly, "filter", "diff",
+	// "merge", or "text".
+	//
+	// It will never contain the special "false" shorthand ("-"), or the
+	// unspecify declarative ("!").
+	K string
+	// V is the value held by that attribute. It is commonly "lfs", or
+	// "false", indicating the special value given by a "-"-prefixed name.
+	V string
+	// Unspecified indicates whether or not this attribute was explicitly
+	// unset by prefixing the keyname with "!".
+	Unspecified bool
+}
+
+// ParseLines parses the given io.Reader "r" line-wise as if it were the
+// contents of a .gitattributes file.
+//
+// If an error was encountered, it will be returned and the []*Line should be
+// considered unusable.
+func ParseLines(r io.Reader) ([]*Line, error) {
+	var lines []*Line
+
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+
+		text := strings.TrimSpace(scanner.Text())
+		if len(text) == 0 {
+			continue
+		}
+
+		var pattern string
+		var applied string
+
+		switch text[0] {
+		case '#':
+			continue
+		case '"':
+			var err error
+			last := strings.LastIndex(text, "\"")
+			if last == 0 {
+				return nil, errors.Errorf("git/gitattr: unbalanced quote: %s", text)
+			}
+			pattern, err = strconv.Unquote(text[:last+1])
+			if err != nil {
+				return nil, errors.Wrapf(err, "git/gitattr")
+			}
+			applied = strings.TrimSpace(text[last+1:])
+		default:
+			splits := strings.SplitN(text, " ", 2)
+
+			pattern = splits[0]
+			if len(splits) == 2 {
+				applied = splits[1]
+			}
+		}
+
+		var attrs []*Attr
+
+		for _, s := range strings.Split(applied, " ") {
+			if s == "" {
+				continue
+			}
+
+			var attr Attr
+
+			if strings.HasPrefix(s, "-") {
+				attr.K = strings.TrimPrefix(s, "-")
+				attr.V = "false"
+			} else if strings.HasPrefix(s, "!") {
+				attr.K = strings.TrimPrefix(s, "!")
+				attr.Unspecified = true
+			} else {
+				splits := strings.SplitN(s, "=", 2)
+				if len(splits) != 2 {
+					return nil, errors.Errorf("git/gitattr: malformed attribute: %s", s)
+				}
+				attr.K = splits[0]
+				attr.V = splits[1]
+			}
+
+			attrs = append(attrs, &attr)
+		}
+
+		lines = append(lines, &Line{
+			Pattern: wildmatch.NewWildmatch(pattern,
+				wildmatch.Basename, wildmatch.SystemCase,
+			),
+			Attrs: attrs,
+		})
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return lines, nil
+}

--- a/git/gitattr/attr_test.go
+++ b/git/gitattr/attr_test.go
@@ -1,0 +1,134 @@
+package gitattr
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseLines(t *testing.T) {
+	lines, err := ParseLines(strings.NewReader("*.dat filter=lfs"))
+
+	assert.NoError(t, err)
+	assert.Len(t, lines, 1)
+
+	assert.Equal(t, lines[0].Pattern.String(), "*.dat")
+	assert.Equal(t, lines[0].Attrs[0], &Attr{
+		K: "filter", V: "lfs",
+	})
+}
+
+func TestParseLinesManyAttrs(t *testing.T) {
+	lines, err := ParseLines(strings.NewReader(
+		"*.dat filter=lfs diff=lfs merge=lfs -text"))
+
+	assert.NoError(t, err)
+
+	assert.Len(t, lines, 1)
+	assert.Equal(t, lines[0].Pattern.String(), "*.dat")
+
+	assert.Len(t, lines[0].Attrs, 4)
+	assert.Equal(t, lines[0].Attrs[0], &Attr{K: "filter", V: "lfs"})
+	assert.Equal(t, lines[0].Attrs[1], &Attr{K: "diff", V: "lfs"})
+	assert.Equal(t, lines[0].Attrs[2], &Attr{K: "merge", V: "lfs"})
+	assert.Equal(t, lines[0].Attrs[3], &Attr{K: "text", V: "false"})
+}
+
+func TestParseLinesManyLines(t *testing.T) {
+	lines, err := ParseLines(strings.NewReader(strings.Join([]string{
+		"*.dat filter=lfs diff=lfs merge=lfs -text",
+		"*.jpg filter=lfs diff=lfs merge=lfs -text",
+		"# *.pdf filter=lfs diff=lfs merge=lfs -text",
+		"*.png filter=lfs diff=lfs merge=lfs -text"}, "\n")))
+
+	assert.NoError(t, err)
+
+	assert.Len(t, lines, 3)
+	assert.Equal(t, lines[0].Pattern.String(), "*.dat")
+	assert.Equal(t, lines[1].Pattern.String(), "*.jpg")
+	assert.Equal(t, lines[2].Pattern.String(), "*.png")
+
+	assert.Len(t, lines[0].Attrs, 4)
+	assert.Equal(t, lines[0].Attrs[0], &Attr{K: "filter", V: "lfs"})
+	assert.Equal(t, lines[0].Attrs[1], &Attr{K: "diff", V: "lfs"})
+	assert.Equal(t, lines[0].Attrs[2], &Attr{K: "merge", V: "lfs"})
+	assert.Equal(t, lines[0].Attrs[3], &Attr{K: "text", V: "false"})
+
+	assert.Len(t, lines[1].Attrs, 4)
+	assert.Equal(t, lines[1].Attrs[0], &Attr{K: "filter", V: "lfs"})
+	assert.Equal(t, lines[1].Attrs[1], &Attr{K: "diff", V: "lfs"})
+	assert.Equal(t, lines[1].Attrs[2], &Attr{K: "merge", V: "lfs"})
+	assert.Equal(t, lines[1].Attrs[3], &Attr{K: "text", V: "false"})
+
+	assert.Len(t, lines[1].Attrs, 4)
+	assert.Equal(t, lines[1].Attrs[0], &Attr{K: "filter", V: "lfs"})
+	assert.Equal(t, lines[1].Attrs[1], &Attr{K: "diff", V: "lfs"})
+	assert.Equal(t, lines[1].Attrs[2], &Attr{K: "merge", V: "lfs"})
+	assert.Equal(t, lines[1].Attrs[3], &Attr{K: "text", V: "false"})
+}
+
+func TestParseLinesUnset(t *testing.T) {
+	lines, err := ParseLines(strings.NewReader("*.dat -filter"))
+
+	assert.NoError(t, err)
+	assert.Len(t, lines, 1)
+
+	assert.Equal(t, lines[0].Pattern.String(), "*.dat")
+	assert.Equal(t, lines[0].Attrs[0], &Attr{
+		K: "filter", V: "false",
+	})
+}
+
+func TestParseLinesUnspecified(t *testing.T) {
+	lines, err := ParseLines(strings.NewReader("*.dat !filter"))
+
+	assert.NoError(t, err)
+	assert.Len(t, lines, 1)
+
+	assert.Equal(t, lines[0].Pattern.String(), "*.dat")
+	assert.Equal(t, lines[0].Attrs[0], &Attr{
+		K: "filter", Unspecified: true,
+	})
+}
+
+func TestParseLinesQuotedPattern(t *testing.T) {
+	lines, err := ParseLines(strings.NewReader(
+		"\"space *.dat\" filter=lfs"))
+
+	assert.NoError(t, err)
+	assert.Len(t, lines, 1)
+
+	assert.Equal(t, lines[0].Pattern.String(), "space *.dat")
+	assert.Equal(t, lines[0].Attrs[0], &Attr{
+		K: "filter", V: "lfs",
+	})
+}
+
+func TestParseLinesCommented(t *testing.T) {
+	lines, err := ParseLines(strings.NewReader(
+		"# \"space *.dat\" filter=lfs"))
+
+	assert.NoError(t, err)
+	assert.Len(t, lines, 0)
+}
+
+func TestParseLinesUnbalancedQuotes(t *testing.T) {
+	const text = "\"space *.dat filter=lfs"
+	lines, err := ParseLines(strings.NewReader(text))
+
+	assert.Empty(t, lines)
+	assert.EqualError(t, err, fmt.Sprintf(
+		"git/gitattr: unbalanced quote: %s", text))
+}
+
+func TestParseLinesWithNoAttributes(t *testing.T) {
+	lines, err := ParseLines(strings.NewReader("*.dat"))
+
+	assert.Len(t, lines, 1)
+	assert.NoError(t, err)
+
+	assert.Equal(t, lines[0].Pattern.String(), "*.dat")
+	assert.Empty(t, lines[0].Attrs)
+}

--- a/git/gitattr/tree.go
+++ b/git/gitattr/tree.go
@@ -1,0 +1,104 @@
+package gitattr
+
+import (
+	"strings"
+
+	"github.com/git-lfs/gitobj"
+)
+
+// Tree represents the .gitattributes file at one layer of the tree in a Git
+// repository.
+type Tree struct {
+	// Lines are the lines of the .gitattributes at this level of the tree.
+	Lines []*Line
+	// Children are the named child directories in the repository.
+	Children map[string]*Tree
+}
+
+// New constructs a *Tree starting at the given tree "t" and reading objects
+// from the given ObjectDatabase. If a tree was not able to be read, an error
+// will be propagated up accordingly.
+func New(db *gitobj.ObjectDatabase, t *gitobj.Tree) (*Tree, error) {
+	children := make(map[string]*Tree)
+	lines, err := linesInTree(db, t)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, entry := range t.Entries {
+		if entry.Type() != gitobj.TreeObjectType {
+			continue
+		}
+
+		// For every entry in the current tree, parse its sub-trees to
+		// see if they might contain a .gitattributes.
+		t, err := db.Tree(entry.Oid)
+		if err != nil {
+			return nil, err
+		}
+
+		at, err := New(db, t)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(at.Children) > 0 || len(at.Lines) > 0 {
+			// Only include entries that have either (1) a
+			// .gitattributes in their tree, or (2) a .gitattributes
+			// in a sub-tree.
+			children[entry.Name] = at
+		}
+	}
+
+	return &Tree{
+		Lines:    lines,
+		Children: children,
+	}, nil
+}
+
+// linesInTree parses a given tree's .gitattributes and returns a slice of lines
+// in that .gitattributes, or an error. If no .gitattributes blob was found,
+// return nil.
+func linesInTree(db *gitobj.ObjectDatabase, t *gitobj.Tree) ([]*Line, error) {
+	var at int = -1
+	for i, e := range t.Entries {
+		if e.Name == ".gitattributes" {
+			at = i
+			break
+		}
+	}
+
+	if at < 0 {
+		return nil, nil
+	}
+
+	blob, err := db.Blob(t.Entries[at].Oid)
+	if err != nil {
+		return nil, err
+	}
+	defer blob.Close()
+
+	return ParseLines(blob.Contents)
+}
+
+// Applied returns a slice of attributes applied to the given path, relative to
+// the receiving tree. It traverse through sub-trees in a topological ordering,
+// if there are relevant .gitattributes matching that path.
+func (t *Tree) Applied(to string) []*Attr {
+	var attrs []*Attr
+	for _, line := range t.Lines {
+		if line.Pattern.Match(to) {
+			attrs = append(attrs, line.Attrs...)
+		}
+	}
+
+	splits := strings.SplitN(to, "/", 2)
+	if len(splits) == 2 {
+		car, cdr := splits[0], splits[1]
+		if child, ok := t.Children[car]; ok {
+			attrs = append(attrs, child.Applied(cdr)...)
+		}
+	}
+
+	return attrs
+}

--- a/git/gitattr/tree_test.go
+++ b/git/gitattr/tree_test.go
@@ -1,0 +1,246 @@
+package gitattr
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/git-lfs/gitobj"
+	"github.com/git-lfs/wildmatch"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	dat = wildmatch.NewWildmatch("*.dat",
+		wildmatch.Basename,
+		wildmatch.SystemCase)
+
+	example = &Tree{
+		Lines: []*Line{{
+			Pattern: dat,
+			Attrs: []*Attr{
+				{
+					K: "filter", V: "lfs",
+				},
+				{
+					K: "diff", V: "lfs",
+				},
+				{
+					K: "merge", V: "lfs",
+				},
+				{
+					K: "text", V: "false",
+				},
+			},
+		}},
+		Children: map[string]*Tree{
+			"subdir": &Tree{
+				Lines: []*Line{{
+					Pattern: dat,
+					Attrs: []*Attr{
+						{
+							K: "subdir", V: "yes",
+						},
+					},
+				}},
+			},
+		},
+	}
+)
+
+func TestTreeAppliedInRoot(t *testing.T) {
+	attrs := example.Applied("a.dat")
+
+	assert.Len(t, attrs, 4)
+	assert.Equal(t, attrs[0], &Attr{K: "filter", V: "lfs"})
+	assert.Equal(t, attrs[1], &Attr{K: "diff", V: "lfs"})
+	assert.Equal(t, attrs[2], &Attr{K: "merge", V: "lfs"})
+	assert.Equal(t, attrs[3], &Attr{K: "text", V: "false"})
+}
+
+func TestTreeAppliedInSubtreeRelevant(t *testing.T) {
+	attrs := example.Applied("subdir/a.dat")
+
+	assert.Len(t, attrs, 5)
+	assert.Equal(t, attrs[0], &Attr{K: "filter", V: "lfs"})
+	assert.Equal(t, attrs[1], &Attr{K: "diff", V: "lfs"})
+	assert.Equal(t, attrs[2], &Attr{K: "merge", V: "lfs"})
+	assert.Equal(t, attrs[3], &Attr{K: "text", V: "false"})
+	assert.Equal(t, attrs[4], &Attr{K: "subdir", V: "yes"})
+}
+
+func TestTreeAppliedInSubtreeIrrelevant(t *testing.T) {
+	attrs := example.Applied("subdir/a.txt")
+
+	assert.Empty(t, attrs)
+}
+
+func TestTreeAppliedInIrrelevantSubtree(t *testing.T) {
+	attrs := example.Applied("other/subdir/a.dat")
+
+	assert.Len(t, attrs, 4)
+	assert.Equal(t, attrs[0], &Attr{K: "filter", V: "lfs"})
+	assert.Equal(t, attrs[1], &Attr{K: "diff", V: "lfs"})
+	assert.Equal(t, attrs[2], &Attr{K: "merge", V: "lfs"})
+	assert.Equal(t, attrs[3], &Attr{K: "text", V: "false"})
+}
+
+func TestNewDiscoversSimpleTrees(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+	defer os.Remove(tmp)
+
+	db, err := gitobj.FromFilesystem(tmp, "")
+	require.NoError(t, err)
+	defer db.Close()
+
+	blob, err := db.WriteBlob(gitobj.NewBlobFromBytes([]byte(`
+		*.dat filter=lfs diff=lfs merge=lfs -text
+	`)))
+	require.NoError(t, err)
+
+	tree, err := New(db, &gitobj.Tree{Entries: []*gitobj.TreeEntry{
+		{
+			Name:     ".gitattributes",
+			Oid:      blob,
+			Filemode: 0100644,
+		},
+	}})
+	require.NoError(t, err)
+
+	attrs := tree.Applied("foo.dat")
+
+	assert.Len(t, attrs, 4)
+	assert.Equal(t, attrs[0], &Attr{K: "filter", V: "lfs"})
+	assert.Equal(t, attrs[1], &Attr{K: "diff", V: "lfs"})
+	assert.Equal(t, attrs[2], &Attr{K: "merge", V: "lfs"})
+	assert.Equal(t, attrs[3], &Attr{K: "text", V: "false"})
+}
+
+func TestNewDiscoversSimpleChildrenTrees(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+	defer os.Remove(tmp)
+
+	db, err := gitobj.FromFilesystem(tmp, "")
+	require.NoError(t, err)
+	defer db.Close()
+
+	blob, err := db.WriteBlob(gitobj.NewBlobFromBytes([]byte(`
+		*.dat filter=lfs diff=lfs merge=lfs -text
+	`)))
+	require.NoError(t, err)
+
+	child, err := db.WriteTree(&gitobj.Tree{Entries: []*gitobj.TreeEntry{
+		{
+			Name:     ".gitattributes",
+			Oid:      blob,
+			Filemode: 0100644,
+		},
+	}})
+
+	tree, err := New(db, &gitobj.Tree{Entries: []*gitobj.TreeEntry{
+		{
+			Name:     "child",
+			Oid:      child,
+			Filemode: 040000,
+		},
+	}})
+	require.NoError(t, err)
+
+	attrs := tree.Applied("child/foo.dat")
+
+	assert.Len(t, attrs, 4)
+	assert.Equal(t, attrs[0], &Attr{K: "filter", V: "lfs"})
+	assert.Equal(t, attrs[1], &Attr{K: "diff", V: "lfs"})
+	assert.Equal(t, attrs[2], &Attr{K: "merge", V: "lfs"})
+	assert.Equal(t, attrs[3], &Attr{K: "text", V: "false"})
+}
+
+func TestNewDiscoversIndirectChildrenTrees(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+	defer os.Remove(tmp)
+
+	db, err := gitobj.FromFilesystem(tmp, "")
+	require.NoError(t, err)
+	defer db.Close()
+
+	blob, err := db.WriteBlob(gitobj.NewBlobFromBytes([]byte(`
+		*.dat filter=lfs diff=lfs merge=lfs -text
+	`)))
+	require.NoError(t, err)
+
+	indirect, err := db.WriteTree(&gitobj.Tree{Entries: []*gitobj.TreeEntry{
+		{
+			Name:     ".gitattributes",
+			Oid:      blob,
+			Filemode: 0100644,
+		},
+	}})
+
+	child, err := db.WriteTree(&gitobj.Tree{Entries: []*gitobj.TreeEntry{
+		{
+			Name:     "indirect",
+			Oid:      indirect,
+			Filemode: 040000,
+		},
+	}})
+
+	tree, err := New(db, &gitobj.Tree{Entries: []*gitobj.TreeEntry{
+		{
+			Name:     "child",
+			Oid:      child,
+			Filemode: 040000,
+		},
+	}})
+	require.NoError(t, err)
+
+	attrs := tree.Applied("child/indirect/foo.dat")
+
+	assert.Len(t, attrs, 4)
+	assert.Equal(t, attrs[0], &Attr{K: "filter", V: "lfs"})
+	assert.Equal(t, attrs[1], &Attr{K: "diff", V: "lfs"})
+	assert.Equal(t, attrs[2], &Attr{K: "merge", V: "lfs"})
+	assert.Equal(t, attrs[3], &Attr{K: "text", V: "false"})
+}
+
+func TestNewIgnoresChildrenAppropriately(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+	defer os.Remove(tmp)
+
+	db, err := gitobj.FromFilesystem(tmp, "")
+	require.NoError(t, err)
+	defer db.Close()
+
+	blob, err := db.WriteBlob(gitobj.NewBlobFromBytes([]byte(`
+		*.dat filter=lfs diff=lfs merge=lfs -text
+	`)))
+	require.NoError(t, err)
+
+	child, err := db.WriteTree(&gitobj.Tree{Entries: []*gitobj.TreeEntry{
+		{
+			Name:     "README.md",
+			Oid:      []byte("00000000000000000000"),
+			Filemode: 0100644,
+		},
+	}})
+
+	tree, err := New(db, &gitobj.Tree{Entries: []*gitobj.TreeEntry{
+		{
+			Name:     ".gitattributes",
+			Oid:      blob,
+			Filemode: 0100644,
+		},
+		{
+			Name:     "child",
+			Oid:      child,
+			Filemode: 040000,
+		},
+	}})
+	require.NoError(t, err)
+
+	assert.NotContains(t, tree.Children, "child")
+}

--- a/git/githistory/rewriter_test.go
+++ b/git/githistory/rewriter_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/filepathfilter"
 	"github.com/git-lfs/gitobj"
 	"github.com/stretchr/testify/assert"
@@ -290,6 +291,76 @@ func TestRewriterAllowsAdditionalTreeEntries(t *testing.T) {
 
 	AssertBlobContents(t, db, tree3, "hello.txt", "1")
 	AssertBlobContents(t, db, tree3, "extra.txt", "extra\n")
+}
+
+func TestHistoryRewriterCallbacks(t *testing.T) {
+	type Call struct {
+		Type string
+		Path string
+	}
+
+	var calls []*Call
+
+	db := DatabaseFromFixture(t, "linear-history.git")
+	r := NewRewriter(db)
+
+	_, err := r.Rewrite(&RewriteOptions{Include: []string{"refs/heads/master"},
+		BlobFn: func(path string, b *gitobj.Blob) (*gitobj.Blob, error) {
+			calls = append(calls, &Call{
+				Type: "blob",
+				Path: path,
+			})
+			return b, nil
+		},
+
+		TreePreCallbackFn: func(path string, t *gitobj.Tree) error {
+			calls = append(calls, &Call{
+				Type: "tree-pre",
+				Path: path,
+			})
+			return nil
+		},
+
+		TreeCallbackFn: func(path string, t *gitobj.Tree) (*gitobj.Tree, error) {
+			calls = append(calls, &Call{
+				Type: "tree-post",
+				Path: path,
+			})
+			return t, nil
+		},
+	})
+
+	assert.Nil(t, err)
+
+	assert.Len(t, calls, 9)
+	assert.Equal(t, calls[0], &Call{Type: "tree-pre", Path: "/"})
+	assert.Equal(t, calls[1], &Call{Type: "blob", Path: "hello.txt"})
+	assert.Equal(t, calls[2], &Call{Type: "tree-post", Path: "/"})
+	assert.Equal(t, calls[3], &Call{Type: "tree-pre", Path: "/"})
+	assert.Equal(t, calls[4], &Call{Type: "blob", Path: "hello.txt"})
+	assert.Equal(t, calls[5], &Call{Type: "tree-post", Path: "/"})
+	assert.Equal(t, calls[6], &Call{Type: "tree-pre", Path: "/"})
+	assert.Equal(t, calls[7], &Call{Type: "blob", Path: "hello.txt"})
+	assert.Equal(t, calls[8], &Call{Type: "tree-post", Path: "/"})
+}
+
+func TestHistoryRewriterTreePreCallbackPropagatesErrors(t *testing.T) {
+	expected := errors.Errorf("my error")
+
+	db := DatabaseFromFixture(t, "linear-history.git")
+	r := NewRewriter(db)
+
+	_, err := r.Rewrite(&RewriteOptions{Include: []string{"refs/heads/master"},
+		BlobFn: func(path string, b *gitobj.Blob) (*gitobj.Blob, error) {
+			return b, nil
+		},
+
+		TreePreCallbackFn: func(path string, t *gitobj.Tree) error {
+			return expected
+		},
+	})
+
+	assert.Equal(t, err, expected)
 }
 
 func TestHistoryRewriterUseOriginalParentsForPartialMigration(t *testing.T) {

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 28cfce2b07c2f75e13f9347f903b1f5b73379c8c84c5a66c85b6328df7d3540f
-updated: 2018-07-05T11:50:15.501713165-05:00
+hash: a39eef1817877f30955e685f12d3d610f277c5f6abc0756f6bab6944dc27c4dd
+updated: 2018-07-06T12:09:00.254181079-05:00
 imports:
 - name: github.com/alexbrainman/sspi
   version: 4729b3d4d8581b2db83864d1018926e4154f9406
@@ -18,7 +18,7 @@ imports:
   subpackages:
   - netrc
 - name: github.com/git-lfs/wildmatch
-  version: 8a0518641565a619e62a2738c7d4498fc345daf6
+  version: b31c34466d64fcd421b503261f815a303e74296e
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/kr/pty

--- a/glide.yaml
+++ b/glide.yaml
@@ -27,7 +27,7 @@ import:
 - package: github.com/pkg/errors
   version: c605e284fe17294bda444b34710735b29d1a9d90
 - package: github.com/git-lfs/wildmatch
-  version: 8a0518641565a619e62a2738c7d4498fc345daf6
+  version: b31c34466d64fcd421b503261f815a303e74296e
 - package: github.com/alexbrainman/sspi
   version: 4729b3d4d8581b2db83864d1018926e4154f9406
   subpackages:

--- a/test/test-migrate-fixtures.sh
+++ b/test/test-migrate-fixtures.sh
@@ -111,6 +111,32 @@ setup_single_local_branch_tracked() {
   git commit -m "add a.{txt,md}"
 }
 
+# setup_single_local_branch_tracked_corrupt creates a repository as follows:
+#
+#   A
+#    \
+#     refs/heads/master
+#
+# - Commit 'A' has 120 bytes of random data in a.txt, and tracks *.txt under Git
+#   LFS, but a.txt is not stored as an LFS object.
+setup_single_local_branch_tracked_corrupt() {
+  set -e
+
+  reponame="migrate-single-locla-branch-with-attrs-corrupt"
+
+  remove_and_create_local_repo "$reponame"
+
+  git lfs track "*.txt"
+  git lfs uninstall
+
+  base64 < /dev/urandom | head -c 120 > a.txt
+
+  git add .gitattributes a.txt
+  git commit -m "initial commit"
+
+  git lfs install
+}
+
 # setup_multiple_local_branches creates a repository as follows:
 #
 #     B

--- a/vendor/github.com/git-lfs/wildmatch/wildmatch_test.go
+++ b/vendor/github.com/git-lfs/wildmatch/wildmatch_test.go
@@ -597,6 +597,41 @@ var Cases = []*Case{
 		Subject: `foo-a.txt`,
 		Match:   false,
 	},
+	{
+		Pattern: `*.txt`,
+		Subject: `file.txt`,
+		Opts:    []opt{Basename},
+		Match:   true,
+	},
+	{
+		Pattern: `*.txt`,
+		Subject: `path/to/file.txt`,
+		Opts:    []opt{Basename},
+		Match:   true,
+	},
+	{
+		Pattern: `path/to/*.txt`,
+		Subject: `path/to/file.txt`,
+		Opts:    []opt{Basename},
+		Match:   true,
+	},
+	{
+		Pattern: `path/to/*.txt`,
+		Subject: `path/to/file.txt`,
+		Match:   true,
+	},
+	{
+		Pattern: `path/to/*.txt`,
+		Subject: `outside/of/path/to/file.txt`,
+		Opts:    []opt{Basename},
+		Match:   false,
+	},
+	{
+		Pattern: `path/to/*.txt`,
+		Subject: `path/to/some/intermediaries/to/file.txt`,
+		Opts:    []opt{Basename},
+		Match:   false,
+	},
 }
 
 func TestWildmatch(t *testing.T) {


### PR DESCRIPTION
This pull request introduces a new flag for the `git lfs migrate import` mode, `--fixup`.

This is useful in situations where the state of a repository does not mirror what is expected from the .gitattributes file(s) present in that repository.

Instead of a longer description in the body of this pull request, I have opted to include instead a thorough walk-through in each commit.

##

/cc @git-lfs/core 