### PR TITLE
tq: enable transfer debugging when GIT_CURL_VERBOSE is set

### DIFF
--- a/lfs/lfs.go
+++ b/lfs/lfs.go
@@ -87,6 +87,8 @@ func init() {
 	if len(os.Getenv("GIT_TRACE")) < 1 {
 		if tt := os.Getenv("GIT_TRANSFER_TRACE"); len(tt) > 0 {
 			os.Setenv("GIT_TRACE", tt)
+		} else if cv := os.Getenv("GIT_CURL_VERBOSE"); len(cv) > 0 {
+			os.Setenv("GIT_TRACE", cv)
 		}
 	}
 }

--- a/tq/adapterbase.go
+++ b/tq/adapterbase.go
@@ -74,7 +74,8 @@ func (a *adapterBase) Begin(cfg AdapterConfig, cb ProgressCallback) error {
 	a.remote = cfg.Remote()
 	a.cb = cb
 	a.jobChan = make(chan *job, 100)
-	a.debugging = a.apiClient.OSEnv().Bool("GIT_TRANSFER_TRACE", false)
+	a.debugging = a.apiClient.OSEnv().Bool("GIT_TRANSFER_TRACE", false) ||
+		a.apiClient.OSEnv().Bool("GIT_CURL_VERBOSE", false)
 	maxConcurrency := cfg.ConcurrentTransfers()
 
 	a.Trace("xfer: adapter %q Begin() with %d workers", a.Name(), maxConcurrency)


### PR DESCRIPTION
When something goes wrong, many users will happily provide output using
GIT_TRACE and GIT_CURL_VERBOSE.  This is very useful for Git, but Git
LFS doesn't honor the latter (since we don't use libcurl).  Instead, we
require users to set GIT_TRANSFER_TRACE.  This makes for a prolonged and
more difficult debugging experience.

Despite the fact that we don't use libcurl, honor the GIT_CURL_VERBOSE
flag and act as if the user had set GIT_TRANSFER_TRACE instead.  This
honors the intent of what the user wanted (transfer-related debugging
information) and makes debugging easier for end users and maintainers
alike.