### PR TITLE
Honor umask and core.sharedRepository

### DIFF
--- a/config/util_nix.go
+++ b/config/util_nix.go
@@ -1,0 +1,13 @@
+// +build !windows
+
+package config
+
+import "syscall"
+
+func umask() int {
+	// umask(2), which this function wraps, also sets the umask, so set it
+	// back.
+	umask := syscall.Umask(022)
+	syscall.Umask(umask)
+	return umask
+}

--- a/config/util_windows.go
+++ b/config/util_windows.go
@@ -1,0 +1,9 @@
+// +build windows
+
+package config
+
+// Windows doesn't provide the umask syscall, so return something sane as a
+// default.  os.Chmod will only care about the owner bits anyway.
+func umask() int {
+	return 077
+}

--- a/lfs/extension.go
+++ b/lfs/extension.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -89,7 +88,7 @@ func pipeExtensions(cfg *config.Configuration, request *pipeRequest) (response p
 	var output io.WriteCloser
 	input = pipeReader
 	extcmds[0].cmd.Stdin = input
-	if response.file, err = ioutil.TempFile(cfg.TempDir(), ""); err != nil {
+	if response.file, err = TempFile(cfg, ""); err != nil {
 		return
 	}
 	defer response.file.Close()

--- a/lfs/gitfilter_clean.go
+++ b/lfs/gitfilter_clean.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/git-lfs/git-lfs/errors"
@@ -61,7 +60,7 @@ func (f *GitFilter) Clean(reader io.Reader, fileName string, fileSize int64, cb 
 }
 
 func (f *GitFilter) copyToTemp(reader io.Reader, fileSize int64, cb tools.CopyCallback) (oid string, size int64, tmp *os.File, err error) {
-	tmp, err = ioutil.TempFile(f.cfg.TempDir(), "")
+	tmp, err = TempFile(f.cfg, "")
 	if err != nil {
 		return
 	}

--- a/lfs/util.go
+++ b/lfs/util.go
@@ -189,7 +189,7 @@ func IsWindows() bool {
 }
 
 func CopyFileContents(cfg *config.Configuration, src string, dst string) error {
-	tmp, err := ioutil.TempFile(cfg.TempDir(), filepath.Base(dst))
+	tmp, err := TempFile(cfg, filepath.Base(dst))
 	if err != nil {
 		return err
 	}
@@ -238,7 +238,7 @@ func TempFile(cfg *config.Configuration, pattern string) (*os.File, error) {
 		return nil, err
 	}
 
-	perms := cfg.RepositoryPermissions(false)
+	perms := cfg.RepositoryPermissions()
 	err = os.Chmod(tmp.Name(), perms)
 	if err != nil {
 		tmp.Close()

--- a/lfs/util.go
+++ b/lfs/util.go
@@ -223,3 +223,27 @@ func LinkOrCopy(cfg *config.Configuration, src string, dst string) error {
 	}
 	return CopyFileContents(cfg, src, dst)
 }
+
+// TempFile creates a temporary file in the temporary directory specified by the
+// configuration that has the proper permissions for the repository.  On
+// success, it returns an open, non-nil *os.File, and the caller is responsible
+// for closing and/or removing it.  On failure, the temporary file is
+// automatically cleaned up and an error returned.
+//
+// This function is designed to handle only temporary files that will be renamed
+// into place later somewhere within the Git repository.
+func TempFile(cfg *config.Configuration, pattern string) (*os.File, error) {
+	tmp, err := ioutil.TempFile(cfg.TempDir(), pattern)
+	if err != nil {
+		return nil, err
+	}
+
+	perms := cfg.RepositoryPermissions(false)
+	err = os.Chmod(tmp.Name(), perms)
+	if err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
+		return nil, err
+	}
+	return tmp, nil
+}

--- a/t/t-umask.sh
+++ b/t/t-umask.sh
@@ -32,3 +32,29 @@ begin_test "honors umask"
   [ "$(perms_for 87c1b129fbadd7b6e9abc0a9ef7695436d767aece042bec198a97e949fcbe14c)" = "-rw-rw----" ]
 )
 end_test
+
+# This is tested more comprehensively in the unit tests.
+begin_test "honors core.sharedrepository"
+(
+  set -e
+  clean_setup "shared-repo"
+
+  umask 027
+  git config core.sharedRepository 0660
+  echo "whatever" | git lfs clean | tee clean.log
+  [ "$(perms_for cd293be6cea034bd45a0352775a219ef5dc7825ce55d1f7dae9762d80ce64411)" = "-rw-rw----" ]
+
+  git config core.sharedRepository everybody
+  echo "random" | git lfs clean | tee clean.log
+  [ "$(perms_for 87c1b129fbadd7b6e9abc0a9ef7695436d767aece042bec198a97e949fcbe14c)" = "-rw-rw-r--" ]
+
+  git config core.sharedRepository false
+  echo "something else" | git lfs clean | tee clean.log
+  [ "$(perms_for a1621be95040239ee14362c16e20510ddc20f527d772d823b2a1679b33f5cd74)" = "-rw-r-----" ]
+
+  umask 007
+  echo "who cares" | git lfs clean | tee clean.log
+  [ "$(perms_for 261ded5f01a8ca18d9fb1958e8f58c53fa77648cc88a6d67c93d241a91133f3e)" = "-rw-rw----" ]
+
+)
+end_test

--- a/t/t-umask.sh
+++ b/t/t-umask.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+. "$(dirname "$0")/testlib.sh"
+
+if [ $IS_WINDOWS -eq 1 ]; then
+  echo "skip $0: Windows lacks POSIX permissions"
+  exit
+fi
+
+clean_setup () {
+  mkdir "$1"
+  cd "$1"
+  git init
+}
+
+perms_for () {
+  local file=$(echo "$1" | sed "s!^\(..\)\(..\)!.git/lfs/objects/\1/\2/\1\2!")
+  ls -l "$file" | awk '{print $1}'
+}
+
+begin_test "honors umask"
+(
+  set -e
+  clean_setup "simple"
+
+  umask 027
+  echo "whatever" | git lfs clean | tee clean.log
+  [ "$(perms_for cd293be6cea034bd45a0352775a219ef5dc7825ce55d1f7dae9762d80ce64411)" = "-rw-r-----" ]
+
+  umask 007
+  echo "random" | git lfs clean | tee clean.log
+  [ "$(perms_for 87c1b129fbadd7b6e9abc0a9ef7695436d767aece042bec198a97e949fcbe14c)" = "-rw-rw----" ]
+)
+end_test


### PR DESCRIPTION
When writing files into the repository LFS object store, Git LFS uses a temporary file and then renames it into place.  For security reasons, temporary files are created with 600 permissions; however, this causes problems in repositories accessed by multiple users, since neither the umask nor `core.sharedRepository` are honored.

This series introduces support for umask and `core.sharedRepository` into Git LFS.

This fixes #2015 and also fixes #2992.