### PR TITLE
t: avoid using shell variables in printf's first argument

### DIFF
--- a/t/t-batch-error-handling.sh
+++ b/t/t-batch-error-handling.sh
@@ -29,7 +29,7 @@ begin_test "batch error handling"
   contents="a"
   contents_oid=$(calc_oid "$contents")
 
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
   git add a.dat
   git add .gitattributes
   git commit -m "add a.dat" 2>&1 | tee commit.log

--- a/t/t-batch-retries.sh
+++ b/t/t-batch-retries.sh
@@ -12,7 +12,7 @@ begin_test "batch storage upload causes retries"
 
   contents="storage-upload-retry"
   oid="$(calc_oid "$contents")"
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
 
   git lfs track "*.dat"
   git add .gitattributes a.dat
@@ -43,7 +43,7 @@ begin_test "batch storage download causes retries"
 
   contents="storage-download-retry"
   oid="$(calc_oid "$contents")"
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
 
   git lfs track "*.dat"
   git add .gitattributes a.dat

--- a/t/t-batch-transfer.sh
+++ b/t/t-batch-transfer.sh
@@ -31,7 +31,7 @@ begin_test "batch transfer"
   contents="a"
   contents_oid=$(calc_oid "$contents")
 
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
   git add a.dat
   git add .gitattributes
   git commit -m "add a.dat" 2>&1 | tee commit.log
@@ -79,11 +79,11 @@ begin_test "batch transfers occur in reverse order by size"
 
   small_contents="small"
   small_oid="$(calc_oid "$small_contents")"
-  printf "$small_contents" > small.dat
+  printf "%s" "$small_contents" > small.dat
 
   bigger_contents="bigger"
   bigger_oid="$(calc_oid "$bigger_contents")"
-  printf "$bigger_contents" > bigger.dat
+  printf "%s" "$bigger_contents" > bigger.dat
 
   git add *.dat
   git commit -m "add small and large objects"
@@ -116,7 +116,7 @@ begin_test "batch transfers with ssh endpoint"
   contents="test"
   oid="$(calc_oid "$contents")"
   git lfs track "*.dat"
-  printf "$contents" > test.dat
+  printf "%s" "$contents" > test.dat
   git add .gitattributes test.dat
   git commit -m "initial commit"
 
@@ -138,7 +138,7 @@ begin_test "batch transfers with ntlm server"
   contents="test"
   oid="$(calc_oid "$contents")"
   git lfs track "*.dat"
-  printf "$contents" > test.dat
+  printf "%s" "$contents" > test.dat
   git add .gitattributes test.dat
   git commit -m "initial commit"
 

--- a/t/t-batch-unknown-oids.sh
+++ b/t/t-batch-unknown-oids.sh
@@ -15,7 +15,7 @@ begin_test "transfer queue rejects unknown OIDs"
   git commit -m "initial commit"
 
   contents="unknown-oid"
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
 
   git add a.dat
   git commit -m "add objects"

--- a/t/t-checkout.sh
+++ b/t/t-checkout.sh
@@ -19,12 +19,12 @@ begin_test "checkout"
   contents_oid=$(calc_oid "$contents")
 
   # Same content everywhere is ok, just one object in lfs db
-  printf "$contents" > file1.dat
-  printf "$contents" > file2.dat
-  printf "$contents" > file3.dat
+  printf "%s" "$contents" > file1.dat
+  printf "%s" "$contents" > file2.dat
+  printf "%s" "$contents" > file3.dat
   mkdir folder1 folder2
-  printf "$contents" > folder1/nested.dat
-  printf "$contents" > folder2/nested.dat
+  printf "%s" "$contents" > folder1/nested.dat
+  printf "%s" "$contents" > folder2/nested.dat
   git add file1.dat file2.dat file3.dat folder1/nested.dat folder2/nested.dat
   git add .gitattributes
   git commit -m "add files"

--- a/t/t-chunked-transfer-encoding.sh
+++ b/t/t-chunked-transfer-encoding.sh
@@ -30,7 +30,7 @@ begin_test "chunked transfer encoding"
   contents_oid=$(calc_oid "$contents")
 
   # Regular Git commands can be used.
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
   git add a.dat
   git add .gitattributes
   git commit -m "add a.dat" 2>&1 | tee commit.log

--- a/t/t-clone.sh
+++ b/t/t-clone.sh
@@ -308,13 +308,13 @@ begin_test "clone (with include/exclude args)"
 
   contents_a="a"
   contents_a_oid=$(calc_oid "$contents_a")
-  printf "$contents_a" > "a.dat"
-  printf "$contents_a" > "a-dupe.dat"
-  printf "$contents_a" > "dupe-a.dat"
+  printf "%s" "$contents_a" > "a.dat"
+  printf "%s" "$contents_a" > "a-dupe.dat"
+  printf "%s" "$contents_a" > "dupe-a.dat"
 
   contents_b="b"
   contents_b_oid=$(calc_oid "$contents_b")
-  printf "$contents_b" > "b.dat"
+  printf "%s" "$contents_b" > "b.dat"
 
   git add *.dat .gitattributes
   git commit -m "add a.dat, b.dat" 2>&1 | tee commit.log
@@ -369,11 +369,11 @@ begin_test "clone (with .lfsconfig)"
 
   contents_a="a"
   contents_a_oid=$(calc_oid "$contents_a")
-  printf "$contents_a" > "a.dat"
+  printf "%s" "$contents_a" > "a.dat"
 
   contents_b="b"
   contents_b_oid=$(calc_oid "$contents_b")
