### PR TITLE
Avoid hang in repos cloned with --shared or --reference

### DIFF
--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -34,8 +34,6 @@ func statusCommand(cmd *cobra.Command, args []string) {
 
 	scanner, err := lfs.NewPointerScanner()
 	if err != nil {
-		scanner.Close()
-
 		ExitWithError(err)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/git-lfs/git-lfs
 require (
 	github.com/ThomsonReutersEikon/go-ntlm v0.0.0-20151030004737-b00ec39bbdd0
 	github.com/alexbrainman/sspi v0.0.0-20180125232955-4729b3d4d858
-	github.com/git-lfs/gitobj v1.0.0
+	github.com/git-lfs/gitobj v1.1.0
 	github.com/git-lfs/go-netrc v0.0.0-20180525200031-e0e9ca483a18
 	github.com/git-lfs/wildmatch v1.0.0
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/alexbrainman/sspi v0.0.0-20180125232955-4729b3d4d858 h1:OZQyEhf4Bviyd
 github.com/alexbrainman/sspi v0.0.0-20180125232955-4729b3d4d858/go.mod h1:976q2ETgjT2snVCf2ZaBnyBbVoPERGjUz+0sofzEfro=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/git-lfs/gitobj v1.0.0 h1:+tZj++WOWMNTMP3aMJrKel8ogWkN+hRRCGNVUE+UXio=
-github.com/git-lfs/gitobj v1.0.0/go.mod h1:EdPNGHVxXe1jTuNXzZT1+CdJCuASoDSLPQuvNOo9nGM=
+github.com/git-lfs/gitobj v1.1.0 h1:XRUyk5nKYTWiO8U4cokO5QeoNUNBL8LKS+jXxXZdCTA=
+github.com/git-lfs/gitobj v1.1.0/go.mod h1:EdPNGHVxXe1jTuNXzZT1+CdJCuASoDSLPQuvNOo9nGM=
 github.com/git-lfs/go-netrc v0.0.0-20180525200031-e0e9ca483a18 h1:7Th0eBA4rT8WJNiM1vppjaIv9W5WJinhpbCJvRJxloI=
 github.com/git-lfs/go-netrc v0.0.0-20180525200031-e0e9ca483a18/go.mod h1:70O4NAtvWn1jW8V8V+OKrJJYcxDLTmIozfi2fmSz5SI=
 github.com/git-lfs/wildmatch v1.0.0 h1:TKsxqSrEXWj73N4xGcN/ISal8/JJOiAcOv9LH6Zprxw=

--- a/lfs/gitscanner_tree.go
+++ b/lfs/gitscanner_tree.go
@@ -49,8 +49,6 @@ func runScanTree(cb GitScannerFoundPointer, ref string, filter *filepathfilter.F
 func catFileBatchTree(treeblobs *TreeBlobChannelWrapper) (*PointerChannelWrapper, error) {
 	scanner, err := NewPointerScanner()
 	if err != nil {
-		scanner.Close()
-
 		return nil, err
 	}
 

--- a/lfs/gitscanner_tree.go
+++ b/lfs/gitscanner_tree.go
@@ -56,8 +56,10 @@ func catFileBatchTree(treeblobs *TreeBlobChannelWrapper) (*PointerChannelWrapper
 	errchan := make(chan error, 10) // Multiple errors possible
 
 	go func() {
+		hasNext := true
 		for t := range treeblobs.Results {
-			hasNext := scanner.Scan(t.Sha1)
+			hasNext = scanner.Scan(t.Sha1)
+
 			if p := scanner.Pointer(); p != nil {
 				p.Name = t.Filename
 				pointers <- p
@@ -72,10 +74,14 @@ func catFileBatchTree(treeblobs *TreeBlobChannelWrapper) (*PointerChannelWrapper
 			}
 		}
 
-		// Deal with nested error from incoming treeblobs
-		err := treeblobs.Wait()
-		if err != nil {
-			errchan <- err
+		// If the scanner quit early, we may still have treeblobs to
+		// read, so waiting for it to close will cause a deadlock.
+		if hasNext {
+			// Deal with nested error from incoming treeblobs
+			err := treeblobs.Wait()
+			if err != nil {
+				errchan <- err
+			}
 		}
 
 		if err = scanner.Close(); err != nil {

--- a/t/t-fetch.sh
+++ b/t/t-fetch.sh
@@ -51,8 +51,9 @@ begin_test "init for fetch tests"
   git push origin newbranch
   assert_server_object "$reponame" "$b_oid"
 
-  # This clone is used for subsequent tests
+  # These clones are used for subsequent tests
   clone_repo "$reponame" clone
+  git clone --shared "$TRASHDIR/clone" "$TRASHDIR/shared"
 )
 end_test
 
@@ -63,6 +64,21 @@ begin_test "fetch"
   rm -rf .git/lfs/objects
 
   git lfs fetch 2>&1 | grep "Downloading LFS objects: 100% (1/1), 1 B"
+  assert_local_object "$contents_oid" 1
+
+  git lfs fsck 2>&1 | tee fsck.log
+  grep "Git LFS fsck OK" fsck.log
+)
+end_test
+
+begin_test "fetch (shared repository)"
+(
+  set -e
+  cd shared
+  rm -rf .git/lfs/objects
+
+  git lfs fetch 2>&1 | tee fetch.log
+  ! grep "Could not scan" fetch.log
   assert_local_object "$contents_oid" 1
 
   git lfs fsck 2>&1 | tee fsck.log

--- a/vendor/github.com/git-lfs/gitobj/backend.go
+++ b/vendor/github.com/git-lfs/gitobj/backend.go
@@ -1,7 +1,10 @@
 package gitobj
 
 import (
+	"bufio"
 	"io"
+	"os"
+	"path"
 
 	"github.com/git-lfs/gitobj/pack"
 	"github.com/git-lfs/gitobj/storage"
@@ -15,7 +18,46 @@ func NewFilesystemBackend(root, tmp string) (storage.Backend, error) {
 		return nil, err
 	}
 
-	return &filesystemBackend{fs: fsobj, packs: packs}, nil
+	storage, err := findAllBackends(fsobj, packs, root)
+	if err != nil {
+		return nil, err
+	}
+
+	return &filesystemBackend{
+		fs:       fsobj,
+		backends: storage,
+	}, nil
+}
+
+func findAllBackends(mainLoose *fileStorer, mainPacked *pack.Storage, root string) ([]storage.Storage, error) {
+	storage := make([]storage.Storage, 2)
+	storage[0] = mainLoose
+	storage[1] = mainPacked
+	f, err := os.Open(path.Join(root, "info", "alternates"))
+	if err != nil {
+		// No alternates file, no problem.
+		if err != os.ErrNotExist {
+			return storage, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		storage = append(storage, newFileStorer(scanner.Text(), ""))
+		pack, err := pack.NewStorage(scanner.Text())
+		if err != nil {
+			return nil, err
+		}
+		storage = append(storage, pack)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return storage, nil
 }
 
 // NewMemoryBackend initializes a new memory-based backend.
@@ -27,12 +69,12 @@ func NewMemoryBackend(m map[string]io.ReadWriter) (storage.Backend, error) {
 }
 
 type filesystemBackend struct {
-	fs    *fileStorer
-	packs *pack.Storage
+	fs       *fileStorer
+	backends []storage.Storage
 }
 
 func (b *filesystemBackend) Storage() (storage.Storage, storage.WritableStorage) {
-	return storage.MultiStorage(b.fs, b.packs), b.fs
+	return storage.MultiStorage(b.backends...), b.fs
 }
 
 type memoryBackend struct {

--- a/vendor/github.com/git-lfs/gitobj/object_db.go
+++ b/vendor/github.com/git-lfs/gitobj/object_db.go
@@ -285,7 +285,7 @@ func (o *ObjectDatabase) open(sha []byte) (*ObjectReader, error) {
 	if o.ro.IsCompressed() {
 		return NewObjectReadCloser(f)
 	}
-	return NewUncompressedObjectReader(f)
+	return NewUncompressedObjectReadCloser(f)
 }
 
 // openDecode calls decode (see: below) on the object named "sha" after openin

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -6,7 +6,7 @@ github.com/alexbrainman/sspi
 github.com/alexbrainman/sspi/ntlm
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/git-lfs/gitobj v1.0.0
+# github.com/git-lfs/gitobj v1.1.0
 github.com/git-lfs/gitobj
 github.com/git-lfs/gitobj/errors
 github.com/git-lfs/gitobj/pack


### PR DESCRIPTION
When a repository is cloned with --shared or --reference, it contains an alternates file with references to other repositories.  Because earlier versions of `gitobj` did not read from alternate repositories, the object scanner could finish early.  When it did so, we tried to read the error from the treeblob scanner, but there was none, and the channel would remain open since the treeblob scanner was not yet finished providing data.  Since we no longer read data from the treeblob scanner, we would deadlock, with the object scanner waiting to read the treeblob scanner's error channel and the treeblob scanner waiting to write to the now-full data channel.

Fix this by updating to a fixed `gitobj` version to avoid an early return from the object scanner and avoiding deadlock by not waiting on the error channel if we do return early.

This series fixes #3358.

/cc @dfa1 and @whitty for testing that this is fixed on y'all's systems