### PR TITLE
Makefile: list prerequisites for resource.syso

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,13 @@ bin/git-lfs.exe : $(SOURCES) resource.syso
 # resource.syso installs the 'goversioninfo' command and uses it in order to
 # generate a binary that has information included necessary to create the
 # Windows installer.
-resource.syso:
+#
+# Generating a new resource.syso is a pure function of the contents in the
+# prerequisites listed below.
+resource.syso : \
+versioninfo.json script/windows-installer/git-lfs-logo.bmp \
+script/windows-installer/git-lfs-logo.ico \
+script/windows-installer/git-lfs-wizard-image.bmp
 	@$(GO) get github.com/josephspurrier/goversioninfo/cmd/goversioninfo
 	$(GO) generate
 


### PR DESCRIPTION
When building Git LFS v2.5.0, we noticed that the resource.syso was
unchanged between builds and thus retained the old version information
found in 'master' before v2.5.0.

Hence we built binaries in bin/git-lfs.exe with a commit tagged
'v2.5.0', but a version info indicating that the binary was of the
v2.4.0-era.

Let's list out the dependencies of 'resource.syso' explicitly, and thus
rebuild it when any of those change. In particular, it is unlikely the
installer icons. But, if we change the version information during a
release in versioninfo.json, we should update the resource.syso file
accordingly.

##

/cc @git-lfs/core