### PR TITLE
config: add origin to remote list

### DIFF
--- a/commands/command_env.go
+++ b/commands/command_env.go
@@ -19,8 +19,10 @@ func envCommand(cmd *cobra.Command, args []string) {
 	Print(gitV)
 	Print("")
 
+	defaultRemote := ""
 	if cfg.IsDefaultRemote() {
-		endpoint := getAPIClient().Endpoints.Endpoint("download", cfg.Remote())
+		defaultRemote = cfg.Remote()
+		endpoint := getAPIClient().Endpoints.Endpoint("download", defaultRemote)
 		if len(endpoint.Url) > 0 {
 			access := getAPIClient().Endpoints.AccessFor(endpoint.Url)
 			Print("Endpoint=%s (auth=%s)", endpoint.Url, access)
@@ -31,6 +33,9 @@ func envCommand(cmd *cobra.Command, args []string) {
 	}
 
 	for _, remote := range cfg.Remotes() {
+		if remote == defaultRemote {
+			continue
+		}
 		remoteEndpoint := getAPIClient().Endpoints.RemoteEndpoint("download", remote)
 		remoteAccess := getAPIClient().Endpoints.AccessFor(remoteEndpoint.Url)
 		Print("Endpoint (%s)=%s (auth=%s)", remote, remoteEndpoint.Url, remoteAccess)

--- a/config/config.go
+++ b/config/config.go
@@ -82,10 +82,7 @@ func (c *Configuration) readGitConfig(gitconfigs ...*git.ConfigurationSource) En
 	gf, extensions, uniqRemotes := readGitConfig(gitconfigs...)
 	c.extensions = extensions
 	c.remotes = make([]string, 0, len(uniqRemotes))
-	for remote, isOrigin := range uniqRemotes {
-		if isOrigin {
-			continue
-		}
+	for remote := range uniqRemotes {
 		c.remotes = append(c.remotes, remote)
 	}
 

--- a/t/t-pull.sh
+++ b/t/t-pull.sh
@@ -218,6 +218,36 @@ begin_test "pull with raw remote url"
 )
 end_test
 
+begin_test "pull with multiple remotes"
+(
+  set -e
+  mkdir multiple
+  cd multiple
+  git init
+  git lfs install --local --skip-smudge
+
+  git remote add origin "$GITSERVER/t-pull"
+  git remote add bad-remote "invalid-url"
+  git pull origin master
+
+  contents="a"
+  contents_oid=$(calc_oid "$contents")
+
+  # LFS object not downloaded, pointer in working directory
+  refute_local_object "$contents_oid"
+  grep "$contents_oid" a.dat
+
+  # pull should default to origin instead of bad-remote
+  git lfs pull
+  echo "pulled!"
+
+  # LFS object downloaded and in working directory
+  assert_local_object "$contents_oid" 1
+  [ "0" = "$(grep -c "$contents_oid" a.dat)" ]
+  [ "a" = "$(cat a.dat)" ]
+)
+end_test
+
 begin_test "pull: with missing object"
 (
   set -e


### PR DESCRIPTION
Previously, origin was being explicitly excluded from the list
of remotes. This could cause the wrong remote to be used in some
cases, such as with `git lfs pull`, and for the `origin` remote to
be missed in `git lfs env`. This commit ensures that the remote
list has the correct contents, and that `git lfs pull` and
`git lfs env` now function as expected.

Closes #2915 