### PR TITLE
Makefile: silence some output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -321,7 +321,7 @@ endif
 # are vendored in via vendor (see: above).
 .PHONY : lint
 lint : $(SOURCES)
-	$(GO) list -f '{{ join .Deps "\n" }}' . \
+	@$(GO) list -f '{{ join .Deps "\n" }}' . \
 	| $(XARGS) $(GO) list -f '{{ if not .Standard }}{{ .ImportPath }}{{ end }}' \
 	| $(GREP) -v "github.com/git-lfs/git-lfs" || exit 0
 

--- a/Makefile
+++ b/Makefile
@@ -311,7 +311,7 @@ vendor : glide.lock
 .PHONY : fmt
 ifeq ($(shell test -x "`which $(GOIMPORTS)`"; echo $$?),0)
 fmt : $(SOURCES) | lint
-	$(GOIMPORTS) $(GOIMPORTS_EXTRA_OPTS) $?;
+	@$(GOIMPORTS) $(GOIMPORTS_EXTRA_OPTS) $?;
 else
 fmt : $(SOURCES) | lint
 	@echo "git-lfs: skipping fmt, no goimports found at \`$(GOIMPORTS)\` ..."


### PR DESCRIPTION
This pull request silences some of the output that we have been generating in our newly minted Makefile.

The rationale for each silencing is described in depth in the patches below, but the overarching concern is that the verbosity of both the `go list` and `goimports` command-line invocation does not ever provide useful information to the caller, who is primarily interested in the `go build` invocation instead.

Therefore, let's get rid of each of them and make the `make` output a little cleaner:

```ShellSession
$ make
GOOS= GOARCH= go build -ldflags=" -X github.com/git-lfs/git-lfs/config.GitCommit=1f6d3a7f -s -w " -gcflags=" " -o ./bin/git-lfs ./git-lfs.go
```

##

/cc @git-lfs/core 