-  printf "$contents_b" > "b.dat"
+  printf "%s" "$contents_b" > "b.dat"
 
   git add a.dat b.dat .gitattributes
   git commit -m "add a.dat, b.dat" 2>&1 | tee commit.log
@@ -474,7 +474,7 @@ begin_test "clone (without clean filter)"
 
   contents_a="a"
   contents_a_oid=$(calc_oid "$contents_a")
-  printf "$contents_a" > "a.dat"
+  printf "%s" "$contents_a" > "a.dat"
 
   git add *.dat .gitattributes
   git commit -m "add a.dat, b.dat" 2>&1 | tee commit.log
@@ -527,7 +527,7 @@ begin_test "clone with submodules"
 
   contents_sub2="Inception. Now, before you bother telling me it's impossible..."
   contents_sub2_oid=$(calc_oid "$contents_sub2")
-  printf "$contents_sub2" > "sub2.dat"
+  printf "%s" "$contents_sub2" > "sub2.dat"
   git add sub2.dat .gitattributes
   git commit -m "Nested submodule level 2"
   git push origin master
@@ -538,7 +538,7 @@ begin_test "clone with submodules"
 
   contents_sub1="We're dreaming?"
   contents_sub1_oid=$(calc_oid "$contents_sub1")
-  printf "$contents_sub1" > "sub1.dat"
+  printf "%s" "$contents_sub1" > "sub1.dat"
   # add submodule2 as submodule of submodule1
   git submodule add "$GITSERVER/$submodname2" sub2
   git submodule update
@@ -552,7 +552,7 @@ begin_test "clone with submodules"
 
   contents_root="Downwards is the only way forwards."
   contents_root_oid=$(calc_oid "$contents_root")
-  printf "$contents_root" > "root.dat"
+  printf "%s" "$contents_root" > "root.dat"
   # add submodule1 as submodule of root
   git submodule add "$GITSERVER/$submodname1" sub1
   git submodule update
@@ -597,7 +597,7 @@ begin_test "clone in current directory"
   contents="contents"
   contents_oid="$(calc_oid "$contents")"
 
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
 
   git add .gitattributes a.dat
 

--- a/t/t-credentials.sh
+++ b/t/t-credentials.sh
@@ -62,7 +62,7 @@ begin_test "credentials without useHttpPath, with bad path password"
   credcalls="$(grep "creds: git credential" push.log)"
   [ "0" -eq "$(echo "$credcalls" | grep "no-httppath-bad-password" | wc -l)" ]
   expected="$(echo "$credcalls" | wc -l)"
-  [ "$expected" -eq "$(printf "$credcalls" | grep '", "")' | wc -l)" ]
+  [ "$expected" -eq "$(printf "%s" "$credcalls" | grep '", "")' | wc -l)" ]
 )
 end_test
 
@@ -116,7 +116,7 @@ begin_test "credentials with useHttpPath, with wrong password"
   contents="a"
   contents_oid=$(calc_oid "$contents")
 
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
   git add a.dat
   git add .gitattributes
   git commit -m "add a.dat"
@@ -150,7 +150,7 @@ begin_test "credentials with useHttpPath, with correct password"
   contents="b"
   contents_oid=$(calc_oid "$contents")
 
-  printf "$contents" > b.dat
+  printf "%s" "$contents" > b.dat
   git add b.dat
   git add .gitattributes
   git commit -m "add b.dat"
@@ -165,7 +165,7 @@ begin_test "credentials with useHttpPath, with correct password"
   credcalls="$(grep "creds: git credential" push.log)"
   [ "0" -eq "$(echo "$credcalls" | grep '", "")' | wc -l)" ]
   expected="$(echo "$credcalls" | wc -l)"
-  [ "$expected" -eq "$(printf "$credcalls" | grep "t-credentials" | wc -l)" ]
+  [ "$expected" -eq "$(printf "%s" "$credcalls" | grep "t-credentials" | wc -l)" ]
 )
 end_test
 

--- a/t/t-custom-transfers.sh
+++ b/t/t-custom-transfers.sh
@@ -21,7 +21,7 @@ begin_test "custom-transfer-wrong-path"
   contents="jksgdfljkgsdlkjafg lsjdgf alkjgsd lkfjag sldjkgf alkjsgdflkjagsd kljfg asdjgf kalsd"
   contents_oid=$(calc_oid "$contents")
 
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
   git add a.dat
   git add .gitattributes
   git commit -m "add a.dat" 2>&1 | tee commit.log

--- a/t/t-duplicate-oids.sh
+++ b/t/t-duplicate-oids.sh
@@ -21,7 +21,7 @@ begin_test "multiple revs with same OID get pushed once"
   object_dir="$(echo $contents_oid \
     | awk '{ print substr($0, 0, 2) "/" substr($0, 3, 2) }')"
   mkdir -p ".git/lfs/objects/$object_dir"
-  printf "$contents" > ".git/lfs/objects/$object_dir/$contents_oid"
+  printf "%s" "$contents" > ".git/lfs/objects/$object_dir/$contents_oid"
 
   # Create a pointer with the old "http://git-media.io" spec
   legacy_pointer="$(pointer $contents_oid 8 http://git-media.io/v/2)"
@@ -30,13 +30,13 @@ begin_test "multiple revs with same OID get pushed once"
   latest_pointer="$(pointer $contents_oid 8)"
 
   # Commit the legacy pointer
