### PR TITLE
🚧fetch: add option to exclude OIDs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -149,6 +149,23 @@ func (c *Configuration) FetchExcludePaths() []string {
 	return tools.CleanPaths(patterns, ",")
 }
 
+func (c *Configuration) FetchExcludeOIDs() []string {
+	var cleaned []string
+	oids, _ := c.Git.Get("lfs.fetchexcludeoids")
+
+	if oids = strings.TrimSpace(oids); len(oids) == 0 {
+		return cleaned
+	}
+
+	for _, part := range strings.Split(oids, ",") {
+		part = strings.TrimSpace(part)
+		cleaned = append(cleaned, part)
+	}
+
+	// TODO: normalize case?
+	return cleaned
+}
+
 func (c *Configuration) CurrentRef() *git.Ref {
 	c.loading.Lock()
 	defer c.loading.Unlock()

--- a/lfs/lfs.go
+++ b/lfs/lfs.go
@@ -61,6 +61,9 @@ func Environ(cfg *config.Configuration, manifest *tq.Manifest) []string {
 		fmt.Sprintf("DownloadTransfers=%s", strings.Join(dltransfers, ",")),
 		fmt.Sprintf("UploadTransfers=%s", strings.Join(ultransfers, ",")),
 	)
+	if len(cfg.FetchExcludeOIDs()) > 0 {
+		env = append(env, fmt.Sprintf("FetchExcludeOIDs=%s", strings.Join(cfg.FetchExcludeOIDs(), ", ")))
+	}
 	if len(cfg.FetchExcludePaths()) > 0 {
 		env = append(env, fmt.Sprintf("FetchExclude=%s", strings.Join(cfg.FetchExcludePaths(), ", ")))
 	}

--- a/t/t-fetch.sh
+++ b/t/t-fetch.sh
@@ -192,12 +192,29 @@ begin_test "fetch with include/exclude filters in gitconfig"
 )
 end_test
 
-begin_test "fetch with include filter in cli"
+begin_test "fetch with excluded OIDs"
 (
   set -e
   cd clone
   git config --unset "lfs.fetchinclude"
   git config --unset "lfs.fetchexclude"
+  rm -rf .git/lfs/objects
+
+  git config "lfs.fetchexcludeoids" "$contents_oid"
+  git lfs fetch --all origin
+  refute_local_object "$contents_oid"
+  assert_local_object "$b_oid" 1
+  objectlist=$(find .git/lfs/objects -type f)
+  [ "$(echo "$objectlist" | wc -l)" -eq 1 ]
+
+)
+end_test
+
+begin_test "fetch with include filter in cli"
+(
+  set -e
+  cd clone
+  git config --unset "lfs.fetchexcludeoids"
   rm -rf .git/lfs/objects
 
   git lfs fetch --include="a*" origin master newbranch


### PR DESCRIPTION
In exceptional cases Git LFS objects might not be available anymore on
a Git LFS server. This leads to errors if those objects are still
referenced in a Git repository. The only way to overcome these errors
is to rewrite the Git history and remove the "dangling" pointers.
Unfortunately, a history rewrite is not be possible in every case.

Therefore, add a config "lfs.fetchexcludeoids" to exclude certain Git
LFS object IDs. The multiple object IDs are separate by a comma. The
config can be set via the local Git config mechanism or via the
.lfsconfig mechanism.

Example:
```
[lfs]
  fetchexcludeoids = "hash1, hash2"
```

---

This is just a proof of concept. If you agree with the idea, I will implement it properly in every Git LFS call. Furthermore, I might implement it directly in the Scanner similar to the path filter mechanism.

/cc @git-lfs/core @terrorobe @mattpollard