### PR TITLE
t: make testsuite run under git rebase -x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,7 +301,8 @@ test-race : GO_TEST_EXTRA_ARGS=-race
 #
 # And so on.
 test : fmt
-	$(GO) test $(GO_TEST_EXTRA_ARGS) $(addprefix ./,$(PKGS))
+	(unset GIT_DIR; unset GIT_WORK_TREE; \
+	$(GO) test $(GO_TEST_EXTRA_ARGS) $(addprefix ./,$(PKGS)))
 
 # integration is a shorthand for running 'make' in the 't' directory.
 .PHONY : integration

--- a/t/testenv.sh
+++ b/t/testenv.sh
@@ -130,6 +130,12 @@ export GIT_CONFIG_NOSYSTEM
 export GIT_SSH
 export APPVEYOR_REPO_COMMIT_MESSAGE
 
+# Don't fail if run under git rebase -x.
+unset GIT_DIR
+unset GIT_WORK_TREE
+unset GIT_EXEC_PATH
+unset GIT_CHERRY_PICK_HELP
+
 mkdir -p "$TMPDIR"
 mkdir -p "$TRASHDIR"
 


### PR DESCRIPTION
When making a complex change to Git LFS (or any other project), it is
common to write a multiple patch series.  When doing so, it's ideal to
ensure that each patch is logical and independent and that the tests
pass at each step.  Often this is done using "git rebase -x" to run the
testsuite at each step.

Make the testsuite able to be run under "git rebase -x" by unsetting
environment variables that cause the tests to fail or to operate on the
git-lfs repository itself.  In the Makefile, use a subshell with unset
because env -u is not in POSIX and is supported by neither NetBSD nor
OpenBSD.