### PR TITLE
fs/fs.go: support alternates from environment variable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -346,7 +346,12 @@ func (c *Configuration) Filesystem() *fs.Filesystem {
 
 	if c.fs == nil {
 		lfsdir, _ := c.Git.Get("lfs.storage")
-		c.fs = fs.New(c.LocalGitDir(), c.LocalWorkingDir(), lfsdir)
+		c.fs = fs.New(
+			c.Os,
+			c.LocalGitDir(),
+			c.LocalWorkingDir(),
+			lfsdir,
+		)
 	}
 
 	return c.fs

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -242,7 +242,7 @@ func resolveReferenceDirs(env Environment, gitStorageDir string) []string {
 // not, the empty string and false is returned instead.
 func existsAlternate(objs string) (string, bool) {
 	objs = strings.TrimSpace(objs)
-	if strings.HasPrefix(objs, "#") {
+	if strings.HasPrefix(objs, "\"") {
 		var err error
 
 		unquote := strings.LastIndex(objs, "\"")

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -217,10 +217,9 @@ func resolveReferenceDirs(env Environment, gitStorageDir string) []string {
 		defer f.Close()
 
 		scanner := bufio.NewScanner(f)
-	L:
 		for scanner.Scan() {
 			text := strings.TrimSpace(scanner.Text())
-			if len(text) == 0 || strings.StartsWith(text, "#") {
+			if len(text) == 0 || strings.HasPrefix(text, "#") {
 				continue
 			}
 
@@ -243,15 +242,15 @@ func resolveReferenceDirs(env Environment, gitStorageDir string) []string {
 // not, the empty string and false is returned instead.
 func existsAlternate(objs string) (string, bool) {
 	objs = strings.TrimSpace(objs)
-	if objs.StartsWith(objs, "#") {
+	if strings.HasPrefix(objs, "#") {
 		var err error
 
-		unquote := strings.LastIndex(text, "\"")
+		unquote := strings.LastIndex(objs, "\"")
 		if unquote == 0 {
-			continue L
+			return "", false
 		}
 
-		objs, err = strconv.Unquote(text[:unquote+1])
+		objs, err = strconv.Unquote(objs[:unquote+1])
 		if err != nil {
 			return "", false
 		}

--- a/test/test-alternates.sh
+++ b/test/test-alternates.sh
@@ -91,3 +91,53 @@ begin_test "alternates (quoted)"
   [ "0" -eq "$(grep -c "sending batch of size 1" fetch.log)" ]
 )
 end_test
+
+begin_test "alternates (OS environment, single)"
+(
+  set -e
+
+  reponame="alternates-environment-single-alternate"
+  setup_remote_repo_with_file "$reponame" "a.txt"
+
+  pushd "$TRASHDIR" > /dev/null
+    clone_repo "$reponame" "${reponame}_alternate"
+  popd > /dev/null
+
+  rm -rf .git/lfs/objects
+
+  alternate="$TRASHDIR/${reponame}_alternate/.git/objects"
+
+  GIT_ALTERNATE_OBJECT_DIRECTORIES="$alternate" \
+  GIT_TRACE=1 \
+    git lfs fetch origin master 2>&1 | tee fetch.log
+  [ "0" -eq "$(grep -c "sending batch of size 1" fetch.log)" ]
+)
+end_test
+
+begin_test "alternates (OS environment, multiple)"
+(
+  set -e
+
+  reponame="alternates-environment-multiple-alternates"
+  setup_remote_repo_with_file "$reponame" "a.txt"
+
+  pushd "$TRASHDIR" > /dev/null
+    clone_repo "$reponame" "${reponame}_alternate_stale"
+    rm -rf .git/lfs/objects
+  popd > /dev/null
+  pushd "$TRASHDIR" > /dev/null
+    clone_repo "$reponame" "${reponame}_alternate"
+  popd > /dev/null
+
+  rm -rf .git/lfs/objects
+
+  alternate_stale="$TRASHDIR/${reponame}_alternate_stale/.git/objects"
+  alternate="$TRASHDIR/${reponame}_alternate/.git/objects"
+  sep="$(native_path_list_separator)"
+
+  GIT_ALTERNATE_OBJECT_DIRECTORIES="$alternate_stale$sep$alternate" \
+  GIT_TRACE=1 \
+    git lfs fetch origin master 2>&1 | tee fetch.log
+  [ "0" -eq "$(grep -c "sending batch of size 1" fetch.log)" ]
+)
+end_test

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -730,6 +730,16 @@ native_path_escaped() {
   escape_path "$unescaped"
 }
 
+# native_path_list_separator prints the operating system-specific path list
+# separator.
+native_path_list_separator() {
+  if [ "$IS_WINDOWS" -eq 1 ]; then
+    printf ";";
+  else
+    printf ":";
+  fi
+}
+
 cat_end() {
   if [ $IS_WINDOWS -eq 1 ]; then
     printf '^M$'


### PR DESCRIPTION
The Git documentation also mentions that the
"$GIT_ALTERNATE_OBJECT_DIRECTORIES" environment variable is a valid way
to configure object database remotes [1]:

  2. You could be using the `objects/info/alternates` or
     `$GIT_ALTERNATE_OBJECT_DIRECTORIES` mechanisms to borrow objects
     from other object stores.

Let's support the same by using the last commit, taking in a handle on
the operating-system configuration and using that in addition to the
list found in .git/objects/info/alternates.

[1]: https://git-scm.com/docs/gitrepository-layout#gitrepository-layout-objectsinfoalternates

## 

/cc @git-lfs/core 