-  printf "$legacy_pointer" > a.dat
+  printf "%s" "$legacy_pointer" > a.dat
   git add a.dat
   git commit -m "commit legacy"
 
   # Commit the new pointer, causing a diff on a.dat, but leaving the OID
   # unchanged.
-  printf "$latest_pointer" > a.dat
+  printf "%s" "$latest_pointer" > a.dat
   git add a.dat
   git commit -m "commit latest"
 

--- a/t/t-expired.sh
+++ b/t/t-expired.sh
@@ -20,7 +20,7 @@ for typ in "${expiration_types[@]}"; do
     git add .gitattributes
     git commit -m "initial commit"
 
-    printf "$contents" > a.dat
+    printf "%s" "$contents" > a.dat
 
     git add a.dat
     git commit -m "add a.dat"
@@ -55,7 +55,7 @@ for typ in "${expiration_types[@]}"; do
     git add .gitattributes
     git commit -m "initial commit"
 
-    printf "$contents" > a.dat
+    printf "%s" "$contents" > a.dat
 
     git add a.dat
     git commit -m "add a.dat"

--- a/t/t-fetch-include.sh
+++ b/t/t-fetch-include.sh
@@ -17,13 +17,13 @@ begin_test "fetch: setup for include test"
   mkdir -p big/a
   mkdir -p big/b
 
-  printf "$contents" > big/a/a1.big
-  printf "$contents" > big/b/b1.big
+  printf "%s" "$contents" > big/a/a1.big
+  printf "%s" "$contents" > big/b/b1.big
 
   contents2="big file 2"
-  printf "$contents2" > big/big1.big
-  printf "$contents2" > big/big2.big
-  printf "$contents2" > big/big3.big
+  printf "%s" "$contents2" > big/big1.big
+  printf "%s" "$contents2" > big/big2.big
+  printf "%s" "$contents2" > big/big3.big
 
   git add .gitattributes big
   git commit -m "commit" | tee commit.log

--- a/t/t-fetch-paths.sh
+++ b/t/t-fetch-paths.sh
@@ -17,7 +17,7 @@ begin_test "init fetch unclean paths"
   grep "Tracking \"\*.dat\"" track.log
 
   mkdir dir
-  printf "$contents" > dir/a.dat
+  printf "%s" "$contents" > dir/a.dat
 
   git add dir/a.dat
   git add .gitattributes

--- a/t/t-fetch.sh
+++ b/t/t-fetch.sh
@@ -20,7 +20,7 @@ begin_test "init for fetch tests"
   grep "Tracking \"\*.dat\"" track.log
 
 
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
   git add a.dat
   git add .gitattributes
   git commit -m "add a.dat" 2>&1 | tee commit.log
@@ -43,7 +43,7 @@ begin_test "init for fetch tests"
 
   # Add a file in a different branch
   git checkout -b newbranch
-  printf "$b" > b.dat
+  printf "%s" "$b" > b.dat
   git add b.dat
   git commit -m "add b.dat"
   assert_local_object "$b_oid" 1
@@ -421,7 +421,7 @@ begin_test "fetch with no origin remote"
   contents="a"
   contents_oid=$(calc_oid "$contents")
 
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
   git add a.dat
   git add .gitattributes
   git commit -m "add a.dat" 2>&1 | tee commit.log

--- a/t/t-filter-branch.sh
+++ b/t/t-filter-branch.sh
@@ -11,17 +11,17 @@ begin_test "filter-branch (git-lfs/git-lfs#1773)"
   clone_repo "$reponame" "$reponame"
 
   contents_a="contents (a)"
-  printf "$contents_a" > a.dat
+  printf "%s" "$contents_a" > a.dat
   git add a.dat
   git commit -m "add a.dat"
 
   contents_b="contents (b)"
-  printf "$contents_b" > b.dat
+  printf "%s" "$contents_b" > b.dat
   git add b.dat
   git commit -m "add b.dat"
 
   contents_c="contents (c)"
-  printf "$contents_c" > c.dat
+  printf "%s" "$contents_c" > c.dat
   git add c.dat
   git commit -m "add c.dat"
 

--- a/t/t-filter-process.sh
+++ b/t/t-filter-process.sh
@@ -22,7 +22,7 @@ begin_test "filter process: checking out a branch"
 
   contents_a="contents_a"
   contents_a_oid="$(calc_oid $contents_a)"
-  printf "$contents_a" > a.dat
+  printf "%s" "$contents_a" > a.dat
 
   git add a.dat
   git commit -m "add a.dat"
@@ -31,7 +31,7 @@ begin_test "filter process: checking out a branch"
 
   contents_b="contents_b"
   contents_b_oid="$(calc_oid $contents_b)"
-  printf "$contents_b" > b.dat
+  printf "%s" "$contents_b" > b.dat
 
   git add b.dat
   git commit -m "add b.dat"
@@ -79,7 +79,7 @@ begin_test "filter process: adding a file"
 
   contents="contents"
   contents_oid="$(calc_oid "$contents")"
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
 
   git add a.dat
 

--- a/t/t-happy-path.sh
+++ b/t/t-happy-path.sh
@@ -30,7 +30,7 @@ begin_test "happy path"
   contents_oid=$(calc_oid "$contents")
 
   # Regular Git commands can be used.
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
   git add a.dat
   git add .gitattributes
   git commit -m "add a.dat" 2>&1 | tee commit.log

