### PR TITLE
lfsapi/tq: Have DoWithAuth() caller determine URL Access Mode

### DIFF
--- a/commands/command_env.go
+++ b/commands/command_env.go
@@ -25,7 +25,7 @@ func envCommand(cmd *cobra.Command, args []string) {
 		endpoint := getAPIClient().Endpoints.Endpoint("download", defaultRemote)
 		if len(endpoint.Url) > 0 {
 			access := getAPIClient().Endpoints.AccessFor(endpoint.Url)
-			Print("Endpoint=%s (auth=%s)", endpoint.Url, access.GetMode())
+			Print("Endpoint=%s (auth=%s)", endpoint.Url, access.Mode())
 			if len(endpoint.SshUserAndHost) > 0 {
 				Print("  SSH=%s:%s", endpoint.SshUserAndHost, endpoint.SshPath)
 			}
@@ -38,7 +38,7 @@ func envCommand(cmd *cobra.Command, args []string) {
 		}
 		remoteEndpoint := getAPIClient().Endpoints.RemoteEndpoint("download", remote)
 		remoteAccess := getAPIClient().Endpoints.AccessFor(remoteEndpoint.Url)
-		Print("Endpoint (%s)=%s (auth=%s)", remote, remoteEndpoint.Url, remoteAccess.GetMode())
+		Print("Endpoint (%s)=%s (auth=%s)", remote, remoteEndpoint.Url, remoteAccess.Mode())
 		if len(remoteEndpoint.SshUserAndHost) > 0 {
 			Print("  SSH=%s:%s", remoteEndpoint.SshUserAndHost, remoteEndpoint.SshPath)
 		}

--- a/commands/command_env.go
+++ b/commands/command_env.go
@@ -25,7 +25,7 @@ func envCommand(cmd *cobra.Command, args []string) {
 		endpoint := getAPIClient().Endpoints.Endpoint("download", defaultRemote)
 		if len(endpoint.Url) > 0 {
 			access := getAPIClient().Endpoints.AccessFor(endpoint.Url)
-			Print("Endpoint=%s (auth=%s)", endpoint.Url, access)
+			Print("Endpoint=%s (auth=%s)", endpoint.Url, access.GetMode())
 			if len(endpoint.SshUserAndHost) > 0 {
 				Print("  SSH=%s:%s", endpoint.SshUserAndHost, endpoint.SshPath)
 			}
@@ -38,7 +38,7 @@ func envCommand(cmd *cobra.Command, args []string) {
 		}
 		remoteEndpoint := getAPIClient().Endpoints.RemoteEndpoint("download", remote)
 		remoteAccess := getAPIClient().Endpoints.AccessFor(remoteEndpoint.Url)
-		Print("Endpoint (%s)=%s (auth=%s)", remote, remoteEndpoint.Url, remoteAccess)
+		Print("Endpoint (%s)=%s (auth=%s)", remote, remoteEndpoint.Url, remoteAccess.GetMode())
 		if len(remoteEndpoint.SshUserAndHost) > 0 {
 			Print("  SSH=%s:%s", remoteEndpoint.SshUserAndHost, remoteEndpoint.SshPath)
 		}

--- a/lfs/lfs.go
+++ b/lfs/lfs.go
@@ -56,8 +56,8 @@ func Environ(cfg *config.Configuration, manifest *tq.Manifest) []string {
 		fmt.Sprintf("PruneVerifyRemoteAlways=%v", fetchPruneConfig.PruneVerifyRemoteAlways),
 		fmt.Sprintf("PruneRemoteName=%s", fetchPruneConfig.PruneRemoteName),
 		fmt.Sprintf("LfsStorageDir=%s", cfg.LFSStorageDir()),
-		fmt.Sprintf("AccessDownload=%s", download.GetMode()),
-		fmt.Sprintf("AccessUpload=%s", upload.GetMode()),
+		fmt.Sprintf("AccessDownload=%s", download.Mode()),
+		fmt.Sprintf("AccessUpload=%s", upload.Mode()),
 		fmt.Sprintf("DownloadTransfers=%s", strings.Join(dltransfers, ",")),
 		fmt.Sprintf("UploadTransfers=%s", strings.Join(ultransfers, ",")),
 	)

--- a/lfs/lfs.go
+++ b/lfs/lfs.go
@@ -56,8 +56,8 @@ func Environ(cfg *config.Configuration, manifest *tq.Manifest) []string {
 		fmt.Sprintf("PruneVerifyRemoteAlways=%v", fetchPruneConfig.PruneVerifyRemoteAlways),
 		fmt.Sprintf("PruneRemoteName=%s", fetchPruneConfig.PruneRemoteName),
 		fmt.Sprintf("LfsStorageDir=%s", cfg.LFSStorageDir()),
-		fmt.Sprintf("AccessDownload=%s", download),
-		fmt.Sprintf("AccessUpload=%s", upload),
+		fmt.Sprintf("AccessDownload=%s", download.GetMode()),
+		fmt.Sprintf("AccessUpload=%s", upload.GetMode()),
 		fmt.Sprintf("DownloadTransfers=%s", strings.Join(dltransfers, ",")),
 		fmt.Sprintf("UploadTransfers=%s", strings.Join(ultransfers, ",")),
 	)

--- a/lfsapi/auth.go
+++ b/lfsapi/auth.go
@@ -34,7 +34,7 @@ func (c *Client) DoWithAuth(remote string, access Access, req *http.Request, all
 			// not count this against our redirection
 			// maximum.
 			newAccess := c.Endpoints.AccessFor(access.url)
-			tracerx.Printf("api: http response indicates %q authentication. Resubmitting...", newAccess.GetMode())
+			tracerx.Printf("api: http response indicates %q authentication. Resubmitting...", newAccess.Mode())
 			return c.DoWithAuth(remote, newAccess, req, allowRetry)
 		}
 	}
@@ -64,7 +64,7 @@ func (c *Client) doWithAuth(remote string, access Access, req *http.Request, via
 	if err != nil {
 		if errors.IsAuthError(err) {
 			newAccess := access.Upgrade(getAuthAccess(res))
-			if newAccess.GetMode() != access.GetMode() {
+			if newAccess.Mode() != access.Mode() {
 				c.Endpoints.SetAccess(newAccess)
 			}
 
@@ -83,7 +83,7 @@ func (c *Client) doWithAuth(remote string, access Access, req *http.Request, via
 }
 
 func (c *Client) doWithCreds(req *http.Request, credHelper creds.CredentialHelper, creds creds.Creds, credsURL *url.URL, access Access, via []*http.Request) (*http.Response, error) {
-	if access.GetMode() == NTLMAccess {
+	if access.Mode() == NTLMAccess {
 		return c.doWithNTLM(req, credHelper, creds, credsURL)
 	}
 
@@ -135,8 +135,8 @@ func (c *Client) getCreds(remote string, access Access, req *http.Request) (cred
 	operation := getReqOperation(req)
 	apiEndpoint := ef.Endpoint(operation, remote)
 
-	if access.GetMode() != NTLMAccess {
-		if requestHasAuth(req) || setAuthFromNetrc(netrcFinder, req) || access.GetMode() == NoneAccess {
+	if access.Mode() != NTLMAccess {
+		if requestHasAuth(req) || setAuthFromNetrc(netrcFinder, req) || access.Mode() == NoneAccess {
 			return creds.NullCreds, nil, nil, nil
 		}
 

--- a/lfsapi/auth.go
+++ b/lfsapi/auth.go
@@ -68,7 +68,7 @@ func (c *Client) doWithAuth(remote string, req *http.Request, via []*http.Reques
 	return res, err
 }
 
-func (c *Client) doWithCreds(req *http.Request, credHelper creds.CredentialHelper, creds creds.Creds, credsURL *url.URL, access Access, via []*http.Request) (*http.Response, error) {
+func (c *Client) doWithCreds(req *http.Request, credHelper creds.CredentialHelper, creds creds.Creds, credsURL *url.URL, access AccessMode, via []*http.Request) (*http.Response, error) {
 	if access == NTLMAccess {
 		return c.doWithNTLM(req, credHelper, creds, credsURL)
 	}
@@ -107,7 +107,7 @@ func (c *Client) doWithCreds(req *http.Request, credHelper creds.CredentialHelpe
 // 3. The Git Remote URL, which should be something like "https://git.com/repo.git"
 //    This URL is used for the Git Credential Helper. This way existing https
 //    Git remote credentials can be re-used for LFS.
-func (c *Client) getCreds(remote string, req *http.Request) (lfshttp.Endpoint, Access, creds.CredentialHelper, *url.URL, creds.Creds, error) {
+func (c *Client) getCreds(remote string, req *http.Request) (lfshttp.Endpoint, AccessMode, creds.CredentialHelper, *url.URL, creds.Creds, error) {
 	ef := c.Endpoints
 	if ef == nil {
 		ef = defaultEndpointFinder
@@ -339,7 +339,7 @@ var (
 	authenticateHeaders = []string{"Lfs-Authenticate", "Www-Authenticate"}
 )
 
-func getAuthAccess(res *http.Response) Access {
+func getAuthAccess(res *http.Response) AccessMode {
 	for _, headerName := range authenticateHeaders {
 		for _, auth := range res.Header[headerName] {
 			pieces := strings.SplitN(strings.ToLower(auth), " ", 2)
@@ -347,7 +347,7 @@ func getAuthAccess(res *http.Response) Access {
 				continue
 			}
 
-			switch Access(pieces[0]) {
+			switch AccessMode(pieces[0]) {
 			case NegotiateAccess, NTLMAccess:
 				// When server sends Www-Authentication: Negotiate, it supports both Kerberos and NTLM.
 				// Since git-lfs current does not support Kerberos, we will return NTLM in this case.

--- a/lfsapi/auth_test.go
+++ b/lfsapi/auth_test.go
@@ -89,7 +89,7 @@ func TestDoWithAuthApprove(t *testing.T) {
 	err = MarshalToRequest(req, &authRequest{Test: "Approve"})
 	require.Nil(t, err)
 
-	res, err := c.DoWithAuth("", req)
+	res, err := c.DoWithAuth("", c.Endpoints.AccessFor(srv.URL+"/repo/lfs"), req)
 	require.Nil(t, err)
 
 	assert.Equal(t, http.StatusOK, res.StatusCode)
@@ -155,7 +155,7 @@ func TestDoWithAuthReject(t *testing.T) {
 	err = MarshalToRequest(req, &authRequest{Test: "Reject"})
 	require.Nil(t, err)
 
-	res, err := c.DoWithAuth("", req)
+	res, err := c.DoWithAuth("", c.Endpoints.AccessFor(srv.URL), req)
 	require.Nil(t, err)
 
 	assert.Equal(t, http.StatusOK, res.StatusCode)
@@ -168,6 +168,61 @@ func TestDoWithAuthReject(t *testing.T) {
 		"host":     srv.Listener.Addr().String(),
 	})))
 	assert.EqualValues(t, 3, called)
+}
+
+func TestDoAPIRequestWithAuth(t *testing.T) {
+	var called uint32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		atomic.AddUint32(&called, 1)
+		assert.Equal(t, "POST", req.Method)
+
+		body := &authRequest{}
+		err := json.NewDecoder(req.Body).Decode(body)
+		assert.Nil(t, err)
+		assert.Equal(t, "Approve", body.Test)
+
+		w.Header().Set("Lfs-Authenticate", "Basic")
+		actual := req.Header.Get("Authorization")
+		if len(actual) == 0 {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		expected := "Basic " + strings.TrimSpace(
+			base64.StdEncoding.EncodeToString([]byte("user:pass")),
+		)
+		assert.Equal(t, expected, actual)
+	}))
+	defer srv.Close()
+
+	cred := newMockCredentialHelper()
+	c, err := NewClient(lfshttp.NewContext(nil, nil, map[string]string{
+		"lfs.url": srv.URL + "/repo/lfs",
+	}))
+	require.Nil(t, err)
+	c.Credentials = cred
+
+	assert.Equal(t, NoneAccess, c.Endpoints.AccessFor(srv.URL+"/repo/lfs").mode)
+
+	req, err := http.NewRequest("POST", srv.URL+"/repo/lfs/foo", nil)
+	require.Nil(t, err)
+
+	err = MarshalToRequest(req, &authRequest{Test: "Approve"})
+	require.Nil(t, err)
+
+	res, err := c.DoAPIRequestWithAuth("", req)
+	require.Nil(t, err)
+
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+	assert.True(t, cred.IsApproved(creds.Creds(map[string]string{
+		"username": "user",
+		"password": "pass",
+		"protocol": "http",
+		"host":     srv.Listener.Addr().String(),
+	})))
+	assert.Equal(t, BasicAccess, c.Endpoints.AccessFor(srv.URL+"/repo/lfs").mode)
+	assert.EqualValues(t, 2, called)
 }
 
 type mockCredentialHelper struct {
@@ -228,7 +283,6 @@ func basicAuth(user, pass string) string {
 }
 
 type getCredsExpected struct {
-	Endpoint      string
 	Access        AccessMode
 	Creds         creds.Creds
 	CredsURL      string
@@ -239,6 +293,7 @@ type getCredsTest struct {
 	Remote   string
 	Method   string
 	Href     string
+	Endpoint string
 	Header   map[string]string
 	Config   map[string]string
 	Expected getCredsExpected
@@ -247,28 +302,28 @@ type getCredsTest struct {
 func TestGetCreds(t *testing.T) {
 	tests := map[string]getCredsTest{
 		"no access": getCredsTest{
-			Remote: "origin",
-			Method: "GET",
-			Href:   "https://git-server.com/repo/lfs/locks",
+			Remote:   "origin",
+			Method:   "GET",
+			Href:     "https://git-server.com/repo/lfs/locks",
+			Endpoint: "https://git-server.com/repo/lfs",
 			Config: map[string]string{
 				"lfs.url": "https://git-server.com/repo/lfs",
 			},
 			Expected: getCredsExpected{
-				Access:   NoneAccess,
-				Endpoint: "https://git-server.com/repo/lfs",
+				Access: NoneAccess,
 			},
 		},
 		"basic access": getCredsTest{
-			Remote: "origin",
-			Method: "GET",
-			Href:   "https://git-server.com/repo/lfs/locks",
+			Remote:   "origin",
+			Method:   "GET",
+			Href:     "https://git-server.com/repo/lfs/locks",
+			Endpoint: "https://git-server.com/repo/lfs",
 			Config: map[string]string{
 				"lfs.url": "https://git-server.com/repo/lfs",
 				"lfs.https://git-server.com/repo/lfs.access": "basic",
 			},
 			Expected: getCredsExpected{
 				Access:        BasicAccess,
-				Endpoint:      "https://git-server.com/repo/lfs",
 				Authorization: basicAuth("git-server.com", "monkey"),
 				CredsURL:      "https://git-server.com/repo/lfs",
 				Creds: map[string]string{
@@ -280,9 +335,10 @@ func TestGetCreds(t *testing.T) {
 			},
 		},
 		"basic access with usehttppath": getCredsTest{
-			Remote: "origin",
-			Method: "GET",
-			Href:   "https://git-server.com/repo/lfs/locks",
+			Remote:   "origin",
+			Method:   "GET",
+			Href:     "https://git-server.com/repo/lfs/locks",
+			Endpoint: "https://git-server.com/repo/lfs",
 			Config: map[string]string{
 				"lfs.url": "https://git-server.com/repo/lfs",
 				"lfs.https://git-server.com/repo/lfs.access": "basic",
@@ -290,7 +346,6 @@ func TestGetCreds(t *testing.T) {
 			},
 			Expected: getCredsExpected{
 				Access:        BasicAccess,
-				Endpoint:      "https://git-server.com/repo/lfs",
 				Authorization: basicAuth("git-server.com", "monkey"),
 				CredsURL:      "https://git-server.com/repo/lfs",
 				Creds: map[string]string{
@@ -303,9 +358,10 @@ func TestGetCreds(t *testing.T) {
 			},
 		},
 		"basic access with url-specific usehttppath": getCredsTest{
-			Remote: "origin",
-			Method: "GET",
-			Href:   "https://git-server.com/repo/lfs/locks",
+			Remote:   "origin",
+			Method:   "GET",
+			Href:     "https://git-server.com/repo/lfs/locks",
+			Endpoint: "https://git-server.com/repo/lfs",
 			Config: map[string]string{
 				"lfs.url": "https://git-server.com/repo/lfs",
 				"lfs.https://git-server.com/repo/lfs.access":    "basic",
@@ -313,7 +369,6 @@ func TestGetCreds(t *testing.T) {
 			},
 			Expected: getCredsExpected{
 				Access:        BasicAccess,
-				Endpoint:      "https://git-server.com/repo/lfs",
 				Authorization: basicAuth("git-server.com", "monkey"),
 				CredsURL:      "https://git-server.com/repo/lfs",
 				Creds: map[string]string{
@@ -326,16 +381,16 @@ func TestGetCreds(t *testing.T) {
 			},
 		},
 		"ntlm": getCredsTest{
-			Remote: "origin",
-			Method: "GET",
-			Href:   "https://git-server.com/repo/lfs/locks",
+			Remote:   "origin",
+			Method:   "GET",
+			Href:     "https://git-server.com/repo/lfs/locks",
+			Endpoint: "https://git-server.com/repo/lfs",
 			Config: map[string]string{
 				"lfs.url": "https://git-server.com/repo/lfs",
 				"lfs.https://git-server.com/repo/lfs.access": "ntlm",
 			},
 			Expected: getCredsExpected{
 				Access:   NTLMAccess,
-				Endpoint: "https://git-server.com/repo/lfs",
 				CredsURL: "https://git-server.com/repo/lfs",
 				Creds: map[string]string{
 					"protocol": "https",
@@ -346,16 +401,16 @@ func TestGetCreds(t *testing.T) {
 			},
 		},
 		"ntlm with netrc": getCredsTest{
-			Remote: "origin",
-			Method: "GET",
-			Href:   "https://netrc-host.com/repo/lfs/locks",
+			Remote:   "origin",
+			Method:   "GET",
+			Href:     "https://netrc-host.com/repo/lfs/locks",
+			Endpoint: "https://netrc-host.com/repo/lfs",
 			Config: map[string]string{
 				"lfs.url": "https://netrc-host.com/repo/lfs",
 				"lfs.https://netrc-host.com/repo/lfs.access": "ntlm",
 			},
 			Expected: getCredsExpected{
 				Access:   NTLMAccess,
-				Endpoint: "https://netrc-host.com/repo/lfs",
 				CredsURL: "https://netrc-host.com/repo/lfs",
 				Creds: map[string]string{
 					"protocol": "https",
@@ -367,9 +422,10 @@ func TestGetCreds(t *testing.T) {
 			},
 		},
 		"custom auth": getCredsTest{
-			Remote: "origin",
-			Method: "GET",
-			Href:   "https://git-server.com/repo/lfs/locks",
+			Remote:   "origin",
+			Method:   "GET",
+			Href:     "https://git-server.com/repo/lfs/locks",
+			Endpoint: "https://git-server.com/repo/lfs",
 			Header: map[string]string{
 				"Authorization": "custom",
 			},
@@ -379,35 +435,34 @@ func TestGetCreds(t *testing.T) {
 			},
 			Expected: getCredsExpected{
 				Access:        BasicAccess,
-				Endpoint:      "https://git-server.com/repo/lfs",
 				Authorization: "custom",
 			},
 		},
 		"netrc": getCredsTest{
-			Remote: "origin",
-			Method: "GET",
-			Href:   "https://netrc-host.com/repo/lfs/locks",
+			Remote:   "origin",
+			Method:   "GET",
+			Href:     "https://netrc-host.com/repo/lfs/locks",
+			Endpoint: "https://netrc-host.com/repo/lfs",
 			Config: map[string]string{
 				"lfs.url": "https://netrc-host.com/repo/lfs",
 				"lfs.https://netrc-host.com/repo/lfs.access": "basic",
 			},
 			Expected: getCredsExpected{
 				Access:        BasicAccess,
-				Endpoint:      "https://netrc-host.com/repo/lfs",
 				Authorization: basicAuth("abc", "def"),
 			},
 		},
 		"username in url": getCredsTest{
-			Remote: "origin",
-			Method: "GET",
-			Href:   "https://git-server.com/repo/lfs/locks",
+			Remote:   "origin",
+			Method:   "GET",
+			Href:     "https://git-server.com/repo/lfs/locks",
+			Endpoint: "https://git-server.com/repo/lfs",
 			Config: map[string]string{
 				"lfs.url": "https://user@git-server.com/repo/lfs",
 				"lfs.https://git-server.com/repo/lfs.access": "basic",
 			},
 			Expected: getCredsExpected{
 				Access:        BasicAccess,
-				Endpoint:      "https://git-server.com/repo/lfs",
 				Authorization: basicAuth("user", "monkey"),
 				CredsURL:      "https://user@git-server.com/repo/lfs",
 				Creds: map[string]string{
@@ -419,9 +474,10 @@ func TestGetCreds(t *testing.T) {
 			},
 		},
 		"different remote url, basic access": getCredsTest{
-			Remote: "origin",
-			Method: "GET",
-			Href:   "https://git-server.com/repo/lfs/locks",
+			Remote:   "origin",
+			Method:   "GET",
+			Href:     "https://git-server.com/repo/lfs/locks",
+			Endpoint: "https://git-server.com/repo/lfs",
 			Config: map[string]string{
 				"lfs.url": "https://git-server.com/repo/lfs",
 				"lfs.https://git-server.com/repo/lfs.access": "basic",
@@ -429,7 +485,6 @@ func TestGetCreds(t *testing.T) {
 			},
 			Expected: getCredsExpected{
 				Access:        BasicAccess,
-				Endpoint:      "https://git-server.com/repo/lfs",
 				Authorization: basicAuth("git-server.com", "monkey"),
 				CredsURL:      "https://git-server.com/repo",
 				Creds: map[string]string{
@@ -441,23 +496,24 @@ func TestGetCreds(t *testing.T) {
 			},
 		},
 		"api url auth": getCredsTest{
-			Remote: "origin",
-			Method: "GET",
-			Href:   "https://git-server.com/repo/locks",
+			Remote:   "origin",
+			Method:   "GET",
+			Href:     "https://git-server.com/repo/locks",
+			Endpoint: "https://git-server.com/repo",
 			Config: map[string]string{
 				"lfs.url":                                "https://user:pass@git-server.com/repo",
 				"lfs.https://git-server.com/repo.access": "basic",
 			},
 			Expected: getCredsExpected{
 				Access:        BasicAccess,
-				Endpoint:      "https://git-server.com/repo",
 				Authorization: basicAuth("user", "pass"),
 			},
 		},
 		"git url auth": getCredsTest{
-			Remote: "origin",
-			Method: "GET",
-			Href:   "https://git-server.com/repo/locks",
+			Remote:   "origin",
+			Method:   "GET",
+			Href:     "https://git-server.com/repo/locks",
+			Endpoint: "https://git-server.com/repo",
 			Config: map[string]string{
 				"lfs.url":                                "https://git-server.com/repo",
 				"lfs.https://git-server.com/repo.access": "basic",
@@ -465,21 +521,20 @@ func TestGetCreds(t *testing.T) {
 			},
 			Expected: getCredsExpected{
 				Access:        BasicAccess,
-				Endpoint:      "https://git-server.com/repo",
 				Authorization: basicAuth("user", "pass"),
 			},
 		},
 		"scheme mismatch": getCredsTest{
-			Remote: "origin",
-			Method: "GET",
-			Href:   "http://git-server.com/repo/lfs/locks",
+			Remote:   "origin",
+			Method:   "GET",
+			Href:     "http://git-server.com/repo/lfs/locks",
+			Endpoint: "https://git-server.com/repo/lfs",
 			Config: map[string]string{
 				"lfs.url": "https://git-server.com/repo/lfs",
 				"lfs.https://git-server.com/repo/lfs.access": "basic",
 			},
 			Expected: getCredsExpected{
 				Access:        BasicAccess,
-				Endpoint:      "https://git-server.com/repo/lfs",
 				Authorization: basicAuth("git-server.com", "monkey"),
 				CredsURL:      "http://git-server.com/repo/lfs/locks",
 				Creds: map[string]string{
@@ -491,16 +546,16 @@ func TestGetCreds(t *testing.T) {
 			},
 		},
 		"host mismatch": getCredsTest{
-			Remote: "origin",
-			Method: "GET",
-			Href:   "https://lfs-server.com/repo/lfs/locks",
+			Remote:   "origin",
+			Method:   "GET",
+			Href:     "https://lfs-server.com/repo/lfs/locks",
+			Endpoint: "https://git-server.com/repo/lfs",
 			Config: map[string]string{
 				"lfs.url": "https://git-server.com/repo/lfs",
 				"lfs.https://git-server.com/repo/lfs.access": "basic",
 			},
 			Expected: getCredsExpected{
 				Access:        BasicAccess,
-				Endpoint:      "https://git-server.com/repo/lfs",
 				Authorization: basicAuth("lfs-server.com", "monkey"),
 				CredsURL:      "https://lfs-server.com/repo/lfs/locks",
 				Creds: map[string]string{
@@ -512,16 +567,16 @@ func TestGetCreds(t *testing.T) {
 			},
 		},
 		"port mismatch": getCredsTest{
-			Remote: "origin",
-			Method: "GET",
-			Href:   "https://git-server.com:8080/repo/lfs/locks",
+			Remote:   "origin",
+			Method:   "GET",
+			Href:     "https://git-server.com:8080/repo/lfs/locks",
+			Endpoint: "https://git-server.com/repo/lfs",
 			Config: map[string]string{
 				"lfs.url": "https://git-server.com/repo/lfs",
 				"lfs.https://git-server.com/repo/lfs.access": "basic",
 			},
 			Expected: getCredsExpected{
 				Access:        BasicAccess,
-				Endpoint:      "https://git-server.com/repo/lfs",
 				Authorization: basicAuth("git-server.com:8080", "monkey"),
 				CredsURL:      "https://git-server.com:8080/repo/lfs/locks",
 				Creds: map[string]string{
@@ -533,9 +588,10 @@ func TestGetCreds(t *testing.T) {
 			},
 		},
 		"bare ssh URI": getCredsTest{
-			Remote: "origin",
-			Method: "POST",
-			Href:   "https://git-server.com/repo/lfs/objects/batch",
+			Remote:   "origin",
+			Method:   "POST",
+			Href:     "https://git-server.com/repo/lfs/objects/batch",
+			Endpoint: "https://git-server.com/repo/lfs",
 			Config: map[string]string{
 				"lfs.url": "https://git-server.com/repo/lfs",
 				"lfs.https://git-server.com/repo/lfs.access": "basic",
@@ -544,7 +600,6 @@ func TestGetCreds(t *testing.T) {
 			},
 			Expected: getCredsExpected{
 				Access:        BasicAccess,
-				Endpoint:      "https://git-server.com/repo/lfs",
 				Authorization: basicAuth("git-server.com", "monkey"),
 				CredsURL:      "https://git-server.com/repo/lfs",
 				Creds: map[string]string{
@@ -574,12 +629,11 @@ func TestGetCreds(t *testing.T) {
 		client.Credentials = &fakeCredentialFiller{}
 		client.Netrc = &fakeNetrc{}
 		client.Endpoints = NewEndpointFinder(ctx)
-		access, _, credsURL, creds, err := client.getCreds(test.Remote, req)
+		_, credsURL, creds, err := client.getCreds(test.Remote, client.Endpoints.AccessFor(test.Endpoint), req)
 		if !assert.Nil(t, err) {
 			continue
 		}
-		assert.Equal(t, test.Expected.Endpoint, access.url, "endpoint")
-		assert.Equal(t, test.Expected.Access, access.mode, "access")
+
 		assert.Equal(t, test.Expected.Authorization, req.Header.Get("Authorization"), "authorization")
 
 		if test.Expected.Creds != nil {
@@ -686,7 +740,7 @@ func TestClientRedirectReauthenticate(t *testing.T) {
 	req, err := http.NewRequest("GET", srv1.URL, nil)
 	require.Nil(t, err)
 
-	_, err = c.DoWithAuth("", req)
+	_, err = c.DoAPIRequestWithAuth("", req)
 	assert.Nil(t, err)
 
 	// called1 is 2 since LFS tries an unauthenticated request first

--- a/lfsapi/auth_test.go
+++ b/lfsapi/auth_test.go
@@ -23,7 +23,7 @@ type authRequest struct {
 }
 
 func TestAuthenticateHeaderAccess(t *testing.T) {
-	tests := map[string]Access{
+	tests := map[string]AccessMode{
 		"":                BasicAccess,
 		"basic 123":       BasicAccess,
 		"basic":           BasicAccess,
@@ -229,7 +229,7 @@ func basicAuth(user, pass string) string {
 
 type getCredsExpected struct {
 	Endpoint      string
-	Access        Access
+	Access        AccessMode
 	Creds         creds.Creds
 	CredsURL      string
 	Authorization string

--- a/lfsapi/auth_test.go
+++ b/lfsapi/auth_test.go
@@ -81,7 +81,7 @@ func TestDoWithAuthApprove(t *testing.T) {
 	require.Nil(t, err)
 	c.Credentials = cred
 
-	assert.Equal(t, NoneAccess, c.Endpoints.AccessFor(srv.URL+"/repo/lfs"))
+	assert.Equal(t, NoneAccess, c.Endpoints.AccessFor(srv.URL+"/repo/lfs").mode)
 
 	req, err := http.NewRequest("POST", srv.URL+"/repo/lfs/foo", nil)
 	require.Nil(t, err)
@@ -99,7 +99,7 @@ func TestDoWithAuthApprove(t *testing.T) {
 		"protocol": "http",
 		"host":     srv.Listener.Addr().String(),
 	})))
-	assert.Equal(t, BasicAccess, c.Endpoints.AccessFor(srv.URL+"/repo/lfs"))
+	assert.Equal(t, BasicAccess, c.Endpoints.AccessFor(srv.URL+"/repo/lfs").mode)
 	assert.EqualValues(t, 2, called)
 }
 
@@ -407,7 +407,7 @@ func TestGetCreds(t *testing.T) {
 			},
 			Expected: getCredsExpected{
 				Access:        BasicAccess,
-				Endpoint:      "https://user@git-server.com/repo/lfs",
+				Endpoint:      "https://git-server.com/repo/lfs",
 				Authorization: basicAuth("user", "monkey"),
 				CredsURL:      "https://user@git-server.com/repo/lfs",
 				Creds: map[string]string{
@@ -450,7 +450,7 @@ func TestGetCreds(t *testing.T) {
 			},
 			Expected: getCredsExpected{
 				Access:        BasicAccess,
-				Endpoint:      "https://user:pass@git-server.com/repo",
+				Endpoint:      "https://git-server.com/repo",
 				Authorization: basicAuth("user", "pass"),
 			},
 		},
@@ -574,12 +574,12 @@ func TestGetCreds(t *testing.T) {
 		client.Credentials = &fakeCredentialFiller{}
 		client.Netrc = &fakeNetrc{}
 		client.Endpoints = NewEndpointFinder(ctx)
-		endpoint, access, _, credsURL, creds, err := client.getCreds(test.Remote, req)
+		access, _, credsURL, creds, err := client.getCreds(test.Remote, req)
 		if !assert.Nil(t, err) {
 			continue
 		}
-		assert.Equal(t, test.Expected.Endpoint, endpoint.Url, "endpoint")
-		assert.Equal(t, test.Expected.Access, access, "access")
+		assert.Equal(t, test.Expected.Endpoint, access.url, "endpoint")
+		assert.Equal(t, test.Expected.Access, access.mode, "access")
 		assert.Equal(t, test.Expected.Authorization, req.Header.Get("Authorization"), "authorization")
 
 		if test.Expected.Creds != nil {

--- a/lfsapi/auth_test.go
+++ b/lfsapi/auth_test.go
@@ -89,7 +89,7 @@ func TestDoWithAuthApprove(t *testing.T) {
 	err = MarshalToRequest(req, &authRequest{Test: "Approve"})
 	require.Nil(t, err)
 
-	res, err := c.DoWithAuth("", c.Endpoints.AccessFor(srv.URL+"/repo/lfs"), req, true)
+	res, err := c.DoWithAuth("", c.Endpoints.AccessFor(srv.URL+"/repo/lfs"), req)
 	require.Nil(t, err)
 
 	assert.Equal(t, http.StatusOK, res.StatusCode)
@@ -155,7 +155,7 @@ func TestDoWithAuthReject(t *testing.T) {
 	err = MarshalToRequest(req, &authRequest{Test: "Reject"})
 	require.Nil(t, err)
 
-	res, err := c.DoWithAuth("", c.Endpoints.AccessFor(srv.URL), req, true)
+	res, err := c.DoWithAuth("", c.Endpoints.AccessFor(srv.URL), req)
 	require.Nil(t, err)
 
 	assert.Equal(t, http.StatusOK, res.StatusCode)
@@ -170,7 +170,7 @@ func TestDoWithAuthReject(t *testing.T) {
 	assert.EqualValues(t, 3, called)
 }
 
-func TestDoWithAuthNoRetries(t *testing.T) {
+func TestDoWithAuthNoRetry(t *testing.T) {
 	var called uint32
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -211,7 +211,7 @@ func TestDoWithAuthNoRetries(t *testing.T) {
 	err = MarshalToRequest(req, &authRequest{Test: "Approve"})
 	require.Nil(t, err)
 
-	res, err := c.DoWithAuth("", c.Endpoints.AccessFor(srv.URL+"/repo/lfs"), req, false)
+	res, err := c.DoWithAuthNoRetry("", c.Endpoints.AccessFor(srv.URL+"/repo/lfs"), req)
 	assert.True(t, errors.IsAuthError(err))
 	assert.Equal(t, http.StatusUnauthorized, res.StatusCode)
 	assert.Equal(t, BasicAccess, c.Endpoints.AccessFor(srv.URL+"/repo/lfs").mode)

--- a/lfsapi/endpoint_finder.go
+++ b/lfsapi/endpoint_finder.go
@@ -36,7 +36,7 @@ func (a *Access) Upgrade(newMode AccessMode) Access {
 	return Access{url: a.url, mode: newMode}
 }
 
-func (a *Access) GetMode() AccessMode {
+func (a *Access) Mode() AccessMode {
 	return a.mode
 }
 
@@ -236,18 +236,18 @@ func (e *endpointGitFinder) AccessFor(rawurl string) Access {
 
 func (e *endpointGitFinder) SetAccess(access Access) {
 	key := fmt.Sprintf("lfs.%s.access", access.url)
-	tracerx.Printf("setting repository access to %s", access.mode)
+	tracerx.Printf("setting repository access to %s", access.Mode())
 
 	e.accessMu.Lock()
 	defer e.accessMu.Unlock()
 
-	switch access.mode {
+	switch access.Mode() {
 	case emptyAccess, NoneAccess:
 		e.gitConfig.UnsetLocalKey(key)
 		e.urlAccess[access.url] = NoneAccess
 	default:
-		e.gitConfig.SetLocal(key, string(access.mode))
-		e.urlAccess[access.url] = access.mode
+		e.gitConfig.SetLocal(key, string(access.Mode()))
+		e.urlAccess[access.url] = access.Mode()
 	}
 }
 

--- a/lfsapi/endpoint_finder_test.go
+++ b/lfsapi/endpoint_finder_test.go
@@ -281,7 +281,7 @@ func TestLocalPathEndpointPreservesDotGit(t *testing.T) {
 
 func TestAccessConfig(t *testing.T) {
 	type accessTest struct {
-		Access        string
+		AccessMode    string
 		PrivateAccess bool
 	}
 
@@ -304,11 +304,11 @@ func TestAccessConfig(t *testing.T) {
 		dl := finder.Endpoint("upload", "")
 		ul := finder.Endpoint("download", "")
 
-		if access := finder.AccessFor(dl.Url); access != Access(expected.Access) {
-			t.Errorf("Expected Access() with value %q to be %v, got %v", value, expected.Access, access)
+		if access := finder.AccessFor(dl.Url); access != AccessMode(expected.AccessMode) {
+			t.Errorf("Expected AccessMode() with value %q to be %v, got %v", value, expected.AccessMode, access)
 		}
-		if access := finder.AccessFor(ul.Url); access != Access(expected.Access) {
-			t.Errorf("Expected Access() with value %q to be %v, got %v", value, expected.Access, access)
+		if access := finder.AccessFor(ul.Url); access != AccessMode(expected.AccessMode) {
+			t.Errorf("Expected AccessMode() with value %q to be %v, got %v", value, expected.AccessMode, access)
 		}
 	}
 
@@ -325,11 +325,11 @@ func TestAccessConfig(t *testing.T) {
 		dl := finder.Endpoint("upload", "")
 		ul := finder.Endpoint("download", "")
 
-		if access := finder.AccessFor(dl.Url); access != Access(expected.Access) {
-			t.Errorf("Expected Access() with value %q to be %v, got %v", value, expected.Access, access)
+		if access := finder.AccessFor(dl.Url); access != AccessMode(expected.AccessMode) {
+			t.Errorf("Expected AccessMode() with value %q to be %v, got %v", value, expected.AccessMode, access)
 		}
-		if access := finder.AccessFor(ul.Url); access != Access(expected.Access) {
-			t.Errorf("Expected Access() with value %q to be %v, got %v", value, expected.Access, access)
+		if access := finder.AccessFor(ul.Url); access != AccessMode(expected.AccessMode) {
+			t.Errorf("Expected AccessMode() with value %q to be %v, got %v", value, expected.AccessMode, access)
 		}
 	}
 }
@@ -374,7 +374,7 @@ func TestDeleteAccessWithEmptyString(t *testing.T) {
 	}))
 
 	assert.Equal(t, BasicAccess, finder.AccessFor("http://example.com"))
-	finder.SetAccess("http://example.com", Access(""))
+	finder.SetAccess("http://example.com", AccessMode(""))
 	assert.Equal(t, NoneAccess, finder.AccessFor("http://example.com"))
 }
 

--- a/lfsapi/endpoint_finder_test.go
+++ b/lfsapi/endpoint_finder_test.go
@@ -304,10 +304,10 @@ func TestAccessConfig(t *testing.T) {
 		dl := finder.Endpoint("upload", "")
 		ul := finder.Endpoint("download", "")
 
-		if access := finder.AccessFor(dl.Url); access.mode != AccessMode(expected.AccessMode) {
+		if access := finder.AccessFor(dl.Url); access.Mode() != AccessMode(expected.AccessMode) {
 			t.Errorf("Expected AccessMode() with value %q to be %v, got %v", value, expected.AccessMode, access)
 		}
-		if access := finder.AccessFor(ul.Url); access.mode != AccessMode(expected.AccessMode) {
+		if access := finder.AccessFor(ul.Url); access.Mode() != AccessMode(expected.AccessMode) {
 			t.Errorf("Expected AccessMode() with value %q to be %v, got %v", value, expected.AccessMode, access)
 		}
 	}
@@ -325,10 +325,10 @@ func TestAccessConfig(t *testing.T) {
 		dl := finder.Endpoint("upload", "")
 		ul := finder.Endpoint("download", "")
 
-		if access := finder.AccessFor(dl.Url); access.mode != AccessMode(expected.AccessMode) {
+		if access := finder.AccessFor(dl.Url); access.Mode() != AccessMode(expected.AccessMode) {
 			t.Errorf("Expected AccessMode() with value %q to be %v, got %v", value, expected.AccessMode, access)
 		}
-		if access := finder.AccessFor(ul.Url); access.mode != AccessMode(expected.AccessMode) {
+		if access := finder.AccessFor(ul.Url); access.Mode() != AccessMode(expected.AccessMode) {
 			t.Errorf("Expected AccessMode() with value %q to be %v, got %v", value, expected.AccessMode, access)
 		}
 	}
@@ -336,8 +336,12 @@ func TestAccessConfig(t *testing.T) {
 
 func TestAccessAbsentConfig(t *testing.T) {
 	finder := NewEndpointFinder(nil)
-	assert.Equal(t, NoneAccess, finder.AccessFor(finder.Endpoint("download", "").Url).mode)
-	assert.Equal(t, NoneAccess, finder.AccessFor(finder.Endpoint("upload", "").Url).mode)
+
+	downloadAccess := finder.AccessFor(finder.Endpoint("download", "").Url)
+	assert.Equal(t, NoneAccess, downloadAccess.Mode())
+
+	uploadAccess := finder.AccessFor(finder.Endpoint("upload", "").Url)
+	assert.Equal(t, NoneAccess, uploadAccess.Mode())
 }
 
 func TestSetAccess(t *testing.T) {
@@ -345,13 +349,13 @@ func TestSetAccess(t *testing.T) {
 	url := "http://example.com"
 	access := finder.AccessFor(url)
 
-	assert.Equal(t, NoneAccess, access.mode)
+	assert.Equal(t, NoneAccess, access.Mode())
 	assert.Equal(t, url, access.url)
 
 	finder.SetAccess(access.Upgrade(NTLMAccess))
 
 	newAccess := finder.AccessFor(url)
-	assert.Equal(t, NTLMAccess, newAccess.mode)
+	assert.Equal(t, NTLMAccess, newAccess.Mode())
 	assert.Equal(t, url, newAccess.url)
 }
 
@@ -362,13 +366,13 @@ func TestChangeAccess(t *testing.T) {
 
 	url := "http://example.com"
 	access := finder.AccessFor(url)
-	assert.Equal(t, BasicAccess, access.mode)
+	assert.Equal(t, BasicAccess, access.Mode())
 	assert.Equal(t, url, access.url)
 
 	finder.SetAccess(access.Upgrade(NTLMAccess))
 
 	newAccess := finder.AccessFor(url)
-	assert.Equal(t, NTLMAccess, newAccess.mode)
+	assert.Equal(t, NTLMAccess, newAccess.Mode())
 	assert.Equal(t, url, newAccess.url)
 }
 
@@ -380,13 +384,13 @@ func TestDeleteAccessWithNone(t *testing.T) {
 	url := "http://example.com"
 
 	access := finder.AccessFor(url)
-	assert.Equal(t, BasicAccess, access.mode)
+	assert.Equal(t, BasicAccess, access.Mode())
 	assert.Equal(t, url, access.url)
 
 	finder.SetAccess(access.Upgrade(NoneAccess))
 
 	newAccess := finder.AccessFor(url)
-	assert.Equal(t, NoneAccess, newAccess.mode)
+	assert.Equal(t, NoneAccess, newAccess.Mode())
 	assert.Equal(t, url, newAccess.url)
 }
 
@@ -398,13 +402,13 @@ func TestDeleteAccessWithEmptyString(t *testing.T) {
 	url := "http://example.com"
 
 	access := finder.AccessFor(url)
-	assert.Equal(t, BasicAccess, access.mode)
+	assert.Equal(t, BasicAccess, access.Mode())
 	assert.Equal(t, url, access.url)
 
 	finder.SetAccess(access.Upgrade(AccessMode("")))
 
 	newAccess := finder.AccessFor(url)
-	assert.Equal(t, NoneAccess, newAccess.mode)
+	assert.Equal(t, NoneAccess, newAccess.Mode())
 	assert.Equal(t, url, newAccess.url)
 }
 

--- a/lfsapi/ntlm_test.go
+++ b/lfsapi/ntlm_test.go
@@ -114,7 +114,7 @@ func TestNtlmAuth(t *testing.T) {
 	}
 	credHelper.Approve(cred)
 
-	res, err := cli.DoWithAuth("remote", req)
+	res, err := cli.DoWithAuth("remote", cli.Endpoints.AccessFor(srv.URL+"/ntlm"), req)
 	require.Nil(t, err)
 	assert.Equal(t, 200, res.StatusCode)
 	assert.True(t, credHelper.IsApproved(cred))

--- a/lfsapi/ntlm_test.go
+++ b/lfsapi/ntlm_test.go
@@ -114,7 +114,7 @@ func TestNtlmAuth(t *testing.T) {
 	}
 	credHelper.Approve(cred)
 
-	res, err := cli.DoWithAuth("remote", cli.Endpoints.AccessFor(srv.URL+"/ntlm"), req)
+	res, err := cli.DoWithAuth("remote", cli.Endpoints.AccessFor(srv.URL+"/ntlm"), req, true)
 	require.Nil(t, err)
 	assert.Equal(t, 200, res.StatusCode)
 	assert.True(t, credHelper.IsApproved(cred))

--- a/lfsapi/ntlm_test.go
+++ b/lfsapi/ntlm_test.go
@@ -114,7 +114,7 @@ func TestNtlmAuth(t *testing.T) {
 	}
 	credHelper.Approve(cred)
 
-	res, err := cli.DoWithAuth("remote", cli.Endpoints.AccessFor(srv.URL+"/ntlm"), req, true)
+	res, err := cli.DoWithAuth("remote", cli.Endpoints.AccessFor(srv.URL+"/ntlm"), req)
 	require.Nil(t, err)
 	assert.Equal(t, 200, res.StatusCode)
 	assert.True(t, credHelper.IsApproved(cred))

--- a/locking/api.go
+++ b/locking/api.go
@@ -58,7 +58,7 @@ func (c *lockClient) Lock(remote string, lockReq *lockRequest) (*lockResponse, *
 	}
 
 	req = c.Client.LogRequest(req, "lfs.locks.lock")
-	res, err := c.DoWithAuth(remote, req)
+	res, err := c.DoAPIRequestWithAuth(remote, req)
 	if err != nil {
 		return nil, res, err
 	}
@@ -103,7 +103,7 @@ func (c *lockClient) Unlock(ref *git.Ref, remote, id string, force bool) (*unloc
 	}
 
 	req = c.Client.LogRequest(req, "lfs.locks.unlock")
-	res, err := c.DoWithAuth(remote, req)
+	res, err := c.DoAPIRequestWithAuth(remote, req)
 	if err != nil {
 		return nil, res, err
 	}
@@ -193,7 +193,7 @@ func (c *lockClient) Search(remote string, searchReq *lockSearchRequest) (*lockL
 	req.URL.RawQuery = q.Encode()
 
 	req = c.Client.LogRequest(req, "lfs.locks.search")
-	res, err := c.DoWithAuth(remote, req)
+	res, err := c.DoAPIRequestWithAuth(remote, req)
 	if err != nil {
 		return nil, res, err
 	}
@@ -253,7 +253,7 @@ func (c *lockClient) SearchVerifiable(remote string, vreq *lockVerifiableRequest
 	}
 
 	req = c.Client.LogRequest(req, "lfs.locks.verify")
-	res, err := c.DoWithAuth(remote, req)
+	res, err := c.DoAPIRequestWithAuth(remote, req)
 	if err != nil {
 		return nil, res, err
 	}

--- a/t/cmd/lfstest-customadapter.go
+++ b/t/cmd/lfstest-customadapter.go
@@ -115,7 +115,7 @@ func performDownload(apiClient *lfsapi.Client, oid string, size int64, a *action
 		req.Header.Set(k, a.Header[k])
 	}
 
-	res, err := apiClient.DoWithAuth("origin", req)
+	res, err := apiClient.DoAPIRequestWithAuth("origin", req)
 	if err != nil {
 		statusCode := 6
 		if res != nil {
@@ -197,7 +197,7 @@ func performUpload(apiClient *lfsapi.Client, oid string, size int64, a *action, 
 	}
 	req.Body = tools.NewBodyWithCallback(f, size, cb)
 
-	res, err := apiClient.DoWithAuth("origin", req)
+	res, err := apiClient.DoAPIRequestWithAuth("origin", req)
 	if err != nil {
 		sendTransferError(oid, res.StatusCode, fmt.Sprintf("Error uploading data for %s: %v", oid, err), writer, errWriter)
 		return

--- a/t/cmd/lfstest-gitserver.go
+++ b/t/cmd/lfstest-gitserver.go
@@ -1257,6 +1257,11 @@ func missingRequiredCreds(w http.ResponseWriter, r *http.Request, repo string) b
 	}
 
 	auth := r.Header.Get("Authorization")
+	if len(auth) == 0 {
+		writeLFSError(w, 401, "Error: Authorization Required")
+		return true
+	}
+
 	user, pass, err := extractAuth(auth)
 	if err != nil {
 		writeLFSError(w, 403, err.Error())

--- a/t/t-credentials.sh
+++ b/t/t-credentials.sh
@@ -352,7 +352,7 @@ begin_test "credentials from lfs.url"
   grep "HTTP: 401" push.log
   # Ensure we didn't make a second batch request, which means the request
   # was successfully retried internally
-  [ ! $(grep "tq: retrying object" push.log) ]
+  [ ! "$(grep "tq: retrying object" push.log)" ]
   grep "Uploading LFS objects:   0% (0/1), 0 B" push.log
 
   echo "bad fetch"
@@ -369,7 +369,7 @@ begin_test "credentials from lfs.url"
   GIT_TRACE=1 git lfs fetch --all 2>&1 | tee fetch.log
   # No 401 should occur as we've already set an access mode for the
   # storage endpoint during the push
-  [ ! $(grep "HTTP: 401" fetch.log) ]
+  [ ! "$(grep "HTTP: 401" fetch.log)" ]
   grep "Downloading LFS objects: 100% (1/1), 7 B" fetch.log
 
   echo "good fetch, setting access mode"
@@ -383,7 +383,7 @@ begin_test "credentials from lfs.url"
   grep "HTTP: 401" fetch.log
   # Ensure we didn't make a second batch request, which means the request
   # was successfully retried internally
-  [ ! $(grep "tq: retrying object" fetch.log) ]
+  [ ! "$(grep "tq: retrying object" fetch.log)" ]
   grep "Downloading LFS objects: 100% (1/1), 7 B" fetch.log
 )
 end_test
@@ -416,7 +416,7 @@ begin_test "credentials from remote.origin.url"
   grep "HTTP: 401" push.log
   # Ensure we didn't make a second batch request, which means the request
   # was successfully retried internally
-  [ ! $(grep "tq: retrying object" push.log) ]
+  [ ! "$(grep "tq: retrying object" push.log)" ]
   grep "Uploading LFS objects: 100% (1/1), 7 B" push.log
 
   echo "bad fetch"
@@ -434,7 +434,7 @@ begin_test "credentials from remote.origin.url"
   GIT_TRACE=1 git lfs fetch --all 2>&1 | tee fetch.log
   # No 401 should occur as we've already set an access mode for the
   # storage endpoint during the push
-  [ ! $(grep "HTTP: 401" fetch.log) ]
+  [ ! "$(grep "HTTP: 401" fetch.log)" ]
   grep "Downloading LFS objects: 100% (1/1), 7 B" fetch.log
 
   echo "good fetch, setting access mode"
@@ -448,7 +448,7 @@ begin_test "credentials from remote.origin.url"
   grep "HTTP: 401" fetch.log
   # Ensure we didn't make a second batch request, which means the request
   # was successfully retried internally
-  [ ! $(grep "tq: retrying object" fetch.log) ]
+  [ ! "$(grep "tq: retrying object" fetch.log)" ]
   grep "Downloading LFS objects: 100% (1/1), 7 B" fetch.log
 )
 end_test

--- a/t/t-credentials.sh
+++ b/t/t-credentials.sh
@@ -346,7 +346,10 @@ begin_test "credentials from lfs.url"
   gitserverhost=$(echo "$GITSERVER" | cut -d'/' -f3)
   git config lfs.url http://requirecreds:pass@$gitserverhost/$reponame.git/info/lfs
   git lfs env
-  git lfs push origin master 2>&1 | tee push.log
+  GIT_TRACE=1 git lfs push origin master 2>&1 | tee push.log
+  # A 401 indicates URL access mode for the /storage endpoint
+  # was used instead of for the lfsapi endpoint
+  grep "HTTP: 401" push.log
   grep "Uploading LFS objects:   0% (0/1), 0 B" push.log
 
   echo "bad fetch"
@@ -387,7 +390,10 @@ begin_test "credentials from remote.origin.url"
   gitserverhost=$(echo "$GITSERVER" | cut -d'/' -f3)
   git config remote.origin.url http://requirecreds:pass@$gitserverhost/$reponame.git
   git lfs env
-  git lfs push origin master 2>&1 | tee push.log
+  GIT_TRACE=1 git lfs push origin master 2>&1 | tee push.log
+  # A 401 indicates URL access mode for the /storage endpoint
+  # was used instead of for the lfsapi endpoint
+  grep "HTTP: 401" push.log
   grep "Uploading LFS objects: 100% (1/1), 7 B" push.log
 
   echo "bad fetch"

--- a/tq/adapterbase.go
+++ b/tq/adapterbase.go
@@ -215,7 +215,7 @@ func (a *adapterBase) doHTTP(t *Transfer, req *http.Request) (*http.Response, er
 		return a.apiClient.Do(req)
 	}
 	endpoint := endpointURL(req.URL.String(), t.Oid)
-	return a.apiClient.DoWithAuth(a.remote, a.apiClient.Endpoints.AccessFor(endpoint), req, false)
+	return a.apiClient.DoWithAuthNoRetry(a.remote, a.apiClient.Endpoints.AccessFor(endpoint), req)
 }
 
 func advanceCallbackProgress(cb ProgressCallback, t *Transfer, numBytes int64) {

--- a/tq/adapterbase.go
+++ b/tq/adapterbase.go
@@ -214,7 +214,7 @@ func (a *adapterBase) doHTTP(t *Transfer, req *http.Request) (*http.Response, er
 	if t.Authenticated {
 		return a.apiClient.Do(req)
 	}
-	return a.apiClient.DoWithAuth(a.remote, req)
+	return a.apiClient.DoAPIRequestWithAuth(a.remote, req)
 }
 
 func advanceCallbackProgress(cb ProgressCallback, t *Transfer, numBytes int64) {

--- a/tq/adapterbase.go
+++ b/tq/adapterbase.go
@@ -214,7 +214,8 @@ func (a *adapterBase) doHTTP(t *Transfer, req *http.Request) (*http.Response, er
 	if t.Authenticated {
 		return a.apiClient.Do(req)
 	}
-	return a.apiClient.DoAPIRequestWithAuth(a.remote, req)
+	endpoint := endpointURL(req.URL.String(), t.Oid)
+	return a.apiClient.DoWithAuth(a.remote, a.apiClient.Endpoints.AccessFor(endpoint), req, false)
 }
 
 func advanceCallbackProgress(cb ProgressCallback, t *Transfer, numBytes int64) {
@@ -233,4 +234,8 @@ func advanceCallbackProgress(cb ProgressCallback, t *Transfer, numBytes int64) {
 
 		}
 	}
+}
+
+func endpointURL(rawurl, oid string) string {
+	return strings.Split(rawurl, oid)[0]
 }

--- a/tq/api.go
+++ b/tq/api.go
@@ -66,7 +66,7 @@ func (c *tqClient) Batch(remote string, bReq *batchRequest) (*BatchResponse, err
 	tracerx.Printf("api: batch %d files", len(bReq.Objects))
 
 	req = c.Client.LogRequest(req, "lfs.batch")
-	res, err := c.DoWithAuth(remote, lfshttp.WithRetries(req, c.MaxRetries))
+	res, err := c.DoAPIRequestWithAuth(remote, lfshttp.WithRetries(req, c.MaxRetries))
 	if err != nil {
 		tracerx.Printf("api error: %s", err)
 		return nil, errors.Wrap(err, "batch response")

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -764,7 +764,8 @@ func (q *TransferQueue) ensureAdapterBegun(e lfshttp.Endpoint) error {
 func (q *TransferQueue) toAdapterCfg(e lfshttp.Endpoint) AdapterConfig {
 	apiClient := q.manifest.APIClient()
 	concurrency := q.manifest.ConcurrentTransfers()
-	if apiClient.Endpoints.AccessFor(e.Url) == lfsapi.NTLMAccess {
+	access := apiClient.Endpoints.AccessFor(e.Url)
+	if access.GetMode() == lfsapi.NTLMAccess {
 		concurrency = 1
 	}
 

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -765,7 +765,7 @@ func (q *TransferQueue) toAdapterCfg(e lfshttp.Endpoint) AdapterConfig {
 	apiClient := q.manifest.APIClient()
 	concurrency := q.manifest.ConcurrentTransfers()
 	access := apiClient.Endpoints.AccessFor(e.Url)
-	if access.GetMode() == lfsapi.NTLMAccess {
+	if access.Mode() == lfsapi.NTLMAccess {
 		concurrency = 1
 	}
 

--- a/tq/verify.go
+++ b/tq/verify.go
@@ -51,7 +51,7 @@ func verifyUpload(c *lfsapi.Client, remote string, t *Transfer) error {
 		if t.Authenticated {
 			res, err = c.Do(req)
 		} else {
-			res, err = c.DoWithAuth(remote, c.Endpoints.AccessFor(action.Href), req, true)
+			res, err = c.DoWithAuth(remote, c.Endpoints.AccessFor(action.Href), req)
 		}
 
 		if err != nil {

--- a/tq/verify.go
+++ b/tq/verify.go
@@ -51,7 +51,7 @@ func verifyUpload(c *lfsapi.Client, remote string, t *Transfer) error {
 		if t.Authenticated {
 			res, err = c.Do(req)
 		} else {
-			res, err = c.DoWithAuth(remote, req)
+			res, err = c.DoAPIRequestWithAuth(remote, req)
 		}
 
 		if err != nil {

--- a/tq/verify.go
+++ b/tq/verify.go
@@ -51,7 +51,7 @@ func verifyUpload(c *lfsapi.Client, remote string, t *Transfer) error {
 		if t.Authenticated {
 			res, err = c.Do(req)
 		} else {
-			res, err = c.DoAPIRequestWithAuth(remote, req)
+			res, err = c.DoWithAuth(remote, c.Endpoints.AccessFor(action.Href), req, true)
 		}
 
 		if err != nil {

--- a/tq/verify_test.go
+++ b/tq/verify_test.go
@@ -45,8 +45,13 @@ func TestVerifySuccess(t *testing.T) {
 	}))
 	defer srv.Close()
 
+	// Set auth on the server URL but not on the /verify endpoint. Since auth
+	// will cause the request to fail, this will test that the correct access
+	// mode is being passed to `DoWithAuth()`
 	c, err := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
-		"lfs.transfer.maxverifies": "1",
+		"lfs.transfer.maxverifies":          "1",
+		"lfs." + srv.URL + ".access":        "Basic",
+		"lfs." + srv.URL + "/verify.access": "None",
 	}))
 	require.Nil(t, err)
 	tr := &Transfer{


### PR DESCRIPTION
This PR moves the responsibility to determine the URL Access Mode out of `DoWithAuth()` and into the hands of the caller. This removes our built-in assumption that all requests will be made against the LFS API endpoint, and allows other endpoints to be used for the access mode.

The transfer adapters generally don't make requests against the LFS API endpoint, generally making requests against a storage endpoint instead. This change means that requests coming from the transfer queue will now use that storage endpoint to determine the URL Access Mode instead of the LFS API endpoint.

This PR ended up being more complicated than expected, so there's a fair number of commits here. I've tried to commit atomic changes with descriptive commit messages, so I think it makes sense to review this one on a commit-by-commit basis.

/cc @git-lfs/core 