### PR TITLE
t: mark test sources as .PHONY

### DIFF
--- a/t/Makefile
+++ b/t/Makefile
@@ -29,6 +29,7 @@ test : $(TEST_CMDS)
 	$(PROVE) $(PROVE_EXTRA_ARGS) ./t-*.sh
 	@GIT_LFS_NO_TEST_COUNT= bash -c '. ./testenv.sh && shutdown'
 
+.PHONY : $(TEST_SRCS)
 $(TEST_SRCS) : $(TEST_CMDS)
 	$(RM) -r remote test_count{,.lock}
 	$(PROVE) -v $(PROVE_EXTRA_ARGS) $@

--- a/t/Makefile
+++ b/t/Makefile
@@ -19,6 +19,8 @@ TEST_CMDS += ../bin/lfstest-gitserver$X
 TEST_CMDS += ../bin/lfstest-standalonecustomadapter$X
 TEST_CMDS += ../bin/lfstest-testutils$X
 
+TEST_SRCS = $(wildcard t-*.sh)
+
 all : $(DEFAULT_TEST_TARGET)
 
 test : $(TEST_CMDS)
@@ -27,7 +29,7 @@ test : $(TEST_CMDS)
 	$(PROVE) $(PROVE_EXTRA_ARGS) ./t-*.sh
 	@GIT_LFS_NO_TEST_COUNT= bash -c '. ./testenv.sh && shutdown'
 
-./t-%.sh : $(TEST_CMDS)
+$(TEST_SRCS) : $(TEST_CMDS)
 	$(RM) -r remote test_count{,.lock}
 	$(PROVE) -v $(PROVE_EXTRA_ARGS) $@
 


### PR DESCRIPTION
This pull request makes `t/t-*.sh` targets `.PHONY`, so that we can repeatedly invoke them as `make t-*.sh` without having to pass `-B`.

##

/cc @git-lfs/core 