--- a/t/t-lock.sh
+++ b/t/t-lock.sh
@@ -160,7 +160,7 @@ begin_test "locking a nested file"
   contents="contents"
   contents_oid="$(calc_oid "$contents")"
 
-  printf "$contents" > foo/bar/baz/a.dat
+  printf "%s" "$contents" > foo/bar/baz/a.dat
   git add foo/bar/baz/a.dat
   git commit -m "add a.dat"
 

--- a/t/t-ls-files.sh
+++ b/t/t-ls-files.sh
@@ -50,8 +50,8 @@ begin_test "ls-files: --size"
   git commit -m "initial commit"
 
   contents="contents"
-  size="$(printf "$contents" | wc -c | awk '{ print $1 }')"
-  printf "$contents" > a.dat
+  size="$(printf "%s" "$contents" | wc -c | awk '{ print $1 }')"
+  printf "%s" "$contents" > a.dat
 
   git add a.dat
   git commit -m "add a.dat"
@@ -74,7 +74,7 @@ begin_test "ls-files: indexed files without tree"
 
   contents="a"
   oid="$(calc_oid "$contents")"
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
 
   [ "" = "$(git lfs ls-files)" ]
 
@@ -99,14 +99,14 @@ begin_test "ls-files: indexed file with tree"
   tree_contents="a"
   tree_oid="$(calc_oid "$tree_contents")"
 
-  printf "$tree_contents" > a.dat
+  printf "%s" "$tree_contents" > a.dat
   git add a.dat
   git commit -m "add a.dat"
 
   index_contents="b"
   index_oid="$(calc_oid "$index_contents")"
 
-  printf "$index_contents" > a.dat
+  printf "%s" "$index_contents" > a.dat
   git add a.dat
 
   [ "${index_oid:0:10} * a.dat" = "$(git lfs ls-files)" ]

--- a/t/t-pointer.sh
+++ b/t/t-pointer.sh
@@ -123,7 +123,7 @@ begin_test "pointer --stdin with bad pointer"
 
 Pointer file error: invalid header"
 
-  diff -u <(printf "$expected") <(printf "$output")
+  diff -u <(printf "%s" "$expected") <(printf "%s" "$output")
 
   [ "1" = "$status" ]
 )
@@ -243,7 +243,7 @@ begin_test "pointer invalid --pointer"
 
 Pointer file error: invalid header"
 
-  diff -u <(printf "$expected") <(printf "$output")
+  diff -u <(printf "%s" "$expected") <(printf "%s" "$output")
 
   [ "$expected" = "$output" ]
 )

--- a/t/t-pre-push.sh
+++ b/t/t-pre-push.sh
@@ -292,7 +292,7 @@ begin_test "pre-push with missing pointer which is on server"
   contents="common data"
   contents_oid=$(calc_oid "$contents")
   git lfs track "*.dat"
-  printf "$contents" > common1.dat
+  printf "%s" "$contents" > common1.dat
   git add common1.dat
   git add .gitattributes
   git commit -m "add first file"
@@ -307,7 +307,7 @@ begin_test "pre-push with missing pointer which is on server"
   assert_server_object "$reponame" "$contents_oid"
 
   # create another commit referencing same oid, then delete local data & push
-  printf "$contents" > common2.dat
+  printf "%s" "$contents" > common2.dat
   git add common2.dat
   git commit -m "add second file, same content"
   rm -rf .git/lfs/objects
@@ -334,11 +334,11 @@ begin_test "pre-push with missing and present pointers (lfs.allowincompletepush 
 
   present="present"
   present_oid="$(calc_oid "$present")"
-  printf "$present" > present.dat
+  printf "%s" "$present" > present.dat
 
   missing="missing"
   missing_oid="$(calc_oid "$missing")"
-  printf "$missing" > missing.dat
+  printf "%s" "$missing" > missing.dat
 
   git add present.dat missing.dat
   git commit -m "add present.dat and missing.dat"
@@ -385,11 +385,11 @@ begin_test "pre-push reject missing pointers (lfs.allowincompletepush default)"
 
   present="present"
   present_oid="$(calc_oid "$present")"
-  printf "$present" > present.dat
+  printf "%s" "$present" > present.dat
 
   missing="missing"
   missing_oid="$(calc_oid "$missing")"
-  printf "$missing" > missing.dat
+  printf "%s" "$missing" > missing.dat
 
   git add present.dat missing.dat
   git commit -m "add present.dat and missing.dat"
@@ -646,7 +646,7 @@ begin_test "pre-push with our lock"
   git commit -m "initial commit"
 
   contents="locked contents"
-  printf "$contents" > locked.dat
+  printf "%s" "$contents" > locked.dat
   git add locked.dat
   git commit -m "add locked.dat"
 
@@ -684,7 +684,7 @@ begin_test "pre-push with their lock on lfs file"
   contents="locked contents"
 
   # any lock path with "theirs" is returned as "their" lock by /locks/verify
-  printf "$contents" > locked_theirs.dat
+  printf "%s" "$contents" > locked_theirs.dat
   git add locked_theirs.dat
   git commit -m "add locked_theirs.dat"
 
@@ -789,7 +789,7 @@ begin_test "pre-push locks verify 5xx with verification enabled"
 
   contents="example"
   contents_oid="$(calc_oid "$contents")"
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
   git lfs track "*.dat"
   git add .gitattributes a.dat
   git commit --message "initial commit"
