### PR TITLE
Remove `git lfs clone` command from man

### DIFF
--- a/docs/man/git-lfs.1.ronn
+++ b/docs/man/git-lfs.1.ronn
@@ -33,8 +33,6 @@ commands and low level ("plumbing") commands.
     Display the Git LFS environment.
 * git-lfs-checkout(1):
     Populate working copy with real content from Git LFS files.
-* git-lfs-clone(1):
-    Efficiently clone a Git LFS-enabled repository.
 * git-lfs-fetch(1):
     Download Git LFS files from a remote.
 * git-lfs-fsck(1):


### PR DESCRIPTION
The warning you get when you run `git lfs clone` is a bit misleading (see https://github.com/git-lfs/git-lfs/commit/47fa8523cda3582937077b63dd71d33db5390731#r30762174). This will remove the `git lfs clone` command from `man` (see https://github.com/git-lfs/git-lfs/commit/47fa8523cda3582937077b63dd71d33db5390731#r30753241). @PastelMobileSuit could you review this? 🍄 