### PR TITLE
Properly `lfs track` files with escaped characters in their name - fixes #3189 

### DIFF
--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -72,7 +72,7 @@ ArgsLoop:
 		pattern := trimCurrentPrefix(cleanRootPath(unsanitizedPattern))
 		if !trackNoModifyAttrsFlag {
 			for _, known := range knownPatterns {
-				if known.Path == filepath.Join(relpath, pattern) &&
+				if unescapeAttrPattern(known.Path) == filepath.Join(relpath, pattern) &&
 					((trackLockableFlag && known.Lockable) || // enabling lockable & already lockable (no change)
 						(trackNotLockableFlag && !known.Lockable) || // disabling lockable & not lockable (no change)
 						(!trackLockableFlag && !trackNotLockableFlag)) { // leave lockable as-is in all cases
@@ -132,7 +132,7 @@ ArgsLoop:
 					continue
 				}
 
-				pattern := fields[0]
+				pattern := unescapeAttrPattern(fields[0])
 				if newline, ok := changedAttribLines[pattern]; ok {
 					// Replace this line (newline already embedded)
 					attributesFile.WriteString(newline)

--- a/t/t-track.sh
+++ b/t/t-track.sh
@@ -610,5 +610,13 @@ begin_test "track: escaped pattern in .gitattributes"
 
   [ "Tracking \"$filename\"" = "$(git lfs track "$filename")" ]
   [ "\"$filename\" already supported" = "$(git lfs track "$filename")" ]
+  
+  #changing flags should track the file again
+  [ "Tracking \"$filename\"" = "$(git lfs track -l "$filename")" ]
+
+  if (( 1 != $(wc -l < .gitattributes) )); then
+    echo >&2 "changing flag for an existing tracked file shouldn't add another line"
+    exit 1
+  fi
 )
 end_test

--- a/t/t-track.sh
+++ b/t/t-track.sh
@@ -595,3 +595,20 @@ begin_test "track (system gitattributes)"
   grep "*.dat" track.log
 )
 end_test
+
+begin_test "track: escaped pattern in .gitattributes"
+(
+  set -e
+
+  reponame="track-escaped"
+  git init "$reponame"
+  cd "$reponame"
+
+  filename="file with spaces.#"
+
+  echo "I need escaping" > "$filename"
+
+  [ "Tracking \"$filename\"" = "$(git lfs track "$filename")" ]
+  [ "\"$filename\" already supported" = "$(git lfs track "$filename")" ]
+)
+end_test

--- a/t/t-track.sh
+++ b/t/t-track.sh
@@ -614,7 +614,7 @@ begin_test "track: escaped pattern in .gitattributes"
   #changing flags should track the file again
   [ "Tracking \"$filename\"" = "$(git lfs track -l "$filename")" ]
 
-  if (( 1 != $(wc -l < .gitattributes) )); then
+  if [ 1 -ne "$(wc -l .gitattributes | awk '{ print $1 }')" ]; then
     echo >&2 "changing flag for an existing tracked file shouldn't add another line"
     exit 1
   fi

--- a/t/t-untrack.sh
+++ b/t/t-untrack.sh
@@ -158,4 +158,3 @@ begin_test "untrack removes escaped pattern in .gitattributes"
   fi
 )
 end_test
-

--- a/t/t-untrack.sh
+++ b/t/t-untrack.sh
@@ -89,7 +89,7 @@ begin_test "untrack removes prefixed patterns (legacy)"
   git lfs untrack "./a.dat"
 
   if [ ! -z "$(cat .gitattributes)" ]; then
-    echo &>2 "fatal: expected 'git lfs untrack' to clear .gitattributes"
+    echo >&2 "fatal: expected 'git lfs untrack' to clear .gitattributes"
     exit 1
   fi
 
@@ -98,7 +98,7 @@ begin_test "untrack removes prefixed patterns (legacy)"
   git lfs untrack "a.dat"
 
   if [ ! -z "$(cat .gitattributes)" ]; then
-    echo &>2 "fatal: expected 'git lfs untrack' to clear .gitattributes"
+    echo >&2 "fatal: expected 'git lfs untrack' to clear .gitattributes"
     exit 1
   fi
 )
@@ -120,7 +120,7 @@ begin_test "untrack removes prefixed patterns (modern)"
   git lfs untrack "./a.dat"
 
   if [ ! -z "$(cat .gitattributes)" ]; then
-    echo &>2 "fatal: expected 'git lfs untrack' to clear .gitattributes"
+    echo >&2 "fatal: expected 'git lfs untrack' to clear .gitattributes"
     exit 1
   fi
 
@@ -129,7 +129,7 @@ begin_test "untrack removes prefixed patterns (modern)"
   git lfs untrack "a.dat"
 
   if [ ! -z "$(cat .gitattributes)" ]; then
-    echo &>2 "fatal: expected 'git lfs untrack' to clear .gitattributes"
+    echo >&2 "fatal: expected 'git lfs untrack' to clear .gitattributes"
     exit 1
   fi
 )
@@ -153,7 +153,7 @@ begin_test "untrack removes escaped pattern in .gitattributes"
   git lfs untrack "$filename"
 
   if [ ! -z "$(cat .gitattributes)" ]; then
-    echo &>2 "fatal: expected 'git lfs untrack' to clear .gitattributes even if the file name was escaped"
+    echo >&2 "fatal: expected 'git lfs untrack' to clear .gitattributes even if the file name was escaped"
     exit 1
   fi
 )

--- a/t/t-untrack.sh
+++ b/t/t-untrack.sh
@@ -134,3 +134,28 @@ begin_test "untrack removes prefixed patterns (modern)"
   fi
 )
 end_test
+
+begin_test "untrack removes escaped pattern in .gitattributes"
+(
+  set -e
+
+  reponame="untrack-escaped"
+  git init "$reponame"
+  cd "$reponame"
+
+  filename="file with spaces.#"
+
+  # emulate multiple instances of the same file in gitattributes
+  echo 'file[[:space:]]with[[:space:]]spaces.\# filter=lfs diff=lfs merge=lfs -text' >> .gitattributes
+  echo 'file[[:space:]]with[[:space:]]spaces.\# filter=lfs diff=lfs merge=lfs -text' >> .gitattributes
+  echo 'file[[:space:]]with[[:space:]]spaces.\# filter=lfs diff=lfs merge=lfs -text' >> .gitattributes
+
+  git lfs untrack "$filename"
+
+  if [ ! -z "$(cat .gitattributes)" ]; then
+    echo &>2 "fatal: expected 'git lfs untrack' to clear .gitattributes even if the file name was escaped"
+    exit 1
+  fi
+)
+end_test
+


### PR DESCRIPTION
fixes and verifies  #3189