### PR TITLE
Canonicalize paths properly on Windows

### DIFF
--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/git"
@@ -86,8 +85,13 @@ func lockPath(file string) (string, error) {
 	}
 
 	abs := filepath.Join(wd, file)
-	path := strings.TrimPrefix(abs, repo)
-	path = strings.TrimPrefix(path, string(os.PathSeparator))
+	path, err := filepath.Rel(repo, abs)
+	if err != nil {
+		return "", err
+	}
+
+	path = filepath.ToSlash(path)
+
 	if stat, err := os.Stat(abs); err != nil {
 		return "", err
 	} else {


### PR DESCRIPTION
On Windows, the filesystem is typically case insensitive.  We formed the
lock path by stripping off the repo portion from the absolute pathname
using the strings package.  However, if the drive letters of the
absolute pathname and the canonicalized pathname differed in case, then
we would not strip any values off, and instead just concatenate the two
paths together.  Use the filepath.Rel function that's built into Go to
help us make the path relative in a way that is appropriate for the
operating system.

Fixes #3276 