### PR TITLE
commands/command_status.go: require a working copy

### DIFF
--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -22,6 +22,7 @@ var (
 
 func statusCommand(cmd *cobra.Command, args []string) {
 	requireInRepo()
+	requireWorkingCopy()
 
 	// tolerate errors getting ref so this works before first commit
 	ref, _ := git.CurrentRef()

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -309,6 +309,22 @@ func requireInRepo() {
 	}
 }
 
+// requireWorkingCopy requires that the working directory be a work tree, i.e.,
+// that it not be bare. If it is bare (or the state of the repository could not
+// be determined), this function will terminate the program.
+func requireWorkingCopy() {
+	bare, err := git.IsBare()
+	if err != nil {
+		ExitWithError(errors.Wrap(
+			err, "fatal: could not determine bareness"))
+	}
+
+	if bare {
+		Print("This operation must be run in a work tree.")
+		os.Exit(128)
+	}
+}
+
 func handlePanic(err error) string {
 	if err == nil {
 		return ""

--- a/docs/man/git-lfs-status.1.ronn
+++ b/docs/man/git-lfs-status.1.ronn
@@ -18,6 +18,8 @@ Display paths of Git LFS objects that
 * have differences between the working tree and the index file.  These
   are files that could be staged using `git add`.
 
+This command must be run in a non-bare repository.
+
 ## OPTIONS
 
 * `--porcelain`:

--- a/t/t-status.sh
+++ b/t/t-status.sh
@@ -448,3 +448,19 @@ Git LFS objects not staged for commit:"
   [ "$expected" = "$(git lfs status)" ]
 )
 end_test
+
+begin_test "status (without a working copy)"
+(
+  reponame="status-no-working-copy.git"
+
+  git init --bare "$reponame"
+  cd "$reponame"
+
+  git lfs status 2>&1 | tee status.log
+  if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+    echo >&2 "git lfs status should have failed, didn't ..."
+    exit 1
+  fi
+  [ "This operation must be run in a work tree." = "$(cat status.log)" ]
+)
+end_test


### PR DESCRIPTION
'git lfs status' is functional in a non-work tree repository only some
of the time. Particularly, when there is nothing to report (and
therefore no files to open), 'git lfs status' work as expected.

However, when there are files changed in the index, Git LFS tries to
open them to see what their hash was before/after the change, and in
particular, if they are/were/remain Git LFS pointers. This feature is
used to power the "Git <sha-1> -> LFS <sha-256>" output of 'git lfs
status'.

When in a bare repository and in the aforementioned scenario, the above
operation will fail to open a file that does not exist, for the
repository is bare and thus does not contain a working tree.

In order to bring about a more consistent experience when using 'git lfs
status', let's match the behavior upstream and exit immediately with the
message:

    $ git lfs status
    This operation must be run in a work tree.

Closes: https://github.com/git-lfs/git-lfs/issues/3373.

##

/cc @git-lfs/core 
/cc @mloskot https://github.com/git-lfs/git-lfs/issues/3373