### PR TITLE
all: use Go 1.11 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # http://docs.travis-ci.com/user/languages/go/
 language: go
 
-go: 1.10.3
+go: 1.11
 
 os:
   - linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,8 @@ install:
   - rd C:\Go /s /q
   - rd C:\Perl /s /q
   - refreshenv
-  - curl -sL -o go1.10.3.windows-amd64.zip https://storage.googleapis.com/golang/go1.10.3.windows-amd64.zip
-  - 7z x go1.10.3.windows-amd64.zip -oC:\ >nul
+  - curl -sL -o go1.11.windows-amd64.zip https://storage.googleapis.com/golang/go1.11.windows-amd64.zip
+  - 7z x go1.11.windows-amd64.zip -oC:\ >nul
   - C:\go\bin\go version
   - cinst InnoSetup -y
   - cinst strawberryperl -y


### PR DESCRIPTION
Per [1], we would like to build Git LFS on Go version 1.11, following
testing over several weeks. As is done in [2], let's upgrade the version
of Go used in continuous integration (particularly on AppVeyor and
CircleCI) to match.

Since Chocolatey has not yet shipped Go 1.11 on their default channel,
we'll continue to download the binary ourselves manually. Once the
desired version of Go is available, this should be upgraded, too.

Notably, this change does not include Go Module support (as introduced
in version 1.11), so the value for $GO111MODULE is left unset, as to
avoid breaking existing checkouts of Git LFS that reside in a $GOPATH. A
subsequent change will introduce Go Module support, at which point
existing check-outs of Git LFS will need to be relocated.

##

/cc @git-lfs/core 

[1]: build-dockers@46040a6 (all: build against Go 1.11, 2018-08-28)
[2]: d4df80b4 ({.travis,appveyor}.yml: upgrade to Go 1.10.3, 2018-07-25)