@@ -816,7 +816,7 @@ begin_test "pre-push disable locks verify on exact url"
 
   contents="example"
   contents_oid="$(calc_oid "$contents")"
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
   git lfs track "*.dat"
   git add .gitattributes a.dat
   git commit --message "initial commit"
@@ -842,7 +842,7 @@ begin_test "pre-push disable locks verify on partial url"
 
   contents="example"
   contents_oid="$(calc_oid "$contents")"
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
   git lfs track "*.dat"
   git add .gitattributes a.dat
   git commit --message "initial commit"
@@ -866,7 +866,7 @@ begin_test "pre-push locks verify 403 with good ref"
 
   contents="example"
   contents_oid="$(calc_oid "$contents")"
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
   git lfs track "*.dat"
   git add .gitattributes a.dat
   git commit --message "initial commit"
@@ -888,7 +888,7 @@ begin_test "pre-push locks verify 403 with good tracked ref"
 
   contents="example"
   contents_oid="$(calc_oid "$contents")"
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
   git lfs track "*.dat"
   git add .gitattributes a.dat
   git commit --message "initial commit"
@@ -912,7 +912,7 @@ begin_test "pre-push locks verify 403 with explicit ref"
 
   contents="example"
   contents_oid="$(calc_oid "$contents")"
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
   git lfs track "*.dat"
   git add .gitattributes a.dat
   git commit --message "initial commit"
@@ -934,7 +934,7 @@ begin_test "pre-push locks verify 403 with bad ref"
 
   contents="example"
   contents_oid="$(calc_oid "$contents")"
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
   git lfs track "*.dat"
   git add .gitattributes a.dat
   git commit --message "initial commit"
@@ -958,7 +958,7 @@ begin_test "pre-push locks verify 5xx with verification unset"
 
   contents="example"
   contents_oid="$(calc_oid "$contents")"
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
   git lfs track "*.dat"
   git add .gitattributes a.dat
   git commit --message "initial commit"
@@ -984,7 +984,7 @@ begin_test "pre-push locks verify 501 with verification enabled"
 
   contents="example"
   contents_oid="$(calc_oid "$contents")"
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
   git lfs track "*.dat"
   git add .gitattributes a.dat
   git commit --message "initial commit"
@@ -1011,7 +1011,7 @@ begin_test "pre-push locks verify 501 with verification disabled"
 
   contents="example"
   contents_oid="$(calc_oid "$contents")"
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
   git lfs track "*.dat"
   git add .gitattributes a.dat
   git commit --message "initial commit"
@@ -1037,7 +1037,7 @@ begin_test "pre-push locks verify 501 with verification unset"
 
   contents="example"
   contents_oid="$(calc_oid "$contents")"
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
   git lfs track "*.dat"
   git add .gitattributes a.dat
   git commit --message "initial commit"
@@ -1064,7 +1064,7 @@ begin_test "pre-push locks verify 200"
 
   contents="example"
   contents_oid="$(calc_oid "$contents")"
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
   git lfs track "*.dat"
   git add .gitattributes a.dat
   git commit --message "initial commit"
@@ -1089,7 +1089,7 @@ begin_test "pre-push locks verify 403 with verification enabled"
 
   contents="example"
   contents_oid="$(calc_oid "$contents")"
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
   git lfs track "*.dat"
   git add .gitattributes a.dat
   git commit --message "initial commit"
@@ -1116,7 +1116,7 @@ begin_test "pre-push locks verify 403 with verification disabled"
 
   contents="example"
   contents_oid="$(calc_oid "$contents")"
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
   git lfs track "*.dat"
   git add .gitattributes a.dat
   git commit --message "initial commit"
@@ -1142,7 +1142,7 @@ begin_test "pre-push locks verify 403 with verification unset"
 
   contents="example"
   contents_oid="$(calc_oid "$contents")"
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
   git lfs track "*.dat"
   git add .gitattributes a.dat
   git commit --message "initial commit"

--- a/t/t-progress-meter.sh
+++ b/t/t-progress-meter.sh
@@ -15,7 +15,7 @@ begin_test "progress meter displays positive progress"
   git commit -m "initial commit"
 
   for i in `seq 1 128`; do
-    printf "$i" > "$i.dat"
+    printf "%s" "$i" > "$i.dat"
   done
 
   git add *.dat

--- a/t/t-pull.sh
+++ b/t/t-pull.sh
@@ -24,9 +24,9 @@ begin_test "pull"
 
   mkdir dir
   echo "*.log" > .gitignore
-  printf "$contents" > a.dat
-  printf "$contents2" > á.dat
-  printf "$contents3" > dir/dir.dat
+  printf "%s" "$contents" > a.dat
+  printf "%s" "$contents2" > á.dat
+  printf "%s" "$contents3" > dir/dir.dat
   git add .
   git commit -m "add files" 2>&1 | tee commit.log
   grep "master (root-commit)" commit.log

--- a/t/t-push-failures-local.sh
+++ b/t/t-push-failures-local.sh
@@ -16,11 +16,11 @@ begin_test "push with missing objects (lfs.allowincompletepush true)"
 
   present="present"
   present_oid="$(calc_oid "$present")"
-  printf "$present" > present.dat
+  printf "%s" "$present" > present.dat
 
   missing="missing"
   missing_oid="$(calc_oid "$missing")"
-  printf "$missing" > missing.dat
+  printf "%s" "$missing" > missing.dat
 
   git add missing.dat present.dat
   git commit -m "add objects"
