### PR TITLE
Support pushInsteadOf aliases when determining endpoints

### DIFF
--- a/lfsapi/endpoint_finder.go
+++ b/lfsapi/endpoint_finder.go
@@ -288,8 +288,16 @@ func (e *endpointGitFinder) ReplaceUrlAlias(rawurl string) string {
 	e.aliasMu.Lock()
 	defer e.aliasMu.Unlock()
 
+	rawurl, _ = e.replaceUrlAlias(e.aliases, rawurl)
+
+	return rawurl
+}
+
+// replaceUrlAlias is a helper function for ReplaceUrlAlias.  It must only be
+// called while the e.aliasMu mutex is held.
+func (e *endpointGitFinder) replaceUrlAlias(aliases map[string]string, rawurl string) (string, bool) {
 	var longestalias string
-	for alias, _ := range e.aliases {
+	for alias, _ := range aliases {
 		if !strings.HasPrefix(rawurl, alias) {
 			continue
 		}
@@ -300,10 +308,10 @@ func (e *endpointGitFinder) ReplaceUrlAlias(rawurl string) string {
 	}
 
 	if len(longestalias) > 0 {
-		return e.aliases[longestalias] + rawurl[len(longestalias):]
+		return aliases[longestalias] + rawurl[len(longestalias):], true
 	}
 
-	return rawurl
+	return rawurl, false
 }
 
 const (

--- a/lfsapi/endpoint_finder_test.go
+++ b/lfsapi/endpoint_finder_test.go
@@ -421,7 +421,7 @@ func (c *EndpointParsingTestCase) Assert(t *testing.T) {
 	finder := NewEndpointFinder(lfshttp.NewContext(nil, nil, map[string]string{
 		"url.https://github.com/.insteadof": "gh:",
 	}))
-	actual := finder.NewEndpoint(c.Given)
+	actual := finder.NewEndpoint("upload", c.Given)
 	assert.Equal(t, c.Expected, actual, "lfsapi: expected endpoint for %q to be %#v (was %#v)", c.Given, c.Expected, actual)
 }
 
@@ -505,7 +505,7 @@ func TestNewEndpointFromCloneURLWithConfig(t *testing.T) {
 
 	finder := NewEndpointFinder(nil)
 	for _, actual := range tests {
-		e := finder.NewEndpointFromCloneURL(actual)
+		e := finder.NewEndpointFromCloneURL("upload", actual)
 		if e.Url != expected {
 			t.Errorf("%s returned bad endpoint url %s", actual, e.Url)
 		}

--- a/lfsapi/endpoint_finder_test.go
+++ b/lfsapi/endpoint_finder_test.go
@@ -494,6 +494,76 @@ func TestEndpointParsing(t *testing.T) {
 	}
 }
 
+type InsteadOfTestCase struct {
+	Given     string
+	Operation string
+	Expected  lfshttp.Endpoint
+}
+
+func (c *InsteadOfTestCase) Assert(t *testing.T) {
+	finder := NewEndpointFinder(lfshttp.NewContext(nil, nil, map[string]string{
+		"remote.test.url":                      c.Given,
+		"url.https://example.com/.insteadof":   "ex:",
+		"url.ssh://example.com/.pushinsteadof": "ex:",
+		"url.ssh://example.com/.insteadof":     "exp:",
+	}))
+	actual := finder.Endpoint(c.Operation, "test")
+	assert.Equal(t, c.Expected, actual, "lfsapi: expected endpoint for %q to be %#v (was %#v)", c.Given, c.Expected, actual)
+}
+
+func TestInsteadOf(t *testing.T) {
+	// Note that many of these tests will produce silly or completely broken
+	// values for the Url, and that's okay: they work nevertheless.
+	for desc, c := range map[string]InsteadOfTestCase{
+		"insteadof alias (download)": {
+			"ex:git-lfs/git-lfs.git",
+			"download",
+			lfshttp.Endpoint{
+				Url:            "https://example.com/git-lfs/git-lfs.git/info/lfs",
+				SshUserAndHost: "",
+				SshPath:        "",
+				SshPort:        "",
+				Operation:      "download",
+			},
+		},
+		"pushinsteadof alias (upload)": {
+			"ex:git-lfs/git-lfs.git",
+			"upload",
+			lfshttp.Endpoint{
+				Url:            "https://example.com/git-lfs/git-lfs.git/info/lfs",
+				SshUserAndHost: "example.com",
+				SshPath:        "git-lfs/git-lfs.git",
+				SshPort:        "",
+				Operation:      "upload",
+			},
+		},
+		"exp alias (download)": {
+			"exp:git-lfs/git-lfs.git",
+			"download",
+			lfshttp.Endpoint{
+				Url:            "https://example.com/git-lfs/git-lfs.git/info/lfs",
+				SshUserAndHost: "example.com",
+				SshPath:        "git-lfs/git-lfs.git",
+				SshPort:        "",
+				Operation:      "download",
+			},
+		},
+		"exp alias (upload)": {
+			"exp:git-lfs/git-lfs.git",
+			"upload",
+			lfshttp.Endpoint{
+				Url:            "https://example.com/git-lfs/git-lfs.git/info/lfs",
+				SshUserAndHost: "example.com",
+				SshPath:        "git-lfs/git-lfs.git",
+				SshPort:        "",
+				Operation:      "upload",
+			},
+		},
+	} {
+		t.Run(desc, c.Assert)
+	}
+}
+
 func TestNewEndpointFromCloneURLWithConfig(t *testing.T) {
 	expected := "https://foo/bar.git/info/lfs"
 	tests := []string{


### PR DESCRIPTION
Git understands how to specify aliases that differ between fetch and pull by using `pushInsteadOf` aliases.  This series introduces support for this type of alias in Git LFS so that we can authenticate to the right endpoint when performing a push, as the user intended.

The first patch updates various callers; the second and third patches split out functions and should have no functional changes. The fourth patch introduces the new alias support.  Note that we use the same mutex for protecting all the aliases since there's no reason to distinguish between them.

This fixes #2433.