### PR TITLE
Support listing only filename tracked by git lfs using --name (-n) option

### DIFF
--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -15,7 +15,7 @@ var (
 	lsFilesScanAll      = false
 	lsFilesScanDeleted  = false
 	lsFilesShowSize     = false
-	lsFilesShowFileOnly = false
+	lsFilesShowNameOnly = false
 	debug               = false
 )
 
@@ -82,7 +82,7 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 				p.Version)
 		} else {
 			msg := []string{p.Oid[:showOidLen], lsFilesMarker(p), p.Name}
-			if lsFilesShowFileOnly {
+			if lsFilesShowNameOnly {
 				msg = []string{p.Name}
 			}
 			if lsFilesShowSize {
@@ -146,7 +146,7 @@ func init() {
 	RegisterCommand("ls-files", lsFilesCommand, func(cmd *cobra.Command) {
 		cmd.Flags().BoolVarP(&longOIDs, "long", "l", false, "")
 		cmd.Flags().BoolVarP(&lsFilesShowSize, "size", "s", false, "")
-		cmd.Flags().BoolVarP(&lsFilesShowFileOnly, "name", "n", false, "")
+		cmd.Flags().BoolVarP(&lsFilesShowNameOnly, "name-only", "n", false, "")
 		cmd.Flags().BoolVarP(&debug, "debug", "d", false, "")
 		cmd.Flags().BoolVarP(&lsFilesScanAll, "all", "a", false, "")
 		cmd.Flags().BoolVar(&lsFilesScanDeleted, "deleted", false, "")

--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -82,9 +82,9 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 				p.Version)
 		} else {
 			msg := []string{p.Oid[:showOidLen], lsFilesMarker(p), p.Name}
-            if lsFilesShowFileOnly {
-                msg = []string{p.Name}
-            }
+			if lsFilesShowFileOnly {
+				msg = []string{p.Name}
+			}
 			if lsFilesShowSize {
 				size := humanize.FormatBytes(uint64(p.Size))
 				msg = append(msg, "("+size+")")

--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -11,18 +11,19 @@ import (
 )
 
 var (
-	longOIDs           = false
-	lsFilesScanAll     = false
-	lsFilesScanDeleted = false
-	lsFilesShowSize    = false
-	debug              = false
+	longOIDs            = false
+	lsFilesScanAll      = false
+	lsFilesScanDeleted  = false
+	lsFilesShowSize     = false
+	lsFilesShowFileOnly = false
+	debug               = false
 )
 
 func lsFilesCommand(cmd *cobra.Command, args []string) {
 	requireInRepo()
 
 	var ref string
-
+    Print("Hellow ");
 	if len(args) == 1 {
 		if lsFilesScanAll {
 			Exit("fatal: cannot use --all with explicit reference")
@@ -82,6 +83,9 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 				p.Version)
 		} else {
 			msg := []string{p.Oid[:showOidLen], lsFilesMarker(p), p.Name}
+            if lsFilesShowFileOnly {
+                msg = []string{p.Name}
+            }
 			if lsFilesShowSize {
 				size := humanize.FormatBytes(uint64(p.Size))
 				msg = append(msg, "("+size+")")
@@ -143,6 +147,7 @@ func init() {
 	RegisterCommand("ls-files", lsFilesCommand, func(cmd *cobra.Command) {
 		cmd.Flags().BoolVarP(&longOIDs, "long", "l", false, "")
 		cmd.Flags().BoolVarP(&lsFilesShowSize, "size", "s", false, "")
+		cmd.Flags().BoolVarP(&lsFilesShowFileOnly, "name", "n", false, "")
 		cmd.Flags().BoolVarP(&debug, "debug", "d", false, "")
 		cmd.Flags().BoolVarP(&lsFilesScanAll, "all", "a", false, "")
 		cmd.Flags().BoolVar(&lsFilesScanDeleted, "deleted", false, "")

--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -23,7 +23,6 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 	requireInRepo()
 
 	var ref string
-    Print("Hellow ");
 	if len(args) == 1 {
 		if lsFilesScanAll {
 			Exit("fatal: cannot use --all with explicit reference")

--- a/docs/man/git-lfs-ls-files.1.ronn
+++ b/docs/man/git-lfs-ls-files.1.ronn
@@ -37,6 +37,8 @@ An asterisk (*) after the OID indicates a LFS pointer, a minus (-) a full object
 * `-X` <paths> `--exclude=`<paths>:
   Exclude paths matching any of these patterns; see [FETCH SETTINGS].
 
+* `-n` `--name`:
+  Show only the lfs tracked file names.
 ## SEE ALSO
 
 git-lfs-status(1), git-lfs-config(5).

--- a/docs/man/git-lfs-ls-files.1.ronn
+++ b/docs/man/git-lfs-ls-files.1.ronn
@@ -37,7 +37,7 @@ An asterisk (*) after the OID indicates a LFS pointer, a minus (-) a full object
 * `-X` <paths> `--exclude=`<paths>:
   Exclude paths matching any of these patterns; see [FETCH SETTINGS].
 
-* `-n` `--name`:
+* `-n` `--name-only`:
   Show only the lfs tracked file names.
 ## SEE ALSO
 

--- a/t/t-ls-files.sh
+++ b/t/t-ls-files.sh
@@ -418,3 +418,27 @@ begin_test "ls-files: list/stat files with escaped runes in path before commit"
 
 )
 end_test
+
+begin_test "ls-files: --name"
+(
+  set -e
+
+  reponame="ls-files-name"
+  git init "$reponame"
+  cd "$reponame"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  contents="test contents"
+  echo "$contents" > a.dat
+
+  git add a.dat
+  git commit -m "add a.dat"
+
+  git lfs ls-files --name 2>&1 | tee ls.log
+  [ "a.dat" = "$(cat ls.log)" ]
+)
+end_test
+

--- a/t/t-ls-files.sh
+++ b/t/t-ls-files.sh
@@ -419,7 +419,7 @@ begin_test "ls-files: list/stat files with escaped runes in path before commit"
 )
 end_test
 
-begin_test "ls-files: --name"
+begin_test "ls-files: --name-only"
 (
   set -e
 
@@ -437,7 +437,7 @@ begin_test "ls-files: --name"
   git add a.dat
   git commit -m "add a.dat"
 
-  git lfs ls-files --name 2>&1 | tee ls.log
+  git lfs ls-files --name-only 2>&1 | tee ls.log
   [ "a.dat" = "$(cat ls.log)" ]
 )
 end_test


### PR DESCRIPTION
Some users just want to have the list of LFS files. This is particularly useful when you want to programatically scan the working tree and would like to avoid additional parsing