### PR TITLE
config: expand core.hooksPath

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -138,7 +138,11 @@ func downloadTransfer(p *lfs.WrappedPointer) (name, path, oid string, size int64
 
 // Get user-readable manual install steps for hooks
 func getHookInstallSteps() string {
-	hooks := lfs.LoadHooks(cfg.HookDir())
+	hookDir, err := cfg.HookDir()
+	if err != nil {
+		ExitWithError(err)
+	}
+	hooks := lfs.LoadHooks(hookDir)
 	steps := make([]string, 0, len(hooks))
 	for _, h := range hooks {
 		steps = append(steps, fmt.Sprintf(
@@ -150,7 +154,11 @@ func getHookInstallSteps() string {
 }
 
 func installHooks(force bool) error {
-	hooks := lfs.LoadHooks(cfg.HookDir())
+	hookDir, err := cfg.HookDir()
+	if err != nil {
+		return err
+	}
+	hooks := lfs.LoadHooks(hookDir)
 	for _, h := range hooks {
 		if err := h.Install(force); err != nil {
 			return err
@@ -166,7 +174,11 @@ func uninstallHooks() error {
 		return errors.New("Not in a git repository")
 	}
 
-	hooks := lfs.LoadHooks(cfg.HookDir())
+	hookDir, err := cfg.HookDir()
+	if err != nil {
+		return err
+	}
+	hooks := lfs.LoadHooks(hookDir)
 	for _, h := range hooks {
 		if err := h.Uninstall(); err != nil {
 			return err

--- a/config/config.go
+++ b/config/config.go
@@ -268,14 +268,14 @@ func (c *Configuration) SetLockableFilesReadOnly() bool {
 	return c.Os.Bool("GIT_LFS_SET_LOCKABLE_READONLY", true) && c.Git.Bool("lfs.setlockablereadonly", true)
 }
 
-func (c *Configuration) HookDir() string {
+func (c *Configuration) HookDir() (string, error) {
 	if git.IsGitVersionAtLeast("2.9.0") {
 		hp, ok := c.Git.Get("core.hooksPath")
 		if ok {
-			return hp
+			return hp, nil
 		}
 	}
-	return filepath.Join(c.LocalGitDir(), "hooks")
+	return filepath.Join(c.LocalGitDir(), "hooks"), nil
 }
 
 func (c *Configuration) InRepo() bool {

--- a/config/config.go
+++ b/config/config.go
@@ -268,11 +268,14 @@ func (c *Configuration) SetLockableFilesReadOnly() bool {
 	return c.Os.Bool("GIT_LFS_SET_LOCKABLE_READONLY", true) && c.Git.Bool("lfs.setlockablereadonly", true)
 }
 
+// HookDir returns the location of the hooks owned by this repository. If the
+// core.hooksPath configuration variable is supported, we prefer that and expand
+// paths appropriately.
 func (c *Configuration) HookDir() (string, error) {
 	if git.IsGitVersionAtLeast("2.9.0") {
 		hp, ok := c.Git.Get("core.hooksPath")
 		if ok {
-			return hp, nil
+			return tools.ExpandPath(hp, false)
 		}
 	}
 	return filepath.Join(c.LocalGitDir(), "hooks"), nil

--- a/t/t-install-custom-hooks-path.sh
+++ b/t/t-install-custom-hooks-path.sh
@@ -7,6 +7,18 @@
 #   - core.hooksPath support
 ensure_git_version_isnt $VERSION_LOWER "2.9.0"
 
+assert_hooks() {
+  local hooks_dir="$1"
+  [ -e "$hooks_dir/pre-push" ]
+  [ ! -e ".git/pre-push" ]
+  [ -e "$hooks_dir/post-checkout" ]
+  [ ! -e ".git/post-checkout" ]
+  [ -e "$hooks_dir/post-commit" ]
+  [ ! -e ".git/post-commit" ]
+  [ -e "$hooks_dir/post-merge" ]
+  [ ! -e ".git/post-merge" ]
+}
+
 begin_test "install with supported core.hooksPath"
 (
   set -e
@@ -23,13 +35,26 @@ begin_test "install with supported core.hooksPath"
   git lfs install 2>&1 | tee install.log
   grep "Updated git hooks" install.log
 
-  [ -e "$hooks_dir/pre-push" ]
-  [ ! -e ".git/pre-push" ]
-  [ -e "$hooks_dir/post-checkout" ]
-  [ ! -e ".git/post-checkout" ]
-  [ -e "$hooks_dir/post-commit" ]
-  [ ! -e ".git/post-commit" ]
-  [ -e "$hooks_dir/post-merge" ]
-  [ ! -e ".git/post-merge" ]
+  assert_hooks "$hooks_dir"
+)
+end_test
+
+begin_test "install with supported expandable core.hooksPath"
+(
+  set -e
+
+  repo_name="supported-custom-hooks-expandable-path"
+  git init "$repo_name"
+  cd "$repo_name"
+
+  hooks_dir="~/custom_hooks_dir"
+  mkdir -p "$hooks_dir"
+
+  git config --local core.hooksPath "$hooks_dir"
+
+  git lfs install 2>&1 | tee install.log
+  grep "Updated git hooks" install.log
+
+  assert_hooks "$HOME/custom_hooks_dir"
 )
 end_test

--- a/tools/filetools_test.go
+++ b/tools/filetools_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/user"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -21,6 +22,103 @@ func TestCleanPathsCleansPaths(t *testing.T) {
 func TestCleanPathsReturnsNoResultsWhenGivenNoPaths(t *testing.T) {
 	cleaned := CleanPaths("", ",")
 	assert.Empty(t, cleaned)
+}
+
+type ExpandPathTestCase struct {
+	Path   string
+	Expand bool
+
+	Want    string
+	WantErr string
+
+	currentUser func() (*user.User, error)
+	lookupUser  func(who string) (*user.User, error)
+}
+
+func (c *ExpandPathTestCase) Assert(t *testing.T) {
+	if c.currentUser != nil {
+		oldCurrentUser := currentUser
+		currentUser = c.currentUser
+		defer func() { currentUser = oldCurrentUser }()
+	}
+
+	if c.lookupUser != nil {
+		oldLookupUser := lookupUser
+		lookupUser = c.lookupUser
+		defer func() { lookupUser = oldLookupUser }()
+	}
+
+	got, err := ExpandPath(c.Path, c.Expand)
+	if err != nil || len(c.WantErr) > 0 {
+		assert.EqualError(t, err, c.WantErr)
+	}
+	assert.Equal(t, filepath.ToSlash(c.Want), filepath.ToSlash(got))
+}
+
+func TestExpandPath(t *testing.T) {
+	for desc, c := range map[string]*ExpandPathTestCase{
+		"no expand": {
+			Path: "/path/to/hooks",
+			Want: "/path/to/hooks",
+		},
+		"current": {
+			Path: "~/path/to/hooks",
+			Want: "/home/jane/path/to/hooks",
+			currentUser: func() (*user.User, error) {
+				return &user.User{
+					HomeDir: "/home/jane",
+				}, nil
+			},
+		},
+		"current, slash": {
+			Path: "~/",
+			Want: "/home/jane",
+			currentUser: func() (*user.User, error) {
+				return &user.User{
+					HomeDir: "/home/jane",
+				}, nil
+			},
+		},
+		"current, no slash": {
+			Path: "~",
+			Want: "/home/jane",
+			currentUser: func() (*user.User, error) {
+				return &user.User{
+					HomeDir: "/home/jane",
+				}, nil
+			},
+		},
+		"non-current": {
+			Path: "~other/path/to/hooks",
+			Want: "/home/special/path/to/hooks",
+			lookupUser: func(who string) (*user.User, error) {
+				assert.Equal(t, "other", who)
+				return &user.User{
+					HomeDir: "/home/special",
+				}, nil
+			},
+		},
+		"non-current, no slash": {
+			Path: "~other",
+			Want: "/home/special",
+			lookupUser: func(who string) (*user.User, error) {
+				assert.Equal(t, "other", who)
+				return &user.User{
+					HomeDir: "/home/special",
+				}, nil
+			},
+		},
+		"non-current (missing)": {
+			Path:    "~other/path/to/hooks",
+			WantErr: "could not find user other: missing",
+			lookupUser: func(who string) (*user.User, error) {
+				assert.Equal(t, "other", who)
+				return nil, fmt.Errorf("missing")
+			},
+		},
+	} {
+		t.Run(desc, c.Assert)
+	}
 }
 
 func TestFastWalkBasic(t *testing.T) {


### PR DESCRIPTION
This pull request expands the value of `core.hooksPath` as read from the Git configuration, before it is evaluate by `git lfs install`.

In practice, this makes it possible to do `git config core.hooksPath ~/path/to/hooks`, and Git LFS will properly look inside `/path/to/hooks` from within `$HOME`. It also supports incantations such as `~user/path/to/hooks`.

Closes: https://github.com/git-lfs/git-lfs/issues/3211.

##

/cc @git-lfs/core 
/cc @ktchen14 https://github.com/git-lfs/git-lfs/issues/3211