### PR TITLE
docs/man: update `git-lfs-fetch(1)` manpage

### DIFF
--- a/docs/man/git-lfs-fetch.1.ronn
+++ b/docs/man/git-lfs-fetch.1.ronn
@@ -40,10 +40,10 @@ You can configure Git LFS to only fetch objects to satisfy references in certain
 paths of the repo, and/or to exclude certain paths of the repo, to reduce the
 time you spend downloading things you do not use.
 
-In gitconfig, set lfs.fetchinclude and lfs.fetchexclude to comma-separated lists
-of paths to include/exclude in the fetch (pattern matching as per golang's
-`filepath.Match()`).  Only paths which are matched by fetchinclude and not
-matched by fetchexclude will have objects fetched for them.
+In gitconfig, set `lfs.fetchinclude` and `lfs.fetchexclude` to comma-separated
+lists of paths to include/exclude in the fetch (pattern matching as per golang's
+`filepath.Match()`). Only paths which are matched by `fetchinclude` and not
+matched by `fetchexclude` will have objects fetched for them.
 
 ### Examples:
 

--- a/docs/man/git-lfs-fetch.1.ronn
+++ b/docs/man/git-lfs-fetch.1.ronn
@@ -41,9 +41,9 @@ paths of the repo, and/or to exclude certain paths of the repo, to reduce the
 time you spend downloading things you do not use.
 
 In gitconfig, set `lfs.fetchinclude` and `lfs.fetchexclude` to comma-separated
-lists of paths to include/exclude in the fetch (pattern matching as per golang's
-`filepath.Match()`). Only paths which are matched by `fetchinclude` and not
-matched by `fetchexclude` will have objects fetched for them.
+lists of paths to include/exclude in the fetch. Only paths which are matched by
+`fetchinclude` and not matched by `fetchexclude` will have objects fetched for
+them.
 
 ### Examples:
 


### PR DESCRIPTION
Since [1], we have remarked that the `--include` and `--exclude` options
belonging to `git-lfs-fetch(1)` were subject to the file matching rules
of package `path/filepath`'s `Match()` implementation.

Since [2], however, this is no longer accurate: the implementation of
`filepathfilter.New()` converts its arguments to wildmatch-style
semantics, which do _not_ follow the rules of the aforementioned
`path/filepath.Match()`, and instead adhere to Git's guidelines.

The relevant call-chain is as follows:

  1. `commands/command_fetch.go` calls `buildFilepathFilter`.
  2. `buildFilepathFilter` calls `determineIncludeExcludePaths`, and
     then calls `filepathfilter.New()`.
  3. Finally, `filepathfilter.New()` calls `wildmatch.New()` after doing
     some sanitization.

Since the behavior that we are deviating from is adherent to Git's
behavior in similar circumstances, let's avoid explicitly documenting it
as such, since it is a reasonable inference from the context.

[1]: 7926b505 (update fetch include/exclude docs for pattern matching,
     2016-08-16)
[2]: 629a935b (filepathfilter: implement in terms of wildmatch,
     2018-02-07)

##

/cc @git-lfs/core 
/cc @darxriggs https://github.com/git-lfs/git-lfs/commit/7926b505018e37b9cb1b3f6562ee1eff6a2cb4f9#r32029395