### PR TITLE
Treat [host:port]:path URLs correctly

### DIFF
--- a/lfsapi/endpoint.go
+++ b/lfsapi/endpoint.go
@@ -33,7 +33,8 @@ func endpointOperation(e Endpoint, method string) string {
 
 // endpointFromBareSshUrl constructs a new endpoint from a bare SSH URL:
 //
-//   user@host.com:path/to/repo.git
+//   user@host.com:path/to/repo.git or
+//   [user@host.com:port]:path/to/repo.git
 //
 func endpointFromBareSshUrl(rawurl string) Endpoint {
 	parts := strings.Split(rawurl, ":")
@@ -45,6 +46,9 @@ func endpointFromBareSshUrl(rawurl string) Endpoint {
 	// Treat presence of ':' as a bare URL
 	var newPath string
 	if len(parts) > 2 { // port included; really should only ever be 3 parts
+		// Correctly handle [host:port]:path URLs
+		parts[0] = strings.TrimPrefix(parts[0], "[")
+		parts[1] = strings.TrimSuffix(parts[1], "]")
 		newPath = fmt.Sprintf("%v:%v", parts[0], strings.Join(parts[1:], "/"))
 	} else {
 		newPath = strings.Join(parts, "/")

--- a/lfsapi/endpoint_finder_test.go
+++ b/lfsapi/endpoint_finder_test.go
@@ -177,6 +177,18 @@ func TestBareSSHEndpointAddsLfsSuffix(t *testing.T) {
 	assert.Equal(t, "", e.SshPort)
 }
 
+func TestBareSSSHEndpointWithCustomPortInBrackets(t *testing.T) {
+	finder := NewEndpointFinder(NewContext(nil, nil, map[string]string{
+		"remote.origin.url": "[git@example.com:2222]:foo/bar.git",
+	}))
+
+	e := finder.Endpoint("download", "")
+	assert.Equal(t, "https://example.com/foo/bar.git/info/lfs", e.Url)
+	assert.Equal(t, "git@example.com", e.SshUserAndHost)
+	assert.Equal(t, "foo/bar.git", e.SshPath)
+	assert.Equal(t, "2222", e.SshPort)
+}
+
 func TestSSHEndpointFromGlobalLfsUrl(t *testing.T) {
 	finder := NewEndpointFinder(NewContext(nil, nil, map[string]string{
 		"lfs.url": "git@example.com:foo/bar.git",


### PR DESCRIPTION
Remotes with custom ssh ports look like this in .git/config:

    [remote "origin"]
    url = [git@example.com:2323]:path/to.git

Strip the brackets from the URL parts to support those URLs.