### PR TITLE
TST: Trim security context when checking permissions.

### DIFF
--- a/t/t-umask.sh
+++ b/t/t-umask.sh
@@ -15,7 +15,9 @@ clean_setup () {
 
 perms_for () {
   local file=$(echo "$1" | sed "s!^\(..\)\(..\)!.git/lfs/objects/\1/\2/\1\2!")
-  ls -l "$file" | awk '{print $1}'
+  local perms=$(ls -l "$file" | awk '{print $1}')
+  # Trim extended attributes:
+  echo ${perms:0:10}
 }
 
 assert_dir_perms () {


### PR DESCRIPTION
This fixes the umask tests on a file system that uses security context, as that prints out an extra dot in the permissions.

This is something that occurs on, e.g., Fedora which uses SELinux contexts on all files.