### PR TITLE
commands: list explicitly excluded patterns separately

### DIFF
--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -25,6 +25,7 @@ var (
 	trackVerboseLoggingFlag bool
 	trackDryRunFlag         bool
 	trackNoModifyAttrsFlag  bool
+	trackNoExcludedFlag     bool
 )
 
 func trackCommand(cmd *cobra.Command, args []string) {
@@ -229,6 +230,10 @@ func listPatterns() {
 		}
 	}
 
+	if trackNoExcludedFlag {
+		return
+	}
+
 	Print("Listing excluded patterns")
 	for _, t := range knownPatterns {
 		if !t.Tracked && !t.Lockable {
@@ -302,5 +307,6 @@ func init() {
 		cmd.Flags().BoolVarP(&trackVerboseLoggingFlag, "verbose", "v", false, "log which files are being tracked and modified")
 		cmd.Flags().BoolVarP(&trackDryRunFlag, "dry-run", "d", false, "preview results of running `git lfs track`")
 		cmd.Flags().BoolVarP(&trackNoModifyAttrsFlag, "no-modify-attrs", "", false, "skip modifying .gitattributes file")
+		cmd.Flags().BoolVarP(&trackNoExcludedFlag, "no-excluded", "", false, "skip listing excluded paths")
 	})
 }

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -224,7 +224,14 @@ func listPatterns() {
 	for _, t := range knownPatterns {
 		if t.Lockable {
 			Print("    %s [lockable] (%s)", t.Path, t.Source)
-		} else {
+		} else if t.Tracked {
+			Print("    %s (%s)", t.Path, t.Source)
+		}
+	}
+
+	Print("Listing excluded patterns")
+	for _, t := range knownPatterns {
+		if !t.Tracked && !t.Lockable {
 			Print("    %s (%s)", t.Path, t.Source)
 		}
 	}

--- a/docs/man/git-lfs-track.1.ronn
+++ b/docs/man/git-lfs-track.1.ronn
@@ -39,6 +39,10 @@ to match paths.
   Remove the lockable flag from the paths so they are no longer read-only unless
   locked.
 
+* `--no-excluded`
+  Do not list patterns that are excluded in the output; only list patterns that
+  are tracked.
+
 * `--no-modify-attrs`
   Makes matched entries stat-dirty so that Git can re-index files you wish to
   convert to LFS. Does not modify any `.gitattributes` file(s).

--- a/t/t-track.sh
+++ b/t/t-track.sh
@@ -45,6 +45,14 @@ begin_test "track"
   grep "* text=auto" .gitattributes
   grep "diff=csharp" .gitattributes
   grep "*.jpg" .gitattributes
+
+  echo "*.gif -filter -text" >> a/b/.gitattributes
+  echo "*.mov -filter=lfs -text" >> a/b/.gitattributes
+
+  git lfs track | tee track.log
+  tail -n 3 track.log | head -n 1 | grep "Listing excluded patterns"
+  tail -n 3 track.log | grep "*.gif ($(native_path_escaped "a/b/.gitattributes"))"
+  tail -n 3 track.log | grep "*.mov ($(native_path_escaped "a/b/.gitattributes"))"
 )
 end_test
 

--- a/t/t-track.sh
+++ b/t/t-track.sh
@@ -56,6 +56,28 @@ begin_test "track"
 )
 end_test
 
+begin_test "track --no-excluded"
+(
+  set -e
+
+  reponame="track_no_excluded"
+  mkdir "$reponame"
+  cd "$reponame"
+  git init
+
+  mkdir -p a/b .git/info
+
+  echo "*.mov filter=lfs -text" > .git/info/attributes
+  echo "*.gif filter=lfs -text" > a/.gitattributes
+  echo "*.png filter=lfs -text" > a/b/.gitattributes
+  echo "*.gif -filter -text" >> a/b/.gitattributes
+  echo "*.mov -filter=lfs -text" >> a/b/.gitattributes
+
+  git lfs track --no-excluded | tee track.log
+  ! grep "Listing excluded patterns" track.log
+)
+end_test
+
 begin_test "track --verbose"
 (
   set -e


### PR DESCRIPTION
Currently, if a user has disabled Git LFS for a pattern in a .gitattributes file (such as in a subdirectory) by writing "-filter=lfs", we render the pattern as a tracked pattern in "git lfs track", even though those paths are not enabled for Git LFS.

Improve this situation by listing excluded patterns as well as tracked patterns.  Compute whether a pattern is excluded by looking for an attribute entry that starts with "-filter" and if so, list the entry as excluded.  Add tests for both the "-filter" and "-filter=lfs" situations.

Fix #2442.