### PR TITLE
filepathfilter: don't say file is both accepted and rejected

### DIFF
--- a/filepathfilter/filepathfilter.go
+++ b/filepathfilter/filepathfilter.go
@@ -61,8 +61,8 @@ func (f *Filter) Allows(filename string) bool {
 		}
 	}
 
-	tracerx.Printf("filepathfilter: rejecting %q via %v", filename, f.include)
 	if !included && len(f.include) > 0 {
+		tracerx.Printf("filepathfilter: rejecting %q via %v", filename, f.include)
 		return false
 	}
 

--- a/t/t-checkout.sh
+++ b/t/t-checkout.sh
@@ -41,13 +41,15 @@ begin_test "checkout"
   rm -rf file1.dat file2.dat file3.dat folder1/nested.dat folder2/nested.dat
 
   echo "checkout should replace all"
-  git lfs checkout 2>&1 | tee checkout.log
+  GIT_TRACE=1 git lfs checkout 2>&1 | tee checkout.log
   [ "$contents" = "$(cat file1.dat)" ]
   [ "$contents" = "$(cat file2.dat)" ]
   [ "$contents" = "$(cat file3.dat)" ]
   [ "$contents" = "$(cat folder1/nested.dat)" ]
   [ "$contents" = "$(cat folder2/nested.dat)" ]
   grep "Checking out LFS objects: 100% (5/5), 95 B" checkout.log
+  grep 'accepting "file1.dat"' checkout.log
+  ! grep 'rejecting "file1.dat"' checkout.log
 
   # Remove the working directory
   rm -rf file1.dat file2.dat file3.dat folder1/nested.dat folder2/nested.dat


### PR DESCRIPTION
The file path filter can mark a file as either accepted or rejected. However, one of the messages that says that a file was rejected is in the main code path, and is therefore always executed, even if the file is actually accepted.  This leads to contradictory messages and noisier output.

Ensure that we indicate that a file is rejected by the filter only if it is indeed rejected; otherwise, say only that it is accepted.