### PR TITLE
Retry failed netrc cred requests

### DIFF
--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -253,7 +253,7 @@ func (c *Client) doWithRedirects(cli *http.Client, req *http.Request, remote str
 		// presence of the Authorization header), then recur through
 		// doWithAuth, retaining the requests via but only after
 		// authenticating the redirected request.
-		return c.doWithAuth(remote, redirectedReq, via)
+		return c.doWithAuth(remote, redirectedReq, via, false)
 	}
 	return c.doWithRedirects(cli, redirectedReq, remote, via)
 }


### PR DESCRIPTION
When a request is made with netrc credentials and that request
fails, retry the request with non-netrc credentials

Closes #3130 