### PR TITLE
Ensure trimpath works properly on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,13 +34,13 @@ EXTRA_LD_FLAGS ?= -extldflags ${LDFLAGS}
 LD_FLAGS = $(BUILTIN_LD_FLAGS) $(EXTRA_LD_FLAGS)
 
 # BUILTIN_GC_FLAGS are the internal flags used to pass compiler.
-BUILTIN_GC_FLAGS ?= all=-trimpath="$$HOME"
+BUILTIN_GC_FLAGS ?= all=-trimpath=$$HOME
 # EXTRA_GC_FLAGS are the caller-provided flags to pass to the compiler.
 EXTRA_GC_FLAGS =
 # GC_FLAGS are the union of the above two BUILTIN_GC_FLAGS and EXTRA_GC_FLAGS.
 GC_FLAGS = $(BUILTIN_GC_FLAGS) $(EXTRA_GC_FLAGS)
 
-ASM_FLAGS ?= all=-trimpath="$$HOME"
+ASM_FLAGS ?= all=-trimpath=$$HOME
 
 # RONN is the name of the 'ronn' program used to generate man pages.
 RONN ?= ronn


### PR DESCRIPTION
We recently added code to trim paths out of the binary to aid in reproducible builds. However, our code had a bug: since there are multiple sets of double quotes in the build invocation, if the home directory contained spaces, as it often does on Windows, the build would fail because the extra unquoted spaces confused the compiler.

To address this issue, remove the extra double quotes.