### PR TITLE
t/t-smudge.sh: remove unnecessary test

### DIFF
--- a/t/t-smudge.sh
+++ b/t/t-smudge.sh
@@ -121,7 +121,6 @@ begin_test "smudge with skip"
 
   echo "test clone without env"
   unset GIT_LFS_SKIP_SMUDGE
-  [ "$(env | grep LFS_SKIP)" == "" ]
   clone_repo "$reponame" "no-skip"
   [ "smudge a" = "$(cat a.dat)" ]
 


### PR DESCRIPTION
In the "smudge with skip" test (i.e., the one that tests using
$GIT_LFS_SKIP_SMUDGE), we unset the variable in the environment, and
then check that it has indeed been removed.

We expect that the 'unset' program will work without issue, so let's
remove the check that ensures it so.

As an additional benefit (and the reason for this change in the first
place) we allow this test to continue to pass even when the latest
commit message mentions the word "GIT_LFS_SKIP_SMUDGE".

On some CI systems, the commit message from HEAD is placed in the
environment variable (e.g., APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED) and
hence causes this test to fail.

##

/cc @git-lfs/core 