### PR TITLE
git/gitattr: parse 'set' attributes

### DIFF
--- a/git/gitattr/attr.go
+++ b/git/gitattr/attr.go
@@ -105,6 +105,9 @@ func ParseLines(r io.Reader) ([]*Line, error) {
 			} else if eq := strings.Index(s, "="); eq > -1 {
 				attr.K = s[:eq]
 				attr.V = s[eq+1:]
+			} else {
+				attr.K = s
+				attr.V = "true"
 			}
 
 			attrs = append(attrs, &attr)

--- a/git/gitattr/attr.go
+++ b/git/gitattr/attr.go
@@ -102,13 +102,9 @@ func ParseLines(r io.Reader) ([]*Line, error) {
 			} else if strings.HasPrefix(s, "!") {
 				attr.K = strings.TrimPrefix(s, "!")
 				attr.Unspecified = true
-			} else {
-				splits := strings.SplitN(s, "=", 2)
-				if len(splits) != 2 {
-					return nil, errors.Errorf("git/gitattr: malformed attribute: %s", s)
-				}
-				attr.K = splits[0]
-				attr.V = splits[1]
+			} else if eq := strings.Index(s, "="); eq > -1 {
+				attr.K = s[:eq]
+				attr.V = s[eq+1:]
 			}
 
 			attrs = append(attrs, &attr)

--- a/git/gitattr/attr_test.go
+++ b/git/gitattr/attr_test.go
@@ -62,11 +62,11 @@ func TestParseLinesManyLines(t *testing.T) {
 	assert.Equal(t, lines[1].Attrs[2], &Attr{K: "merge", V: "lfs"})
 	assert.Equal(t, lines[1].Attrs[3], &Attr{K: "text", V: "false"})
 
-	assert.Len(t, lines[1].Attrs, 4)
-	assert.Equal(t, lines[1].Attrs[0], &Attr{K: "filter", V: "lfs"})
-	assert.Equal(t, lines[1].Attrs[1], &Attr{K: "diff", V: "lfs"})
-	assert.Equal(t, lines[1].Attrs[2], &Attr{K: "merge", V: "lfs"})
-	assert.Equal(t, lines[1].Attrs[3], &Attr{K: "text", V: "false"})
+	assert.Len(t, lines[2].Attrs, 4)
+	assert.Equal(t, lines[2].Attrs[0], &Attr{K: "filter", V: "lfs"})
+	assert.Equal(t, lines[2].Attrs[1], &Attr{K: "diff", V: "lfs"})
+	assert.Equal(t, lines[2].Attrs[2], &Attr{K: "merge", V: "lfs"})
+	assert.Equal(t, lines[2].Attrs[3], &Attr{K: "text", V: "false"})
 }
 
 func TestParseLinesUnset(t *testing.T) {

--- a/git/gitattr/attr_test.go
+++ b/git/gitattr/attr_test.go
@@ -22,18 +22,19 @@ func TestParseLines(t *testing.T) {
 
 func TestParseLinesManyAttrs(t *testing.T) {
 	lines, err := ParseLines(strings.NewReader(
-		"*.dat filter=lfs diff=lfs merge=lfs -text"))
+		"*.dat filter=lfs diff=lfs merge=lfs -text crlf"))
 
 	assert.NoError(t, err)
 
 	assert.Len(t, lines, 1)
 	assert.Equal(t, lines[0].Pattern.String(), "*.dat")
 
-	assert.Len(t, lines[0].Attrs, 4)
+	assert.Len(t, lines[0].Attrs, 5)
 	assert.Equal(t, lines[0].Attrs[0], &Attr{K: "filter", V: "lfs"})
 	assert.Equal(t, lines[0].Attrs[1], &Attr{K: "diff", V: "lfs"})
 	assert.Equal(t, lines[0].Attrs[2], &Attr{K: "merge", V: "lfs"})
 	assert.Equal(t, lines[0].Attrs[3], &Attr{K: "text", V: "false"})
+	assert.Equal(t, lines[0].Attrs[4], &Attr{K: "crlf", V: "true"})
 }
 
 func TestParseLinesManyLines(t *testing.T) {
@@ -41,14 +42,16 @@ func TestParseLinesManyLines(t *testing.T) {
 		"*.dat filter=lfs diff=lfs merge=lfs -text",
 		"*.jpg filter=lfs diff=lfs merge=lfs -text",
 		"# *.pdf filter=lfs diff=lfs merge=lfs -text",
-		"*.png filter=lfs diff=lfs merge=lfs -text"}, "\n")))
+		"*.png filter=lfs diff=lfs merge=lfs -text",
+		"*.txt text"}, "\n")))
 
 	assert.NoError(t, err)
 
-	assert.Len(t, lines, 3)
+	assert.Len(t, lines, 4)
 	assert.Equal(t, lines[0].Pattern.String(), "*.dat")
 	assert.Equal(t, lines[1].Pattern.String(), "*.jpg")
 	assert.Equal(t, lines[2].Pattern.String(), "*.png")
+	assert.Equal(t, lines[3].Pattern.String(), "*.txt")
 
 	assert.Len(t, lines[0].Attrs, 4)
 	assert.Equal(t, lines[0].Attrs[0], &Attr{K: "filter", V: "lfs"})
@@ -67,6 +70,9 @@ func TestParseLinesManyLines(t *testing.T) {
 	assert.Equal(t, lines[2].Attrs[1], &Attr{K: "diff", V: "lfs"})
 	assert.Equal(t, lines[2].Attrs[2], &Attr{K: "merge", V: "lfs"})
 	assert.Equal(t, lines[2].Attrs[3], &Attr{K: "text", V: "false"})
+
+	assert.Len(t, lines[3].Attrs, 1)
+	assert.Equal(t, lines[3].Attrs[0], &Attr{K: "text", V: "true"})
 }
 
 func TestParseLinesUnset(t *testing.T) {


### PR DESCRIPTION
This pull request teaches package `git/gitattr` to parse attributes that are "set", as in writing the attribute name, but giving no explicit value.

The Git documentation says to treat this as implicitly assigning the string "true", which we do as of 5a54097.

Previously, for example, when encountering a `.gitattributes` containing the contents:

```
*.txt filter=lfs text
```

We would crash, complaining that `text` by itself is an improper attribute. With this change applied, this is no longer the case.

Closes: https://github.com/git-lfs/git-lfs/issues/3254.

##

/cc @git-lfs/core 
/cc @jackknobel, https://github.com/git-lfs/git-lfs/issues/3254