### PR TITLE
Makefile additions for reproducible builds and asmflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ BUILTIN_LD_FLAGS += -s
 BUILTIN_LD_FLAGS += -w
 endif
 # EXTRA_LD_FLAGS are given by the caller, and are passed to the Go linker after
-# BUILTIN_LD_FLAGS are processed.
-EXTRA_LD_FLAGS =
+# BUILTIN_LD_FLAGS are processed. By default the system LDFLAGS are passed.
+EXTRA_LD_FLAGS ?= -extldflags ${LDFLAGS}
 # LD_FLAGS is the union of the above two BUILTIN_LD_FLAGS and EXTRA_LD_FLAGS.
 LD_FLAGS = $(BUILTIN_LD_FLAGS) $(EXTRA_LD_FLAGS)
 


### PR DESCRIPTION
This patch set include setting `$LDFLAGS` as a default `EXTRA_LD_FLAGS` parameter for supporting system linked flags. `trimpath` is set as a default for `BUILTIN_GC_FLAGS` so we are able to support [reproducible builds](https://reproducible-builds.org/) in the Makefile without any extra additions. Also added support for passing `-asmflags` to `go build` as we have support for `-ldflags` and `-gcflags`. This has the same variable for trimpath set as a default.

I also think enabling PIE by default with `-buildmode=pie` should be considered. However that has caused problems for other projects so it should be up to the developers if they want to support this as a default setting or not.