### PR TITLE
Release automation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -288,6 +288,12 @@ bin/releases/git-lfs-%-$(VERSION).zip : $(RELEASE_INCLUDES) bin/git-lfs-%.exe
 bin/releases/git-lfs-$(VERSION).tar.gz :
 	git archive -o $@ --prefix=git-lfs-$(patsubst v%,%,$(VERSION))/ --format tar.gz $(VERSION)
 
+# release-linux is a target that builds Linux packages. It must be run on a
+# system with Docker that can run Linux containers.
+.PHONY : release-linux
+release-linux:
+	./docker/run_dockers.bsh
+
 # release-windows is a target that builds and signs Windows binaries.  It must
 # be run on a Windows machine under Git Bash.
 #

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,10 @@ GOIMPORTS_EXTRA_OPTS ?= -w -l
 TAR_XFORM_ARG ?= $(shell tar --version | grep -q 'GNU tar' && echo '--xform' || echo '-s')
 TAR_XFORM_CMD ?= $(shell tar --version | grep -q 'GNU tar' && echo 's')
 
+# CERT_SHA1 is the SHA-1 hash of the Windows code-signing cert to use.  The
+# actual signature is made with SHA-256.
+CERT_SHA1 ?= 516f21950afecd3779b8b77da92f738fec501f03
+
 # SOURCES is a listing of all .go files in this and child directories, excluding
 # that in vendor.
 SOURCES = $(shell find . -type f -name '*.go' | grep -v vendor)
@@ -283,6 +287,49 @@ bin/releases/git-lfs-%-$(VERSION).zip : $(RELEASE_INCLUDES) bin/git-lfs-%.exe
 # source archive to download and verify cryptographically.
 bin/releases/git-lfs-$(VERSION).tar.gz :
 	git archive -o $@ --prefix=git-lfs-$(patsubst v%,%,$(VERSION))/ --format tar.gz $(VERSION)
+
+# release-windows is a target that builds and signs Windows binaries.  It must
+# be run on a Windows machine under Git Bash.
+#
+# You may sign with a different certificate by specifying CERT_SHA1.
+.PHONY : release-windows
+release-windows: bin/releases/git-lfs-windows-assets-$(VERSION).tar.gz
+
+bin/releases/git-lfs-windows-assets-$(VERSION).tar.gz :
+	$(RM) git-lfs-windows-*.exe
+	@# Using these particular filenames is required for the Inno Setup script to
+	@# work properly.
+	$(MAKE) -B GOARCH=amd64 && cp ./bin/git-lfs.exe ./git-lfs-x64.exe
+	$(MAKE) -B GOARCH=386 && cp ./bin/git-lfs.exe ./git-lfs-x86.exe
+	signtool.exe sign /sha1 $(CERT_SHA1) /fd sha256 /tr http://timestamp.digicert.com /td sha256 /v git-lfs-x64.exe
+	signtool.exe sign /sha1 $(CERT_SHA1) /fd sha256 /tr http://timestamp.digicert.com /td sha256 /v git-lfs-x86.exe
+	iscc.exe script/windows-installer/inno-setup-git-lfs-installer.iss
+	@# This file will be named according to the version number in the
+	@# versioninfo.json, not according to $(VERSION).
+	mv git-lfs-windows-*.exe git-lfs-windows.exe
+	signtool.exe sign /sha1 $(CERT_SHA1) /fd sha256 /tr http://timestamp.digicert.com /td sha256 /v git-lfs-windows.exe
+	mv git-lfs-x64.exe git-lfs-windows-amd64.exe
+	mv git-lfs-x86.exe git-lfs-windows-386.exe
+	@# We use tar because Git Bash doesn't include zip.
+	tar -cf $@ git-lfs-windows-amd64.exe git-lfs-windows-386.exe git-lfs-windows.exe
+	$(RM) git-lfs-windows-amd64.exe git-lfs-windows-386.exe git-lfs-windows.exe
+
+# release-windows-rebuild takes the archive produced by release-windows and
+# incorporates the signed binaries into the existing zip archives.
+.PHONY : release-windows-rebuild
+release-windows-rebuild: bin/releases/git-lfs-windows-assets-$(VERSION).tar.gz
+	temp=$$(mktemp -d); \
+	file="$$PWD/$^"; \
+		( \
+			tar -C "$$temp" -xzf "$$file" && \
+			for i in 386 amd64; do \
+				cp "$$temp/git-lfs-windows-$$i.exe" "$$temp/git-lfs.exe" && \
+				zip -d bin/releases/git-lfs-windows-$$i-$(VERSION).zip "git-lfs-windows-$$i.exe" && \
+				zip -j -l bin/releases/git-lfs-windows-$$i-$(VERSION).zip  "$$temp/git-lfs.exe";  \
+			done && \
+			cp "$$temp/git-lfs-windows.exe" bin/releases/git-lfs-windows-$(VERSION).exe \
+		); \
+		status="$$?"; [ -n "$$temp" ] && $(RM) -r "$$temp"; exit "$$status"
 
 # TEST_TARGETS is a list of all phony test targets. Each one of them corresponds
 # to a specific kind or subset of tests to run.

