### PR TITLE
commands/command_migrate_import.go: install hooks

### DIFF
--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -33,6 +33,11 @@ func migrateImportCommand(cmd *cobra.Command, args []string) {
 	}
 	defer db.Close()
 
+	// To avoid confusion later, let's make sure that we've installed the
+	// necessary hooks so that a newly migrated repository is `git
+	// push`-able immediately following a `git lfs migrate import`.
+	installHooks(false)
+
 	if migrateNoRewrite {
 		if migrateFixup {
 			ExitWithError(errors.Errorf("fatal: --no-rewrite and --fixup cannot be combined"))

--- a/t/t-migrate-import.sh
+++ b/t/t-migrate-import.sh
@@ -30,6 +30,10 @@ begin_test "migrate import (default branch)"
 
   echo "$master_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
   echo "$master_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"
+
+  # Ensure that hooks are installed. If we find 'git-lfs' somewhere in
+  # .git/hooks/pre-push we assume that the rest went correctly, too.
+  grep -q "git-lfs" .git/hooks/pre-push
 )
 end_test
 


### PR DESCRIPTION
When migrating a repository to use Git LFS for the first time, a user is
also required to run 'git lfs install' inside of their newly-migrated
repository, lest they are unable to push.

This is due to the fact that 'git lfs install' writes
.git/hooks/pre-push, which Git invokes, in turn invoking Git LFS to push
Git LFS objects to the remote before sending Git objects.

Without this, we will push only plain-text pointer files, which puts the
pusher at risk of loosing data, or failing any provider-specific
verification/integrity checks.

So, let's run installHooks() to place hooks in the right place, which
makes the following command sequence possible:

  $ git lfs migrate import ...
  $ git push --all

Let's avoid running this in 'git lfs migrate info' and 'git lfs migrate
export', since neither require it.

##

/cc @git-lfs/core 