### PR TITLE
Add support for retries with delays (ex. rate limiting)

### DIFF
--- a/lfshttp/errors.go
+++ b/lfshttp/errors.go
@@ -3,9 +3,7 @@ package lfshttp
 import (
 	"fmt"
 	"net/http"
-	"strconv"
 	"strings"
-	"time"
 
 	"github.com/git-lfs/git-lfs/errors"
 )
@@ -67,16 +65,9 @@ func (c *Client) handleResponse(res *http.Response) error {
 	if res.StatusCode == 429 {
 		// The Retry-After header could be set, check to see if it exists.
 		h := res.Header.Get("Retry-After")
-		if h != "" {
-			retryAfter, err := strconv.Atoi(h)
-			if err == nil {
-				return errors.NewRetriableLaterErrorFromDelay(err, retryAfter)
-			}
-
-			date, err := time.Parse(time.RFC1123, h)
-			if err == nil {
-				return errors.NewRetriableLaterErrorFromTime(err, date)
-			}
+		retLaterErr := errors.NewRetriableLaterError(err, h)
+		if retLaterErr != nil {
+			return retLaterErr
 		}
 	}
 

--- a/t/t-batch-retries-ratelimit.sh
+++ b/t/t-batch-retries-ratelimit.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+. "$(dirname "$0")/testlib.sh"
+
+begin_test "batch storage upload causes retries"
+(
+  set -e
+
+  reponame="batch-storage-upload-retry-later"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" batch-storage-repo-upload
+
+  contents="storage-upload-retry-later"
+  oid="$(calc_oid "$contents")"
+  printf "%s" "$contents" > a.dat
+
+  git lfs track "*.dat"
+  git add .gitattributes a.dat
+  git commit -m "initial commit"
+
+  GIT_TRACE=1 git push origin master 2>&1 | tee push.log
+  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected \`git push origin master\` to succeed ..."
+    exit 1
+  fi
+
+  assert_server_object "$reponame" "$oid"
+)
+end_test
+
+begin_test "batch storage download causes retries"
+(
+  set -e
+
+  reponame="batch-storage-download-retry-later"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" batch-storage-repo-download
+
+  contents="storage-download-retry-later"
+  oid="$(calc_oid "$contents")"
+  printf "%s" "$contents" > a.dat
+
+  git lfs track "*.dat"
+  git add .gitattributes a.dat
+  git commit -m "initial commit"
+
+  git push origin master
+  assert_server_object "$reponame" "$oid"
+
+  pushd ..
+    git \
+      -c "filter.lfs.process=" \
+      -c "filter.lfs.smudge=cat" \
+      -c "filter.lfs.required=false" \
+      clone "$GITSERVER/$reponame" "$reponame-assert"
+
+    cd "$reponame-assert"
+
+    git config credential.helper lfstest
+
+    GIT_TRACE=1 git lfs pull origin master 2>&1 | tee pull.log
+    if [ "0" -ne "${PIPESTATUS[0]}" ]; then
+      echo >&2 "fatal: expected \`git lfs pull origin master\` to succeed ..."
+      exit 1
+    fi
+
+	assert_local_object "$oid" "${#contents}"
+  popd
+)
+end_test

--- a/tq/basic_download.go
+++ b/tq/basic_download.go
@@ -119,6 +119,15 @@ func (a *basicDownloadAdapter) download(t *Transfer, cb ProgressCallback, authOk
 			os.Remove(dlFile.Name())
 			return a.download(t, cb, authOkFunc, nil, 0, nil)
 		}
+
+		// Special-cae status code 429 - retry after certain time
+		if res.StatusCode == 429 {
+			retLaterErr := errors.NewRetriableLaterError(err, res.Header["Retry-After"][0])
+			if retLaterErr != nil {
+				return retLaterErr
+			}
+		}
+
 		return errors.NewRetriableError(err)
 	}
 

--- a/tq/basic_upload.go
+++ b/tq/basic_upload.go
@@ -123,6 +123,12 @@ func (a *basicUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb Progres
 			err = errors.Wrap(err, perr.Error())
 		}
 
+		if res.StatusCode == 429 {
+			retLaterErr := errors.NewRetriableLaterError(err, res.Header["Retry-After"][0])
+			if retLaterErr != nil {
+				return retLaterErr
+			}
+		}
 		return errors.NewRetriableError(err)
 	}
 


### PR DESCRIPTION
Fixes #3122 
This pull request introduces a new type of error which contains information regarding "Retry-After" header when a rate limit is hit. The error then behaves similar to the is-retriable error, except that this doesn't get re-added to the queue immediately, but rather waits until the time is up.

To test this I modified the git-lfs/lfs-test-server server to rate limit requests (maybe I can clean this up and make a PR for this as well), though I guess some automatic test would be needed. What would you suggest for this?