### PR TITLE
status: handle deleted files gracefully

### DIFF
--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -145,6 +145,9 @@ func blobInfo(s *lfs.PointerScanner, blobSha, name string) (sha, from string, er
 	}
 
 	f, err := os.Open(filepath.Join(cfg.LocalWorkingDir(), name))
+	if os.IsNotExist(err) {
+		return "deleted", "File", nil
+	}
 	if err != nil {
 		return "", "", err
 	}


### PR DESCRIPTION
If a had a file (either Git LFS or plain Git) that was deleted with git rm but not yet committed, git lfs status would produce an error indicating that the file could not be opened. Since this is not helpful, if the user has deleted the file, instead indicate this by showing that the behavior to be committed is a file deletion.

Note that we will only traverse this code path when the destination Git hash is all zeros (indicating a deleted or missing file).
