### PR TITLE
Ensure 32-bit Git LFS binaries can handle files larger than 4 GiB

### DIFF
--- a/lfs/pointer.go
+++ b/lfs/pointer.go
@@ -164,7 +164,7 @@ func decodeKV(data []byte) (*Pointer, error) {
 	}
 
 	value, ok = kvps["size"]
-	size, err := strconv.ParseInt(value, 10, 0)
+	size, err := strconv.ParseInt(value, 10, 64)
 	if err != nil || size < 0 {
 		return nil, fmt.Errorf("Invalid size: %q", value)
 	}


### PR DESCRIPTION
When parsing pointers, we parsed the size of the object using ParseInt with a third argument of 0. This caused the argument to be parsed as an int, which on 32-bit systems is 32 bits in size. Consequently, when we had an object larger than 4 GiB in size on a 32-bit system, we would reject the pointer file as invalid and never realize the object needed to be pushed, leading to the server side rejecting our pushes due to missing objects.

Set the size of the integer we're parsing to 64 bits to ensure that we can always parse a pointer correctly. With this change, we can handle files larger than 4 GiB on 32-bit binaries.

I have opted not to add a test to this case because the processing time to hash a 4 GiB file is significant and the test would be fairly slow, but if people feel strongly that we should add one anyway, I can do that. Note that this would likely not affect CI, because I believe all of those systems are 64 bit.