### PR TITLE
CI improvements

### DIFF
--- a/lfsapi/creds.go
+++ b/lfsapi/creds.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"net/url"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -230,13 +231,16 @@ func (h *commandCredentialHelper) exec(subcommand string, input Creds) (Creds, e
 	cmd.Stdin = bufferCreds(input)
 	cmd.Stdout = output
 	/*
-	   There is a reason we don't hook up stderr here:
+	   There is a reason we don't read from stderr here:
 	   Git's credential cache daemon helper does not close its stderr, so if this
 	   process is the process that fires up the daemon, it will wait forever
 	   (until the daemon exits, really) trying to read from stderr.
 
+	   Instead, we simply pass it through to our stderr.
+
 	   See https://github.com/git-lfs/git-lfs/issues/117 for more details.
 	*/
+	cmd.Stderr = os.Stderr
 
 	err := cmd.Start()
 	if err == nil {

--- a/t/cmd/git-credential-lfstest.go
+++ b/t/cmd/git-credential-lfstest.go
@@ -14,8 +14,8 @@ import (
 var (
 	commands = map[string]func(){
 		"get":   fill,
-		"store": noop,
-		"erase": noop,
+		"store": log,
+		"erase": log,
 	}
 
 	delim    = '\n'
@@ -111,4 +111,6 @@ func credsFromFilename(file string) (string, string, error) {
 	return credsPieces[0], credsPieces[1], nil
 }
 
-func noop() {}
+func log() {
+	fmt.Fprintf(os.Stderr, "CREDS received command: %s (ignored)\n", os.Args[1])
+}

--- a/t/t-pre-push.sh
+++ b/t/t-pre-push.sh
@@ -96,7 +96,7 @@ begin_test "pre-push"
   git config "lfs.$(repo_endpoint $GITSERVER $reponame).locksverify" true
 
   echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
-    git lfs pre-push origin "$GITSERVER/$reponame" 2>&1 |
+    git lfs pre-push origin "$GITSERVER/$reponame" |
     tee push.log
   # no output if nothing to do
   [ "$(du -k push.log | cut -f 1)" == "0" ]
@@ -134,7 +134,7 @@ begin_test "pre-push dry-run"
   git config "lfs.$(repo_endpoint $GITSERVER $reponame).locksverify" true
 
   echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
-    git lfs pre-push --dry-run origin "$GITSERVER/$reponame" 2>&1 |
+    git lfs pre-push --dry-run origin "$GITSERVER/$reponame" |
     tee push.log
 
   [ "" = "$(cat push.log)" ]
@@ -148,7 +148,7 @@ begin_test "pre-push dry-run"
   refute_server_object "$reponame" 2840e0eafda1d0760771fe28b91247cf81c76aa888af28a850b5648a338dc15b
 
   echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
-    git lfs pre-push --dry-run origin "$GITSERVER/$reponame" 2>&1 |
+    git lfs pre-push --dry-run origin "$GITSERVER/$reponame" |
     tee push.log
   grep "push 2840e0eafda1d0760771fe28b91247cf81c76aa888af28a850b5648a338dc15b => hi.dat" push.log
   cat push.log

--- a/t/t-push.sh
+++ b/t/t-push.sh
@@ -83,7 +83,7 @@ begin_test "push"
 
   git lfs push --dry-run origin master 2>&1 | tee push.log
   grep "push 4c48d2a6991c9895bcddcf027e1e4907280bcf21975492b1afbade396d6a3340 => a.dat" push.log
-  [ $(grep -c "push" push.log) -eq 1 ]
+  [ $(grep -c "^push " push.log) -eq 1 ]
 
   git lfs push origin master 2>&1 | tee push.log
   grep "Uploading LFS objects: 100% (1/1), 7 B" push.log
@@ -96,14 +96,14 @@ begin_test "push"
   git lfs push --dry-run origin push-b 2>&1 | tee push.log
   grep "push 4c48d2a6991c9895bcddcf027e1e4907280bcf21975492b1afbade396d6a3340 => a.dat" push.log
   grep "push 82be50ad35070a4ef3467a0a650c52d5b637035e7ad02c36652e59d01ba282b7 => b.dat" push.log
-  [ $(grep -c "push" < push.log) -eq 2 ]
+  [ $(grep -c "^push " < push.log) -eq 2 ]
 
   # simulate remote ref
   mkdir -p .git/refs/remotes/origin
   git rev-parse HEAD > .git/refs/remotes/origin/HEAD
 
   git lfs push --dry-run origin push-b 2>&1 | tee push.log
-  [ $(grep -c "push" push.log) -eq 0 ]
+  [ $(grep -c "^push " push.log) -eq 0 ]
 
   rm -rf .git/refs/remotes
 
@@ -197,7 +197,7 @@ begin_test "push --all (no ref args)"
   grep "push $oid4 => file1.dat" push.log
   grep "push $oid5 => file1.dat" push.log
   grep "push $extraoid => file2.dat" push.log
-  [ $(grep -c "push" < push.log) -eq 6 ]
+  [ $(grep -c "^push " < push.log) -eq 6 ]
 
   git push --all origin 2>&1 | tee push.log
   [ $(grep -c "Uploading LFS objects: 100% (6/6), 36 B" push.log) -eq 1 ]
@@ -229,7 +229,7 @@ begin_test "push --all (no ref args)"
   grep "push $oid4 => file1.dat" push.log
   grep "push $oid5 => file1.dat" push.log
   grep "push $extraoid => file2.dat" push.log
-  [ $(grep -c "push" push.log) -eq 6 ]
+  [ $(grep -c "^push " push.log) -eq 6 ]
 
   git push --all origin 2>&1 | tee push.log
   grep "Uploading LFS objects: 100% (6/6), 36 B" push.log
@@ -251,7 +251,7 @@ begin_test "push --all (1 ref arg)"
   grep "push $oid1 => file1.dat" push.log
   grep "push $oid2 => file1.dat" push.log
   grep "push $oid3 => file1.dat" push.log
-  [ $(grep -c "push" < push.log) -eq 3 ]
+  [ $(grep -c "^push " < push.log) -eq 3 ]
 
   git lfs push --all origin branch 2>&1 | tee push.log
   grep "3 files" push.log
@@ -279,7 +279,7 @@ begin_test "push --all (1 ref arg)"
   grep "push $oid1 => file1.dat" push.log
   grep "push $oid2 => file1.dat" push.log
   grep "push $oid3 => file1.dat" push.log
-  [ $(grep -c "push" push.log) -eq 3 ]
+  [ $(grep -c "^push " push.log) -eq 3 ]
 
   git push --all origin branch 2>&1 | tee push.log
   grep "5 files, 1 skipped" push.log # should be 5?
@@ -302,7 +302,7 @@ begin_test "push --all (multiple ref args)"
   grep "push $oid2 => file1.dat" push.log
   grep "push $oid3 => file1.dat" push.log
   grep "push $oid4 => file1.dat" push.log
-  [ $(grep -c "push" push.log) -eq 4 ]
+  [ $(grep -c "^push " push.log) -eq 4 ]
 
   git lfs push --all origin branch tag 2>&1 | tee push.log
   grep "4 files" push.log
@@ -331,7 +331,7 @@ begin_test "push --all (multiple ref args)"
   grep "push $oid2 => file1.dat" push.log
   grep "push $oid3 => file1.dat" push.log
   grep "push $oid4 => file1.dat" push.log
-  [ $(grep -c "push" push.log) -eq 3 ]
+  [ $(grep -c "^push " push.log) -eq 3 ]
 
   git push --all origin branch tag 2>&1 | tee push.log
   grep "5 files, 1 skipped" push.log # should be 5?
@@ -355,7 +355,7 @@ begin_test "push --all (ref with deleted files)"
   grep "push $oid4 => file1.dat" push.log
   grep "push $oid5 => file1.dat" push.log
   grep "push $extraoid => file2.dat" push.log
-  [ $(grep -c "push" push.log) -eq 5 ]
+  [ $(grep -c "^push " push.log) -eq 5 ]
 
   git lfs push --all origin master 2>&1 | tee push.log
   grep "5 files" push.log
@@ -385,7 +385,7 @@ begin_test "push --all (ref with deleted files)"
   grep "push $oid4 => file1.dat" push.log
   grep "push $oid5 => file1.dat" push.log
   grep "push $extraoid => file2.dat" push.log
-  [ $(grep -c "push" push.log) -eq 5 ]
+  [ $(grep -c "^push " push.log) -eq 5 ]
 
   git push --all origin master 2>&1 | tee push.log
   grep "5 files, 1 skipped" push.log # should be 5?

--- a/t/testlib.sh
+++ b/t/testlib.sh
@@ -100,11 +100,17 @@ end_test () {
     # close fd 5 (GIT_TRACE)
     exec 5>&-
 
+    local dump_output="$LFS_DUMP_TEST_OUTPUT"
     if [ "$test_status" -eq 0 ]; then
         printf "ok %d - %-60s\n" "$tests" "$test_description ..."
     else
         failures=$(( failures + 1 ))
         printf "not ok %d - %-60s\n" "$tests" "$test_description ..."
+        dump_output=1
+    fi
+
+    if [ -n "$dump_output" ]
+    then
         (
             echo "# -- stdout --"
             sed 's/^/#     /' <"$TRASHDIR/out"


### PR DESCRIPTION
These are a bunch of small improvements to make troubleshooting credential-related CI failures easier.  The only user-visible change is to pass standard error through when filling credentials to make sure that we get log output from the credential helper.  This should be a net positive altogether, since it's the same behavior that Git has.

In addition, there are changes to make getting debugging output from successful tests easier and to make the lfstest credential helper log all of its operations.  Each change should be self-explanatory.

If someone has a suggestion for a better name for the environment variable in the final commit, I'm all ears.