### PR TITLE
Run go generate only on Windows

### DIFF
--- a/git-lfs.go
+++ b/git-lfs.go
@@ -1,5 +1,3 @@
-//go:generate goversioninfo
-
 package main
 
 import (

--- a/git-lfs_windows.go
+++ b/git-lfs_windows.go
@@ -1,0 +1,4 @@
+//+build windows
+//go:generate goversioninfo
+
+package main


### PR DESCRIPTION
On Windows, we want to run `goversioninfo`, which embeds certain version information into Windows binaries. However, despite compiling and running on non-Windows systems, it isn't very useful there. Move the `go:generate` comment into a separate file that's only built on Windows.

This improves the lives of packagers on Debian, where the packaging tools want to run `go generate` by default.

I've confirmed that running `go generate` produces a `resource.syso` file on Windows and does not on macOS.

Fixes #3473.

/cc @ssgelm