### PR TITLE
Fix test server API

### DIFF
--- a/t/Makefile
+++ b/t/Makefile
@@ -19,7 +19,12 @@ TEST_CMDS += ../bin/lfstest-gitserver$X
 TEST_CMDS += ../bin/lfstest-standalonecustomadapter$X
 TEST_CMDS += ../bin/lfstest-testutils$X
 
-TEST_SRCS = $(wildcard t-*.sh)
+# Not used for the integration tests, but build it here anyway to ensure it
+# continues to work.
+TEST_CMDS += ../bin/git-lfs-test-server-api$X
+
+TEST_SRCS     = $(wildcard t-*.sh)
+TEST_API_SRCS = $(wildcard git-lfs-test-server-api/*.go)
 
 all : $(DEFAULT_TEST_TARGET)
 
@@ -40,4 +45,7 @@ clean :
 	$(RM) $(TEST_CMDS)
 
 ../bin/%$X : cmd/%.go
+	go build -o $@ $^
+
+../bin/git-lfs-test-server-api$X : $(TEST_API_SRCS)
 	go build -o $@ $^

--- a/t/git-lfs-test-server-api/main.go
+++ b/t/git-lfs-test-server-api/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/fs"
 	"github.com/git-lfs/git-lfs/lfsapi"
+	"github.com/git-lfs/git-lfs/lfshttp"
 	t "github.com/git-lfs/git-lfs/t/cmd/util"
 	"github.com/git-lfs/git-lfs/tasklog"
 	"github.com/git-lfs/git-lfs/tq"
@@ -141,11 +142,11 @@ func buildManifest(r *t.Repo) (*tq.Manifest, error) {
 	// Configure the endpoint manually
 	finder := lfsapi.NewEndpointFinder(r)
 
-	var endp lfsapi.Endpoint
+	var endp lfshttp.Endpoint
 	if len(cloneUrl) > 0 {
-		endp = finder.NewEndpointFromCloneURL(cloneUrl)
+		endp = finder.NewEndpointFromCloneURL("upload", cloneUrl)
 	} else {
-		endp = finder.NewEndpoint(apiUrl)
+		endp = finder.NewEndpoint("upload", apiUrl)
 	}
 
 	apiClient, err := lfsapi.NewClient(r)
@@ -160,18 +161,20 @@ func buildManifest(r *t.Repo) (*tq.Manifest, error) {
 }
 
 type constantEndpoint struct {
-	e lfsapi.Endpoint
+	e lfshttp.Endpoint
 
 	lfsapi.EndpointFinder
 }
 
-func (c *constantEndpoint) NewEndpointFromCloneURL(rawurl string) lfsapi.Endpoint { return c.e }
+func (c *constantEndpoint) NewEndpointFromCloneURL(operation, rawurl string) lfshttp.Endpoint {
+	return c.e
+}
 
-func (c *constantEndpoint) NewEndpoint(rawurl string) lfsapi.Endpoint { return c.e }
+func (c *constantEndpoint) NewEndpoint(operation, rawurl string) lfshttp.Endpoint { return c.e }
 
-func (c *constantEndpoint) Endpoint(operation, remote string) lfsapi.Endpoint { return c.e }
+func (c *constantEndpoint) Endpoint(operation, remote string) lfshttp.Endpoint { return c.e }
 
-func (c *constantEndpoint) RemoteEndpoint(operation, remote string) lfsapi.Endpoint { return c.e }
+func (c *constantEndpoint) RemoteEndpoint(operation, remote string) lfshttp.Endpoint { return c.e }
 
 func buildTestData(repo *t.Repo, manifest *tq.Manifest) (oidsExist, oidsMissing []TestObject, err error) {
 	const oidCount = 50

--- a/t/git-lfs-test-server-api/testupload.go
+++ b/t/git-lfs-test-server-api/testupload.go
@@ -52,7 +52,7 @@ func uploadAllExists(manifest *tq.Manifest, oidsExist, oidsMissing []TestObject)
 	var errbuf bytes.Buffer
 	for _, o := range retobjs {
 		link, _ := o.Rel("upload")
-		if link == nil {
+		if link != nil {
 			errbuf.WriteString(fmt.Sprintf("Upload link should not exist for %s, was %+v\n", o.Oid, link))
 		}
 	}


### PR DESCRIPTION
@Foxboron recently noticed that our server API test program didn't function in the way we expected.  It first of all didn't compile due to several refactors, and then even when fixed, it didn't pass.

This series fixes the code so that it builds, builds it as part of the integration test series to ensure we don't break it again, and fixes the reversed condition that causes it to fail.  I am fairly confident that the last patch is indeed correct, but some :eyes: on that part would be helpful.

This series fixes #3372.