### PR TITLE
docs/man: fix inconsistency in 'git-lfs-ls-files(1)'

### DIFF
--- a/docs/man/git-lfs-ls-files.1.ronn
+++ b/docs/man/git-lfs-ls-files.1.ronn
@@ -9,7 +9,8 @@ git-lfs-ls-files(1) -- Show information about Git LFS files in the index and wor
 
 Display paths of Git LFS files that are found in the tree at the given
 reference.  If no reference is given, scan the currently checked-out branch.
-An asterisk (*) after the OID indicates a LFS pointer, a minus (-) a full object.
+An asterisk (*) after the OID indicates a full object, a minus (-) indicates an
+LFS pointer.
 
 ## OPTIONS
 


### PR DESCRIPTION
In [1], `git lfs ls-files` learned how to print either a '*' or '-' to
indicate a full, or un-smudged LFS pointer, respectively. Likewise, in
[2], the 'git-lfs-ls-files(1)' manual page was updated to include
documentation describing what the new '*' and '-' symbols mean.

Unfortunately, the change in [2] referred to the symbols by their
opposite meaning. Reverse the documentation to make sure that the
meanings listed match the implementation in code.

[1]: 2082b26c (tweak ls-files output, 2015-09-25)
[2]: d7e9960a (Added documentation git-lfs-ls-files' */- output.,
     2017-11-07)

##

/cc @git-lfs/core 
/cc https://github.com/git-lfs/git-lfs/pull/2719#issuecomment-452917172