### PR TITLE
lfshttp: close body on redirect

### DIFF
--- a/lfshttp/client.go
+++ b/lfshttp/client.go
@@ -322,6 +322,8 @@ func (c *Client) DoWithRedirect(cli *http.Client, req *http.Request, remote stri
 		return nil, res, err
 	}
 
+	res.Body.Close()
+
 	return redirectedReq, nil, nil
 }
 


### PR DESCRIPTION
If a redirect occurs, we don't close the HTTP body, forcing us to leave the current connection open and causing us to eventually run out of file handles. Ensure we close the body if we're not using it so that we can reuse the connection, which is both more efficient and nicer to the remote server.

I'm not aware of a good way to test this, although I'm open to suggestions if someone has some.

Fixes #3446.

/cc @snichols and @Socolin, who saw this problem