### PR TITLE
tq: make Content-Type detection disable-able

### DIFF
--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -266,6 +266,12 @@ be scoped inside the configuration for a remote.
   https://git-scm.com/docs/git-config#git-config-httplturlgt. To set this value
   per-host: `git config --global lfs.https://github.com/.locksverify [true|false]`.
 
+* `lfs.<url>.contenttype`
+
+  Determines whether Git LFS should attempt to detect an appropriate HTTP
+  `Content-Type` header when uploading using the 'basic' upload adapter.
+  Default: 'true'.
+
 * `lfs.skipdownloaderrors`
 
   Causes Git LFS not to abort the smudge filter when a download error is

--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -269,8 +269,9 @@ be scoped inside the configuration for a remote.
 * `lfs.<url>.contenttype`
 
   Determines whether Git LFS should attempt to detect an appropriate HTTP
-  `Content-Type` header when uploading using the 'basic' upload adapter.
-  Default: 'true'.
+  `Content-Type` header when uploading using the 'basic' upload adapter. If set
+  to false, the default header of `Content-Type: application/octet-stream` is
+  chosen instead. Default: 'true'.
 
 * `lfs.skipdownloaderrors`
 

--- a/errors/types.go
+++ b/errors/types.go
@@ -127,6 +127,20 @@ func IsDownloadDeclinedError(err error) bool {
 	return false
 }
 
+// IsDownloadDeclinedError indicates that the upload operation failed because of
+// an HTTP 422 response code.
+func IsUnprocessableEntityError(err error) bool {
+	if e, ok := err.(interface {
+		UnprocessableEntityError() bool
+	}); ok {
+		return e.UnprocessableEntityError()
+	}
+	if parent := parentOf(err); parent != nil {
+		return IsUnprocessableEntityError(parent)
+	}
+	return false
+}
+
 // IsRetriableError indicates the low level transfer had an error but the
 // caller may retry the operation.
 func IsRetriableError(err error) bool {
@@ -319,6 +333,20 @@ func (e downloadDeclinedError) DownloadDeclinedError() bool {
 
 func NewDownloadDeclinedError(err error, msg string) error {
 	return downloadDeclinedError{newWrappedError(err, msg)}
+}
+
+// Definitions for IsUnprocessableEntityError()
+
+type unprocessableEntityError struct {
+	*wrappedError
+}
+
+func (e unprocessableEntityError) UnprocessableEntityError() bool {
+	return true
+}
+
+func NewUnprocessableEntityError(err error) error {
+	return unprocessableEntityError{newWrappedError(err, "")}
 }
 
 // Definitions for IsRetriableError()

--- a/lfsapi/errors.go
+++ b/lfsapi/errors.go
@@ -58,6 +58,10 @@ func (c *Client) handleResponse(res *http.Response) error {
 		return errors.NewAuthError(err)
 	}
 
+	if res.StatusCode == 422 {
+		return errors.NewUnprocessableEntityError(err)
+	}
+
 	if res.StatusCode > 499 && res.StatusCode != 501 && res.StatusCode != 507 && res.StatusCode != 509 {
 		return errors.NewFatalError(err)
 	}
@@ -92,6 +96,7 @@ var (
 		401: "Authorization error: %s\nCheck that you have proper access to the repository",
 		403: "Authorization error: %s\nCheck that you have proper access to the repository",
 		404: "Repository or object not found: %s\nCheck that it exists and that you have proper access to it",
+		422: "Unprocessable entity: %s",
 		429: "Rate limit exceeded: %s",
 		500: "Server error: %s",
 		501: "Not Implemented: %s",

--- a/t/t-content-type.sh
+++ b/t/t-content-type.sh
@@ -44,3 +44,24 @@ begin_test "content-type: is disabled by configuration"
   [ 1 -eq "$(grep -c "Content-Type: application/zip" push.log)" ]
 )
 end_test
+
+begin_test "content-type: warning message"
+(
+  set -e
+
+  reponame="content-type-warning-message"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.txt"
+  printf "status-storage-422" > a.txt
+
+  git add .gitattributes a.txt
+  git commit -m "initial commit"
+  git push origin master 2>&1 | tee push.log
+
+  grep "info: Uploading failed due to unsupported Content-Type header(s)." push.log
+  grep "info: Consider disabling Content-Type detection with:" push.log
+  grep "info:   $ git config lfs.contenttype false" push.log
+)
+end_test

--- a/t/t-content-type.sh
+++ b/t/t-content-type.sh
@@ -38,10 +38,10 @@ begin_test "content-type: is disabled by configuration"
 
   git add .gitattributes a.zip
   git commit -m "initial commit"
-  git config "lfs.$GITSERVER/$reponame.git.contenttype" 0
+  git config "lfs.$GITSERVER.contenttype" 0
   GIT_CURL_VERBOSE=1 git push origin master 2>&1 | tee push.log
 
-  [ 1 -eq "$(grep -c "Content-Type: application/zip" push.log)" ]
+  [ 0 -eq "$(grep -c "Content-Type: application/zip" push.log)" ]
 )
 end_test
 

--- a/t/t-content-type.sh
+++ b/t/t-content-type.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+. "$(dirname "$0")/testlib.sh"
+
+begin_test "content-type: is enabled by default"
+(
+  set -e
+
+  reponame="content-type-enabled-default"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.zip"
+  printf "aaaaaaaaaa" > a.txt
+  zip -j a.zip a.txt
+  rm a.txt
+
+  git add .gitattributes a.zip
+  git commit -m "initial commit"
+  GIT_CURL_VERBOSE=1 git push origin master 2>&1 | tee push.log
+
+  [ 1 -eq "$(grep -c "Content-Type: application/zip" push.log)" ]
+)
+end_test
+
+begin_test "content-type: is disabled by configuration"
+(
+  set -e
+
+  reponame="content-type-disabled-by-configuration"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.zip"
+  printf "aaaaaaaaaa" > a.txt
+  zip -j a.zip a.txt
+  rm a.txt
+
+  git add .gitattributes a.zip
+  git commit -m "initial commit"
+  git config "lfs.$GITSERVER/$reponame.git.contenttype" 0
+  GIT_CURL_VERBOSE=1 git push origin master 2>&1 | tee push.log
+
+  [ 1 -eq "$(grep -c "Content-Type: application/zip" push.log)" ]
+)
+end_test

--- a/t/t-content-type.sh
+++ b/t/t-content-type.sh
@@ -10,16 +10,16 @@ begin_test "content-type: is enabled by default"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"
 
-  git lfs track "*.zip"
+  git lfs track "*.tar.gz"
   printf "aaaaaaaaaa" > a.txt
-  zip -j a.zip a.txt
+  tar -czf a.tar.gz a.txt
   rm a.txt
 
-  git add .gitattributes a.zip
+  git add .gitattributes a.tar.gz
   git commit -m "initial commit"
   GIT_CURL_VERBOSE=1 git push origin master 2>&1 | tee push.log
 
-  [ 1 -eq "$(grep -c "Content-Type: application/zip" push.log)" ]
+  [ 1 -eq "$(grep -c "Content-Type: application/x-gzip" push.log)" ]
 )
 end_test
 
