### PR TITLE
.circleci: don't use 'brew prune'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,6 @@ jobs:
     steps:
       - checkout
       - run: brew update
-      - run: brew prune
       - run: brew upgrade go || brew install go
       - run: brew upgrade git || brew install git
       - run: brew upgrade gettext || brew install gettext


### PR DESCRIPTION
In the latest release of Homebrew (which Circle CI has upgraded to for
us) the command `brew prune` has been removed.

In order to stop failing our Circle CI builds, let's remove this
invocation.

The recommended alternative is to run 'brew cleanup', but this is
unnecessary: Homebrew 2.0 already does this for us, so repeating it here
is unnecessary.

##

/cc @git-lfs/core 