### PR TITLE
commands/command_ls_files.go: ignore index with argument

### DIFF
--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -36,7 +36,16 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 	if len(args) == 1 {
 		if lsFilesScanAll {
 			Exit("fatal: cannot use --all with explicit reference")
+		} else if args[0] == "--all" {
+			// Since --all is a valid argument to "git rev-parse",
+			// if we try to give it to git.ResolveRef below, we'll
+			// get an unexpected result.
+			//
+			// So, let's check early that the caller invoked the
+			// command correctly.
+			Exit("fatal: did you mean \"git lfs ls-files --all --\" ?")
 		}
+
 		ref, err = git.ResolveRef(args[0])
 		if err != nil {
 			Exit("fatal: could not resolve ref %s", args[0])

--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -31,7 +31,7 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 	} else {
 		fullref, err := git.CurrentRef()
 		if err != nil {
-			ref = git.RefBeforeFirstCommit
+			ref = git.RefBeforeFirstCommit.Sha
 		} else {
 			ref = fullref.Sha
 		}

--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -21,10 +21,19 @@ var (
 func lsFilesCommand(cmd *cobra.Command, args []string) {
 	requireInRepo()
 
-	var ref *git.Ref
+	var (
+		ref        *git.Ref
+		currentRef *git.Ref
+
+		err error
+	)
+
+	currentRef, err = git.CurrentRef()
+	if err != nil {
+		currentRef = git.RefBeforeFirstCommit
+	}
 
 	if len(args) == 1 {
-		var err error
 		if lsFilesScanAll {
 			Exit("fatal: cannot use --all with explicit reference")
 		}
@@ -33,12 +42,7 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 			Exit("fatal: could not resolve ref %s", args[0])
 		}
 	} else {
-		fullref, err := git.CurrentRef()
-		if err != nil {
-			ref = git.RefBeforeFirstCommit
-		} else {
-			ref = fullref
-		}
+		ref = currentRef
 	}
 
 	showOidLen := 10

--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -105,8 +105,16 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 	includeArg, excludeArg := getIncludeExcludeArgs(cmd)
 	gitscanner.Filter = buildFilepathFilter(cfg, includeArg, excludeArg)
 
-	if err := gitscanner.ScanIndex(ref.Sha, nil); err != nil {
-		Exit("Could not scan for Git LFS index: %s", err)
+	if currentRef.Sha == ref.Sha {
+		// Only scan the index when "git lfs ls-files" was invoked with
+		// no arguments, or a reference pointing to the HEAD checkout
+		// (or before the first commit).
+		//
+		// Do so to avoid showing "mixed" results, e.g., ls-files output
+		// from a specific historical revision, and the index.
+		if err := gitscanner.ScanIndex(ref.Sha, nil); err != nil {
+			Exit("Could not scan for Git LFS index: %s", err)
+		}
 	}
 	if lsFilesScanAll {
 		if err := gitscanner.ScanAll(nil); err != nil {

--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -28,7 +28,7 @@ func statusCommand(cmd *cobra.Command, args []string) {
 
 	scanIndexAt := "HEAD"
 	if ref == nil {
-		scanIndexAt = git.RefBeforeFirstCommit
+		scanIndexAt = git.RefBeforeFirstCommit.Sha
 	}
 
 	scanner, err := lfs.NewPointerScanner()

--- a/git/git.go
+++ b/git/git.go
@@ -33,10 +33,16 @@ const (
 	RefTypeRemoteTag    = RefType(iota)
 	RefTypeHEAD         = RefType(iota) // current checkout
 	RefTypeOther        = RefType(iota) // stash or unknown
+)
 
+var (
 	// A ref which can be used as a placeholder for before the first commit
-	// Equivalent to git mktree < /dev/null, useful for diffing before first commit
-	RefBeforeFirstCommit = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+	// Equivalent to git mktree < /dev/null, useful for diffing before first
+	// commit
+	RefBeforeFirstCommit = &Ref{
+		Type: RefTypeOther,
+		Sha:  "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
+	}
 )
 
 // Prefix returns the given RefType's prefix, "refs/heads", "ref/remotes",

--- a/t/t-ls-files.sh
+++ b/t/t-ls-files.sh
@@ -326,7 +326,7 @@ begin_test "ls-files: invalid --all ordering"
     echo >&2 "fatal: expected \`git lfs ls-files -- --all\' to fail"
     exit 1
   fi
-  grep "Could not scan for Git LFS tree" ls-files.out
+  grep "fatal: did you mean \"git lfs ls-files --all --\" ?" ls-files.out
 )
 end_test
 

--- a/t/t-ls-files.sh
+++ b/t/t-ls-files.sh
@@ -113,6 +113,35 @@ begin_test "ls-files: indexed file with tree"
 )
 end_test
 
+begin_test "ls-files: historical reference ignores index"
+(
+  set -e
+
+  reponame="ls-files-historical-reference-ignores-index"
+  git init "$reponame"
+  cd "$reponame"
+
+  git lfs track "*.txt"
+  echo "a.txt" > a.txt
+  echo "b.txt" > b.txt
+  echo "c.txt" > c.txt
+
+  git add .gitattributes a.txt
+  git commit -m "a.txt: initial commit"
+
+  git add b.txt
+  git commit -m "b.txt: initial commit"
+
+  git add c.txt
+
+  git lfs ls-files "$(git rev-parse HEAD~1)" 2>&1 | tee ls-files.log
+
+  [ 1 -eq "$(grep -c "a.txt" ls-files.log)" ]
+  [ 0 -eq "$(grep -c "b.txt" ls-files.log)" ]
+  [ 0 -eq "$(grep -c "c.txt" ls-files.log)" ]
+)
+end_test
+
 begin_test "ls-files: outside git repository"
 (
   set +e


### PR DESCRIPTION
This pull request teaches `git lfs ls-files` to not traverse the index for Git LFS objects when given an explicit reference that is not equal to the current checkout.

Closes: https://github.com/git-lfs/git-lfs/issues/3213.

##

/cc @git-lfs/core 
/cc @jlisee, https://github.com/git-lfs/git-lfs/issues/3213