### PR TITLE
all: use Go 1.11.1 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # http://docs.travis-ci.com/user/languages/go/
 language: go
 
-go: 1.11
+go: 1.11.1
 
 os:
   - linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,8 @@ install:
   - rd C:\Go /s /q
   - rd C:\Perl /s /q
   - refreshenv
-  - curl -sL -o go1.11.windows-amd64.zip https://storage.googleapis.com/golang/go1.11.windows-amd64.zip
-  - 7z x go1.11.windows-amd64.zip -oC:\ >nul
+  - curl -sL -o go1.11.1.windows-amd64.zip https://storage.googleapis.com/golang/go1.11.1.windows-amd64.zip
+  - 7z x go1.11.1.windows-amd64.zip -oC:\ >nul
   - C:\go\bin\go version
   - cd %USERPROFILE%\src
   - C:\go\bin\go get github.com/josephspurrier/goversioninfo/cmd/goversioninfo


### PR DESCRIPTION
The latest release of Go, 1.11.1 was just published earlier today (on 2
October, 2018).

In the spirit of staying up-to-date with the latest version of Go (see
[1]), let's make sure that we continue to build correctly, even with the
very latest version.

[1] moved the tip to Go 1.11, so there shouldn't be anything surprising
here.

[1]: 074a2d4f (all: use Go 1.11 in CI, 2018-08-28)

##

/cc @git-lfs/core 