### PR TITLE
t: avoid panic in lfstest-customadapter

### DIFF
--- a/t/cmd/lfstest-customadapter.go
+++ b/t/cmd/lfstest-customadapter.go
@@ -117,7 +117,11 @@ func performDownload(apiClient *lfsapi.Client, oid string, size int64, a *action
 
 	res, err := apiClient.DoWithAuth("origin", req)
 	if err != nil {
-		sendTransferError(oid, res.StatusCode, err.Error(), writer, errWriter)
+		statusCode := 6
+		if res != nil {
+			statusCode = res.StatusCode
+		}
+		sendTransferError(oid, statusCode, err.Error(), writer, errWriter)
 		return
 	}
 	defer res.Body.Close()


### PR DESCRIPTION
The custom adapter test binary wraps the HTTP API client and returns
various responses from the HTTP response to the custom transfer adapter.
This code assumes that if an error occurs, we will always have a valid
HTTP response object, but this is not the case.  If we lack such an
object, we will get a nil pointer dereference, a panic, and a segfault
in the client, causing the test to fail.

While it's currently unknown how to reproduce this issue, it has been
seen on the CI servers.  In order to improve the reliability of the
test, check to see if the response object is non-nil before
dereferencing it and produce a different but distinct error code if it
is nil.