### PR TITLE
Don't set -extldflags unless LDFLAGS has a value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,9 @@ BUILTIN_LD_FLAGS += -w
 endif
 # EXTRA_LD_FLAGS are given by the caller, and are passed to the Go linker after
 # BUILTIN_LD_FLAGS are processed. By default the system LDFLAGS are passed.
+ifdef LDFLAGS
 EXTRA_LD_FLAGS ?= -extldflags ${LDFLAGS}
+endif
 # LD_FLAGS is the union of the above two BUILTIN_LD_FLAGS and EXTRA_LD_FLAGS.
 LD_FLAGS = $(BUILTIN_LD_FLAGS) $(EXTRA_LD_FLAGS)
 


### PR DESCRIPTION
Unconditionally setting `-extldflags` to the contents of `LDFLAGS`
causes problems when `LDFLAGS` isn't defined (`-extldflags` doens't
have an corresponding value).

In out case this led to `git-lfs` aborting.

```
$ ./bin/git-lfs
Aborted
```

This change only sets `-extldflags` if `LDFLAGS` is defined.