### PR TITLE
command/env: ensure we honor lfs.url

### DIFF
--- a/commands/command_env.go
+++ b/commands/command_env.go
@@ -36,7 +36,7 @@ func envCommand(cmd *cobra.Command, args []string) {
 		if remote == defaultRemote {
 			continue
 		}
-		remoteEndpoint := getAPIClient().Endpoints.RemoteEndpoint("download", remote)
+		remoteEndpoint := getAPIClient().Endpoints.Endpoint("download", remote)
 		remoteAccess := getAPIClient().Endpoints.AccessFor(remoteEndpoint.Url)
 		Print("Endpoint (%s)=%s (auth=%s)", remote, remoteEndpoint.Url, remoteAccess.Mode())
 		if len(remoteEndpoint.SshUserAndHost) > 0 {

--- a/t/t-env.sh
+++ b/t/t-env.sh
@@ -239,7 +239,6 @@ begin_test "env with multiple remotes and lfs.url config"
   git remote add other "$GITSERVER/env-other-remote"
   git config lfs.url "http://foo/bar"
 
-  endpoint="$GITSERVER/env-other-remote.git/info/lfs (auth=none)"
   localwd=$(native_path "$TRASHDIR/$reponame")
   localgit=$(native_path "$TRASHDIR/$reponame/.git")
   localgitstore=$(native_path "$TRASHDIR/$reponame/.git")
@@ -251,67 +250,7 @@ begin_test "env with multiple remotes and lfs.url config"
 %s
 
 Endpoint=http://foo/bar (auth=none)
-Endpoint (other)=%s
-LocalWorkingDir=%s
-LocalGitDir=%s
-LocalGitStorageDir=%s
-LocalMediaDir=%s
-LocalReferenceDirs=
-TempDir=%s
-ConcurrentTransfers=3
-TusTransfers=false
-BasicTransfersOnly=false
-SkipDownloadErrors=false
-FetchRecentAlways=false
-FetchRecentRefsDays=7
-FetchRecentCommitsDays=0
-FetchRecentRefsIncludeRemotes=true
-PruneOffsetDays=3
-PruneVerifyRemoteAlways=false
-PruneRemoteName=origin
-LfsStorageDir=%s
-AccessDownload=none
-AccessUpload=none
-DownloadTransfers=basic
-UploadTransfers=basic
-%s
-%s
-' "$(git lfs version)" "$(git version)" "$endpoint" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")
-  actual=$(git lfs env | grep -v "^GIT_EXEC_PATH=")
-  contains_same_elements "$expected" "$actual"
-
-  cd .git
-  expected2=$(echo "$expected" | sed -e 's/LocalWorkingDir=.*/LocalWorkingDir=/')
-  actual2=$(git lfs env | grep -v "^GIT_EXEC_PATH=")
-  contains_same_elements "$expected2" "$actual2"
-)
-end_test
-
-begin_test "env with multiple remotes and lfs configs"
-(
-  set -e
-  reponame="env-multiple-remotes-lfs-configs"
-  mkdir $reponame
-  cd $reponame
-  git init
-  git remote add origin "$GITSERVER/env-origin-remote"
-  git remote add other "$GITSERVER/env-other-remote"
-  git config lfs.url "http://foo/bar"
-  git config remote.origin.lfsurl "http://custom/origin"
-  git config remote.other.lfsurl "http://custom/other"
-
-  localwd=$(native_path "$TRASHDIR/$reponame")
-  localgit=$(native_path "$TRASHDIR/$reponame/.git")
-  localgitstore=$(native_path "$TRASHDIR/$reponame/.git")
-  lfsstorage=$(native_path "$TRASHDIR/$reponame/.git/lfs")
-  localmedia=$(native_path "$TRASHDIR/$reponame/.git/lfs/objects")
-  tempdir=$(native_path "$TRASHDIR/$reponame/.git/lfs/tmp")
-  envVars=$(printf "%s" "$(env | grep "^GIT")")
-  expected=$(printf '%s
-%s
-
-Endpoint=http://foo/bar (auth=none)
-Endpoint (other)=http://custom/other (auth=none)
+Endpoint (other)=http://foo/bar (auth=none)
 LocalWorkingDir=%s
 LocalGitDir=%s
 LocalGitStorageDir=%s
@@ -347,7 +286,67 @@ UploadTransfers=basic
 )
 end_test
 
-begin_test "env with multiple remotes and lfs url and batch configs"
+begin_test "env with multiple remotes and lfs configs"
+(
+  set -e
+  reponame="env-multiple-remotes-lfs-configs"
+  mkdir $reponame
+  cd $reponame
+  git init
+  git remote add origin "$GITSERVER/env-origin-remote"
+  git remote add other "$GITSERVER/env-other-remote"
+  git config lfs.url "http://foo/bar"
+  git config remote.origin.lfsurl "http://custom/origin"
+  git config remote.other.lfsurl "http://custom/other"
+
+  localwd=$(native_path "$TRASHDIR/$reponame")
+  localgit=$(native_path "$TRASHDIR/$reponame/.git")
+  localgitstore=$(native_path "$TRASHDIR/$reponame/.git")
+  lfsstorage=$(native_path "$TRASHDIR/$reponame/.git/lfs")
+  localmedia=$(native_path "$TRASHDIR/$reponame/.git/lfs/objects")
+  tempdir=$(native_path "$TRASHDIR/$reponame/.git/lfs/tmp")
+  envVars=$(printf "%s" "$(env | grep "^GIT")")
+  expected=$(printf '%s
+%s
+
+Endpoint=http://foo/bar (auth=none)
+Endpoint (other)=http://foo/bar (auth=none)
+LocalWorkingDir=%s
+LocalGitDir=%s
+LocalGitStorageDir=%s
+LocalMediaDir=%s
+LocalReferenceDirs=
+TempDir=%s
+ConcurrentTransfers=3
+TusTransfers=false
+BasicTransfersOnly=false
+SkipDownloadErrors=false
+FetchRecentAlways=false
+FetchRecentRefsDays=7
+FetchRecentCommitsDays=0
+FetchRecentRefsIncludeRemotes=true
+PruneOffsetDays=3
+PruneVerifyRemoteAlways=false
+PruneRemoteName=origin
+LfsStorageDir=%s
+AccessDownload=none
+AccessUpload=none
+DownloadTransfers=basic
+UploadTransfers=basic
+%s
+%s
+' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")
+  actual=$(git lfs env | grep -v "^GIT_EXEC_PATH=")
+  contains_same_elements "$expected" "$actual"
+
+  cd .git
+  expected2=$(echo "$expected" | sed -e 's/LocalWorkingDir=.*/LocalWorkingDir=/')
+  actual2=$(git lfs env | grep -v "^GIT_EXEC_PATH=")
+  contains_same_elements "$expected2" "$actual2"
+)
+end_test
+
+begin_test "env with multiple remotes and batch configs"
 (
   set -e
   reponame="env-multiple-remotes-lfs-batch-configs"
@@ -356,9 +355,8 @@ begin_test "env with multiple remotes and lfs url and batch configs"
   git init
   git remote add origin "$GITSERVER/env-origin-remote"
   git remote add other "$GITSERVER/env-other-remote"
-  git config lfs.url "http://foo/bar"
   git config lfs.concurrenttransfers 5
-  git config remote.origin.lfsurl "http://custom/origin"
+  git config remote.origin.lfsurl "http://foo/bar"
   git config remote.other.lfsurl "http://custom/other"
 
   localwd=$(native_path "$TRASHDIR/$reponame")


### PR DESCRIPTION
When we attempt to look up an endpoint to push to or pull from a remote, we call the endpoint finder's Endpoint method, which honors lfs.url, not the RemoteEndpoint method, which does not. However, when enumerating remotes in git lfs env, we call RemoteEndpoint, which means we produce the wrong endpoint if the lfs.url option is set.

Update the code to call the correct method, so that we get the correct results. Since the tests check for this case and print the old information (which doesn't match what we actually do), update them as well. Now that we have several tests that produce similar output because they all use lfs.url, update one of the tests to test more useful cases by removing the use of lfs.url.

Fixes #3469.