@@ -31,17 +31,17 @@ begin_test "content-type: is disabled by configuration"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"
 
-  git lfs track "*.zip"
+  git lfs track "*.tar.gz"
   printf "aaaaaaaaaa" > a.txt
-  zip -j a.zip a.txt
+  tar -czf a.tar.gz a.txt
   rm a.txt
 
-  git add .gitattributes a.zip
+  git add .gitattributes a.tar.gz
   git commit -m "initial commit"
   git config "lfs.$GITSERVER.contenttype" 0
   GIT_CURL_VERBOSE=1 git push origin master 2>&1 | tee push.log
 
-  [ 0 -eq "$(grep -c "Content-Type: application/zip" push.log)" ]
+  [ 0 -eq "$(grep -c "Content-Type: application/x-gzip" push.log)" ]
 )
 end_test
 

--- a/t/t-push-failures-remote.sh
+++ b/t/t-push-failures-remote.sh
@@ -65,14 +65,6 @@ begin_test "push: upload file with storage 410"
 )
 end_test
 
-begin_test "push: upload file with storage 422"
-(
-  set -e
-
-  push_fail_test "status-storage-422"
-)
-end_test
-
 begin_test "push: upload file with storage 500"
 (
   set -e

--- a/tq/basic_upload.go
+++ b/tq/basic_upload.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/git-lfs/git-lfs/config"
 	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/lfsapi"
 	"github.com/git-lfs/git-lfs/tools"
@@ -72,7 +73,7 @@ func (a *basicUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb Progres
 	}
 	defer f.Close()
 
-	if err := setContentTypeFor(req, f); err != nil {
+	if err := a.setContentTypeFor(req, f); err != nil {
 		return err
 	}
 
@@ -135,8 +136,10 @@ func (a *basicUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb Progres
 	return verifyUpload(a.apiClient, a.remote, t)
 }
 
-func setContentTypeFor(req *http.Request, r io.ReadSeeker) error {
-	if len(req.Header.Get("Content-Type")) != 0 {
+func (a *adapterBase) setContentTypeFor(req *http.Request, r io.ReadSeeker) error {
+	uc := config.NewURLConfig(a.apiClient.GitEnv())
+	disabled := !uc.Bool("lfs", req.URL.String(), "contenttype", true)
+	if len(req.Header.Get("Content-Type")) != 0 || disabled {
 		return nil
 	}
 


### PR DESCRIPTION
This pull request makes the `Content-Type` detection introduced in #3137 disable-able, thus allowing uploads on implementations that don't support non-octet-stream headers.

Closes: https://github.com/git-lfs/git-lfs/issues/3158.

##

/cc @git-lfs/core 