### PR TITLE
Avoid nil pointer dereference on unexpected failure

### DIFF
--- a/tq/basic_upload.go
+++ b/tq/basic_upload.go
@@ -123,6 +123,12 @@ func (a *basicUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb Progres
 			err = errors.Wrap(err, perr.Error())
 		}
 
+		if res == nil {
+			// We encountered a network or similar error which caused us
+			// to not receive a response at all.
+			return errors.NewRetriableError(err)
+		}
+
 		if res.StatusCode == 429 {
 			retLaterErr := errors.NewRetriableLaterError(err, res.Header["Retry-After"][0])
 			if retLaterErr != nil {


### PR DESCRIPTION
When we get an error making an API request, we check to see if the response is a 429, and if so, we attempt to back off and retry later. However, we failed to check if we actually had a response; if the response was missing (say, because we had a network issue), then we would dereference a nil pointer.

Instead, let's explicitly check for a non-nil response before querying it for a status code.

This series doesn't include a test because I'm not aware of a way to synthesize this failure. It clearly is occurring, though, and it seems fairly obvious what's going on.

Fixes #3533.

/cc @mloskot