### PR TITLE
go.mod: pin github.com/git-lfs/wildmatch to v1.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2 // indirect
 	github.com/git-lfs/gitobj v0.0.0-20180705162808-0fcb9c3796fa
 	github.com/git-lfs/go-netrc v0.0.0-20180525200031-e0e9ca483a18
-	github.com/git-lfs/wildmatch v0.0.0-20180706170425-b31c34466d64
+	github.com/git-lfs/wildmatch v1.0.0
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/kr/pty v0.0.0-20150511174710-5cf931ef8f76
 	github.com/olekukonko/ts v0.0.0-20140412220145-ecf753e7c962

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/git-lfs/go-netrc v0.0.0-20180525200031-e0e9ca483a18 h1:7Th0eBA4rT8WJN
 github.com/git-lfs/go-netrc v0.0.0-20180525200031-e0e9ca483a18/go.mod h1:70O4NAtvWn1jW8V8V+OKrJJYcxDLTmIozfi2fmSz5SI=
 github.com/git-lfs/wildmatch v0.0.0-20180706170425-b31c34466d64 h1:ZPW4Gapp3/5fc/LDTp0A/C+s74yZg9jVZBoVan0GSmM=
 github.com/git-lfs/wildmatch v0.0.0-20180706170425-b31c34466d64/go.mod h1:SdHAGnApDpnFYQ0vAxbniWR0sn7yLJ3QXo9RRfhn2ew=
+github.com/git-lfs/wildmatch v1.0.0 h1:TKsxqSrEXWj73N4xGcN/ISal8/JJOiAcOv9LH6Zprxw=
+github.com/git-lfs/wildmatch v1.0.0/go.mod h1:SdHAGnApDpnFYQ0vAxbniWR0sn7yLJ3QXo9RRfhn2ew=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/kr/pty v0.0.0-20150511174710-5cf931ef8f76 h1:i5TIRQpbCg4aJMUtVHIhkQnSw++Z405Z5pzqHqeNkdU=

--- a/vendor/github.com/git-lfs/wildmatch/.travis.yml
+++ b/vendor/github.com/git-lfs/wildmatch/.travis.yml
@@ -1,3 +1,9 @@
 language: go
+go: 1.11
+before_install:
+  - >
+    mkdir -p ~/src;
+    mv "$TRAVIS_BUILD_DIR" ~/src/wildmatch;
+    export TRAVIS_BUILD_DIR=~/src/wildmatch;
 notifications:
   email: false

--- a/vendor/github.com/git-lfs/wildmatch/go.mod
+++ b/vendor/github.com/git-lfs/wildmatch/go.mod
@@ -1,0 +1,1 @@
+module github.com/git-lfs/wildmatch

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -11,7 +11,7 @@ github.com/git-lfs/gitobj
 github.com/git-lfs/gitobj/pack
 # github.com/git-lfs/go-netrc v0.0.0-20180525200031-e0e9ca483a18
 github.com/git-lfs/go-netrc/netrc
-# github.com/git-lfs/wildmatch v0.0.0-20180706170425-b31c34466d64
+# github.com/git-lfs/wildmatch v1.0.0
 github.com/git-lfs/wildmatch
 # github.com/inconshreveable/mousetrap v1.0.0
 github.com/inconshreveable/mousetrap


### PR DESCRIPTION
In order to prefer semantically versioned tags of our dependent
repositories over Go's date & SHA-1 format, let's tag
github.com/git-lfs/wildmatch.git at v1.0.0 (on the latest master) and
vendor it as such here.

The only change between b31c34466d64 and v1.0.0 is:

  * 83d2acb (Merge pull request #9 from git-lfs/ttaylorr/go-1.11,
    2018-08-31)
  * 2f71dd1 (.travis.yml: build on Go 1.11, 2018-08-30)
  * 4bab7d7 (go.mod: initial commit, 2018-08-30)

Which is the introduction of the go.mod file (and related changes).
Thus, there are no code changes between the two, so this is a safe
change to make.

##

/cc @git-lfs/core 