### PR TITLE
debian/prerm: add --system flag

### DIFF
--- a/debian/prerm
+++ b/debian/prerm
@@ -1,2 +1,2 @@
 #!/bin/sh
-git lfs uninstall
+git lfs uninstall --system


### PR DESCRIPTION
I was wondering why my ~/.gitconfig would sometimes end up being owned
by root, with 0600 permissions, making git unable to read it and thus
interfering with my normal workflow. Looking at the mtime/ctime of
.gitconfig, I finally correlated it with

2018-09-20 09:55:47 upgrade git-lfs:amd64 2.5.1 2.5.2
2018-09-20 09:55:47 status half-configured git-lfs:amd64 2.5.1

in my dpkg.log. So while the postinst script does change the global git
config, the prerm script modifies the .gitconfig of whichever user did
the "apt-get upgrade".