### PR TITLE
lfsapi: handle SSH hostnames and aliases without users

### DIFF
--- a/lfsapi/endpoint_finder.go
+++ b/lfsapi/endpoint_finder.go
@@ -188,8 +188,16 @@ func (e *endpointGitFinder) NewEndpoint(rawurl string) Endpoint {
 	case "":
 		return endpointFromBareSshUrl(u.String())
 	default:
-		// Just passthrough to preserve
-		return Endpoint{Url: rawurl}
+		if strings.HasPrefix(rawurl, u.Scheme+"::") {
+			// Looks like a remote helper; just pass it through.
+			return Endpoint{Url: rawurl}
+		}
+		// We probably got here because the "scheme" that was parsed is
+		// a hostname (whether FQDN or single word) and the URL parser
+		// didn't know what to do with it.  Do what Git does and treat
+		// it as an SSH URL.  This ensures we handle SSH config aliases
+		// properly.
+		return endpointFromBareSshUrl(u.String())
 	}
 }
 

--- a/t/t-config.sh
+++ b/t/t-config.sh
@@ -137,7 +137,7 @@ begin_test "url alias must be prefix"
   git config url."http://actual-url/".insteadOf alias:
   git config lfs.url badalias:rest
   git lfs env | tee env.log
-  grep "Endpoint=badalias:rest (auth=none)" env.log
+  grep "SSH=badalias:rest" env.log
 )
 end_test
 


### PR DESCRIPTION
It's very common for a user to specify an SSH remote that refers to an
alias in their gitconfig file.  For example, if a user must use
different SSH keys when pushing to different remotes, setting different
aliases that use those different keys is the simplest and easiest way to
accomplish that goal.

Unfortunately, our parsing logic was broken for SSH remotes that used
bare SSH URLs (that is, without “ssh://”) with a hostname or alias, but
without a username component.  The URL parser we used saw the hostname
portion as the scheme of a URL, and we passed through any URLs with
unknown schemes.  This led to a failure to push, since we misparsed the
URL as a non-SSH URL and gave up when it also didn't look like an
HTTP(S) URL.

If we get an unknown “scheme” when parsing a URL, check if the URL uses a
remote helper (that is, it contains a double colon), and pass it
through.  Otherwise, do what Git does, and assume the URL is in fact an
SSH URL, and handle it accordingly.

We already handle the url.insteadof syntax properly, even if it looks
like a scheme.  Add tests that we continue to do so, and for the new
code and all the various permutations mentioned above.

This should fix #278 and also fix #2842.