### PR TITLE
release: v2.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Git LFS Changelog
 
+## 2.7.1 (26 February 2019)
+
+This release is a bugfix release to address panics that could occur when certain
+types of upload or download problems happen.
+
+### Bugs
+
+* Avoid nil pointer dereference on download failure #3537 (@bk2204)
+* Avoid nil pointer dereference on unexpected failure #3534 (@bk2204)
+
+### Misc
+
+* Fix asset uploading during releases #3538 (@bk2204)
+
 ## 2.7.0 (15 February 2019)
 
 This release adds better support for large files on 32-bit systems, adds

--- a/config/version.go
+++ b/config/version.go
@@ -12,7 +12,7 @@ var (
 )
 
 const (
-	Version = "2.7.0"
+	Version = "2.7.1"
 )
 
 func init() {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+git-lfs (2.7.1) stable; urgency=low
+
+  * New upstream version
+
+ -- brian m. carlson <bk2204@github.com>  Tue, 26 Feb 2019 14:29:00 -0000
+
 git-lfs (2.7.0) stable; urgency=low
 
   * New upstream version

--- a/docs/howto/release-git-lfs.md
+++ b/docs/howto/release-git-lfs.md
@@ -130,11 +130,10 @@ equal to 0, we say that we are releasing a MINOR version of Git LFS, in the
      following:
 
      ```ShellSession
-     $ (cd bin/releases && shasum -a256 * | gpg --digest-algo SHA256 --clearsign >sha256sums.asc)
+     $ (cd bin/releases && \
+        shasum -a256 -b * | grep -vE '(assets|sha256sums)' | \
+        gpg --digest-algo SHA256 --clearsign >sha256sums.asc)
      ```
-
-     Note that if the sha256sums.asc file exists, you must remove it first so
-     the old version doesn't get written into the new file.
 
   6. Run `script/upload` with the tag name and the file containing the changelog
      entries for this version (not `CHANGELOG.md`, which has all versions). This

--- a/rpm/SPECS/git-lfs.spec
+++ b/rpm/SPECS/git-lfs.spec
@@ -1,5 +1,5 @@
 Name:           git-lfs
-Version:        2.7.0
+Version:        2.7.1
 Release:        1%{?dist}
 Summary:        Git extension for versioning large files
 

--- a/script/upload
+++ b/script/upload
@@ -190,6 +190,8 @@ upload_assets () {
     jq -r '.[] | select(.name == "'"$version"'") | .assets | .[] | .name' \
     > "$WORKDIR/existing-assets"
 
+  mkdir "$WORKDIR/downloads"
+
   for file in $(release_files "$version" | filter_files "$WORKDIR/existing-assets")
   do
     base=$(basename "$file")
@@ -199,10 +201,35 @@ upload_assets () {
     encdesc=$(ruby -ruri -e 'print URI.escape(ARGV[0])' "$desc")
 
     say "\tUploading %s as \"%s\" (Content-Type %s)..." "$base" "$desc" "$ct"
-    curl -d"@$file" -H'Accept: application/vnd.github.v3+json' \
+    curl --data-binary "@$file" -H'Accept: application/vnd.github.v3+json' \
       -H"Content-Type: $ct" "$upload_url?name=$encbase&label=$encdesc" \
-       > /dev/null
+      >"$WORKDIR/response"
+    download=$(jq -r '.url' "$WORKDIR/response")
   done
+
+  curl https://api.github.com/repos/$REPO/releases | \
+    jq -rc '.[] | select(.name == "'"$version"'") | .assets | .[] | [.name,.url]' | \
+    ruby -rjson -ne 'puts JSON.parse($_).join(" ")' \
+    > "$WORKDIR/assets"
+
+  say "Assets uploaded."
+  say "Verifying assets..."
+
+  cat "$WORKDIR/assets" | (while read base url
+  do
+    say "\tDownloading %s for verification..." "$base"
+    (
+      cd "$WORKDIR/downloads" &&
+      curl -Lo "$base" -H"Accept: application/octet-stream" "$url"
+    )
+  done)
+
+  # If the OpenPGP data is not valid, gpg -d will output nothing to stdout, and
+  # shasum will then fail.
+  say "Checking assets for integrity..."
+  (cd "$WORKDIR/downloads" && gpg -d sha256sums.asc | shasum -a 256 -c)
+
+  say "\nAssets look good!"
 }
 
 # Provide a helpful usage message and exit.

--- a/tq/basic_upload.go
+++ b/tq/basic_upload.go
@@ -123,6 +123,12 @@ func (a *basicUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb Progres
 			err = errors.Wrap(err, perr.Error())
 		}
 
+		if res == nil {
+			// We encountered a network or similar error which caused us
+			// to not receive a response at all.
+			return errors.NewRetriableError(err)
+		}
+
 		if res.StatusCode == 429 {
 			retLaterErr := errors.NewRetriableLaterError(err, res.Header["Retry-After"][0])
 			if retLaterErr != nil {

--- a/versioninfo.json
+++ b/versioninfo.json
@@ -4,7 +4,7 @@
 		"FileVersion": {
 			"Major": 2,
 			"Minor": 7,
-			"Patch": 0,
+			"Patch": 1,
 			"Build": 0
 		}
 	},
@@ -13,7 +13,7 @@
 		"FileDescription": "Git LFS",
 		"LegalCopyright": "GitHub, Inc. and Git LFS contributors",
 		"ProductName": "Git Large File Storage (LFS)",
-		"ProductVersion": "2.7.0"
+		"ProductVersion": "2.7.1"
 	},
 	"IconPath": "script/windows-installer/git-lfs-logo.ico"
 }


### PR DESCRIPTION
This is an in-progress look at the next release of Git LFS, v2.7.1, which is scheduled for Tuesday, February 26, 2019.

We're publishing these changes early so that folks on @git-lfs/implementers can check that things work with their various platforms.

I've attached some builds below for people to use for testing:

[git-lfs-darwin-386-v2.7.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/2895628/git-lfs-darwin-386-v2.7.1-pre.tar.gz)
[git-lfs-darwin-amd64-v2.7.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/2895629/git-lfs-darwin-amd64-v2.7.1-pre.tar.gz)
[git-lfs-freebsd-386-v2.7.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/2895630/git-lfs-freebsd-386-v2.7.1-pre.tar.gz)
[git-lfs-freebsd-amd64-v2.7.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/2895631/git-lfs-freebsd-amd64-v2.7.1-pre.tar.gz)
[git-lfs-linux-386-v2.7.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/2895632/git-lfs-linux-386-v2.7.1-pre.tar.gz)
[git-lfs-linux-amd64-v2.7.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/2895633/git-lfs-linux-amd64-v2.7.1-pre.tar.gz)
[git-lfs-linux-arm64-v2.7.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/2895634/git-lfs-linux-arm64-v2.7.1-pre.tar.gz)
[git-lfs-v2.7.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/2895635/git-lfs-v2.7.1-pre.tar.gz)
[git-lfs-windows-386-v2.7.1-pre.zip](https://github.com/git-lfs/git-lfs/files/2895636/git-lfs-windows-386-v2.7.1-pre.zip)
[git-lfs-windows-amd64-v2.7.1-pre.zip](https://github.com/git-lfs/git-lfs/files/2895650/git-lfs-windows-amd64-v2.7.1-pre.zip)



/cc @git-lfs/core
/cc @git-lfs/implementers
/cc @git-lfs/releases 