### PR TITLE
Allow users to specify the credential helper in .lfsconfig

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -118,11 +118,16 @@ func (c *Configuration) getMask() int {
 }
 
 func (c *Configuration) readGitConfig(gitconfigs ...*git.ConfigurationSource) Environment {
-	gf, extensions, uniqRemotes := readGitConfig(gitconfigs...)
+	gf, extensions, uniqRemotes, credHelperKey := readGitConfig(gitconfigs...)
 	c.extensions = extensions
 	c.remotes = make([]string, 0, len(uniqRemotes))
 	for remote := range uniqRemotes {
 		c.remotes = append(c.remotes, remote)
+	}
+	if credHelperKey != "" {
+		if credHelperValue, ok := gf.Get(credHelperKey); ok {
+			c.gitConfig.SetLocal(credHelperKey, credHelperValue)
+		}
 	}
 
 	return EnvironmentOf(gf)

--- a/config/git_fetcher.go
+++ b/config/git_fetcher.go
@@ -15,7 +15,7 @@ type GitFetcher struct {
 	vals map[string][]string
 }
 
-func readGitConfig(configs ...*git.ConfigurationSource) (gf *GitFetcher, extensions map[string]Extension, uniqRemotes map[string]bool) {
+func readGitConfig(configs ...*git.ConfigurationSource) (gf *GitFetcher, extensions map[string]Extension, uniqRemotes map[string]bool, credHelperKey string) {
 	vals := make(map[string][]string)
 	ignored := make([]string, 0)
 
@@ -86,6 +86,9 @@ func readGitConfig(configs ...*git.ConfigurationSource) (gf *GitFetcher, extensi
 				uniqRemotes[remote] = remote == "origin"
 			} else if len(parts) > 2 && parts[len(parts)-1] == "access" {
 				allowed = true
+			} else if len(parts) > 2 && parts[0] == "credential" && parts[len(parts)-1] == "helper" {
+				allowed = true
+				credHelperKey = key
 			}
 
 			if !allowed && keyIsUnsafe(key) {

--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -83,6 +83,11 @@ be scoped inside the configuration for a remote.
 
   Default: `lfs` in Git repository directory (usually `.git/lfs`).
 
+* `credential.https://<host>.helper`
+
+  Sets the Git Credential helper for the host. This can be used to specify the
+  credential helper of the LFS API. This will be copied to the local gitconfig.
+
 ### Transfer (upload / download) settings
 
   These settings control how the upload and download of LFS content occurs.
@@ -345,16 +350,19 @@ The .lfsconfig file in a repository is read and interpreted in the same format
 as the file stored in .git/config. It allows a subset of keys to be used,
 including and limited to:
 
+- lfs.allowincompletepush
 - lfs.fetchexclude
 - lfs.fetchinclude
 - lfs.gitprotocol
+- lfs.locksverify
 - lfs.pushurl
 - lfs.url
 - lfs.extension.{name}.clean
 - lfs.extension.{name}.smudge
 - lfs.extension.{name}.priority
 - remote.{name}.lfsurl
-- remote.{name}.{*}.access
+- lfs.{*}.access
+- credential.{*}.helper
 
 The set of keys allowed in this file is restricted for security reasons.
 


### PR DESCRIPTION
Hello 👋 I'd like to add a credential helper setting in `.lfsconfig` so that the Git LFS will respect it and setup to local git config for me. I'm trying to see if something like this even makes sense or can be considered.

I'm trying to use Git LFS with several different servers across several repositories (the server is actually only one, but the hosts will be different). For example, the repo A will talk to the LFS api/server a.mylfs.com, the repo B will talk b.mylfs.com. These servers have the basic authentication enabled.
I basically want to have some config in the repo (.lfsconfig is good for that) so that only one person need to specify the helper setup and the other contributors will use that helper to talk to the LFS API.

I thought about several options but each has cons:

* netrc way will result lots of entries and potential dirty data (need to add for each a.mylfs.com, b.mylfs.com, ...)
* cred helper + global git config will result lots of entires and potential dirty data too
* cred helper + local git config will require the git config setup for reach repo
* all of above need to know what the LFS server host is beforehand for folks who try to clone the repo or pull from the repo that started using LFS, and clone/pull experience will not be good

I'm also happy to hear any other options or any better way to solve this problem. Thanks!