@@ -64,11 +64,11 @@ begin_test "push reject missing objects (lfs.allowincompletepush false)"
 
   present="present"
   present_oid="$(calc_oid "$present")"
-  printf "$present" > present.dat
+  printf "%s" "$present" > present.dat
 
   missing="missing"
   missing_oid="$(calc_oid "$missing")"
-  printf "$missing" > missing.dat
+  printf "%s" "$missing" > missing.dat
 
   git add missing.dat present.dat
   git commit -m "add objects"
@@ -113,15 +113,15 @@ begin_test "push reject missing objects (lfs.allowincompletepush default)"
 
   missing="missing"
   missing_oid="$(calc_oid "$missing")"
-  missing_len="$(printf "$missing" | wc -c | awk '{ print $1 }')"
-  printf "$missing" > missing.dat
+  missing_len="$(printf "%s" "$missing" | wc -c | awk '{ print $1 }')"
+  printf "%s" "$missing" > missing.dat
   git add missing.dat
   git commit -m "add missing.dat"
 
   present="present"
   present_oid="$(calc_oid "$present")"
-  present_len="$(printf "$present" | wc -c | awk '{ print $1 }')"
-  printf "$present" > present.dat
+  present_len="$(printf "%s" "$present" | wc -c | awk '{ print $1 }')"
+  printf "%s" "$present" > present.dat
   git add present.dat
   git commit -m "add present.dat"
 
@@ -162,15 +162,15 @@ begin_test "push reject corrupt objects (lfs.allowincompletepush default)"
 
   corrupt="corrupt"
   corrupt_oid="$(calc_oid "$corrupt")"
-  corrupt_len="$(printf "$corrupt" | wc -c | awk '{ print $1 }')"
-  printf "$corrupt" > corrupt.dat
+  corrupt_len="$(printf "%s" "$corrupt" | wc -c | awk '{ print $1 }')"
+  printf "%s" "$corrupt" > corrupt.dat
   git add corrupt.dat
   git commit -m "add corrupt.dat"
 
   present="present"
   present_oid="$(calc_oid "$present")"
-  present_len="$(printf "$present" | wc -c | awk '{ print $1 }')"
-  printf "$present" > present.dat
+  present_len="$(printf "%s" "$present" | wc -c | awk '{ print $1 }')"
+  printf "%s" "$present" > present.dat
   git add present.dat
   git commit -m "add present.dat"
 

