### PR TITLE
core.sharedRepository improvements for directories

### DIFF
--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -50,7 +50,7 @@ func checkoutCommand(cmd *cobra.Command, args []string) {
 	logger := tasklog.NewLogger(os.Stdout,
 		tasklog.ForceProgress(cfg.ForceProgress()),
 	)
-	meter := tq.NewMeter()
+	meter := tq.NewMeter(cfg)
 	meter.Direction = tq.Checkout
 	meter.Logger = meter.LoggerFromEnv(cfg.Os)
 	logger.Enqueue(meter)

--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -10,6 +10,7 @@ import (
 	"github.com/git-lfs/git-lfs/filepathfilter"
 	"github.com/git-lfs/git-lfs/git"
 	"github.com/git-lfs/git-lfs/lfs"
+	"github.com/git-lfs/git-lfs/tools"
 	"github.com/spf13/cobra"
 )
 
@@ -76,7 +77,7 @@ func fsckCommand(cmd *cobra.Command, args []string) {
 	badDir := filepath.Join(cfg.LFSStorageDir(), "bad")
 	Print("Moving corrupt objects to %s", badDir)
 
-	if err := os.MkdirAll(badDir, 0755); err != nil {
+	if err := tools.MkdirAll(badDir, cfg); err != nil {
 		ExitWithError(err)
 	}
 

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -41,7 +41,7 @@ func pull(filter *filepathfilter.Filter) {
 	logger := tasklog.NewLogger(os.Stdout,
 		tasklog.ForceProgress(cfg.ForceProgress()),
 	)
-	meter := tq.NewMeter()
+	meter := tq.NewMeter(cfg)
 	meter.Logger = meter.LoggerFromEnv(cfg.Os)
 	logger.Enqueue(meter)
 	remote := cfg.Remote()

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -90,9 +90,9 @@ func closeAPIClient() error {
 }
 
 func newLockClient() *locking.Client {
-	lockClient, err := locking.NewClient(cfg.PushRemote(), getAPIClient())
+	lockClient, err := locking.NewClient(cfg.PushRemote(), getAPIClient(), cfg)
 	if err == nil {
-		os.MkdirAll(cfg.LFSStorageDir(), 0755)
+		tools.MkdirAll(cfg.LFSStorageDir(), cfg)
 		err = lockClient.SetupFileCache(cfg.LFSStorageDir())
 	}
 
@@ -142,7 +142,7 @@ func getHookInstallSteps() string {
 	if err != nil {
 		ExitWithError(err)
 	}
-	hooks := lfs.LoadHooks(hookDir)
+	hooks := lfs.LoadHooks(hookDir, cfg)
 	steps := make([]string, 0, len(hooks))
 	for _, h := range hooks {
 		steps = append(steps, fmt.Sprintf(
@@ -158,7 +158,7 @@ func installHooks(force bool) error {
 	if err != nil {
 		return err
 	}
-	hooks := lfs.LoadHooks(hookDir)
+	hooks := lfs.LoadHooks(hookDir, cfg)
 	for _, h := range hooks {
 		if err := h.Install(force); err != nil {
 			return err
@@ -178,7 +178,7 @@ func uninstallHooks() error {
 	if err != nil {
 		return err
 	}
-	hooks := lfs.LoadHooks(hookDir)
+	hooks := lfs.LoadHooks(hookDir, cfg)
 	for _, h := range hooks {
 		if err := h.Uninstall(); err != nil {
 			return err
@@ -343,7 +343,7 @@ func logPanic(loggedError error) string {
 	name := now.Format("20060102T150405.999999999")
 	full := filepath.Join(cfg.LocalLogDir(), name+".log")
 
-	if err := os.MkdirAll(cfg.LocalLogDir(), 0755); err != nil {
+	if err := tools.MkdirAll(cfg.LocalLogDir(), cfg); err != nil {
 		full = ""
 		fmt.Fprintf(fmtWriter, "Unable to log panic to %s: %s\n\n", cfg.LocalLogDir(), err.Error())
 	} else if file, err := os.Create(full); err != nil {
@@ -464,7 +464,7 @@ func determineIncludeExcludePaths(config *config.Configuration, includeArg, excl
 }
 
 func buildProgressMeter(dryRun bool, d tq.Direction) *tq.Meter {
-	m := tq.NewMeter()
+	m := tq.NewMeter(cfg)
 	m.Logger = m.LoggerFromEnv(cfg.Os)
 	m.DryRun = dryRun
 	m.Direction = d

--- a/commands/run.go
+++ b/commands/run.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/git-lfs/git-lfs/config"
+	"github.com/git-lfs/git-lfs/tools"
 	"github.com/spf13/cobra"
 )
 
@@ -117,7 +118,7 @@ func setupHTTPLogger(cmd *cobra.Command, args []string) {
 	}
 
 	logBase := filepath.Join(cfg.LocalLogDir(), "http")
-	if err := os.MkdirAll(logBase, 0755); err != nil {
+	if err := tools.MkdirAll(logBase, cfg); err != nil {
 		fmt.Fprintf(os.Stderr, "Error logging http stats: %s\n", err)
 		return
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -611,6 +611,10 @@ func (c *Configuration) CurrentAuthorTimestamp() time.Time {
 
 // RepositoryPermissions returns the permissions that should be used to write
 // files in the repository.
-func (c *Configuration) RepositoryPermissions() os.FileMode {
-	return os.FileMode(0666 & ^c.getMask())
+func (c *Configuration) RepositoryPermissions(executable bool) os.FileMode {
+	perms := os.FileMode(0666 & ^c.getMask())
+	if executable {
+		return tools.ExecutablePermissions(perms)
+	}
+	return perms
 }

--- a/config/config.go
+++ b/config/config.go
@@ -407,6 +407,7 @@ func (c *Configuration) Filesystem() *fs.Filesystem {
 			c.LocalGitDir(),
 			c.LocalWorkingDir(),
 			lfsdir,
+			c.RepositoryPermissions(false),
 		)
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -188,7 +188,41 @@ func TestRepositoryPermissions(t *testing.T) {
 				"core.sharedrepository": []string{key},
 			},
 		})
-		assert.Equal(t, os.FileMode(val), cfg.RepositoryPermissions())
+		assert.Equal(t, os.FileMode(val), cfg.RepositoryPermissions(false))
+	}
+}
+
+func TestRepositoryPermissionsExectable(t *testing.T) {
+	perms := 0777 & ^umask()
+
+	values := map[string]int{
+		"group":     0770,
+		"true":      0770,
+		"1":         0770,
+		"YES":       0770,
+		"all":       0775,
+		"world":     0775,
+		"everybody": 0775,
+		"2":         0775,
+		"false":     perms,
+		"umask":     perms,
+		"0":         perms,
+		"NO":        perms,
+		"this does not remotely look like a valid value": perms,
+		"0664": 0775,
+		"0666": 0777,
+		"0600": 0700,
+		"0660": 0770,
+		"0644": 0755,
+	}
+
+	for key, val := range values {
+		cfg := NewFrom(Values{
+			Git: map[string][]string{
+				"core.sharedrepository": []string{key},
+			},
+		})
+		assert.Equal(t, os.FileMode(val), cfg.RepositoryPermissions(true))
 	}
 }
 

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -66,7 +66,7 @@ func (f *Filesystem) ObjectExists(oid string, size int64) bool {
 
 func (f *Filesystem) ObjectPath(oid string) (string, error) {
 	dir := f.localObjectDir(oid)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := tools.MkdirAll(dir, f); err != nil {
 		return "", fmt.Errorf("Error trying to create local storage directory in %q: %s", dir, err)
 	}
 	return filepath.Join(dir, oid), nil
@@ -141,7 +141,7 @@ func (f *Filesystem) LFSObjectDir() string {
 
 	if len(f.lfsobjdir) == 0 {
 		f.lfsobjdir = filepath.Join(f.LFSStorageDir, "objects")
-		os.MkdirAll(f.lfsobjdir, 0755)
+		tools.MkdirAll(f.lfsobjdir, f)
 	}
 
 	return f.lfsobjdir
@@ -153,7 +153,7 @@ func (f *Filesystem) LogDir() string {
 
 	if len(f.logdir) == 0 {
 		f.logdir = filepath.Join(f.LFSStorageDir, "logs")
-		os.MkdirAll(f.logdir, 0755)
+		tools.MkdirAll(f.logdir, f)
 	}
 
 	return f.logdir
@@ -165,7 +165,7 @@ func (f *Filesystem) TempDir() string {
 
 	if len(f.tmpdir) == 0 {
 		f.tmpdir = filepath.Join(f.LFSStorageDir, "tmp")
-		os.MkdirAll(f.tmpdir, 0755)
+		tools.MkdirAll(f.tmpdir, f)
 	}
 
 	return f.tmpdir

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -1,6 +1,11 @@
 package fs
 
-import "testing"
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestDecodeNone(t *testing.T) {
 	evaluate(t, "A:\\some\\regular\\windows\\path", "A:\\some\\regular\\windows\\path")
@@ -23,4 +28,17 @@ func evaluate(t *testing.T, input string, expected string) {
 		t.Errorf("Expecting same path, got: %s, want: %s.", output, expected)
 	}
 
+}
+
+func TestRepositoryPermissions(t *testing.T) {
+	m := map[os.FileMode]os.FileMode{
+		0777: 0666,
+		0755: 0644,
+		0700: 0600,
+	}
+	for k, v := range m {
+		fs := Filesystem{repoPerms: v}
+		assert.Equal(t, k, fs.RepositoryPermissions(true))
+		assert.Equal(t, v, fs.RepositoryPermissions(false))
+	}
 }

--- a/lfs/gitfilter_smudge.go
+++ b/lfs/gitfilter_smudge.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (f *GitFilter) SmudgeToFile(filename string, ptr *Pointer, download bool, manifest *tq.Manifest, cb tools.CopyCallback) error {
-	os.MkdirAll(filepath.Dir(filename), 0755)
+	tools.MkdirAll(filepath.Dir(filename), f.cfg)
 
 	if stat, _ := os.Stat(filename); stat != nil && stat.Mode()&0200 == 0 {
 		if err := os.Chmod(filename, stat.Mode()|0200); err != nil {

--- a/lfs/util.go
+++ b/lfs/util.go
@@ -40,7 +40,7 @@ func (f *GitFilter) CopyCallbackFile(event, filename string, index, totalFiles i
 	}
 
 	cbDir := filepath.Dir(logPath)
-	if err := os.MkdirAll(cbDir, 0755); err != nil {
+	if err := tools.MkdirAll(cbDir, f.cfg); err != nil {
 		return nil, nil, wrapProgressError(err, event, logPath)
 	}
 

--- a/lfs/util.go
+++ b/lfs/util.go
@@ -238,7 +238,7 @@ func TempFile(cfg *config.Configuration, pattern string) (*os.File, error) {
 		return nil, err
 	}
 
-	perms := cfg.RepositoryPermissions()
+	perms := cfg.RepositoryPermissions(false)
 	err = os.Chmod(tmp.Name(), perms)
 	if err != nil {
 		tmp.Close()

--- a/locking/locks_test.go
+++ b/locking/locks_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/git-lfs/git-lfs/config"
 	"github.com/git-lfs/git-lfs/git"
 	"github.com/git-lfs/git-lfs/lfsapi"
 	"github.com/git-lfs/git-lfs/lfshttp"
@@ -57,7 +58,7 @@ func TestRemoteLocksWithCache(t *testing.T) {
 	}))
 	require.Nil(t, err)
 
-	client, err := NewClient("", lfsclient)
+	client, err := NewClient("", lfsclient, config.New())
 	assert.Nil(t, err)
 	assert.Nil(t, client.SetupFileCache(tempDir))
 
@@ -163,7 +164,7 @@ func TestRefreshCache(t *testing.T) {
 	}))
 	require.Nil(t, err)
 
-	client, err := NewClient("", lfsclient)
+	client, err := NewClient("", lfsclient, config.New())
 	assert.Nil(t, err)
 	assert.Nil(t, client.SetupFileCache(tempDir))
 
@@ -235,7 +236,7 @@ func TestGetVerifiableLocks(t *testing.T) {
 	}))
 	require.Nil(t, err)
 
-	client, err := NewClient("", lfsclient)
+	client, err := NewClient("", lfsclient, config.New())
 	assert.Nil(t, err)
 
 	ourLocks, theirLocks, err := client.VerifiableLocks(nil, 0)

--- a/t/cmd/util/testutils.go
+++ b/t/cmd/util/testutils.go
@@ -104,6 +104,10 @@ func (r *Repo) Filesystem() *fs.Filesystem {
 	return r.fs
 }
 
+func (r *Repo) Configuration() *config.Configuration {
+	return r.cfg
+}
+
 func (r *Repo) GitConfig() *git.Configuration {
 	return r.cfg.GitConfig()
 }
@@ -180,10 +184,6 @@ func newRepo(callback RepoCallback, settings *RepoCreateSettings) *Repo {
 		ret.GitDir = filepath.Join(ret.Path, ".git")
 	}
 
-	ret.cfg = config.NewIn(ret.Path, ret.GitDir)
-	ret.fs = ret.cfg.Filesystem()
-	ret.gitfilter = lfs.NewGitFilter(ret.cfg)
-
 	args = append(args, path)
 	cmd := exec.Command("git", args...)
 	err = cmd.Run()
@@ -191,6 +191,10 @@ func newRepo(callback RepoCallback, settings *RepoCreateSettings) *Repo {
 		ret.Cleanup()
 		callback.Fatalf("Unable to create git repo at %v: %v", path, err)
 	}
+
+	ret.cfg = config.NewIn(ret.Path, ret.GitDir)
+	ret.fs = ret.cfg.Filesystem()
+	ret.gitfilter = lfs.NewGitFilter(ret.cfg)
 
 	// Configure default user/email so not reliant on env
 	ret.Pushd()

--- a/t/git-lfs-test-server-api/main.go
+++ b/t/git-lfs-test-server-api/main.go
@@ -185,7 +185,7 @@ func buildTestData(repo *t.Repo, manifest *tq.Manifest) (oidsExist, oidsMissing 
 	logger := tasklog.NewLogger(os.Stdout,
 		tasklog.ForceProgress(false),
 	)
-	meter := tq.NewMeter()
+	meter := tq.NewMeter(repo.Configuration())
 	meter.Logger = meter.LoggerFromEnv(repo.OSEnv())
 	logger.Enqueue(meter)
 	commit := t.CommitInput{CommitterName: "A N Other", CommitterEmail: "noone@somewhere.com"}

--- a/t/t-umask.sh
+++ b/t/t-umask.sh
@@ -18,6 +18,11 @@ perms_for () {
   ls -l "$file" | awk '{print $1}'
 }
 
+assert_dir_perms () {
+  local perms="$1"
+  [ "$(find .git/lfs -type d -ls | grep -vE "$perms")" = "" ]
+}
+
 begin_test "honors umask"
 (
   set -e
@@ -30,6 +35,24 @@ begin_test "honors umask"
   umask 007
   echo "random" | git lfs clean | tee clean.log
   [ "$(perms_for 87c1b129fbadd7b6e9abc0a9ef7695436d767aece042bec198a97e949fcbe14c)" = "-rw-rw----" ]
+)
+end_test
+
+begin_test "honors umask for directories"
+(
+  set -e
+  reponame="simple-directories"
+  setup_remote_repo_with_file "$reponame" "a.dat"
+
+  umask 027
+  clone_repo "$reponame" "$reponame-a"
+  echo "whatever" | git lfs clean
+  assert_dir_perms "drwxr-[xs]---"
+
+  umask 007
+  clone_repo "$reponame" "$reponame-b"
+  echo "whatever" | git lfs clean
+  assert_dir_perms "drwxrw[xs]---"
 )
 end_test
 
@@ -56,5 +79,36 @@ begin_test "honors core.sharedrepository"
   echo "who cares" | git lfs clean | tee clean.log
   [ "$(perms_for 261ded5f01a8ca18d9fb1958e8f58c53fa77648cc88a6d67c93d241a91133f3e)" = "-rw-rw----" ]
 
+)
+end_test
+
+begin_test "honors core.sharedrepository for directories"
+(
+  set -e
+  reponame="shared-repo-directories"
+  setup_remote_repo_with_file "$reponame" "a.dat"
+
+  umask 027
+  git config --global core.sharedRepository 0660
+  clone_repo "$reponame" "$reponame-a"
+  echo "whatever" | git lfs clean
+  assert_dir_perms "drwxrw[xs]---"
+
+  git config --global core.sharedRepository everybody
+  clone_repo "$reponame" "$reponame-b"
+  echo "whatever" | git lfs clean
+  assert_dir_perms "drwxrw[xs]r-x"
+
+  git config --global core.sharedRepository false
+  clone_repo "$reponame" "$reponame-c"
+  echo "whatever" | git lfs clean
+  assert_dir_perms "drwxr-[xs]---"
+
+  umask 007
+  clone_repo "$reponame" "$reponame-d"
+  echo "whatever" | git lfs clean
+  assert_dir_perms "drwxrw[xs]---"
+
+  git config --global --unset-all core.sharedRepository
 )
 end_test

--- a/tools/filetools.go
+++ b/tools/filetools.go
@@ -490,3 +490,11 @@ func SetFileWriteFlag(path string, writeEnabled bool) error {
 	}
 	return os.Chmod(path, os.FileMode(mode))
 }
+
+// ExecutablePermissions takes a set of Unix permissions (which may or may not
+// have the executable bits set) and maps them into a set of permissions in
+// which the executable bits are set, using the same technique as Git does.
+func ExecutablePermissions(perms os.FileMode) os.FileMode {
+	// Copy read bits to executable bits.
+	return perms | ((perms & 0444) >> 2)
+}

--- a/tools/filetools_test.go
+++ b/tools/filetools_test.go
@@ -484,3 +484,9 @@ func TestSetWriteFlag(t *testing.T) {
 		assert.EqualValues(t, 0640, getFileMode(filename))
 	}
 }
+
+func TestExecutablePermissions(t *testing.T) {
+	assert.EqualValues(t, os.FileMode(0755), ExecutablePermissions(0644))
+	assert.EqualValues(t, os.FileMode(0750), ExecutablePermissions(0640))
+	assert.EqualValues(t, os.FileMode(0700), ExecutablePermissions(0600))
+}

--- a/tools/umask_nix.go
+++ b/tools/umask_nix.go
@@ -1,0 +1,11 @@
+// +build !windows
+
+package tools
+
+import "syscall"
+
+func doWithUmask(mask int, f func() error) error {
+	mask = syscall.Umask(mask)
+	defer syscall.Umask(mask)
+	return f()
+}

--- a/tools/umask_windows.go
+++ b/tools/umask_windows.go
@@ -1,0 +1,7 @@
+// +build windows
+
+package tools
+
+func doWithUmask(mask int, f func() error) error {
+	return f()
+}

--- a/tq/basic_download.go
+++ b/tq/basic_download.go
@@ -29,7 +29,7 @@ func (a *basicDownloadAdapter) tempDir() string {
 	// Also make local to this repo not global, and separate to localstorage temp,
 	// which gets cleared at the end of every invocation
 	d := filepath.Join(a.fs.LFSStorageDir, "incomplete")
-	if err := os.MkdirAll(d, 0755); err != nil {
+	if err := tools.MkdirAll(d, a.fs); err != nil {
 		return os.TempDir()
 	}
 	return d

--- a/tq/basic_upload.go
+++ b/tq/basic_upload.go
@@ -33,7 +33,7 @@ func (a *basicUploadAdapter) ClearTempStorage() error {
 func (a *basicUploadAdapter) tempDir() string {
 	// Must be dedicated to this adapter as deleted by ClearTempStorage
 	d := filepath.Join(os.TempDir(), "git-lfs-basic-temp")
-	if err := os.MkdirAll(d, 0755); err != nil {
+	if err := tools.MkdirAll(d, a.fs); err != nil {
 		return os.TempDir()
 	}
 	return d

--- a/tq/meter.go
+++ b/tq/meter.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/git-lfs/git-lfs/config"
 	"github.com/git-lfs/git-lfs/tasklog"
 	"github.com/git-lfs/git-lfs/tools"
 	"github.com/git-lfs/git-lfs/tools/humanize"
@@ -32,6 +33,7 @@ type Meter struct {
 	fileIndex         map[string]int64 // Maps a file name to its transfer number
 	fileIndexMutex    *sync.Mutex
 	updates           chan *tasklog.Update
+	cfg               *config.Configuration
 
 	DryRun    bool
 	Logger    *tools.SyncWriter
@@ -60,7 +62,7 @@ func (m *Meter) LoggerToFile(name string) *tools.SyncWriter {
 		return nil
 	}
 
-	if err := os.MkdirAll(filepath.Dir(name), 0755); err != nil {
+	if err := tools.MkdirAll(filepath.Dir(name), m.cfg); err != nil {
 		printErr(err.Error())
 		return nil
 	}
@@ -75,11 +77,12 @@ func (m *Meter) LoggerToFile(name string) *tools.SyncWriter {
 }
 
 // NewMeter creates a new Meter.
-func NewMeter() *Meter {
+func NewMeter(cfg *config.Configuration) *Meter {
 	m := &Meter{
 		fileIndex:      make(map[string]int64),
 		fileIndexMutex: &sync.Mutex{},
 		updates:        make(chan *tasklog.Update),
+		cfg:            cfg,
 	}
 
 	return m


### PR DESCRIPTION
In de1954d6384c27c63f96e9002a61497f36493fb7, we taught Git LFS how to deal with core.sharedRepository. However, in doing so, we only taught it about files, and not directories. This causes problems not only for clones, but for many situations, since we create directories on demand.

Add a new function that creates directories with the permissions specified in `core.sharedRepository` and use it throughout the codebase where we need to create a directory.

This fixes #3407.