### PR TITLE
release: version 2.6.0 (take 2)

### DIFF
--- a/config/version.go
+++ b/config/version.go
@@ -12,7 +12,7 @@ var (
 )
 
 const (
-	Version = "2.5.0"
+	Version = "2.6.0"
 )
 
 func init() {


### PR DESCRIPTION
Bump the version number in config/version.go.

This time, the PR is into the correct branch.