### PR TITLE
Update CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,21 +25,15 @@ into Git: SSH through public keys, and HTTPS through Git credential helpers.
 Servers can simply host off cloud storage, or implement more efficient methods
 of transferring data.
 
-You can see what the Git LFS team is prioritizing work on in the
-[roadmap](./ROADMAP.md).
-
 ## Project Management
 
-The Git LFS project is managed completely through this open source project and
-its [chat room][chat]. The [roadmap][] shows the high level items that are
-prioritized for future work. Suggestions for major features should be submitted
-as a pull request that adds a markdown file to `docs/proposals` discussing the
-feature. This gives the community time to discuss it before a lot of code has
-been written. Roadmap items are linked to one or more Issue task lists ([example][roadmap-items]), with the `roadmap` label, that go into more detail.
+The Git LFS project is managed completely through this open source project. The
+[milestones][] show the high level items that are prioritized for future work.
+Suggestions for major features should be submitted as a pull request that adds a
+markdown file to `docs/proposals` discussing the feature. This gives the
+community time to discuss it before a lot of code has been written.
 
-[chat]: https://gitter.im/git-lfs/git-lfs
-[roadmap]: ./ROADMAP.md
-[roadmap-items]: https://github.com/git-lfs/git-lfs/issues/490
+[milestones]: https://github.com/git-lfs/git-lfs/milestones
 
 The Git LFS teams mark issues and pull requests with the following labels:
 
@@ -48,8 +42,6 @@ The Git LFS teams mark issues and pull requests with the following labels:
 * `enhancement` - An issue for a possible new feature.
 * `review` - A pull request ready to be reviewed.
 * `release` - A checklist issue showing items marked for an upcoming release.
-* `roadmap` - A checklist issue with tasks to fulfill something from the
-[roadmap](./ROADMAP.md)
 
 ## Branching strategy
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,32 +116,8 @@ tests:
 
 ## Releasing
 
-If you are the current maintainer:
-
-* Create a [new draft Release](https://github.com/git-lfs/git-lfs/releases/new).
-List any changes with links to related PRs.
-* Make sure your local dependencies are up to date: `make vendor`
-* Ensure that tests are green: `script/cibuild`
-* Bump the version in `lfs/lfs.go`, [like this](https://github.com/git-lfs/git-lfs/commit/dd17828e4a6f2394cbba8621037199dc28f046e8).
-* Add the new version to the top of CHANGELOG.md
-* Build for all platforms with `make release` (you need Go setup for
-cross compiling with Mac, Linux, FreeBSD, and Windows support).
-* Test the command locally.  The compiled version will be in `bin/releases/{os}-{arch}/git-lfs-{version}/git-lfs`
-* Get the draft Release ID from the GitHub API: `curl -in https://api.github.com/repos/git-lfs/git-lfs/releases`
-* Run `script/release -id {id}` to upload all of the compiled binaries to the
-release.
-* Publish the Release on GitHub.
-* Update [Git LFS website](https://github.com/git-lfs/git-lfs.github.com/blob/gh-pages/_config.yml#L4)
-(release engineer access rights required).
-* Ping external teams on GitHub:
-  * @github/desktop
-* Build packages:
-  * rpm
-  * apt
-* Bump homebrew version and generate the homebrew hash with `curl --location https://github.com/git-lfs/git-lfs/archive/vx.y.z.tar.gz | shasum -a 256` ([example](https://github.com/Homebrew/homebrew-core/pull/413/commits/dc0eb1f62514f48f3f5a8d01ad3bea06f78bd566))
-* Create release branch for bug fixes, such as `release-1.5`.
-* Increment version in `config/version.go` to the next expected version. If
-v1.5 just shipped, set the version in master to `1.6-pre`, for example.
+If you are the current maintainer, see
+[the release howto](./docs/howto/release-git-lfs.md) for how to perform a release.
 
 ## Resources
 


### PR DESCRIPTION
Update the `CONTRIBUTING.md` file to reflect that we no longer use the roadmap file or roadmap issues, that we no longer use Gitter, and that there is now a howto that the maintainer should use for release steps.