### PR TITLE
Set USER environment variable in build containers

### DIFF
--- a/docker/run_dockers.bsh
+++ b/docker/run_dockers.bsh
@@ -95,6 +95,7 @@ for IMAGE_NAME in "${IMAGES[@]}"; do
   echo Compiling LFS in docker image ${IMAGE_NAME}
   IMAGE_REPO_DIR="${PACKAGE_DIR}"/"${IMAGE_INFO[0]}"/"${IMAGE_INFO[1]}"
   $SUDO docker run "${OTHER_OPTIONS[@]}" ${DOCKER_OTHER_OPTIONS-} \
+                   -e USER=root \
                    -e REPO_HOSTNAME=${REPO_HOSTNAME:-git-lfs.github.com} \
                    -e FINAL_UID=${FINAL_UID} \
                    -e FINAL_GID=${FINAL_GID} \


### PR DESCRIPTION
On Linux, lookup of user information such as the home directory is
handled by the name service switch in libc.  This allows administrators
to use the mechanism of their choice (such as LDAP) for enumerating
users.  Go normally doesn't use libc on Linux, but it does when looking
up information for users, so that programs written in Go handle these
operations like other (non-Go) programs on the system do.

When our build containers run the integration testsuite on i386 Linux,
we don't actually have a 32-bit copy of libc available.  Therefore, we
must be sure not to rely on behavior that needs it, such as the name
service switch.  Our tests want to look up the user's home directory so
that we can expand the core.hooksPath variable, but we also need the
user's name in order to do that.  We have HOME set for the home
directory, but lack USER.  Consequently, we try to call libc to find the
current user, but cannot, and the resulting test failure causes the
build to abort.

Set the USER environment variable in the containers to "root" so that we
can enumerate the current user without the need to call libc and ensure
our tests pass during release builds.