### PR TITLE
Tidy misformatted files

### DIFF
--- a/lfs/gitscanner_log.go
+++ b/lfs/gitscanner_log.go
@@ -29,8 +29,8 @@ var (
 	// lfs changes and format the output suitable for parseLogOutput.. method(s)
 	logLfsSearchArgs = []string{
 		"-G", "oid sha256:", // only diffs which include an lfs file SHA change
-		"-p",   // include diff so we can read the SHA
-		"-U12", // Make sure diff context is always big enough to support 10 extension lines to get whole pointer
+		"-p",                             // include diff so we can read the SHA
+		"-U12",                           // Make sure diff context is always big enough to support 10 extension lines to get whole pointer
 		`--format=lfs-commit-sha: %H %P`, // just a predictable commit header we can detect
 	}
 )

--- a/lfsapi/auth_test.go
+++ b/lfsapi/auth_test.go
@@ -443,7 +443,7 @@ func TestGetCreds(t *testing.T) {
 			Method: "GET",
 			Href:   "https://git-server.com/repo/locks",
 			Config: map[string]string{
-				"lfs.url": "https://user:pass@git-server.com/repo",
+				"lfs.url":                                "https://user:pass@git-server.com/repo",
 				"lfs.https://git-server.com/repo.access": "basic",
 			},
 			Expected: getCredsExpected{
@@ -457,7 +457,7 @@ func TestGetCreds(t *testing.T) {
 			Method: "GET",
 			Href:   "https://git-server.com/repo/locks",
 			Config: map[string]string{
-				"lfs.url": "https://git-server.com/repo",
+				"lfs.url":                                "https://git-server.com/repo",
 				"lfs.https://git-server.com/repo.access": "basic",
 				"remote.origin.url":                      "https://user:pass@git-server.com/repo",
 			},


### PR DESCRIPTION
There are a few misformatted files in the repository.  Run these files through gofmt to reduce diff noise for future developers.