### PR TITLE
tasklog: don't log progress status when stdout is not a tty

### DIFF
--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -47,7 +47,9 @@ func checkoutCommand(cmd *cobra.Command, args []string) {
 
 	var totalBytes int64
 	var pointers []*lfs.WrappedPointer
-	logger := tasklog.NewLogger(os.Stdout)
+	logger := tasklog.NewLogger(os.Stdout,
+		tasklog.ForceProgress(cfg.ForceProgress()),
+	)
 	meter := tq.NewMeter()
 	meter.Direction = tq.Checkout
 	meter.Logger = meter.LoggerFromEnv(cfg.Os)

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -230,7 +230,9 @@ func scanAll() []*lfs.WrappedPointer {
 	task := tasklog.NewSimpleTask()
 	defer task.Complete()
 
-	logger := tasklog.NewLogger(OutputWriter)
+	logger := tasklog.NewLogger(OutputWriter,
+		tasklog.ForceProgress(cfg.ForceProgress()),
+	)
 	logger.Enqueue(task)
 	var numObjs int64
 
@@ -324,7 +326,9 @@ func fetchAndReportToChan(allpointers []*lfs.WrappedPointer, filter *filepathfil
 }
 
 func readyAndMissingPointers(allpointers []*lfs.WrappedPointer, filter *filepathfilter.Filter) ([]*lfs.WrappedPointer, []*lfs.WrappedPointer, *tq.Meter) {
-	logger := tasklog.NewLogger(os.Stdout)
+	logger := tasklog.NewLogger(os.Stdout,
+		tasklog.ForceProgress(cfg.ForceProgress()),
+	)
 	meter := buildProgressMeter(false, tq.Download)
 	logger.Enqueue(meter)
 

--- a/commands/command_migrate_export.go
+++ b/commands/command_migrate_export.go
@@ -19,7 +19,9 @@ import (
 func migrateExportCommand(cmd *cobra.Command, args []string) {
 	ensureWorkingCopyClean(os.Stdin, os.Stderr)
 
-	l := tasklog.NewLogger(os.Stderr)
+	l := tasklog.NewLogger(os.Stderr,
+		tasklog.ForceProgress(cfg.ForceProgress()),
+	)
 	defer l.Close()
 
 	db, err := getObjectDatabase()

--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -24,7 +24,9 @@ import (
 func migrateImportCommand(cmd *cobra.Command, args []string) {
 	ensureWorkingCopyClean(os.Stdin, os.Stderr)
 
-	l := tasklog.NewLogger(os.Stderr)
+	l := tasklog.NewLogger(os.Stderr,
+		tasklog.ForceProgress(cfg.ForceProgress()),
+	)
 	defer l.Close()
 
 	db, err := getObjectDatabase()

--- a/commands/command_migrate_info.go
+++ b/commands/command_migrate_info.go
@@ -40,7 +40,9 @@ var (
 )
 
 func migrateInfoCommand(cmd *cobra.Command, args []string) {
-	l := tasklog.NewLogger(os.Stderr)
+	l := tasklog.NewLogger(os.Stderr,
+		tasklog.ForceProgress(cfg.ForceProgress()),
+	)
 
 	db, err := getObjectDatabase()
 	if err != nil {

--- a/commands/command_prune.go
+++ b/commands/command_prune.go
@@ -57,7 +57,9 @@ func prune(fetchPruneConfig lfs.FetchPruneConfig, verifyRemote, dryRun, verbose 
 	localObjects := make([]fs.Object, 0, 100)
 	retainedObjects := tools.NewStringSetWithCapacity(100)
 
-	logger := tasklog.NewLogger(OutputWriter)
+	logger := tasklog.NewLogger(OutputWriter,
+		tasklog.ForceProgress(cfg.ForceProgress()),
+	)
 	defer logger.Close()
 
 	var reachableObjects tools.StringSet

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -38,7 +38,9 @@ func pull(filter *filepathfilter.Filter) {
 	}
 
 	pointers := newPointerMap()
-	logger := tasklog.NewLogger(os.Stdout)
+	logger := tasklog.NewLogger(os.Stdout,
+		tasklog.ForceProgress(cfg.ForceProgress()),
+	)
 	meter := tq.NewMeter()
 	meter.Logger = meter.LoggerFromEnv(cfg.Os)
 	logger.Enqueue(meter)

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -30,8 +30,8 @@ import (
 var (
 	Debugging    = false
 	ErrorBuffer  = &bytes.Buffer{}
-	ErrorWriter  = io.MultiWriter(os.Stderr, ErrorBuffer)
-	OutputWriter = io.MultiWriter(os.Stdout, ErrorBuffer)
+	ErrorWriter  = newMultiWriter(os.Stderr, ErrorBuffer)
+	OutputWriter = newMultiWriter(os.Stdout, ErrorBuffer)
 	ManPages     = make(map[string]string, 20)
 	tqManifest   = make(map[string]*tq.Manifest)
 

--- a/commands/multiwriter.go
+++ b/commands/multiwriter.go
@@ -1,0 +1,26 @@
+package commands
+
+import (
+	"io"
+	"os"
+)
+
+type multiWriter struct {
+	writer io.Writer
+	fd     uintptr
+}
+
+func newMultiWriter(f *os.File, writers ...io.Writer) *multiWriter {
+	return &multiWriter{
+		writer: io.MultiWriter(append([]io.Writer{f}, writers...)...),
+		fd:     f.Fd(),
+	}
+}
+
+func (w *multiWriter) Write(p []byte) (n int, err error) {
+	return w.writer.Write(p)
+}
+
+func (w *multiWriter) Fd() uintptr {
+	return w.fd
+}

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -111,7 +111,9 @@ func newUploadContext(dryRun bool) *uploadContext {
 		sink = ioutil.Discard
 	}
 
-	ctx.logger = tasklog.NewLogger(sink)
+	ctx.logger = tasklog.NewLogger(sink,
+		tasklog.ForceProgress(cfg.ForceProgress()),
+	)
 	ctx.meter = buildProgressMeter(ctx.DryRun, tq.Upload)
 	ctx.logger.Enqueue(ctx.meter)
 	ctx.committerName, ctx.committerEmail = cfg.CurrentCommitter()

--- a/config/config.go
+++ b/config/config.go
@@ -308,6 +308,10 @@ func (c *Configuration) SetLockableFilesReadOnly() bool {
 	return c.Os.Bool("GIT_LFS_SET_LOCKABLE_READONLY", true) && c.Git.Bool("lfs.setlockablereadonly", true)
 }
 
+func (c *Configuration) ForceProgress() bool {
+	return c.Os.Bool("GIT_LFS_FORCE_PROGRESS", false) || c.Git.Bool("lfs.forceprogress", false)
+}
+
 // HookDir returns the location of the hooks owned by this repository. If the
 // core.hooksPath configuration variable is supported, we prefer that and expand
 // paths appropriately.

--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -306,6 +306,16 @@ be scoped inside the configuration for a remote.
   * `total` The entire size of the file, in bytes.
   * `name` The name of the file.
 
+* `GIT_LFS_FORCE_PROGRESS`
+  `lfs.forceprogress`
+
+  Controls whether Git LFS will suppress progress status when the standard
+  output stream is not attached to a terminal. The default is `false` which
+  makes Git LFS detect whether stdout is a terminal and suppress progress when
+  it's not; you can disable this behaviour and force progress status even when
+  standard output stream is not a terminal by setting either variable to 1,
+  'yes' or 'true'.
+
 * `GIT_LFS_SET_LOCKABLE_READONLY`
   `lfs.setlockablereadonly`
 

--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -158,10 +158,12 @@ var (
 		}
 	}
 
-	// WithLoggerto logs updates caused by the *git/githistory.Rewriter to
+	// WithLoggerTo logs updates caused by the *git/githistory.Rewriter to
 	// the given io.Writer "sink".
-	WithLoggerTo = func(sink io.Writer) rewriterOption {
-		return WithLogger(tasklog.NewLogger(sink))
+	WithLoggerTo = func(sink io.Writer, forceProgress bool) rewriterOption {
+		return WithLogger(tasklog.NewLogger(sink,
+			tasklog.ForceProgress(forceProgress),
+		))
 	}
 
 	// WithLogger logs updates caused by the *git/githistory.Rewriter to the

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/git-lfs/wildmatch v1.0.0
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/kr/pty v0.0.0-20150511174710-5cf931ef8f76
+	github.com/mattn/go-isatty v0.0.4
 	github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0
 	github.com/pkg/errors v0.0.0-20170505043639-c605e284fe17
 	github.com/rubyist/tracerx v0.0.0-20170927163412-787959303086

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 github.com/ThomsonReutersEikon/go-ntlm v0.0.0-20151030004737-b00ec39bbdd0 h1:iBnLwXNz+Mz2K6MndIM9a4sLBb+TouHB8s0tvx16s4s=
 github.com/ThomsonReutersEikon/go-ntlm v0.0.0-20151030004737-b00ec39bbdd0/go.mod h1:0eFwySJYxbNw/r8cJ01IeztpJfwrgrmiLtYig80Yvrc=
+github.com/alexbrainman/sspi v0.0.0-20180125232955-4729b3d4d858 h1:OZQyEhf4BviydsRdmK4ryeJHotDLd7vL1X8+nnxXkfk=
 github.com/alexbrainman/sspi v0.0.0-20180125232955-4729b3d4d858/go.mod h1:976q2ETgjT2snVCf2ZaBnyBbVoPERGjUz+0sofzEfro=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -13,6 +14,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/kr/pty v0.0.0-20150511174710-5cf931ef8f76 h1:i5TIRQpbCg4aJMUtVHIhkQnSw++Z405Z5pzqHqeNkdU=
 github.com/kr/pty v0.0.0-20150511174710-5cf931ef8f76/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs=
+github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0 h1:LiZB1h0GIcudcDci2bxbqI6DXV8bF8POAnArqvRrIyw=
 github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0/go.mod h1:F/7q8/HZz+TXjlsoZQQKVYvXTZaFH4QRa3y+j1p7MS0=
 github.com/pkg/errors v0.0.0-20170505043639-c605e284fe17 h1:chPfVn+gpAM5CTpTyVU9j8J+xgRGwmoDlNDLjKnJiYo=
@@ -33,4 +36,5 @@ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHo
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v0.0.0-20170210233622-6b67b3fab74d h1:BJPiQVOMMtJsJIkrF4T6K3RKbzqr7rkaybMk33dlGUo=
 github.com/xeipuuv/gojsonschema v0.0.0-20170210233622-6b67b3fab74d/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4myDekKRoLuqhs=
+golang.org/x/sys v0.0.0-20180831094639-fa5fdf94c789 h1:T8D7l6WB3tLu+VpKvw06ieD/OhBi1XpJmG1U/FtttZg=
 golang.org/x/sys v0.0.0-20180831094639-fa5fdf94c789/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/t/git-lfs-test-server-api/main.go
+++ b/t/git-lfs-test-server-api/main.go
@@ -179,7 +179,9 @@ func buildTestData(repo *t.Repo, manifest *tq.Manifest) (oidsExist, oidsMissing 
 	oidsMissing = make([]TestObject, 0, oidCount)
 
 	// just one commit
-	logger := tasklog.NewLogger(os.Stdout)
+	logger := tasklog.NewLogger(os.Stdout,
+		tasklog.ForceProgress(false),
+	)
 	meter := tq.NewMeter()
 	meter.Logger = meter.LoggerFromEnv(repo.OSEnv())
 	logger.Enqueue(meter)

--- a/t/testenv.sh
+++ b/t/testenv.sh
@@ -123,12 +123,14 @@ LFS_CLIENT_KEY_FILE_ENCRYPTED="$REMOTEDIR/client.enc.key"
 # the fake home dir used for the initial setup
 TESTHOME="$REMOTEDIR/home"
 
+GIT_LFS_FORCE_PROGRESS=1
 GIT_CONFIG_NOSYSTEM=1
 GIT_TERMINAL_PROMPT=0
 GIT_SSH=lfs-ssh-echo
 APPVEYOR_REPO_COMMIT_MESSAGE="test: env test should look for GIT_SSH too"
 
 export CREDSDIR
+export GIT_LFS_FORCE_PROGRESS
 export GIT_CONFIG_NOSYSTEM
 export GIT_SSH
 export APPVEYOR_REPO_COMMIT_MESSAGE

--- a/vendor/github.com/mattn/go-isatty/.travis.yml
+++ b/vendor/github.com/mattn/go-isatty/.travis.yml
@@ -1,0 +1,13 @@
+language: go
+go:
+  - tip
+
+os:
+  - linux
+  - osx
+
+before_install:
+  - go get github.com/mattn/goveralls
+  - go get golang.org/x/tools/cmd/cover
+script:
+  - $HOME/gopath/bin/goveralls -repotoken 3gHdORO5k5ziZcWMBxnd9LrMZaJs8m9x5

--- a/vendor/github.com/mattn/go-isatty/LICENSE
+++ b/vendor/github.com/mattn/go-isatty/LICENSE
@@ -1,0 +1,9 @@
+Copyright (c) Yasuhiro MATSUMOTO <mattn.jp@gmail.com>
+
+MIT License (Expat)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/mattn/go-isatty/README.md
+++ b/vendor/github.com/mattn/go-isatty/README.md
@@ -1,0 +1,50 @@
+# go-isatty
+
+[![Godoc Reference](https://godoc.org/github.com/mattn/go-isatty?status.svg)](http://godoc.org/github.com/mattn/go-isatty)
+[![Build Status](https://travis-ci.org/mattn/go-isatty.svg?branch=master)](https://travis-ci.org/mattn/go-isatty)
+[![Coverage Status](https://coveralls.io/repos/github/mattn/go-isatty/badge.svg?branch=master)](https://coveralls.io/github/mattn/go-isatty?branch=master)
+[![Go Report Card](https://goreportcard.com/badge/mattn/go-isatty)](https://goreportcard.com/report/mattn/go-isatty)
+
+isatty for golang
+
+## Usage
+
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/mattn/go-isatty"
+	"os"
+)
+
+func main() {
+	if isatty.IsTerminal(os.Stdout.Fd()) {
+		fmt.Println("Is Terminal")
+	} else if isatty.IsCygwinTerminal(os.Stdout.Fd()) {
+		fmt.Println("Is Cygwin/MSYS2 Terminal")
+	} else {
+		fmt.Println("Is Not Terminal")
+	}
+}
+```
+
+## Installation
+
+```
+$ go get github.com/mattn/go-isatty
+```
+
+## License
+
+MIT
+
+## Author
+
+Yasuhiro Matsumoto (a.k.a mattn)
+
+## Thanks
+
+* k-takata: base idea for IsCygwinTerminal
+
+    https://github.com/k-takata/go-iscygpty

--- a/vendor/github.com/mattn/go-isatty/doc.go
+++ b/vendor/github.com/mattn/go-isatty/doc.go
@@ -1,0 +1,2 @@
+// Package isatty implements interface to isatty
+package isatty

--- a/vendor/github.com/mattn/go-isatty/isatty_appengine.go
+++ b/vendor/github.com/mattn/go-isatty/isatty_appengine.go
@@ -1,0 +1,15 @@
+// +build appengine
+
+package isatty
+
+// IsTerminal returns true if the file descriptor is terminal which
+// is always false on on appengine classic which is a sandboxed PaaS.
+func IsTerminal(fd uintptr) bool {
+	return false
+}
+
+// IsCygwinTerminal() return true if the file descriptor is a cygwin or msys2
+// terminal. This is also always false on this environment.
+func IsCygwinTerminal(fd uintptr) bool {
+	return false
+}

--- a/vendor/github.com/mattn/go-isatty/isatty_bsd.go
+++ b/vendor/github.com/mattn/go-isatty/isatty_bsd.go
@@ -1,0 +1,18 @@
+// +build darwin freebsd openbsd netbsd dragonfly
+// +build !appengine
+
+package isatty
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+const ioctlReadTermios = syscall.TIOCGETA
+
+// IsTerminal return true if the file descriptor is terminal.
+func IsTerminal(fd uintptr) bool {
+	var termios syscall.Termios
+	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, fd, ioctlReadTermios, uintptr(unsafe.Pointer(&termios)), 0, 0, 0)
+	return err == 0
+}

--- a/vendor/github.com/mattn/go-isatty/isatty_linux.go
+++ b/vendor/github.com/mattn/go-isatty/isatty_linux.go
@@ -1,0 +1,18 @@
+// +build linux
+// +build !appengine,!ppc64,!ppc64le
+
+package isatty
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+const ioctlReadTermios = syscall.TCGETS
+
+// IsTerminal return true if the file descriptor is terminal.
+func IsTerminal(fd uintptr) bool {
+	var termios syscall.Termios
+	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, fd, ioctlReadTermios, uintptr(unsafe.Pointer(&termios)), 0, 0, 0)
+	return err == 0
+}

--- a/vendor/github.com/mattn/go-isatty/isatty_linux_ppc64x.go
+++ b/vendor/github.com/mattn/go-isatty/isatty_linux_ppc64x.go
@@ -1,0 +1,19 @@
+// +build linux
+// +build ppc64 ppc64le
+
+package isatty
+
+import (
+	"unsafe"
+
+	syscall "golang.org/x/sys/unix"
+)
+
+const ioctlReadTermios = syscall.TCGETS
+
+// IsTerminal return true if the file descriptor is terminal.
+func IsTerminal(fd uintptr) bool {
+	var termios syscall.Termios
+	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, fd, ioctlReadTermios, uintptr(unsafe.Pointer(&termios)), 0, 0, 0)
+	return err == 0
+}

--- a/vendor/github.com/mattn/go-isatty/isatty_others.go
+++ b/vendor/github.com/mattn/go-isatty/isatty_others.go
@@ -1,0 +1,10 @@
+// +build !windows
+// +build !appengine
+
+package isatty
+
+// IsCygwinTerminal return true if the file descriptor is a cygwin or msys2
+// terminal. This is also always false on this environment.
+func IsCygwinTerminal(fd uintptr) bool {
+	return false
+}

--- a/vendor/github.com/mattn/go-isatty/isatty_solaris.go
+++ b/vendor/github.com/mattn/go-isatty/isatty_solaris.go
@@ -1,0 +1,16 @@
+// +build solaris
+// +build !appengine
+
+package isatty
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// IsTerminal returns true if the given file descriptor is a terminal.
+// see: http://src.illumos.org/source/xref/illumos-gate/usr/src/lib/libbc/libc/gen/common/isatty.c
+func IsTerminal(fd uintptr) bool {
+	var termio unix.Termio
+	err := unix.IoctlSetTermio(int(fd), unix.TCGETA, &termio)
+	return err == nil
+}

--- a/vendor/github.com/mattn/go-isatty/isatty_windows.go
+++ b/vendor/github.com/mattn/go-isatty/isatty_windows.go
@@ -1,0 +1,94 @@
+// +build windows
+// +build !appengine
+
+package isatty
+
+import (
+	"strings"
+	"syscall"
+	"unicode/utf16"
+	"unsafe"
+)
+
+const (
+	fileNameInfo uintptr = 2
+	fileTypePipe         = 3
+)
+
+var (
+	kernel32                         = syscall.NewLazyDLL("kernel32.dll")
+	procGetConsoleMode               = kernel32.NewProc("GetConsoleMode")
+	procGetFileInformationByHandleEx = kernel32.NewProc("GetFileInformationByHandleEx")
+	procGetFileType                  = kernel32.NewProc("GetFileType")
+)
+
+func init() {
+	// Check if GetFileInformationByHandleEx is available.
+	if procGetFileInformationByHandleEx.Find() != nil {
+		procGetFileInformationByHandleEx = nil
+	}
+}
+
+// IsTerminal return true if the file descriptor is terminal.
+func IsTerminal(fd uintptr) bool {
+	var st uint32
+	r, _, e := syscall.Syscall(procGetConsoleMode.Addr(), 2, fd, uintptr(unsafe.Pointer(&st)), 0)
+	return r != 0 && e == 0
+}
+
+// Check pipe name is used for cygwin/msys2 pty.
+// Cygwin/MSYS2 PTY has a name like:
+//   \{cygwin,msys}-XXXXXXXXXXXXXXXX-ptyN-{from,to}-master
+func isCygwinPipeName(name string) bool {
+	token := strings.Split(name, "-")
+	if len(token) < 5 {
+		return false
+	}
+
+	if token[0] != `\msys` && token[0] != `\cygwin` {
+		return false
+	}
+
+	if token[1] == "" {
+		return false
+	}
+
+	if !strings.HasPrefix(token[2], "pty") {
+		return false
+	}
+
+	if token[3] != `from` && token[3] != `to` {
+		return false
+	}
+
+	if token[4] != "master" {
+		return false
+	}
+
+	return true
+}
+
+// IsCygwinTerminal() return true if the file descriptor is a cygwin or msys2
+// terminal.
+func IsCygwinTerminal(fd uintptr) bool {
+	if procGetFileInformationByHandleEx == nil {
+		return false
+	}
+
+	// Cygwin/msys's pty is a pipe.
+	ft, _, e := syscall.Syscall(procGetFileType.Addr(), 1, fd, 0, 0)
+	if ft != fileTypePipe || e != 0 {
+		return false
+	}
+
+	var buf [2 + syscall.MAX_PATH]uint16
+	r, _, e := syscall.Syscall6(procGetFileInformationByHandleEx.Addr(),
+		4, fd, fileNameInfo, uintptr(unsafe.Pointer(&buf)),
+		uintptr(len(buf)*2), 0, 0)
+	if r == 0 || e != 0 {
+		return false
+	}
+
+	l := *(*uint32)(unsafe.Pointer(&buf))
+	return isCygwinPipeName(string(utf16.Decode(buf[2 : 2+l/2])))
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -19,6 +19,8 @@ github.com/git-lfs/wildmatch
 github.com/inconshreveable/mousetrap
 # github.com/kr/pty v0.0.0-20150511174710-5cf931ef8f76
 github.com/kr/pty
+# github.com/mattn/go-isatty v0.0.4
+github.com/mattn/go-isatty
 # github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0
 github.com/olekukonko/ts
 # github.com/pkg/errors v0.0.0-20170505043639-c605e284fe17


### PR DESCRIPTION
To avoid filling logs with progress status when running git/git-lfs inside tools and services where the output does not go to a terminal.

The behaviour is overridable by either
 - setting `lfs.forceprogress 1`
 - setting `GIT_LFS_FORCE_PROGRESS=1`

Ideally this should be controllable by command line args (like `git push --progress`) but passing command line args down to filters and hooks is not really an option.