### PR TITLE
docs/man/git-lfs-config.5.ronn: document GIT_LFS_SKIP_SMUDGE

### DIFF
--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -322,6 +322,14 @@ be scoped inside the configuration for a remote.
   standard output stream is not a terminal by setting either variable to 1,
   'yes' or 'true'.
 
+* `GIT_LFS_SKIP_SMUDGE`
+
+  Sets whether or not Git LFS will skip attempting to convert pointers of files
+  tracked into their corresponding objects when checked out into a working copy.
+  If 'true', '1', 'on', or similar, Git LFS will skip the smudge process in both
+  `git lfs smudge` and `git lfs filter-process`. If unset, or set to 'false',
+  '0', 'off', or similar, Git LFS will smudge files as normal.
+
 * `GIT_LFS_SET_LOCKABLE_READONLY`
   `lfs.setlockablereadonly`
 

--- a/docs/man/git-lfs-filter-process.1.ronn
+++ b/docs/man/git-lfs-filter-process.1.ronn
@@ -24,6 +24,9 @@ Without any options, filter-process accepts and responds to requests normally.
 * `--skip`:
     Skip automatic downloading of objects on clone or pull.
 
+* `GIT_LFS_SKIP_SMUDGE`:
+    Disables the smudging process. For more, see: git-lfs-config(5).
+
 ## SEE ALSO
 
 git-lfs-clean(1), git-lfs-install(1), git-lfs-smudge(1), gitattributes(5).

--- a/docs/man/git-lfs-smudge.1.ronn
+++ b/docs/man/git-lfs-smudge.1.ronn
@@ -24,6 +24,9 @@ standard output.
 * `--skip`:
     Skip automatic downloading of objects on clone or pull.
 
+* `GIT_LFS_SKIP_SMUDGE`:
+    Disables the smudging process. For more, see: git-lfs-config(5).
+
 ## KNOWN BUGS
 
 On Windows, Git does not handle files in the working tree larger than 4


### PR DESCRIPTION
Since its inception in [1], the `GIT_LFS_SKIP_SMUDGE` environment
variable has not been documented. This feature is not meant to be
hidden, so let's document how it works in `git-lfs-config.5` in case
users are interested in it.

Let's write this in `git-lfs-config(5)` since this is where environment
variables that aren't tied to a particular command go. We note its
existence in the related manual pages (e.g., `git-lfs-smudge(1)` and
`git-lfs-filter-process(1)`) but refer to the authoritative source in
`git-lfs-config(5)`.

[1]: 8cd51c00 (rename the options to SKIP_SMUDGE and --skip-smudge,
     2015-09-23)

Closes: https://github.com/git-lfs/git-lfs/issues/3505.

##

/cc @git-lfs/core 
/cc @mloskot https://github.com/git-lfs/git-lfs/issues/3505