### PR TITLE
locks: manage write permissions of ignored files

### DIFF
--- a/locking/lockable.go
+++ b/locking/lockable.go
@@ -122,7 +122,7 @@ func (c *Client) fixFileWriteFlags(absPath, workingDir string, lockable, unlocka
 		errs = append(errs, err)
 	}
 
-	tools.FastWalkGitRepo(absPath, func(parentDir string, fi os.FileInfo, err error) {
+	tools.FastWalkGitRepoAll(absPath, func(parentDir string, fi os.FileInfo, err error) {
 		if err != nil {
 			addErr(err)
 			return

--- a/t/t-lock.sh
+++ b/t/t-lock.sh
@@ -229,3 +229,27 @@ begin_test "creating a lock (symlinked working directory)"
   popd > /dev/null
 )
 end_test
+
+begin_test "lock with .gitignore"
+(
+  set -e
+
+  reponame="lock-with-gitignore"
+  setup_remote_repo_with_file "$reponame" "a.txt"
+  clone_repo "$reponame" "$reponame"
+
+  echo "*.txt filter=lfs diff=lfs merge=lfs -text lockable" > .gitattributes
+
+  git add .gitattributes
+  git commit -m ".gitattributes: mark 'a.txt' as lockable"
+
+  rm -f a.txt && git checkout a.txt
+  refute_file_writeable a.txt
+
+  echo "*.txt" > .gitignore
+  git add .gitignore
+  git commit -m ".gitignore: ignore 'a.txt'"
+  rm -f a.txt && git checkout a.txt
+  refute_file_writeable a.txt
+)
+end_test

--- a/tools/filetools.go
+++ b/tools/filetools.go
@@ -152,7 +152,12 @@ type FastWalkCallback func(parentDir string, info os.FileInfo, err error)
 //
 // rootDir - Absolute path to the top of the repository working directory
 func FastWalkGitRepo(rootDir string, cb FastWalkCallback) {
-	walker := fastWalkWithExcludeFiles(rootDir, ".gitignore")
+	fastWalkCallback(fastWalkWithExcludeFiles(rootDir, ".gitignore"), cb)
+}
+
+// fastWalkCallback calls the FastWalkCallback "cb" for all files found by the
+// given *fastWalker, "walker".
+func fastWalkCallback(walker *fastWalker, cb FastWalkCallback) {
 	for file := range walker.ch {
 		cb(file.ParentDir, file.Info, file.Err)
 	}

--- a/tools/filetools.go
+++ b/tools/filetools.go
@@ -155,6 +155,13 @@ func FastWalkGitRepo(rootDir string, cb FastWalkCallback) {
 	fastWalkCallback(fastWalkWithExcludeFiles(rootDir, ".gitignore"), cb)
 }
 
+// FastWalkGitRepoAll behaves as FastWalkGitRepo, with the additional caveat
+// that it does not ignore paths and directories found in .gitignore file(s)
+// throughout the repository.
+func FastWalkGitRepoAll(rootDir string, cb FastWalkCallback) {
+	fastWalkCallback(fastWalkWithExcludeFiles(rootDir, ""), cb)
+}
+
 // fastWalkCallback calls the FastWalkCallback "cb" for all files found by the
 // given *fastWalker, "walker".
 func fastWalkCallback(walker *fastWalker, cb FastWalkCallback) {


### PR DESCRIPTION
This pull request teaches `git lfs lock` to continue to manage lockable files after they have been ignored by a repository's `.gitignore`.

The rationale for this issue arrises from https://github.com/git-lfs/git-lfs/issues/3183, and is explained further in a727fea2 (locking: remove write permission for ignored files, 2018-08-20).

```ShellSession
$ printf "a.txt" > a.txt
$ git lfs track --lockable "*.txt"
Tracking "*.txt"
$ git add .gitattributes a.txt
$ git commit -m ".gitattributes: track 'a.txt' as lockable"
[master (root-commit) e05e353] .gitattributes: track 'a.txt' as lockable
 2 files changed, 4 insertions(+)
 create mode 100644 .gitattributes
 create mode 100644 a.txt
$ rm -f a.txt && git checkout a.txt
$ ls -l a.txt
-r--r--r--  1 ttaylorr  staff  5 Aug 20 07:53 a.txt
$ echo "a.txt" > .gitignore
$ git add .gitignore
$ git commit -m ".gitignore: ignore 'a.txt'"
[master e658686] .gitignore: ignore 'a.txt'
 1 file changed, 1 insertion(+)
 create mode 100644 .gitignore
$ rm -f a.txt && git checkout a.txt
$ ls -l a.txt
-r--r--r--  1 ttaylorr  staff  5 Aug 20 07:53 a.txt
```

Closes: https://github.com/git-lfs/git-lfs/issues/3183.

##

/cc @git-lfs/core 
/cc @zach-r-d https://github.com/git-lfs/git-lfs/issues/3183