### PR TITLE
locking: add flag to control modification of ignored files

### DIFF
--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -331,6 +331,12 @@ be scoped inside the configuration for a remote.
   The default is `true`; you can disable this behaviour and have all files
   writeable by setting either variable to 0, 'no' or 'false'.
 
+* `lfs.lockignoredfiles`
+
+  This setting controls whether Git LFS will set ignored files that match the
+  lockable pattern read only as well as tracked files. The default is `false`;
+  you can enable this behavior by setting the variable to 1, 'yes', or 'true'.
+
 * `lfs.defaulttokenttl`
 
   This setting sets a default token TTL when git-lfs-authenticate does not

--- a/locking/lockable.go
+++ b/locking/lockable.go
@@ -123,7 +123,12 @@ func (c *Client) fixFileWriteFlags(absPath, workingDir string, lockable, unlocka
 		errs = append(errs, err)
 	}
 
-	tools.FastWalkGitRepoAll(absPath, func(parentDir string, fi os.FileInfo, err error) {
+	recursor := tools.FastWalkGitRepo
+	if c.ModifyIgnoredFiles {
+		recursor = tools.FastWalkGitRepoAll
+	}
+
+	recursor(absPath, func(parentDir string, fi os.FileInfo, err error) {
 		if err != nil {
 			addErr(err)
 			return

--- a/locking/locks.go
+++ b/locking/locks.go
@@ -53,6 +53,7 @@ type Client struct {
 	LocalWorkingDir          string
 	LocalGitDir              string
 	SetLockableFilesReadOnly bool
+	ModifyIgnoredFiles       bool
 }
 
 // NewClient creates a new locking client with the given configuration
@@ -60,10 +61,11 @@ type Client struct {
 // it
 func NewClient(remote string, lfsClient *lfsapi.Client, cfg *config.Configuration) (*Client, error) {
 	return &Client{
-		Remote: remote,
-		client: &lockClient{Client: lfsClient},
-		cache:  &nilLockCacher{},
-		cfg:    cfg,
+		Remote:             remote,
+		client:             &lockClient{Client: lfsClient},
+		cache:              &nilLockCacher{},
+		cfg:                cfg,
+		ModifyIgnoredFiles: lfsClient.GitEnv().Bool("lfs.lockignoredfiles", false),
 	}, nil
 }
 

--- a/t/t-lock.sh
+++ b/t/t-lock.sh
@@ -250,6 +250,32 @@ begin_test "lock with .gitignore"
   git add .gitignore
   git commit -m ".gitignore: ignore 'a.txt'"
   rm -f a.txt && git checkout a.txt
+  assert_file_writeable a.txt
+)
+end_test
+
+
+begin_test "lock with .gitignore and lfs.lockignoredfiles"
+(
+  set -e
+
+  reponame="lock-with-gitignore-and-ignoredfiles"
+  setup_remote_repo_with_file "$reponame" "a.txt"
+  clone_repo "$reponame" "$reponame"
+
+  git config lfs.lockignoredfiles true
+  echo "*.txt filter=lfs diff=lfs merge=lfs -text lockable" > .gitattributes
+
+  git add .gitattributes
+  git commit -m ".gitattributes: mark 'a.txt' as lockable"
+
+  rm -f a.txt && git checkout a.txt
+  refute_file_writeable a.txt
+
+  echo "*.txt" > .gitignore
+  git add .gitignore
+  git commit -m ".gitignore: ignore 'a.txt'"
+  rm -f a.txt && git checkout a.txt
   refute_file_writeable a.txt
 )
 end_test


### PR DESCRIPTION
In a727fea2 ("locking: remove write permission for ignored files", 2018-08-20), we learned to set and clear the read-only attribute on ignored files that match the lockable pattern, since "git lfs lock" operates on pathspecs, not actual files.

However, in doing so, we caused a regression for people who have ignored files (such as build files) which match the lockable pattern, but should not have their permissions modified.  Since there is no easy way for us to know if the user would like their files modified, add a config option to control this behavior, and leave it at the historical (i.e., pre-a727fea2) default, off.  Add documentation accordingly.

Choosing the historical behavior is compatible with the most existing use cases and preserves the behavior people expect with Git, which is that it does not touch ignored files.

Fixes #3390.
/cc @ttaylorr 
/cc @zach-r-d #3183
/cc @Kitzibua #3390