### PR TITLE
Checkout options for conflicts

### DIFF
--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -13,8 +13,27 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	checkoutTo     string
+	checkoutBase   bool
+	checkoutOurs   bool
+	checkoutTheirs bool
+)
+
 func checkoutCommand(cmd *cobra.Command, args []string) {
 	requireInRepo()
+
+	stage, err := whichCheckout()
+	if err != nil {
+		Exit("Error parsing args: %v", err)
+	}
+
+	if checkoutTo != "" && stage != git.IndexStageDefault {
+		checkoutConflict(rootedPaths(args)[0], stage)
+		return
+	} else if checkoutTo != "" || stage != git.IndexStageDefault {
+		Exit("--to and exactly one of --theirs, --ours, and --base must be used together")
+	}
 
 	msg := []string{
 		"WARNING: 'git lfs checkout' is deprecated and will be removed in v3.0.0.",
@@ -75,6 +94,63 @@ func checkoutCommand(cmd *cobra.Command, args []string) {
 	singleCheckout.Close()
 }
 
+func checkoutConflict(file string, stage git.IndexStage) {
+	singleCheckout := newSingleCheckout(cfg.Git, "")
+	if singleCheckout.Skip() {
+		fmt.Println("Cannot checkout LFS objects, Git LFS is not installed.")
+		return
+	}
+
+	ref, err := git.ResolveRef(fmt.Sprintf(":%d:%s", stage, file))
+	if err != nil {
+		Exit("Could not checkout (are you not in the middle of a merge?): %v", err)
+	}
+
+	scanner, err := git.NewObjectScanner()
+	if err != nil {
+		Exit("Could not create object scanner: %v", err)
+	}
+
+	if !scanner.Scan(ref.Sha) {
+		Exit("Could not find object %q", ref.Sha)
+	}
+
+	ptr, err := lfs.DecodePointer(scanner.Contents())
+	if err != nil {
+		Exit("Could not find decoder pointer for object %q: %v", ref.Sha, err)
+	}
+
+	p := &lfs.WrappedPointer{Name: file, Pointer: ptr}
+
+	if err := singleCheckout.RunToPath(p, checkoutTo); err != nil {
+		Exit("Error checking out %v to %q: %v", ref.Sha, checkoutTo, err)
+	}
+	singleCheckout.Close()
+}
+
+func whichCheckout() (stage git.IndexStage, err error) {
+	seen := 0
+	stage = git.IndexStageDefault
+
+	if checkoutBase {
+		seen++
+		stage = git.IndexStageBase
+	}
+	if checkoutOurs {
+		seen++
+		stage = git.IndexStageOurs
+	}
+	if checkoutTheirs {
+		seen++
+		stage = git.IndexStageTheirs
+	}
+
+	if seen > 1 {
+		return 0, fmt.Errorf("At most one of --base, --theirs, and --ours is allowed")
+	}
+	return stage, nil
+}
+
 // Parameters are filters
 // firstly convert any pathspecs to the root of the repo, in case this is being
 // executed in a sub-folder
@@ -92,5 +168,10 @@ func rootedPaths(args []string) []string {
 }
 
 func init() {
-	RegisterCommand("checkout", checkoutCommand, nil)
+	RegisterCommand("checkout", checkoutCommand, func(cmd *cobra.Command) {
+		cmd.Flags().StringVar(&checkoutTo, "to", "", "Checkout a conflicted file to this path")
+		cmd.Flags().BoolVar(&checkoutOurs, "ours", false, "Checkout our version of a conflicted file")
+		cmd.Flags().BoolVar(&checkoutTheirs, "theirs", false, "Checkout their version of a conflicted file")
+		cmd.Flags().BoolVar(&checkoutBase, "base", false, "Checkout the base version of a conflicted file")
+	})
 }

--- a/docs/man/git-lfs-checkout.1.ronn
+++ b/docs/man/git-lfs-checkout.1.ronn
@@ -4,14 +4,13 @@ git-lfs-checkout(1) -- Update working copy with file content if available
 ## SYNOPSIS
 
 `git lfs checkout` <filespec>...
+`git lfs checkout` --to <path> { --ours | --theirs | --base } <file>...
 
 ## DESCRIPTION
 
-This command is deprecated, and should be replaced with `git checkout`.
-
 Try to ensure that the working copy contains file content for Git LFS objects
 for the current ref, if the object data is available. Does not download any
-content, see git-lfs-fetch(1) for that. 
+content, see git-lfs-fetch(1) for that.
 
 Checkout scans the current ref for all LFS objects that would be required, then
 where a file is either missing in the working copy, or contains placeholder
@@ -19,6 +18,28 @@ pointer content with the same SHA, the real file content is written, provided
 we have it in the local store. Modified files are never overwritten.
 
 Filespecs can be provided as arguments to restrict the files which are updated.
+
+When used with `--to` and the working tree is in a conflicted state due to a
+merge, this option checks out one of the three stages of the conflict into a
+separate file. This can make using diff tools to inspect and resolve merges
+easier.
+
+## OPTIONS
+
+* `--base`:
+  Check out the merge base of the specified file.
+
+* `--ours`:
+  Check out our side (that of the current branch) of the conflict for the
+  specified file.
+
+* `--theirs`:
+  Check out their side (that of the other branch) of the conflict for the
+  specified file.
+
+* `--to` <path>:
+  If the working tree is in a conflicted state, check out the portion of the
+  conflict specified by `--base`, `--ours`, or `--theirs` to the given path.
 
 ## EXAMPLES
 

--- a/git/git.go
+++ b/git/git.go
@@ -38,6 +38,15 @@ const (
 	RefBeforeFirstCommit = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 )
 
+type IndexStage int
+
+const (
+	IndexStageDefault IndexStage = iota
+	IndexStageBase
+	IndexStageOurs
+	IndexStageTheirs
+)
+
 // Prefix returns the given RefType's prefix, "refs/heads", "ref/remotes",
 // etc. It returns an additional value of either true/false, whether or not this
 // given ref type has a prefix.


### PR DESCRIPTION
When there's a conflict, it can be difficult to access the various stages of the conflict to view in a suitable diff tool.  Add the `--base`, `--ours`, and `--theirs` options to allow checking out the various stages of a conflict into different paths for easier comparison with various tools.

This fixes #3258.