### PR TITLE
Trim embedded paths out of binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,11 +34,13 @@ EXTRA_LD_FLAGS =
 LD_FLAGS = $(BUILTIN_LD_FLAGS) $(EXTRA_LD_FLAGS)
 
 # BUILTIN_GC_FLAGS are the internal flags used to pass compiler.
-BUILTIN_GC_FLAGS =
+BUILTIN_GC_FLAGS ?= all=-trimpath="$$HOME"
 # EXTRA_GC_FLAGS are the caller-provided flags to pass to the compiler.
 EXTRA_GC_FLAGS =
 # GC_FLAGS are the union of the above two BUILTIN_GC_FLAGS and EXTRA_GC_FLAGS.
 GC_FLAGS = $(BUILTIN_GC_FLAGS) $(EXTRA_GC_FLAGS)
+
+ASM_FLAGS ?= all=-trimpath="$$HOME"
 
 # RONN is the name of the 'ronn' program used to generate man pages.
 RONN ?= ronn
@@ -131,6 +133,7 @@ BUILD = GOOS=$(1) GOARCH=$(2) \
 	$(GO) build \
 	-ldflags="$(LD_FLAGS)" \
 	-gcflags="$(GC_FLAGS)" \
+	-asmflags="$(ASM_FLAGS)" \
 	-o ./bin/git-lfs$(3) $(BUILD_MAIN)
 
 # BUILD_TARGETS is the set of all platforms and architectures that Git LFS is


### PR DESCRIPTION
When building binaries, Go embeds the source filenames into the binaries, meaning that on most systems, the build directory is embedded into the binary. This means that binaries are not reproducible when built by other users and in addition that the layout of the building user's system is embedded into the binary.

Go provides an option to trim paths out of the ones stored in the binary, but unfortunately this only works for one path, and since git-lfs is now built outside the GOPATH to take advantage of modules, there are two paths that need to be stripped.

For the benefit of build reproducibility and general build hygiene, let's strip out the user's home directory when building the binary. This is better than the status quo, and we can improve this later if circumstances change.