### PR TITLE
Uninstall improvements

### DIFF
--- a/commands/command_uninstall.go
+++ b/commands/command_uninstall.go
@@ -10,7 +10,7 @@ func uninstallCommand(cmd *cobra.Command, args []string) {
 		Error(err.Error())
 	}
 
-	if localInstall || cfg.InRepo() {
+	if !skipRepoInstall && (localInstall || cfg.InRepo()) {
 		uninstallHooksCommand(cmd, args)
 	}
 
@@ -34,6 +34,7 @@ func init() {
 	RegisterCommand("uninstall", uninstallCommand, func(cmd *cobra.Command) {
 		cmd.Flags().BoolVarP(&localInstall, "local", "l", false, "Set the Git LFS config for the local Git repository only.")
 		cmd.Flags().BoolVarP(&systemInstall, "system", "", false, "Set the Git LFS config in system-wide scope.")
+		cmd.Flags().BoolVarP(&skipRepoInstall, "skip-repo", "", false, "Skip repo setup, just uninstall global filters.")
 		cmd.AddCommand(NewCommand("hooks", uninstallHooksCommand))
 	})
 }

--- a/commands/command_uninstall.go
+++ b/commands/command_uninstall.go
@@ -14,7 +14,9 @@ func uninstallCommand(cmd *cobra.Command, args []string) {
 		uninstallHooksCommand(cmd, args)
 	}
 
-	if !localInstall {
+	if systemInstall {
+		Print("System Git LFS configuration has been removed.")
+	} else if !localInstall {
 		Print("Global Git LFS configuration has been removed.")
 	}
 }

--- a/docs/man/git-lfs-uninstall.1.ronn
+++ b/docs/man/git-lfs-uninstall.1.ronn
@@ -17,6 +17,9 @@ Perform the following actions to remove the Git LFS configuration:
 * --local:
     Removes the "lfs" smudge and clean filters from the local repository's git
     config, instead of the global git config (~/.gitconfig).
+* --system:
+    Removes the "lfs" smudge and clean filters from the system git config,
+    instead of the global git config (~/.gitconfig).
 
 ## SEE ALSO
 

--- a/docs/man/git-lfs-uninstall.1.ronn
+++ b/docs/man/git-lfs-uninstall.1.ronn
@@ -20,6 +20,9 @@ Perform the following actions to remove the Git LFS configuration:
 * --system:
     Removes the "lfs" smudge and clean filters from the system git config,
     instead of the global git config (~/.gitconfig).
+* --skip-repo:
+    Skips cleanup of the local repo; use if you want to uninstall the global lfs
+    filters but not make changes to the current repo.
 
 ## SEE ALSO
 


### PR DESCRIPTION
This series introduces a set of improvements to `git lfs uninstall`.  First, the `--system` option is documented.  Second, we print a more accurate message about which configuration is modified when the `--system` option is provided.  Finally, we add a `--skip-repo` option for parallelism with `git lfs install`.

I will admit that there is some slight duplication in 5541da6, but I was unable to find an elegant way to avoid it.

This series fixes #3322, fixes #3323, and fixes #3324.