### PR TITLE
commands: unambiguously resolve remote references

### DIFF
--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -279,15 +279,11 @@ func getRemoteRefs(l *tasklog.Logger) (map[string][]*git.Ref, error) {
 // formatRefName returns the fully-qualified name for the given Git reference
 // "ref".
 func formatRefName(ref *git.Ref, remote string) string {
-	var name []string
-
-	switch ref.Type {
-	case git.RefTypeRemoteBranch:
-		name = []string{"refs", "remotes", remote, ref.Name}
-	default:
-		return ref.Refspec()
+	if ref.Type == git.RefTypeRemoteBranch {
+		return strings.Join([]string{
+			"refs", "remotes", remote, ref.Name}, "/")
 	}
-	return strings.Join(name, "/")
+	return ref.Refspec()
 
 }
 

--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -221,9 +221,10 @@ func includeExcludeRefs(l *tasklog.Logger, args []string) (include, exclude []st
 				return nil, nil, err
 			}
 
-			for _, refs := range remoteRefs {
+			for remote, refs := range remoteRefs {
 				for _, ref := range refs {
-					exclude = append(exclude, ref.Refspec())
+					exclude = append(exclude,
+						formatRefName(ref, remote))
 				}
 			}
 		}
@@ -261,13 +262,6 @@ func getRemoteRefs(l *tasklog.Logger) (map[string][]*git.Ref, error) {
 
 		if err != nil {
 			return nil, err
-		}
-
-		for i, rr := range refsForRemote {
-			// HACK(@ttaylorr): add remote name to fully-qualify
-			// references:
-			refsForRemote[i].Name =
-				fmt.Sprintf("%s/%s", remote, rr.Name)
 		}
 
 		refs[remote] = refsForRemote

--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -187,7 +187,7 @@ func includeExcludeRefs(l *tasklog.Logger, args []string) (include, exclude []st
 		for _, ref := range refs {
 			switch ref.Type {
 			case git.RefTypeLocalBranch, git.RefTypeLocalTag,
-				git.RefTypeRemoteBranch, git.RefTypeRemoteTag:
+				git.RefTypeRemoteBranch:
 
 				include = append(include, ref.Refspec())
 			case git.RefTypeOther:
@@ -221,9 +221,9 @@ func includeExcludeRefs(l *tasklog.Logger, args []string) (include, exclude []st
 				return nil, nil, err
 			}
 
-			for _, remote := range remoteRefs {
-				for _, rr := range remote {
-					exclude = append(exclude, rr.Refspec())
+			for _, refs := range remoteRefs {
+				for _, ref := range refs {
+					exclude = append(exclude, ref.Refspec())
 				}
 			}
 		}
@@ -284,8 +284,6 @@ func formatRefName(ref *git.Ref, remote string) string {
 	switch ref.Type {
 	case git.RefTypeRemoteBranch:
 		name = []string{"refs", "remotes", remote, ref.Name}
-	case git.RefTypeRemoteTag:
-		name = []string{"refs", "tags", ref.Name}
 	default:
 		return ref.Name
 	}
@@ -303,8 +301,7 @@ func currentRefToMigrate() (*git.Ref, error) {
 	}
 
 	if current.Type == git.RefTypeOther ||
-		current.Type == git.RefTypeRemoteBranch ||
-		current.Type == git.RefTypeRemoteTag {
+		current.Type == git.RefTypeRemoteBranch {
 
 		return nil, errors.Errorf("fatal: cannot migrate non-local ref: %s", current.Name)
 	}

--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -285,7 +285,7 @@ func formatRefName(ref *git.Ref, remote string) string {
 	case git.RefTypeRemoteBranch:
 		name = []string{"refs", "remotes", remote, ref.Name}
 	default:
-		return ref.Name
+		return ref.Refspec()
 	}
 	return strings.Join(name, "/")
 

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -26,11 +26,6 @@ func TestRefString(t *testing.T) {
 			Type: RefTypeRemoteBranch,
 			Sha:  sha,
 		},
-		"refs/remotes/tags/v1.0.0": {
-			Name: "v1.0.0",
-			Type: RefTypeRemoteTag,
-			Sha:  sha,
-		},
 		"refs/tags/v1.0.0": {
 			Name: "v1.0.0",
 			Type: RefTypeLocalTag,
@@ -53,10 +48,9 @@ func TestRefString(t *testing.T) {
 
 func TestParseRefs(t *testing.T) {
 	tests := map[string]RefType{
-		"refs/heads":        RefTypeLocalBranch,
-		"refs/tags":         RefTypeLocalTag,
-		"refs/remotes/tags": RefTypeRemoteTag,
-		"refs/remotes":      RefTypeRemoteBranch,
+		"refs/heads":   RefTypeLocalBranch,
+		"refs/tags":    RefTypeLocalTag,
+		"refs/remotes": RefTypeRemoteBranch,
 	}
 
 	for prefix, expectedType := range tests {
@@ -594,8 +588,6 @@ func TestLocalRefs(t *testing.T) {
 			t.Errorf("Local HEAD ref: %v", r)
 		case RefTypeOther:
 			t.Errorf("Stash or unknown ref: %v", r)
-		case RefTypeRemoteBranch, RefTypeRemoteTag:
-			t.Errorf("Remote ref: %v", r)
 		default:
 			actual[r.Name] = true
 		}
@@ -701,7 +693,6 @@ func TestRefTypeKnownPrefixes(t *testing.T) {
 		RefTypeLocalBranch:  {"refs/heads", true},
 		RefTypeRemoteBranch: {"refs/remotes", true},
 		RefTypeLocalTag:     {"refs/tags", true},
-		RefTypeRemoteTag:    {"refs/remotes/tags", true},
 		RefTypeHEAD:         {"", false},
 		RefTypeOther:        {"", false},
 	} {

--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -539,7 +539,7 @@ func (r *Rewriter) refsToMigrate() ([]*git.Ref, error) {
 
 	var local []*git.Ref
 	for _, ref := range refs {
-		if ref.Type == git.RefTypeRemoteBranch || ref.Type == git.RefTypeRemoteTag {
+		if ref.Type == git.RefTypeRemoteBranch {
 			continue
 		}
 


### PR DESCRIPTION
This pull request fixes a long-standing bug wherein a reference beginning with `refs/remotes/tags` would incorrectly be round-tripped back to Git, causing `git lfs migrate` and others to complain of a reference that does not exist.

Closes: https://github.com/git-lfs/git-lfs/issues/3281.

##

/cc @git-lfs/core 
/cc @zezba9000, https://github.com/git-lfs/git-lfs/issues/3281