### PR TITLE
Document default value of migrate info --top=<n>

### DIFF
--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -60,7 +60,7 @@ The 'info' mode has these additional options:
 
 * `--top=<n>`
     Only include the top 'n' entries, ordered by how many total files match the
-    given pathspec.
+    given pathspec. Default: top 5 entries.
 
 * `--unit=<unit>`
     Format the number of bytes in each entry as a quantity of the storage unit


### PR DESCRIPTION
It took me a couple of attempts to understand why the output does not list all I request via  `--include=` patterns :-) I hope this will help others.