### PR TITLE
Rewrite URL config-matching

### DIFF
--- a/config/url_config_test.go
+++ b/config/url_config_test.go
@@ -17,6 +17,7 @@ func TestURLConfig(t *testing.T) {
 		"http.https://host.com/repo.git.key": []string{".git"},
 		"http.https://host.com/repo.key":     []string{"no .git"},
 		"http.https://host.com/repo2.key":    []string{"no .git"},
+		"http.http://host.com/repo.key":      []string{"http"},
 	})))
 
 	getOne := map[string]string{
@@ -35,6 +36,7 @@ func TestURLConfig(t *testing.T) {
 		"https://host.com/repo2.git/info":             "host-2", // doesn't match /.git/info/lfs\Z/
 		"https://host.com/repo2.git":                  "host-2", // ditto
 		"https://host.com/repo2":                      "no .git",
+		"http://host.com/repo":                        "http",
 	}
 
 	for rawurl, expected := range getOne {

--- a/config/url_config_test.go
+++ b/config/url_config_test.go
@@ -18,6 +18,7 @@ func TestURLConfig(t *testing.T) {
 		"http.https://host.com/repo.key":     []string{"no .git"},
 		"http.https://host.com/repo2.key":    []string{"no .git"},
 		"http.http://host.com/repo.key":      []string{"http"},
+		"http.https://host.*/a.key":          []string{"wild"},
 	})))
 
 	getOne := map[string]string{
@@ -37,6 +38,7 @@ func TestURLConfig(t *testing.T) {
 		"https://host.com/repo2.git":                  "host-2", // ditto
 		"https://host.com/repo2":                      "no .git",
 		"http://host.com/repo":                        "http",
+		"https://host.wild/a/b/c":                     "wild",
 	}
 
 	for rawurl, expected := range getOne {


### PR DESCRIPTION
Rewrite the Git LFS URL-configuration matching to fully match the rules laid out in [the git documentation](https://git-scm.com/docs/git-config#git-config-httplturlgt). 

This largely means that we now support wildcard-matching on hostnames in configuration. There are also a few other minor changes as well, such as support for multiple URL schemes.