--- a/docker/run_dockers.bsh
+++ b/docker/run_dockers.bsh
@@ -54,6 +54,7 @@ while [[ $# > 0 ]]; do
 done
 
 if [[ ${#IMAGES[@]} == 0 ]]; then
+  # If you change this list, change script/upload as well.
   IMAGES=(centos_6 centos_7 debian_7 debian_8 debian_9)
 fi
 

--- a/script/changelog
+++ b/script/changelog
@@ -20,6 +20,32 @@ commit_summary() {
   echo "* $title #$id (@$author)"
 }
 
+revisions_in () {
+  git rev-list --merges --first-parent $1
+}
+
+noninteractive () {
+  local range="$1"
+
+  printf '### Uncategorized\n'
+  for rev in $(revisions_in "$range"); do
+    commit_summary $rev
+  done
+  cat <<-EOF
+
+### Features
+
+### Bugs
+
+### Misc
+EOF
+}
+
+if [ "$1" = "--noninteractive" ]; then
+  noninteractive=1
+  shift
+fi
+
 range=$1
 
 if [ "$range" = "" ]; then
@@ -27,11 +53,17 @@ if [ "$range" = "" ]; then
   exit 1
 fi
 
+if [ -n "$noninteractive" ]
+then
+  noninteractive "$range"
+  exit
+fi
+
 features=""
 bugs=""
 misc=""
 
-for rev in $(git rev-list --merges --first-parent $range); do
+for rev in $(revisions_in "$range"); do
   git show $rev
 
   processed=0

--- a/script/update-version
+++ b/script/update-version
@@ -1,0 +1,78 @@
+#!/bin/sh -e
+
+rfc822_datestamp () {
+  # All the other changelog entries use this exact timestamp, so let's do so as
+  # well.  Use -0000 to indicate that our timestamp is in UTC, even though we
+  # ourselves may not be.
+  LC_ALL=C date +'%a, %d %b %Y 14:29:00 -0000'
+}
+
+user_id () {
+  git var GIT_COMMITTER_IDENT | sed -e 's/^\(.*<[^>]*>\).*$/\1/'
+}
+
+update_go () {
+  local version="$1"
+
+  sed -i '' -e "s/\(Version = \)\"[0-9.]*\"/\\1\"$version\"/" config/version.go
+}
+
+update_debian () {
+  local version="$1"
+
+  # Return if already updated.
+  ! grep -qs -F "git-lfs ($version)" debian/changelog || return
+
+  local tmpdir=$(mktemp -d)
+  local tmpfile="$tmpdir/changelog"
+
+  printf 'git-lfs (%s) stable; urgency=low
+
+  * New upstream version
+
+ -- %s  %s\n\n' "$version" "$(user_id)" "$(rfc822_datestamp)" >"$tmpfile"
+
+  cat debian/changelog >>"$tmpfile"
+  mv "$tmpfile" debian/changelog
+}
+
+update_rpm () {
+  local version="$1"
+
+  ruby -pi -e "\$_.gsub!(/^(Version:\\s+)[0-9.]+$/, '\\1$version')" \
+    rpm/SPECS/git-lfs.spec
+}
+
+update_versioninfo () {
+  local version="$1"
+
+  ruby -pi -e "ver = '$version'; pieces = ver.split('.')" \
+    -e '$_.gsub!(/("Major": )\d+/, %Q(\\1#{pieces[0]}))' \
+    -e '$_.gsub!(/("Minor": )\d+/, %Q(\\1#{pieces[1]}))' \
+    -e '$_.gsub!(/("Patch": )\d+/, %Q(\\1#{pieces[2]}))' \
+    -e '$_.gsub!(/("ProductVersion": )"[\d.]+"/, %Q(\\1"#{ver}"))' \
+    versioninfo.json
+}
+
+main () {
+  local version="$1"
+
+  if [ -z "$version" ] || [ "$version" = "--help" ]
+  then
+    cat <<EOM
+Usage: update-version NEW-VERSION
+
+NEW-VERSION will have the 'v' automatically stripped.
+EOM
+    exit
+  fi
+
+  version=$(echo "$version" | sed -e 's/^v//')
+
+  update_go "$version"
+  update_debian "$version"
+  update_rpm "$version"
+  update_versioninfo "$version"
+}
+
+main "$@"

--- a/script/upload
+++ b/script/upload
@@ -1,0 +1,258 @@
+#!/bin/sh
+
+set -e
+
+REPO="git-lfs/git-lfs"
+WORKDIR="$(mktemp -d)"
+
+trap 'rm -fr "$WORKDIR"' EXIT
+
+say () {
+  [ -n "$QUIET" ] && return
+  local format="$1"
+  shift
+  printf "$format\n" "$@" >&2
+}
+
+abort () {
+  local format="$1"
+  shift
+  printf "$format\n" "$@" >&2
+  exit 2
+}
+
+curl () {
+  command curl -nfSs "$@"
+}
+
+categorize_os () {
+  local os="$1"
+
+  if [ "$os" = "freebsd" ]
+  then
+    echo FreeBSD
+  else
+    ruby -e 'puts ARGV[0].capitalize' "$os"
+  fi
+}
+
+categorize_arch () {
+  local arch="$1"
+
+  echo "$arch" | tr a-z A-Z
+}
+
+# Categorize a release asset and print its human readable name to standard
+# output.
+categorize_asset () {
+  local file="$1"
+  local os=$(echo "$file" | sed -e 's/^git-lfs-//' -e 's/[-.].*$//')
+  local arch=$(echo "$file" | ruby -pe '$_.gsub!(/\Agit-lfs-[^-]+-([^-]+)[-.].*/, "\\1")')
+
+  case "$file" in
+    git-lfs-v*.*.*.tar.gz)
+      echo "Source";;
+    git-lfs-windows-v*.*.*.exe)
+      echo "Windows Installer";;
+    sha256sums.asc)
+      echo "Signed SHA-256 Hashes";;
+    *)
+      printf "%s %s\n" "$(categorize_os "$os")" "$(categorize_arch "$arch")";;
+  esac
+}
+
+# Provide a content type for the asset based on its file name.
+content_type () {
+  local file="$1"
+
+  case "$file" in
+    *.zip)
+      echo "application/zip";;
+    *.tar.gz)
+      echo "application/gzip";;
+    *.exe)
+      echo "application/octet-stream";;
+    *.asc)
+      echo "text/plain";;
+  esac
+}
+
+# Format the JSON for creating the release and print it to standard output.
+format_release_json () {
+  local version="$1"
+  local bodyfile="$2"
+
+  ruby -rjson -e 'puts JSON.generate({
+    tag_name: ARGV[0],
+    name: ARGV[0],
+    draft: true,
+    body: File.read(ARGV[1]),
+  })' "$version" "$bodyfile"
+}
+
+# Create a draft release and print the upload URL for release assets to the
+# standard output. If a release with that version already exists, do nothing
+# instead.
+create_release () {
+  local version="$1"
+  local bodyfile="$2"
+
+  # Check to see if we already have such a release. If so, don't create it.
+  curl https://api.github.com/repos/$REPO/releases | \
+    jq -r '.[].name' | grep -qsF "$version" && {
+    say "Found an existing release for this version."
+    curl https://api.github.com/repos/$REPO/releases | \
+      jq -r '.[] | select(.name == "'"$version"'") | .upload_url' | \
+      sed -e 's/{.*}//g'
+    return
+  }
+
+  # This can be large, so pass it in a file.
+  format_release_json "$version" "$bodyfile" >> "$WORKDIR/release-json"
+
+  curl -H'Content-Type: application/json' -d"@$WORKDIR/release-json" \
+    https://api.github.com/repos/$REPO/releases | \
+    jq -r '.upload_url' |
+    sed -e 's/{.*}//g'
+}
+
+# Find the release files for the given version.
+release_files () {
+  local version="$1"
+
+  [ -n "$version" ] || return 1
+
+  find bin/releases -name '*.tar.gz' -o -name '*386*.zip' -o \
+    -name '*amd64*.zip' -o -name '*.exe' -o -name 'sha256sums.asc' | \
+    grep -E "$version|sha256sums.asc" | \
+    grep -v "assets" | \
+    LC_ALL=C sort
+}
+
+# Format the body message and print the file which contains it to the standard
+# output.
+finalize_body_message () {
+  local version="$1"
+  local changelog="$2"
+
+  version=$(echo "$version" | sed -e 's/^v//')
+
+  # If you change the list of distributions here, change docker/run_dockers.bsh
+  # as well.
+  cat "$changelog" > "$WORKDIR/body-template"
+  cat <<EOM >> "$WORKDIR/body-template"
+## Packages
+
+Up to date packages are available on [PackageCloud](https://packagecloud.io/github/git-lfs) and [Homebrew](http://brew.sh/).
+
+[RPM RHEL 6/CentOS 6](https://packagecloud.io/github/git-lfs/packages/el/6/git-lfs-VERSION-1.el6.x86_64.rpm/download)
+[RPM RHEL 7/CentOS 7](https://packagecloud.io/github/git-lfs/packages/el/7/git-lfs-VERSION-1.el7.x86_64.rpm/download)
+[Debian 7](https://packagecloud.io/github/git-lfs/packages/debian/wheezy/git-lfs_VERSION_amd64.deb/download)
+[Debian 8](https://packagecloud.io/github/git-lfs/packages/debian/jessie/git-lfs_VERSION_amd64.deb/download)
+[Debian 9](https://packagecloud.io/github/git-lfs/packages/debian/stretch/git-lfs_VERSION_amd64.deb/download)
+
+## SHA-256 hashes:
+EOM
+
+  shasum -a256 $(release_files "$version") | \
+    ruby -pe '$_.chomp!' \
+    -e '$_.gsub!(/^([0-9a-f]+)\s+.*\/([^\/]+)$/, "**\\2**\n\\1\n\n")' | \
+    ruby -0777 -pe '$_.gsub!(/\n+\z/, "\n")' >> "$WORKDIR/body-template"
+
+  sed -e "s/VERSION/$version/g" < "$WORKDIR/body-template" > "$WORKDIR/body"
+  echo "$WORKDIR/body"
+}
+
+# Filter a list of files from standard input, removing entries found in the file
+# provided.
+filter_files () {
+  local filter="$1"
+
+  # If the filter file is empty (that is, no assets have been uploaded), grep
+  # will produce no output, and therefore nothing will be uploaded. That's not
+  # what we want, so handle this case specially.
+  if [ -s "$filter" ]
+  then
+    grep -vF -f "$filter"
+  else
+    cat
+  fi
+}
+
+# Upload assets from the release directory to GitHub. Only assets that are not
+# already existing should be uploaded.
+upload_assets () {
+  local version="$1"
+  local upload_url="$2"
+  local file desc base ct encdesc encbase
+
+  curl https://api.github.com/repos/$REPO/releases | \
+    jq -r '.[] | select(.name == "'"$version"'") | .assets | .[] | .name' \
+    > "$WORKDIR/existing-assets"
+
+  for file in $(release_files "$version" | filter_files "$WORKDIR/existing-assets")
+  do
+    base=$(basename "$file")
+    desc=$(categorize_asset "$base")
+    ct=$(content_type "$base")
+    encbase=$(ruby -ruri -e 'print URI.escape(ARGV[0])' "$base")
+    encdesc=$(ruby -ruri -e 'print URI.escape(ARGV[0])' "$desc")
+
+    say "\tUploading %s as \"%s\" (Content-Type %s)..." "$base" "$desc" "$ct"
+    curl -d"@$file" -H'Accept: application/vnd.github.v3+json' \
+      -H"Content-Type: $ct" "$upload_url?name=$encbase&label=$encdesc" \
+       > /dev/null
+  done
+}
+
+# Provide a helpful usage message and exit.
+usage () {
+  local status="$1"
+  cat <<EOM
+Usage: $0 VERSION CHANGELOG
+
+Create a draft GitHub release for Git LFS using the tag specified by VERSION and
+the changelog specified in the file CHANGELOG. Before running this script, the
+release assets should be built and ready for upload, including the signed
+sha256sums.asc file.
+
+This script requires ruby, curl, shasum, and jq.
+EOM
+  exit $status
+}
+
+# The main program.
+main () {
+  local version="$1"
+  local changelog="$2"
+
+  [ "$version" = "--help" ] && usage 0
+  [ -z "$changelog" ] && usage 1 >&2
+
+  say "Checking that you've got some release artifacts..."
+  [ -n "$(release_files "$version")" ] || \
+    abort "I couldn't find any release files for $version."
+
+  say "Looking for the necessary entries in .netrc..."
+  grep -qsF api.github.com "$HOME/.netrc" || \
+    abort "I couldn't find api.github.com in your .netrc."
+  grep -qsF uploads.github.com "$HOME/.netrc" || \
+    abort "I couldn't find uploads.github.com in your .netrc."
+
+  say "Okay, everything looks good."
+
+  say "Formatting the body of the GitHub release now..."
+
+  local bodyfile=$(finalize_body_message "$version" "$changelog")
+
+  say "Creating a GitHub release for %s..." "$version"
+
+  local upload_url=$(create_release "$version" "$bodyfile")
+
+  say "Uploading assets to GitHub..."
+  upload_assets "$version" "$upload_url"
+
+  say "Okay, done. Sanity-check the release and publish it."
+}
+
+main "$@"


### PR DESCRIPTION
Our current release process is highly manual and requires several individual steps to go through. This series is a first step at automating parts of this process.

Included are changes to automate most of the Windows build process, which is an area that has caused us problems in the past, a script to create a GitHub release and upload assets, and a script to bump version numbers.

The entire process is not yet complete, but since this series provides valuable improvements that we can take advantage of now, I thought I'd submit it and let us use parts of it. I've already used the Windows build process to great success in the last release.