### PR TITLE
Ensure correct syntax for commit headers in lfs migrate import

### DIFF
--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -80,12 +80,23 @@ func migrateImportCommand(cmd *cobra.Command, args []string) {
 			}
 		}
 
-		name, email := cfg.CurrentCommitter()
-		author := fmt.Sprintf("%s <%s>", name, email)
+		name, email := cfg.CurrentAuthor()
+		author := &gitobj.Signature{
+			Name:  name,
+			Email: email,
+			When:  cfg.CurrentAuthorTimestamp(),
+		}
+
+		name, email = cfg.CurrentCommitter()
+		committer := &gitobj.Signature{
+			Name:  name,
+			Email: email,
+			When:  cfg.CurrentCommitterTimestamp(),
+		}
 
 		oid, err := db.WriteCommit(&gitobj.Commit{
-			Author:    author,
-			Committer: author,
+			Author:    author.String(),
+			Committer: committer.String(),
 			ParentIDs: [][]byte{sha},
 			Message:   generateMigrateCommitMessage(cmd, strings.Join(args, ",")),
 			TreeID:    root,

--- a/config/config.go
+++ b/config/config.go
@@ -479,7 +479,7 @@ func (c *Configuration) loadGitConfig() {
 	}
 }
 
-// CurrentCommitter returns the name/email that would be used to author a commit
+// CurrentCommitter returns the name/email that would be used to commit a change
 // with this configuration. In particular, the "user.name" and "user.email"
 // configuration values are used
 func (c *Configuration) CurrentCommitter() (name, email string) {

--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/git-lfs/git-lfs/fs"
 	"github.com/git-lfs/git-lfs/git"
@@ -51,6 +52,7 @@ type Configuration struct {
 	extensions map[string]Extension
 	mask       int
 	maskOnce   sync.Once
+	timestamp  time.Time
 }
 
 func New() *Configuration {
@@ -62,6 +64,7 @@ func NewIn(workdir, gitdir string) *Configuration {
 	c := &Configuration{
 		Os:        EnvironmentOf(NewOsFetcher()),
 		gitConfig: gitConf,
+		timestamp: time.Now(),
 	}
 
 	if len(gitConf.WorkDir) > 0 {
@@ -142,6 +145,7 @@ func NewFrom(v Values) *Configuration {
 	c := &Configuration{
 		Os:        EnvironmentOf(mapFetcher(v.Os)),
 		gitConfig: git.NewConfig("", ""),
+		timestamp: time.Now(),
 	}
 	c.Git = &delayedEnvironment{
 		callback: func() Environment {
@@ -486,6 +490,12 @@ func (c *Configuration) CurrentCommitter() (name, email string) {
 	name, _ = c.Git.Get("user.name")
 	email, _ = c.Git.Get("user.email")
 	return
+}
+
+// CurrentCommitterTimestamp returns the timestamp that would be used to commit
+// a change with this configuration.
+func (c *Configuration) CurrentCommitterTimestamp() time.Time {
+	return c.timestamp
 }
 
 // RepositoryPermissions returns the permissions that should be used to write

--- a/config/config.go
+++ b/config/config.go
@@ -533,6 +533,19 @@ func (c *Configuration) CurrentCommitterTimestamp() time.Time {
 	return c.timestamp
 }
 
+// CurrentAuthor returns the name/email that would be used to author a change
+// with this configuration. In particular, the "user.name" and "user.email"
+// configuration values are used
+func (c *Configuration) CurrentAuthor() (name, email string) {
+	return c.findUserData("author")
+}
+
+// CurrentCommitterTimestamp returns the timestamp that would be used to commit
+// a change with this configuration.
+func (c *Configuration) CurrentAuthorTimestamp() time.Time {
+	return c.timestamp
+}
+
 // RepositoryPermissions returns the permissions that should be used to write
 // files in the repository.
 func (c *Configuration) RepositoryPermissions() os.FileMode {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -234,4 +234,24 @@ func TestCurrentUser(t *testing.T) {
 	name, email = cfg.CurrentCommitter()
 	assert.Equal(t, name, "Sam Roe")
 	assert.Equal(t, email, "sroe@example.net")
+
+	cfg = NewFrom(Values{
+		Git: map[string][]string{
+			"user.name":  []string{"Pat Doe"},
+			"user.email": []string{"pdoe@example.org"},
+		},
+		Os: map[string][]string{
+			"GIT_AUTHOR_NAME":  []string{"Sam Roe"},
+			"GIT_AUTHOR_EMAIL": []string{"sroe@example.net"},
+			"EMAIL":            []string{"pdoe@example.com"},
+		},
+	})
+
+	name, email = cfg.CurrentCommitter()
+	assert.Equal(t, name, "Pat Doe")
+	assert.Equal(t, email, "pdoe@example.org")
+
+	name, email = cfg.CurrentAuthor()
+	assert.Equal(t, name, "Sam Roe")
+	assert.Equal(t, email, "sroe@example.net")
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -190,3 +190,48 @@ func TestRepositoryPermissions(t *testing.T) {
 		assert.Equal(t, os.FileMode(val), cfg.RepositoryPermissions())
 	}
 }
+
+func TestCurrentUser(t *testing.T) {
+	cfg := NewFrom(Values{
+		Git: map[string][]string{
+			"user.name":  []string{"Pat Doe"},
+			"user.email": []string{"pdoe@example.org"},
+		},
+		Os: map[string][]string{
+			"EMAIL": []string{"pdoe@example.com"},
+		},
+	})
+
+	name, email := cfg.CurrentCommitter()
+	assert.Equal(t, name, "Pat Doe")
+	assert.Equal(t, email, "pdoe@example.org")
+
+	cfg = NewFrom(Values{
+		Git: map[string][]string{
+			"user.name": []string{"Pat Doe"},
+		},
+		Os: map[string][]string{
+			"EMAIL": []string{"pdoe@example.com"},
+		},
+	})
+
+	name, email = cfg.CurrentCommitter()
+	assert.Equal(t, name, "Pat Doe")
+	assert.Equal(t, email, "pdoe@example.com")
+
+	cfg = NewFrom(Values{
+		Git: map[string][]string{
+			"user.name":  []string{"Pat Doe"},
+			"user.email": []string{"pdoe@example.org"},
+		},
+		Os: map[string][]string{
+			"GIT_COMMITTER_NAME":  []string{"Sam Roe"},
+			"GIT_COMMITTER_EMAIL": []string{"sroe@example.net"},
+			"EMAIL":               []string{"pdoe@example.com"},
+		},
+	})
+
+	name, email = cfg.CurrentCommitter()
+	assert.Equal(t, name, "Sam Roe")
+	assert.Equal(t, email, "sroe@example.net")
+}

--- a/t/t-migrate-import-no-rewrite.sh
+++ b/t/t-migrate-import-no-rewrite.sh
@@ -33,6 +33,9 @@ begin_test "migrate import --no-rewrite (default branch)"
   # Ensure a new commit message was generated based on the list of imported files
   commit_msg="$(git log -1 --pretty=format:%s)"
   echo "$commit_msg" | grep -q "a.txt: convert to Git LFS"
+
+  # Ensure we write a valid commit object.
+  git fsck
 )
 end_test
 


### PR DESCRIPTION
We accidentally wrote ill-formed commit headers when writing commits for `git lfs migrate import --no-rewrite` because the author and committer fields lacked timestamps.  In addition, we could write empty email addresses if the user did not have a `user.email` field set but instead used the `EMAIL` environment variable to set their email.

Correct both of these issues and honor the distinction between author and committer.  Note that due to limitations of the Go standard library, this series does not honor `GIT_AUTHOR_DATE` and `GIT_COMMITTER_DATE` even though it honors the name- and email-related environment variables; this will be tracked in #3312.

This fixes #3310.