--- a/t/t-push-failures-remote.sh
+++ b/t/t-push-failures-remote.sh
@@ -21,7 +21,7 @@ push_fail_test() {
 
   git lfs track "*.dat"
   printf "hi" > good.dat
-  printf "$contents" > bad.dat
+  printf "%s" "$contents" > bad.dat
   git add .gitattributes good.dat bad.dat
   git commit -m "welp"
 

--- a/t/t-push.sh
+++ b/t/t-push.sh
@@ -563,8 +563,8 @@ begin_test "push (retry with expired actions)"
   git lfs track "*.dat"
   contents="return-expired-action"
   contents_oid="$(calc_oid "$contents")"
-  contents_size="$(printf "$contents" | wc -c | awk '{ print $1 }')"
-  printf "$contents" > a.dat
+  contents_size="$(printf "%s" "$contents" | wc -c | awk '{ print $1 }')"
+  printf "%s" "$contents" > a.dat
   git add .gitattributes a.dat
 
   git commit -m "add a.dat, .gitattributes" 2>&1 | tee commit.log
@@ -596,7 +596,7 @@ begin_test "push to raw remote url"
   contents="raw"
   contents_oid=$(calc_oid "$contents")
 
-  printf "$contents" > raw.dat
+  printf "%s" "$contents" > raw.dat
   git add raw.dat .gitattributes
   git commit -m "add" 2>&1 | tee commit.log
   grep "master (root-commit)" commit.log
@@ -622,7 +622,7 @@ begin_test "push (with invalid object size)"
 
   git lfs track "*.dat"
   contents="return-invalid-size"
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
 
   git add a.dat .gitattributes
   git commit -m "add a.dat, .gitattributes" 2>&1 | tee commit.log
@@ -658,7 +658,7 @@ begin_test "push with deprecated _links"
 
   contents="send-deprecated-links"
   contents_oid="$(calc_oid "$contents")"
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
   git add a.dat
   git commit -m "add a.dat"
 

--- a/t/t-reference-clone.sh
+++ b/t/t-reference-clone.sh
@@ -34,7 +34,7 @@ begin_test "clone with reference"
   contents="a"
   oid=$(calc_oid "$contents")
 
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
   git add a.dat
   git add .gitattributes
   git commit -m "add a.dat" 2>&1
@@ -75,7 +75,7 @@ begin_test "fetch from clone reference"
   contents="a"
   oid=$(calc_oid "$contents")
 
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
   git add a.dat
   git add .gitattributes
   git commit -m "add a.dat" 2>&1

--- a/t/t-resume-http-range.sh
+++ b/t/t-resume-http-range.sh
@@ -19,7 +19,7 @@ begin_test "resume-http-range"
   contents="status-batch-resume-206"
   contents_oid=$(calc_oid "$contents")
 
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
   git add a.dat
   git add .gitattributes
   git commit -m "add a.dat" 2>&1 | tee commit.log
@@ -60,7 +60,7 @@ begin_test "resume-http-range-fallback"
   contents="batch-resume-fail-fallback"
   contents_oid=$(calc_oid "$contents")
 
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
   git add a.dat
   git add .gitattributes
   git commit -m "add a.dat" 2>&1 | tee commit.log

--- a/t/t-resume-tus.sh
+++ b/t/t-resume-tus.sh
@@ -19,7 +19,7 @@ begin_test "tus-upload-uninterrupted"
   contents="send-verify-action"
   contents_oid=$(calc_oid "$contents")
 
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
   git add a.dat
   git add .gitattributes
   git commit -m "add a.dat" 2>&1 | tee commit.log
@@ -54,8 +54,8 @@ begin_test "tus-upload-interrupted-resume"
   contents="234587134187634598o634857619384765b747qcvtuedvoaicwtvseudtvcoqi7280r7qvow4i7r8c46pr9q6v9pri6ioq2r8"
   contents_oid=$(calc_oid "$contents")
 
-  printf "$contents" > a.dat
-  printf "$contents_verify" > verify.dat
+  printf "%s" "$contents" > a.dat
+  printf "%s" "$contents_verify" > verify.dat
   git add a.dat verify.dat
   git add .gitattributes
   git commit -m "add a.dat, verify.dat" 2>&1 | tee commit.log

--- a/t/t-smudge.sh
+++ b/t/t-smudge.sh
@@ -149,7 +149,7 @@ begin_test "smudge clone with include/exclude"
   contents="a"
   contents_oid=$(calc_oid "$contents")
 
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
   git add a.dat
   git add .gitattributes
   git commit -m "add a.dat" 2>&1 | tee commit.log

--- a/t/t-ssh.sh
+++ b/t/t-ssh.sh
@@ -17,7 +17,7 @@ begin_test "ssh with proxy command in lfs.url"
   contents="test"
   oid="$(calc_oid "$contents")"
   git lfs track "*.dat"
-  printf "$contents" > test.dat
+  printf "%s" "$contents" > test.dat
   git add .gitattributes test.dat
   git commit -m "initial commit"
 

--- a/t/t-status.sh
+++ b/t/t-status.sh
@@ -14,31 +14,31 @@ begin_test "status"
   file_1="some data"
   file_1_oid="$(calc_oid "$file_1")"
   file_1_oid_short="$(echo "$file_1_oid" | head -c 7)"
-  printf "$file_1" > file1.dat
+  printf "%s" "$file_1" > file1.dat
   git add file1.dat
   git commit -m "file1.dat"
 
   file_1_new="other data"
   file_1_new_oid="$(calc_oid "$file_1_new")"
   file_1_new_oid_short="$(echo "$file_1_new_oid" | head -c 7)"
-  printf "$file_1_new" > file1.dat
+  printf "%s" "$file_1_new" > file1.dat
 
   file_2="file2 data"
   file_2_oid="$(calc_oid "$file_2")"
   file_2_oid_short="$(echo "$file_2_oid" | head -c 7)"
-  printf "$file_2" > file2.dat
+  printf "%s" "$file_2" > file2.dat
   git add file2.dat
 
   file_3="file3 data"
   file_3_oid="$(calc_oid "$file_3")"
   file_3_oid_short="$(echo "$file_3_oid" | head -c 7)"
-  printf "$file_3" > file3.dat
+  printf "%s" "$file_3" > file3.dat
   git add file3.dat
 
   file_3_new="file3 other data"
   file_3_new_oid="$(calc_oid "$file_3_new")"
   file_3_new_oid_short="$(echo "$file_3_new_oid" | head -c 7)"
-  printf "$file_3_new" > file3.dat
+  printf "%s" "$file_3_new" > file3.dat
 
   expected="On branch master
 
@@ -179,7 +179,7 @@ begin_test "status - before initial commit"
   contents_oid="$(calc_oid "$contents")"
   contents_oid_short="$(echo "$contents_oid" | head -c 7)"
 
-  printf "$contents" > file1.dat
+  printf "%s" "$contents" > file1.dat
   git add file1.dat
 
   expected="
@@ -205,8 +205,8 @@ begin_test "status shows multiple files with identical contents"
   git lfs track "*.dat"
 
   contents="contents"
-  printf "$contents" > a.dat
-  printf "$contents" > b.dat
+  printf "%s" "$contents" > a.dat
+  printf "%s" "$contents" > b.dat
 
   git add --all .
 
@@ -232,7 +232,7 @@ begin_test "status shows multiple copies of partially staged files"
   contents_1="part 1"
   contents_1_oid="$(calc_oid "$contents_1")"
   contents_1_oid_short="$(echo "$contents_1_oid" | head -c 7)"
-  printf "$contents_1" > a.dat
+  printf "%s" "$contents_1" > a.dat
 
   # "$contents_1" changes are staged
   git add a.dat
@@ -241,7 +241,7 @@ begin_test "status shows multiple copies of partially staged files"
   contents_2="part 2"
   contents_2_oid="$(calc_oid "$contents_2")"
   contents_2_oid_short="$(echo "$contents_2_oid" | head -c 7)"
-  printf "$contents_2" > a.dat
+  printf "%s" "$contents_2" > a.dat
 
   expected="On branch master
 
@@ -274,7 +274,7 @@ begin_test "status: LFS to LFS change"
   git add .gitattributes
   git commit -m "track *.dat files"
 
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
   git add a.dat
   git commit -m "add a.dat"
 
@@ -282,7 +282,7 @@ begin_test "status: LFS to LFS change"
   contents_new_oid="$(calc_oid "$contents_new")"
   contents_new_oid_short="$(echo $contents_new_oid | head -c 7)"
 
-  printf "$contents_new" > a.dat
+  printf "%s" "$contents_new" > a.dat
   git add a.dat
 
   expected="On branch master
@@ -310,7 +310,7 @@ begin_test "status: Git to LFS change"
   contents_oid="$(calc_oid "$contents")"
   contents_oid_short="$(echo "$contents_oid" | head -c 7)"
 
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
   git add a.dat
   git commit -m "add a.dat"
 
@@ -322,7 +322,7 @@ begin_test "status: Git to LFS change"
   contents_new_oid="$(calc_oid "$contents_new")"
   contents_new_oid_short="$(echo $contents_new_oid | head -c 7)"
 
-  printf "$contents_new" > a.dat
+  printf "%s" "$contents_new" > a.dat
   git add a.dat
 
   expected="On branch master
@@ -350,7 +350,7 @@ begin_test "status: Git to LFS conversion"
   contents_oid="$(calc_oid "$contents")"
   contents_oid_short="$(echo "$contents_oid" | head -c 7)"
 
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
   git add a.dat
   git commit -m "add a.dat"
 
@@ -430,7 +430,7 @@ begin_test "status (unpushed objects)"
 
   contents="a"
   oid="$(calc_oid "$contents")"
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
 
   git add a.dat
   git commit -m "add a large file"

--- a/t/t-submodule-lfsconfig.sh
+++ b/t/t-submodule-lfsconfig.sh
@@ -22,7 +22,7 @@ begin_test "submodule env with .lfsconfig"
   git lfs track "*.dat"
   submodcontent="submodule lfs file"
   submodoid=$(calc_oid "$submodcontent")
-  printf "$submodcontent" > dir/test.dat
+  printf "%s" "$submodcontent" > dir/test.dat
   git add .lfsconfig .gitattributes dir
   git commit -m "create submodule"
   git push origin master
@@ -39,7 +39,7 @@ begin_test "submodule env with .lfsconfig"
   mkdir dir
   repocontent="repository lfs file"
   repooid=$(calc_oid "$repocontent")
-  printf "$repocontent" > dir/test.dat
+  printf "%s" "$repocontent" > dir/test.dat
   git add .gitattributes .lfsconfig .gitmodules dir sub
   git commit -m "create repo"
   git push origin master

--- a/t/t-uninstall.sh
+++ b/t/t-uninstall.sh
@@ -13,9 +13,9 @@ begin_test "uninstall outside repository"
   clean="$(git config filter.lfs.clean)"
   filter="$(git config filter.lfs.process)"
 
-  printf "$smudge" | grep "git-lfs smudge"
-  printf "$clean" | grep "git-lfs clean"
-  printf "$filter" | grep "git-lfs filter-process"
+  printf "%s" "$smudge" | grep "git-lfs smudge"
+  printf "%s" "$clean" | grep "git-lfs clean"
+  printf "%s" "$filter" | grep "git-lfs filter-process"
 
   # uninstall multiple times to trigger https://github.com/git-lfs/git-lfs/issues/529
   git lfs uninstall

--- a/t/t-verify.sh
+++ b/t/t-verify.sh
@@ -17,7 +17,7 @@ begin_test "verify with retries"
   contents="send-verify-action"
   contents_oid="$(calc_oid "$contents")"
   contents_short_oid="$(echo "$contents_oid" | head -c 7)"
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
 
   git add a.dat
   git commit -m "add a.dat"
@@ -46,7 +46,7 @@ begin_test "verify with retries (success without retry)"
   contents="send-verify-action"
   contents_oid="$(calc_oid "$contents")"
   contents_short_oid="$(echo "$contents_oid" | head -c 7)"
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
 
   git add a.dat
   git commit -m "add a.dat"
@@ -75,7 +75,7 @@ begin_test "verify with retries (insufficient retries)"
   contents="send-verify-action"
   contents_oid="$(calc_oid "$contents")"
   contents_short_oid="$(echo "$contents_oid" | head -c 7)"
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
 
   git add a.dat
   git commit -m "add a.dat"
@@ -110,7 +110,7 @@ begin_test "verify with retries (bad .gitconfig)"
   contents="send-verify-action"
   contents_oid="$(calc_oid "$contents")"
   contents_short_oid="$(echo "$contents_oid" | head -c 7)"
-  printf "$contents" > a.dat
+  printf "%s" "$contents" > a.dat
 
   git add a.dat
   git commit -m "add a.dat"

--- a/t/t-zero-len-file.sh
+++ b/t/t-zero-len-file.sh
@@ -17,7 +17,7 @@ begin_test "push zero len file"
 
   contents="full"
   contents_oid=$(calc_oid "$contents")
-  printf "$contents" > full.dat
+  printf "%s" "$contents" > full.dat
   git add .gitattributes *.dat
   git commit -m "add files" | tee commit.log
 


### PR DESCRIPTION
The printf(1) command, like it's C cousin, takes a format string as its
first argument.  If a shell variable is passed as the first argument, it
will be interpreted as a format string; this can lead to surprising
behavior and can cause the test suite to fail if we accidentally insert
a format string character into the variable.

Modify all the places in the individual tests that we use a plain quoted
variable as the format string by running the following Ruby one-liner:

  ruby -i -pe '$_.gsub!(/printf "\$/, %q(printf "%s" "$))' t/t-*.sh

Avoid modifying the test helpers, as there are places (such as calc_oid)
where we want to pass text containing escapes (such as "\n") and have
those be properly interpreted by printf(1).