### PR TITLE
Improve error message on missing object

### DIFF
--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -347,7 +347,7 @@ func (c *uploadContext) uploadTransfer(p *lfs.WrappedPointer) (*tq.Transfer, err
 	}
 
 	if len(filename) > 0 {
-		if err = c.ensureFile(filename, localMediaPath); err != nil && !errors.IsCleanPointerError(err) {
+		if err = c.ensureFile(filename, localMediaPath, oid); err != nil && !errors.IsCleanPointerError(err) {
 			return nil, err
 		}
 	}
@@ -362,7 +362,7 @@ func (c *uploadContext) uploadTransfer(p *lfs.WrappedPointer) (*tq.Transfer, err
 
 // ensureFile makes sure that the cleanPath exists before pushing it.  If it
 // does not exist, it attempts to clean it by reading the file at smudgePath.
-func (c *uploadContext) ensureFile(smudgePath, cleanPath string) error {
+func (c *uploadContext) ensureFile(smudgePath, cleanPath, oid string) error {
 	if _, err := os.Stat(cleanPath); err == nil {
 		return nil
 	}
@@ -373,7 +373,7 @@ func (c *uploadContext) ensureFile(smudgePath, cleanPath string) error {
 		if c.allowMissing {
 			return nil
 		}
-		return err
+		return errors.Wrapf(err, "Unable to find source for object %v (try running git lfs fetch --all)", oid)
 	}
 
 	defer file.Close()


### PR DESCRIPTION
When attempting a push, we need to ensure that we have every object we want to push.  The object scanner produces pointer objects that contain the object ID of the object we want to push plus the path at which the scanner found the object.  Before pushing, we iterate over every object we want to push and if the object is not found in the LFS object store, we attempt to read the file that is at the path in question to try to create the object.

If that attempt fails since the file is no longer present (i.e., it was present in a previous revision but has since been deleted), we produce an error message that the file could not be opened without any context, causing the user to be confused as to why we would have attempted to open a file that has since been deleted.  Improve this error message by indicating what the actual problem is (that we cannot find the source file), a possible step that they can take to solve it (running git lfs fetch --all), and the error message when attempting to open the file.

This fixes #1113 and #3386.