### PR TITLE
docs/man/mangen.go: don't show non-fatal output without --verbose

### DIFF
--- a/docs/man/mangen.go
+++ b/docs/man/mangen.go
@@ -3,12 +3,17 @@ package main
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 )
+
+func infof(w io.Writer, format string, a ...interface{}) {
+	fmt.Fprintf(w, format, a...)
+}
 
 func readManDir() (string, []os.FileInfo) {
 	rootDirs := []string{
@@ -35,7 +40,7 @@ func readManDir() (string, []os.FileInfo) {
 // that there are no compilation errors if 'go generate' hasn't been run, just
 // blank man files.
 func main() {
-	fmt.Fprintf(os.Stderr, "Converting man pages into code...\n")
+	infof(os.Stderr, "Converting man pages into code...\n")
 	rootDir, fs := readManDir()
 	manDir := filepath.Join(rootDir, "docs", "man")
 	out, err := os.Create(filepath.Join(rootDir, "commands", "mancontent_gen.go"))
@@ -55,7 +60,7 @@ func main() {
 	count := 0
 	for _, f := range fs {
 		if match := fileregex.FindStringSubmatch(f.Name()); match != nil {
-			fmt.Fprintf(os.Stderr, "%v\n", f.Name())
+			infof(os.Stderr, "%v\n", f.Name())
 			cmd := match[1]
 			if len(cmd) == 0 {
 				// This is git-lfs.1.ronn
@@ -145,6 +150,6 @@ func main() {
 		}
 	}
 	out.WriteString("}\n")
-	fmt.Fprintf(os.Stderr, "Successfully processed %d man pages.\n", count)
+	infof(os.Stderr, "Successfully processed %d man pages.\n", count)
 
 }

--- a/docs/man/mangen.go
+++ b/docs/man/mangen.go
@@ -15,6 +15,10 @@ func infof(w io.Writer, format string, a ...interface{}) {
 	fmt.Fprintf(w, format, a...)
 }
 
+func warnf(w io.Writer, format string, a ...interface{}) {
+	fmt.Fprintf(w, format, a...)
+}
+
 func readManDir() (string, []os.FileInfo) {
 	rootDirs := []string{
 		"..",
@@ -29,7 +33,7 @@ func readManDir() (string, []os.FileInfo) {
 		}
 	}
 
-	fmt.Fprintf(os.Stderr, "Failed to open man dir: %v\n", err)
+	warnf(os.Stderr, "Failed to open man dir: %v\n", err)
 	os.Exit(2)
 	return "", nil
 }
@@ -45,7 +49,7 @@ func main() {
 	manDir := filepath.Join(rootDir, "docs", "man")
 	out, err := os.Create(filepath.Join(rootDir, "commands", "mancontent_gen.go"))
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create go file: %v\n", err)
+		warnf(os.Stderr, "Failed to create go file: %v\n", err)
 		os.Exit(2)
 	}
 	out.WriteString("package commands\n\nfunc init() {\n")
@@ -69,7 +73,7 @@ func main() {
 			out.WriteString("ManPages[\"" + cmd + "\"] = `")
 			contentf, err := os.Open(filepath.Join(manDir, f.Name()))
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to open %v: %v\n", f.Name(), err)
+				warnf(os.Stderr, "Failed to open %v: %v\n", f.Name(), err)
 				os.Exit(2)
 			}
 			// Process the ronn to make it nicer as help text

--- a/docs/man/mangen.go
+++ b/docs/man/mangen.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -38,12 +39,18 @@ func readManDir() (string, []os.FileInfo) {
 	return "", nil
 }
 
+var (
+	verbose = flag.Bool("verbose", false, "Show verbose output.")
+)
+
 // Reads all .ronn files & and converts them to string literals
 // triggered by "go generate" comment
 // Literals are inserted into a map using an init function, this means
 // that there are no compilation errors if 'go generate' hasn't been run, just
 // blank man files.
 func main() {
+	flag.Parse()
+
 	infof(os.Stderr, "Converting man pages into code...\n")
 	rootDir, fs := readManDir()
 	manDir := filepath.Join(rootDir, "docs", "man")

--- a/docs/man/mangen.go
+++ b/docs/man/mangen.go
@@ -13,7 +13,7 @@ import (
 )
 
 func infof(w io.Writer, format string, a ...interface{}) {
-	if !verbose {
+	if !*verbose {
 		return
 	}
 	fmt.Fprintf(w, format, a...)

--- a/docs/man/mangen.go
+++ b/docs/man/mangen.go
@@ -13,6 +13,9 @@ import (
 )
 
 func infof(w io.Writer, format string, a ...interface{}) {
+	if !verbose {
+		return
+	}
 	fmt.Fprintf(w, format, a...)
 }
 


### PR DESCRIPTION
This pull request changes the behavior of docs/man/mangen.go to not show any non-fatal output unless `--verbose` is given.

While merging #3160, I noticed that this program can be quite noisy when run normally. These patches make things a little quieter, while still retaining information that might be important, like failing to open a file, or otherwise.

##

/cc @git-lfs/core 