### PR TITLE
commands/command_migrate.go: loosen meaning of '--everything'

### DIFF
--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -173,13 +173,31 @@ func includeExcludeRefs(l *tasklog.Logger, args []string) (include, exclude []st
 		include = append(include, migrateIncludeRefs...)
 		exclude = append(exclude, migrateExcludeRefs...)
 	} else if migrateEverything {
-		localRefs, err := git.LocalRefs()
+		refs, err := git.AllRefsIn("")
 		if err != nil {
 			return nil, nil, err
 		}
 
-		for _, ref := range localRefs {
-			include = append(include, ref.Refspec())
+		for _, ref := range refs {
+			switch ref.Type {
+			case git.RefTypeLocalBranch, git.RefTypeLocalTag,
+				git.RefTypeRemoteBranch, git.RefTypeRemoteTag:
+
+				include = append(include, ref.Refspec())
+			case git.RefTypeOther:
+				parts := strings.SplitN(ref.Refspec(), "/", 3)
+				if len(parts) < 2 {
+					continue
+				}
+
+				switch parts[1] {
+				// The following are GitLab-, GitHub-, VSTS-,
+				// and BitBucket-specific reference naming
+				// conventions.
+				case "merge-requests", "pull", "pull-requests":
+					include = append(include, ref.Refspec())
+				}
+			}
 		}
 	} else {
 		bare, err := git.IsBare()

--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -190,8 +190,8 @@ The following configuration:
 
 Would, therefore, include commits: F, E, D, C, B, but exclude commit A.
 
-The presence of flag `--everything` indicates that all local references should be
-migrated.
+The presence of flag `--everything` indicates that all local and remote
+references should be migrated.
 
 ## EXAMPLES
 

--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -253,16 +253,20 @@ Note: This will require a force push to any existing Git remotes.
 
 ### Migrate without rewriting local history
 
-You can also migrate files without modifying the existing history of your respoitory:
+You can also migrate files without modifying the existing history of your
+repository:
 
 Without a specified commit message:
+
 ```
-    git lfs migrate import --no-rewrite test.zip *.mp3 *.psd
+$ git lfs migrate import --no-rewrite test.zip *.mp3 *.psd
 ```
+
 With a specified commit message:
+
 ```
-    git lfs migrate import --no-rewrite -m "Import .zip, .mp3, .psd files" \
-      test.zip *.mpd *.psd
+$ git lfs migrate import --no-rewrite -m "Import .zip, .mp3, .psd files" \
+  test.zip *.mpd *.psd
 ```
 
 ## SEE ALSO

--- a/test/test-migrate-fixtures.sh
+++ b/test/test-migrate-fixtures.sh
@@ -218,6 +218,29 @@ setup_multiple_local_branches_with_gitattrs() {
   git commit -m "add .gitattributes"
 }
 
+# setup_multiple_local_branches_non_standard creates a repository as follows:
+#
+#      refs/pull/1/head
+#     /
+#     |
+#     B
+#    / \
+#   A   refs/heads/my-feature
+#   |\
+#   | refs/heads/master
+#    \
+#     refs/pull/1/base
+#
+# With the same contents in 'A' and 'B' as setup_multiple_local_branches.
+setup_multiple_local_branches_non_standard() {
+  set -e
+
+  setup_multiple_local_branches
+
+  git update-ref --create refs/pull/1/head "$(git rev-parse my-feature)"
+  git update-ref --create refs/pull/1/base "$(git rev-parse master)"
+}
+
 # setup_multiple_local_branches_tracked creates a repo with exactly the same
 # structure as in setup_multiple_local_branches, but with all files tracked by
 # Git LFS

--- a/test/test-migrate-fixtures.sh
+++ b/test/test-migrate-fixtures.sh
@@ -178,7 +178,7 @@ setup_single_local_branch_tracked_corrupt() {
 #
 # - Commit 'A' has 120, 140 bytes of data in a.txt, and a.md, respectively.
 #
-# - Commit 'B' has 30 bytes of data in a.txt, and includes commit 'A' as a
+# - Commit 'B' has 30 bytes of data in a.md, and includes commit 'A' as a
 #   parent.
 setup_multiple_local_branches() {
   set -e

--- a/test/test-migrate-fixtures.sh
+++ b/test/test-migrate-fixtures.sh
@@ -237,8 +237,8 @@ setup_multiple_local_branches_non_standard() {
 
   setup_multiple_local_branches
 
-  git update-ref --create refs/pull/1/head "$(git rev-parse my-feature)"
-  git update-ref --create refs/pull/1/base "$(git rev-parse master)"
+  git update-ref refs/pull/1/head "$(git rev-parse my-feature)"
+  git update-ref refs/pull/1/base "$(git rev-parse master)"
 }
 
 # setup_multiple_local_branches_tracked creates a repo with exactly the same


### PR DESCRIPTION
In [1] and [2], callers of the 'git lfs migrate' command were surprised
when `--everything` did not migrate over everything, as its name
implies.

In the documentation, we specified that `--everything` applies only to
local references, as the default behavior of 'git lfs migrate' is to
never require a force-push unless asked to do so explicitly.

--everything sounds dangerous enough that it would imply that a user
wants _everything_ in their repository migrated. So, let's loosen the
requirement and make it mean that.

Alternatively, we could change the meaning of `--everything` in this
fashion and replace it with `--everything-local`. We could also
introduce `--force`, leave the meaning of `--evrything` unchanged, and
only exhibit this behavior with `--everything --force`. Both of these
options add too much surface area and complexity for use cases that seem
less-common, and/or could be accomplished with clever `git for-each-ref`
and `xargs`-ing.

Closes: https://github.com/git-lfs/git-lfs/issues/2984.
Closes: https://github.com/git-lfs/git-lfs/issues/3118.

##

/cc @git-lfs/core 

[1]: #2984
[2]: #3118