### PR TITLE
commands/checkout: checkout over read-only files

### DIFF
--- a/lfs/gitfilter_smudge.go
+++ b/lfs/gitfilter_smudge.go
@@ -16,6 +16,18 @@ import (
 
 func (f *GitFilter) SmudgeToFile(filename string, ptr *Pointer, download bool, manifest *tq.Manifest, cb tools.CopyCallback) error {
 	os.MkdirAll(filepath.Dir(filename), 0755)
+
+	if stat, _ := os.Stat(filename); stat != nil && stat.Mode()&0200 == 0 {
+		if err := os.Chmod(filename, stat.Mode()|0200); err != nil {
+			return errors.Wrap(err,
+				"Could not restore write permission")
+		}
+
+		// When we're done, return the file back to its normal
+		// permission bits.
+		defer os.Chmod(filename, stat.Mode())
+	}
+
 	file, err := os.Create(filename)
 	if err != nil {
 		return fmt.Errorf("Could not create working directory file: %v", err)

--- a/test/testhelpers.sh
+++ b/test/testhelpers.sh
@@ -40,7 +40,7 @@ refute_pointer() {
 
   file=$(git cat-file -p $gitblob)
   version="version https://git-lfs.github.com/spec/v[0-9]"
-  oid="oid sha256:[0-9a-f]\{32\}"
+  oid="oid sha256:[0-9a-f]\{64\}"
   size="size [0-9]*"
   regex="$version.*$oid.*$size"
 


### PR DESCRIPTION
This pull request teaches the deprecated `git lfs checkout` command to
be able to checkout read-only files in the working copy.

If a file tracked with Git LFS is locked, it will not have the writing
bit unless the user themselves holds the lock. In the former case, if a
user wants to check out a locked Git LFS file--provided that they will
not push a changed version of that file--they should be allowed to check
that file out.

To do so, let's recognize when a file is marked as read-only,
temporarily grant it writing permissions, and then restore the original
permissions once we're done.

Closes: https://github.com/git-lfs/git-lfs/issues/3102.

##

/cc @git-lfs/core 