### PR TITLE
release: v2.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Git LFS Changelog
 
+## 2.5.2 (17 September, 2018)
+
+### Bugs
+
+* config: Treat [host:port]:path URLs correctly #3226 (@saschpe)
+* tq: Always provide a Content-Type when uploading files #3201 (@bk2204)
+* commands/track: Properly `lfs track` files with escaped characters in their
+  name #3192 (@leonid-s-usov)
+
+### Misc
+
+* packagecloud.rb: remove older versions #3210 (@andyneff)
+
 ## 2.5.1 (2 August, 2018)
 
 This release contains miscellaneous bug fixes since v2.5.0. Most notably,

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -72,7 +72,7 @@ ArgsLoop:
 		pattern := trimCurrentPrefix(cleanRootPath(unsanitizedPattern))
 		if !trackNoModifyAttrsFlag {
 			for _, known := range knownPatterns {
-				if known.Path == filepath.Join(relpath, pattern) &&
+				if unescapeAttrPattern(known.Path) == filepath.Join(relpath, pattern) &&
 					((trackLockableFlag && known.Lockable) || // enabling lockable & already lockable (no change)
 						(trackNotLockableFlag && !known.Lockable) || // disabling lockable & not lockable (no change)
 						(!trackLockableFlag && !trackNotLockableFlag)) { // leave lockable as-is in all cases
@@ -132,7 +132,7 @@ ArgsLoop:
 					continue
 				}
 
-				pattern := fields[0]
+				pattern := unescapeAttrPattern(fields[0])
 				if newline, ok := changedAttribLines[pattern]; ok {
 					// Replace this line (newline already embedded)
 					attributesFile.WriteString(newline)

--- a/config/version.go
+++ b/config/version.go
@@ -12,7 +12,7 @@ var (
 )
 
 const (
-	Version = "2.5.1"
+	Version = "2.5.2"
 )
 
 func init() {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+git-lfs (2.5.2) stable; urgency=low
+
+  * New upstream version
+
+ -- Taylor Blau <me@ttaylorr.com>  Mon, 17 Sep 2018 14:29:00 +0000
+
 git-lfs (2.5.1) stable; urgency=low
 
   * New upstream version

--- a/lfsapi/endpoint.go
+++ b/lfsapi/endpoint.go
@@ -33,7 +33,8 @@ func endpointOperation(e Endpoint, method string) string {
 
 // endpointFromBareSshUrl constructs a new endpoint from a bare SSH URL:
 //
-//   user@host.com:path/to/repo.git
+//   user@host.com:path/to/repo.git or
+//   [user@host.com:port]:path/to/repo.git
 //
 func endpointFromBareSshUrl(rawurl string) Endpoint {
 	parts := strings.Split(rawurl, ":")
@@ -45,6 +46,9 @@ func endpointFromBareSshUrl(rawurl string) Endpoint {
 	// Treat presence of ':' as a bare URL
 	var newPath string
 	if len(parts) > 2 { // port included; really should only ever be 3 parts
+		// Correctly handle [host:port]:path URLs
+		parts[0] = strings.TrimPrefix(parts[0], "[")
+		parts[1] = strings.TrimSuffix(parts[1], "]")
 		newPath = fmt.Sprintf("%v:%v", parts[0], strings.Join(parts[1:], "/"))
 	} else {
 		newPath = strings.Join(parts, "/")

--- a/lfsapi/endpoint_finder_test.go
+++ b/lfsapi/endpoint_finder_test.go
@@ -177,6 +177,18 @@ func TestBareSSHEndpointAddsLfsSuffix(t *testing.T) {
 	assert.Equal(t, "", e.SshPort)
 }
 
+func TestBareSSSHEndpointWithCustomPortInBrackets(t *testing.T) {
+	finder := NewEndpointFinder(NewContext(nil, nil, map[string]string{
+		"remote.origin.url": "[git@example.com:2222]:foo/bar.git",
+	}))
+
+	e := finder.Endpoint("download", "")
+	assert.Equal(t, "https://example.com/foo/bar.git/info/lfs", e.Url)
+	assert.Equal(t, "git@example.com", e.SshUserAndHost)
+	assert.Equal(t, "foo/bar.git", e.SshPath)
+	assert.Equal(t, "2222", e.SshPort)
+}
+
 func TestSSHEndpointFromGlobalLfsUrl(t *testing.T) {
 	finder := NewEndpointFinder(NewContext(nil, nil, map[string]string{
 		"lfs.url": "git@example.com:foo/bar.git",

--- a/rpm/SPECS/git-lfs.spec
+++ b/rpm/SPECS/git-lfs.spec
@@ -1,5 +1,5 @@
 Name:           git-lfs
-Version:        2.5.1
+Version:        2.5.2
 Release:        1%{?dist}
 Summary:        Git extension for versioning large files
 

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -33,11 +33,11 @@ $distro_name_map = {
   ),
   "centos/7" => %w(
     el/7
-    fedora/22
-    fedora/23
-    fedora/24
-    fedora/25
-    fedora/26
+    fedora/27
+    fedora/28
+    opensuse/42.3
+    sles/11.4
+    sles/12.3
   ),
   "debian/7" => %w(
     debian/wheezy
@@ -58,6 +58,7 @@ $distro_name_map = {
     linuxmint/serena
     linuxmint/sonya
     linuxmint/sylvia
+    linuxmint/tara
     ubuntu/xenial
     ubuntu/yakkety
     ubuntu/zesty

--- a/t/t-content-type.sh
+++ b/t/t-content-type.sh
@@ -20,6 +20,7 @@ begin_test "content-type: is enabled by default"
   GIT_CURL_VERBOSE=1 git push origin master 2>&1 | tee push.log
 
   [ 1 -eq "$(grep -c "Content-Type: application/x-gzip" push.log)" ]
+  [ 0 -eq "$(grep -c "Content-Type: application/octet-stream" push.log)" ]
 )
 end_test
 
@@ -42,6 +43,7 @@ begin_test "content-type: is disabled by configuration"
   GIT_CURL_VERBOSE=1 git push origin master 2>&1 | tee push.log
 
   [ 0 -eq "$(grep -c "Content-Type: application/x-gzip" push.log)" ]
+  [ 1 -eq "$(grep -c "Content-Type: application/octet-stream" push.log)" ]
 )
 end_test
 

--- a/t/t-track.sh
+++ b/t/t-track.sh
@@ -595,3 +595,28 @@ begin_test "track (system gitattributes)"
   grep "*.dat" track.log
 )
 end_test
+
+begin_test "track: escaped pattern in .gitattributes"
+(
+  set -e
+
+  reponame="track-escaped"
+  git init "$reponame"
+  cd "$reponame"
+
+  filename="file with spaces.#"
+
+  echo "I need escaping" > "$filename"
+
+  [ "Tracking \"$filename\"" = "$(git lfs track "$filename")" ]
+  [ "\"$filename\" already supported" = "$(git lfs track "$filename")" ]
+  
+  #changing flags should track the file again
+  [ "Tracking \"$filename\"" = "$(git lfs track -l "$filename")" ]
+
+  if [ 1 -ne "$(wc -l .gitattributes | awk '{ print $1 }')" ]; then
+    echo >&2 "changing flag for an existing tracked file shouldn't add another line"
+    exit 1
+  fi
+)
+end_test

--- a/t/t-untrack.sh
+++ b/t/t-untrack.sh
@@ -89,7 +89,7 @@ begin_test "untrack removes prefixed patterns (legacy)"
   git lfs untrack "./a.dat"
 
   if [ ! -z "$(cat .gitattributes)" ]; then
-    echo &>2 "fatal: expected 'git lfs untrack' to clear .gitattributes"
+    echo >&2 "fatal: expected 'git lfs untrack' to clear .gitattributes"
     exit 1
   fi
 
@@ -98,7 +98,7 @@ begin_test "untrack removes prefixed patterns (legacy)"
   git lfs untrack "a.dat"
 
   if [ ! -z "$(cat .gitattributes)" ]; then
-    echo &>2 "fatal: expected 'git lfs untrack' to clear .gitattributes"
+    echo >&2 "fatal: expected 'git lfs untrack' to clear .gitattributes"
     exit 1
   fi
 )
@@ -120,7 +120,7 @@ begin_test "untrack removes prefixed patterns (modern)"
   git lfs untrack "./a.dat"
 
   if [ ! -z "$(cat .gitattributes)" ]; then
-    echo &>2 "fatal: expected 'git lfs untrack' to clear .gitattributes"
+    echo >&2 "fatal: expected 'git lfs untrack' to clear .gitattributes"
     exit 1
   fi
 
@@ -129,7 +129,31 @@ begin_test "untrack removes prefixed patterns (modern)"
   git lfs untrack "a.dat"
 
   if [ ! -z "$(cat .gitattributes)" ]; then
-    echo &>2 "fatal: expected 'git lfs untrack' to clear .gitattributes"
+    echo >&2 "fatal: expected 'git lfs untrack' to clear .gitattributes"
+    exit 1
+  fi
+)
+end_test
+
+begin_test "untrack removes escaped pattern in .gitattributes"
+(
+  set -e
+
+  reponame="untrack-escaped"
+  git init "$reponame"
+  cd "$reponame"
+
+  filename="file with spaces.#"
+
+  # emulate multiple instances of the same file in gitattributes
+  echo 'file[[:space:]]with[[:space:]]spaces.\# filter=lfs diff=lfs merge=lfs -text' >> .gitattributes
+  echo 'file[[:space:]]with[[:space:]]spaces.\# filter=lfs diff=lfs merge=lfs -text' >> .gitattributes
+  echo 'file[[:space:]]with[[:space:]]spaces.\# filter=lfs diff=lfs merge=lfs -text' >> .gitattributes
+
+  git lfs untrack "$filename"
+
+  if [ ! -z "$(cat .gitattributes)" ]; then
+    echo >&2 "fatal: expected 'git lfs untrack' to clear .gitattributes even if the file name was escaped"
     exit 1
   fi
 )

--- a/versioninfo.json
+++ b/versioninfo.json
@@ -4,7 +4,7 @@
 		"FileVersion": {
 			"Major": 2,
 			"Minor": 5,
-			"Patch": 1,
+			"Patch": 2,
 			"Build": 0
 		}
 	},
@@ -13,7 +13,7 @@
 		"FileDescription": "Git LFS",
 		"LegalCopyright": "GitHub, Inc. and Git LFS contributors",
 		"ProductName": "Git Large File Storage (LFS)",
-		"ProductVersion": "2.5.1"
+		"ProductVersion": "2.5.2"
 	},
 	"IconPath": "script/windows-installer/git-lfs-logo.ico"
 }


### PR DESCRIPTION
This pull request provides an in-progress look at our next release, Git LFS v2.5.2, anticipated to land September 17, 2018.

We're publishing these changes early so that people on @git-lfs/implementers can take a look and make sure that everything is working as expected before the aforementioned date. In particular, we'd love to know that (after running `git config lfs.contentType false`) Git LFS users are able to push to the host that you represent/maintain.

Here are some advance-copy builds based on the tip of this branch (at the time: 6169805f (release: v2.5.2, 2018-09-05)):

[git-lfs-darwin-386-v2.5.2-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/2354134/git-lfs-darwin-386-v2.5.2-pre.tar.gz)
[git-lfs-darwin-amd64-v2.5.2-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/2354135/git-lfs-darwin-amd64-v2.5.2-pre.tar.gz)
[git-lfs-freebsd-386-v2.5.2-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/2354136/git-lfs-freebsd-386-v2.5.2-pre.tar.gz)
[git-lfs-freebsd-amd64-v2.5.2-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/2354137/git-lfs-freebsd-amd64-v2.5.2-pre.tar.gz)
[git-lfs-linux-386-v2.5.2-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/2354138/git-lfs-linux-386-v2.5.2-pre.tar.gz)
[git-lfs-linux-amd64-v2.5.2-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/2354139/git-lfs-linux-amd64-v2.5.2-pre.tar.gz)
[git-lfs-windows-386-v2.5.2-pre.zip](https://github.com/git-lfs/git-lfs/files/2354140/git-lfs-windows-386-v2.5.2-pre.zip)
[git-lfs-windows-amd64-v2.5.2-pre.zip](https://github.com/git-lfs/git-lfs/files/2354141/git-lfs-windows-amd64-v2.5.2-pre.zip)

##

/cc @git-lfs/core 
/cc @git-lfs/implementers