### PR TITLE
locking: cache JSON response from server

### DIFF
--- a/commands/command_unlock.go
+++ b/commands/command_unlock.go
@@ -121,10 +121,10 @@ func unlockAbortIfFileModifiedById(id string, lockClient *locking.Client) {
 	// Get the path so we can check the status
 	filter := map[string]string{"id": id}
 	// try local cache first
-	locks, _ := lockClient.SearchLocks(filter, 0, true)
+	locks, _ := lockClient.SearchLocks(filter, 0, true, false)
 	if len(locks) == 0 {
 		// Fall back on calling server
-		locks, _ = lockClient.SearchLocks(filter, 0, false)
+		locks, _ = lockClient.SearchLocks(filter, 0, false, false)
 	}
 
 	if len(locks) == 0 {

--- a/docs/man/git-lfs-locks.1.ronn
+++ b/docs/man/git-lfs-locks.1.ronn
@@ -21,7 +21,13 @@ Lists current locks from the Git LFS server.
   Specifies a lock by its path. Returns a single result.
 
 * `--local`:
-  Lists only the locks cached locally. Skips a remote call.
+  Lists only our own locks which are cached locally. Skips a remote call.
+
+* `--cached`:
+  Lists cached locks from the last remote call. Contrary to --local, this will
+  include locks of other users as well. This option is intended to display the
+  last known locks in case you are offline. There is no guarantee that locks
+  on the server have not changed in the meanwhile.
 
 * `-l <num>` `--limit=<num>`:
   Specifies number of results to return.

--- a/locking/locks.go
+++ b/locking/locks.go
@@ -204,7 +204,7 @@ type Lock struct {
 // If localOnly = true, don't query the server & report only own local locks
 func (c *Client) SearchLocks(filter map[string]string, limit int, localOnly bool) ([]Lock, error) {
 	if localOnly {
-		return c.searchCachedLocks(filter, limit)
+		return c.searchLocalLocks(filter, limit)
 	} else {
 		return c.searchRemoteLocks(filter, limit)
 	}
@@ -272,7 +272,7 @@ func (c *Client) VerifiableLocks(ref *git.Ref, limit int) (ourLocks, theirLocks 
 	return ourLocks, theirLocks, nil
 }
 
-func (c *Client) searchCachedLocks(filter map[string]string, limit int) ([]Lock, error) {
+func (c *Client) searchLocalLocks(filter map[string]string, limit int) ([]Lock, error) {
 	cachedlocks := c.cache.Locks()
 	path, filterByPath := filter["path"]
 	id, filterById := filter["id"]
@@ -372,7 +372,7 @@ func (c *Client) lockIdFromPath(path string) (string, error) {
 // current user, as cached locally
 func (c *Client) IsFileLockedByCurrentCommitter(path string) bool {
 	filter := map[string]string{"path": path}
-	locks, err := c.searchCachedLocks(filter, 1)
+	locks, err := c.searchLocalLocks(filter, 1)
 	if err != nil {
 		tracerx.Printf("Error searching cached locks: %s\nForcing remote search", err)
 		locks, _ = c.searchRemoteLocks(filter, 1)


### PR DESCRIPTION
.git/lfs/cache/locks stores the JSON response that we got from the remote verbatim and will be updated when "git lfs locks" is issued

Partially fixes https://github.com/git-lfs/git-lfs/issues/3107