### PR TITLE
Keep the testsuite from writing into .git/config

### DIFF
--- a/git/config_test.go
+++ b/git/config_test.go
@@ -1,0 +1,14 @@
+package git_test // to avoid import cycles
+
+import (
+	"testing"
+
+	. "github.com/git-lfs/git-lfs/git"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReadOnlyConfig(t *testing.T) {
+	cfg := NewReadOnlyConfig("", "")
+	_, err := cfg.SetLocal("lfs.this.should", "fail")
+	assert.Equal(t, err, ErrReadOnly)
+}

--- a/lfsapi/auth_test.go
+++ b/lfsapi/auth_test.go
@@ -75,9 +75,11 @@ func TestDoWithAuthApprove(t *testing.T) {
 	defer srv.Close()
 
 	cred := newMockCredentialHelper()
-	c, err := NewClient(lfshttp.NewContext(nil, nil, map[string]string{
-		"lfs.url": srv.URL + "/repo/lfs",
-	}))
+	c, err := NewClient(lfshttp.NewContext(git.NewReadOnlyConfig("", ""),
+		nil, map[string]string{
+			"lfs.url": srv.URL + "/repo/lfs",
+		},
+	))
 	require.Nil(t, err)
 	c.Credentials = cred
 
@@ -145,9 +147,11 @@ func TestDoWithAuthReject(t *testing.T) {
 
 	c, _ := NewClient(nil)
 	c.Credentials = cred
-	c.Endpoints = NewEndpointFinder(lfshttp.NewContext(nil, nil, map[string]string{
-		"lfs.url": srv.URL,
-	}))
+	c.Endpoints = NewEndpointFinder(lfshttp.NewContext(git.NewReadOnlyConfig("", ""),
+		nil, map[string]string{
+			"lfs.url": srv.URL,
+		},
+	))
 
 	req, err := http.NewRequest("POST", srv.URL, nil)
 	require.Nil(t, err)
@@ -197,9 +201,11 @@ func TestDoWithAuthNoRetry(t *testing.T) {
 	defer srv.Close()
 
 	creds := newMockCredentialHelper()
-	c, err := NewClient(lfshttp.NewContext(nil, nil, map[string]string{
-		"lfs.url": srv.URL + "/repo/lfs",
-	}))
+	c, err := NewClient(lfshttp.NewContext(git.NewReadOnlyConfig("", ""),
+		nil, map[string]string{
+			"lfs.url": srv.URL + "/repo/lfs",
+		},
+	))
 	require.Nil(t, err)
 	c.Credentials = creds
 
@@ -245,9 +251,11 @@ func TestDoAPIRequestWithAuth(t *testing.T) {
 	defer srv.Close()
 
 	cred := newMockCredentialHelper()
-	c, err := NewClient(lfshttp.NewContext(nil, nil, map[string]string{
-		"lfs.url": srv.URL + "/repo/lfs",
-	}))
+	c, err := NewClient(lfshttp.NewContext(git.NewReadOnlyConfig("", ""),
+		nil, map[string]string{
+			"lfs.url": srv.URL + "/repo/lfs",
+		},
+	))
 	require.Nil(t, err)
 	c.Credentials = cred
 
@@ -637,7 +645,7 @@ func TestGetCreds(t *testing.T) {
 			req.Header.Set(key, value)
 		}
 
-		ctx := lfshttp.NewContext(git.NewConfig("", ""), nil, test.Config)
+		ctx := lfshttp.NewContext(git.NewReadOnlyConfig("", ""), nil, test.Config)
 		client, _ := NewClient(ctx)
 		client.Credentials = &fakeCredentialFiller{}
 		client.Endpoints = NewEndpointFinder(ctx)


### PR DESCRIPTION
I noticed that something in the testsuite was writing test entries into my `.git/config`.  I at first thought it was the integration tests, but then realized it was actually the unit tests.  We write certain entries of the form `lfs.*.access = basic` into `.git/config` in the tests for the `lfsapi` module via a call to the endpoint code.

This series introduces a new read-only config object which rejects any attempts to write to a configuration file with an error.  Fortuitously, the endpoint code ignores the return value from this attempt, meaning that we silently do nothing.  Ignoring any errors happens to be fine in this code, because we're setting a setting that we've just intuited other ways, so if the write fails for some other reason, we're no worse off.

With this change, running `make test integration` results in no change to the SHA-256 digest of my `.git/config`.