### PR TITLE
Fix asset uploading during releases

### DIFF
--- a/docs/howto/release-git-lfs.md
+++ b/docs/howto/release-git-lfs.md
@@ -130,11 +130,10 @@ equal to 0, we say that we are releasing a MINOR version of Git LFS, in the
      following:
 
      ```ShellSession
-     $ (cd bin/releases && shasum -a256 * | gpg --digest-algo SHA256 --clearsign >sha256sums.asc)
+     $ (cd bin/releases && \
+        shasum -a256 -b * | grep -vE '(assets|sha256sums)' | \
+        gpg --digest-algo SHA256 --clearsign >sha256sums.asc)
      ```
-
-     Note that if the sha256sums.asc file exists, you must remove it first so
-     the old version doesn't get written into the new file.
 
   6. Run `script/upload` with the tag name and the file containing the changelog
      entries for this version (not `CHANGELOG.md`, which has all versions). This

--- a/script/upload
+++ b/script/upload
@@ -190,6 +190,8 @@ upload_assets () {
     jq -r '.[] | select(.name == "'"$version"'") | .assets | .[] | .name' \
     > "$WORKDIR/existing-assets"
 
+  mkdir "$WORKDIR/downloads"
+
   for file in $(release_files "$version" | filter_files "$WORKDIR/existing-assets")
   do
     base=$(basename "$file")
@@ -201,8 +203,33 @@ upload_assets () {
     say "\tUploading %s as \"%s\" (Content-Type %s)..." "$base" "$desc" "$ct"
     curl --data-binary "@$file" -H'Accept: application/vnd.github.v3+json' \
       -H"Content-Type: $ct" "$upload_url?name=$encbase&label=$encdesc" \
-       > /dev/null
+      >"$WORKDIR/response"
+    download=$(jq -r '.url' "$WORKDIR/response")
   done
+
+  curl https://api.github.com/repos/$REPO/releases | \
+    jq -rc '.[] | select(.name == "'"$version"'") | .assets | .[] | [.name,.url]' | \
+    ruby -rjson -ne 'puts JSON.parse($_).join(" ")' \
+    > "$WORKDIR/assets"
+
+  say "Assets uploaded."
+  say "Verifying assets..."
+
+  cat "$WORKDIR/assets" | (while read base url
+  do
+    say "\tDownloading %s for verification..." "$base"
+    (
+      cd "$WORKDIR/downloads" &&
+      curl -Lo "$base" -H"Accept: application/octet-stream" "$url"
+    )
+  done)
+
+  # If the OpenPGP data is not valid, gpg -d will output nothing to stdout, and
+  # shasum will then fail.
+  say "Checking assets for integrity..."
+  (cd "$WORKDIR/downloads" && gpg -d sha256sums.asc | shasum -a 256 -c)
+
+  say "\nAssets look good!"
 }
 
 # Provide a helpful usage message and exit.

--- a/script/upload
+++ b/script/upload
@@ -199,7 +199,7 @@ upload_assets () {
     encdesc=$(ruby -ruri -e 'print URI.escape(ARGV[0])' "$desc")
 
     say "\tUploading %s as \"%s\" (Content-Type %s)..." "$base" "$desc" "$ct"
-    curl -d"@$file" -H'Accept: application/vnd.github.v3+json' \
+    curl --data-binary "@$file" -H'Accept: application/vnd.github.v3+json' \
       -H"Content-Type: $ct" "$upload_url?name=$encbase&label=$encdesc" \
        > /dev/null
   done


### PR DESCRIPTION
When uploading assets during releases, we'd generally like to include all of the bytes in them, including newlines. To help us do this, we use the --data-binary option for uploads. To avoid additional problems during releases and make sure that they're intact, download the assets and verify the signature and hashes as part of the upload process. This lets us be confident that we're shipping a complete release to users.

Finally, to help maintainers avoid including files in the signed manifest that shouldn't be there, we update the documentation with a suitable invocation of shasum that strips these files out. We also update the documentation to create hash files that are more easily verifiable on Windows by causing Windows systems to use binary mode for reading files.