### PR TITLE
Modify logic of 'migrate info' to process extensionless files

### DIFF
--- a/commands/command_migrate_info.go
+++ b/commands/command_migrate_info.go
@@ -74,22 +74,29 @@ func migrateInfoCommand(cmd *cobra.Command, args []string) {
 		BlobFn: func(path string, b *gitobj.Blob) (*gitobj.Blob, error) {
 			ext := fmt.Sprintf("*%s", filepath.Ext(path))
 
+			// If extension exists, group all items under extension,
+			// else just use the file name.
+			var groupName string
 			if len(ext) > 1 {
-				entry := exts[ext]
-				if entry == nil {
-					entry = &MigrateInfoEntry{Qualifier: ext}
-				}
-
-				entry.Total++
-				entry.BytesTotal += b.Size
-
-				if b.Size > int64(migrateInfoAbove) {
-					entry.TotalAbove++
-					entry.BytesAbove += b.Size
-				}
-
-				exts[ext] = entry
+				groupName = ext
+			} else {
+				groupName = filepath.Base(path)
 			}
+
+			entry := exts[groupName]
+			if entry == nil {
+				entry = &MigrateInfoEntry{Qualifier: groupName}
+			}
+
+			entry.Total++
+			entry.BytesTotal += b.Size
+
+			if b.Size > int64(migrateInfoAbove) {
+				entry.TotalAbove++
+				entry.BytesAbove += b.Size
+			}
+
+			exts[groupName] = entry
 
 			return b, nil
 		},

--- a/t/fixtures/migrate.sh
+++ b/t/fixtures/migrate.sh
@@ -203,6 +203,32 @@ setup_multiple_local_branches() {
   git checkout master
 }
 
+# setup_multiple_local_branches_with_alternate_names performs the same task
+# as setup_multiple_local_branches, but creates a file with no extension.
+setup_multiple_local_branches_with_alternate_names() {
+  set -e
+
+  reponame="migrate-info-multiple-local-branches"
+
+  remove_and_create_local_repo "$reponame"
+
+  base64 < /dev/urandom | head -c 120 > no_extension
+  base64 < /dev/urandom | head -c 140 > a.txt
+
+  git add no_extension a.txt
+  git commit -m "initial commit"
+
+  git checkout -b my-feature
+
+  base64 < /dev/urandom | head -c 30 > a.txt
+  base64 < /dev/urandom | head -c 100 > no_extension
+
+  git add no_extension a.txt
+  git commit -m "add an additional 30 bytes to a.txt"
+
+  git checkout master
+}
+
 # setup_multiple_local_branches_with_gitattrs creates a repository in the same way
 # as setup_multiple_local_branches, but also adds relevant lfs filters to the
 # .gitattributes file in the master branch

--- a/t/t-migrate-info.sh
+++ b/t/t-migrate-info.sh
@@ -344,6 +344,31 @@ begin_test "migrate info (empty set)"
 )
 end_test
 
+begin_test "migrate info (no-extension files)"
+(
+  set -e
+
+  setup_multiple_local_branches_with_alternate_names
+  git checkout master
+
+  original_master="$(git rev-parse refs/heads/master)"
+  original_feature="$(git rev-parse refs/heads/my-feature)"
+
+  git lfs migrate info --everything
+
+  diff -u <(git lfs migrate info --everything 2>&1 | tail -n 2) <(cat <<-EOF
+	no_extension	220 B	2/2 files(s)	100%
+	*.txt       	170 B	2/2 files(s)	100%
+	EOF)
+
+  migrated_master="$(git rev-parse refs/heads/master)"
+  migrated_feature="$(git rev-parse refs/heads/my-feature)"
+
+  assert_ref_unmoved "refs/heads/master" "$original_master" "$migrated_master"
+  assert_ref_unmoved "refs/heads/my-feature" "$original_feature" "$migrated_feature"
+)
+end_test
+
 begin_test "migrate info (--everything)"
 (
   set -e


### PR DESCRIPTION
Fixes #3453

It seems like to fix this, the the name to group the collection of file sizes should fall back to the file name if no extension exists. This leads to output that looks like this:

```
large5noext	315 MB	  1/1 files(s)	100%
*.c        	315 MB	  1/1 files(s)	100%
*.go       	98 KB 	11/11 files(s)	100%
LICENSE    	35 KB 	  1/1 files(s)	100%
*.sed      	25 KB 	45/45 files(s)	100% 