### PR TITLE
Update packagecloud.rb

### DIFF
--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -33,11 +33,11 @@ $distro_name_map = {
   ),
   "centos/7" => %w(
     el/7
-    fedora/22
-    fedora/23
-    fedora/24
-    fedora/25
-    fedora/26
+    fedora/27
+    fedora/28
+    opensuse/42.3
+    sles/11.4
+    sles/12.3
   ),
   "debian/7" => %w(
     debian/wheezy
@@ -58,6 +58,7 @@ $distro_name_map = {
     linuxmint/serena
     linuxmint/sonya
     linuxmint/sylvia
+    linuxmint/tara
     ubuntu/xenial
     ubuntu/yakkety
     ubuntu/zesty


### PR DESCRIPTION
Updating Fedoras to supported versions and adding opensuse and sles #1055 

Fedora 22-26 are EOL https://fedoraproject.org/wiki/End_of_life
SLES 12.2 is EOL 6 months after 12.3 came out https://www.suse.com/releasenotes/x86_64/SUSE-SLES/12-SP2/#Intro.Lifecycle
Only openSUSE 15 and 42.3 are not EOL https://en.opensuse.org/Lifetime
Mint Tara added https://linuxmint.com/download_all.php