### PR TITLE
Fix parameter name on List Locks API Documentation

### DIFF
--- a/docs/api/locking.md
+++ b/docs/api/locking.md
@@ -158,11 +158,11 @@ The properties are sent as URI query values, instead of through a JSON body:
 should be the `next_cursor` from a previous request.
 * `limit` - The integer limit of the number of locks to return. The server
 should have its own upper and lower bounds on the supported limits.
-* `ref` - Optional fully qualified server refspec
+* `refspec` - Optional fully qualified server refspec
 from which to search for locks.
 
 ```js
-// GET https://lfs-server.com/locks?path=&id=&cursor=&limit=
+// GET https://lfs-server.com/locks?path=&id=&cursor=&limit=&refspec=
 // Accept: application/vnd.git-lfs+json
 // Authorization: Basic ... (if needed)
 ```


### PR DESCRIPTION
On locks listing, the git-lfs client is not querying the `ref` parameter but the `refspec` one. Fix the documentation accordingly.

For reference: https://github.com/git-lfs/git-lfs/blame/84f47a430beb9695ceb8427443f304e091128edd/locking/api.go#156-L157