### PR TITLE
Switch from manually running go generate to using dh-golang to run it

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -18,6 +18,7 @@ BUILD_DIR := obj-$(DEB_HOST_GNU_TYPE)
 export DH_GOPKG := github.com/git-lfs/git-lfs
 # DH_GOLANG_EXCLUDES typically incorporates vendor exclusions
 export DH_GOLANG_EXCLUDES := test github.com/olekukonko/ts/* github.com/xeipuuv/* github.com/spf13/cobra/* github.com/kr/* github.com/pkg/errors github.com/alexbrainman/sspi/*
+export DH_GOLANG_GO_GENERATE := 1
 export PATH := $(CURDIR)/$(BUILD_DIR)/bin:$(PATH)
 
 # by-default, dh_golang only copies *.go and other source - this upsets a bunch of vendor test routines
@@ -32,7 +33,6 @@ override_dh_clean:
 	dh_clean
 
 override_dh_auto_build:
-	cd ${BUILD_DIR}/src/github.com/git-lfs/git-lfs && go generate ./commands
 	dh_auto_build
 	#dh_golang doesn't do anything here in deb 8, and it's needed in both
 	if [ "$(DEB_HOST_GNU_TYPE)" != "$(DEB_BUILD_GNU_TYPE)" ]; then\


### PR DESCRIPTION
This fixes #2013.  For some reason I could only reproduce the issue from within the docker builder, not when running outside of docker.  Regardless, this appears to fix the problem and is a generally cleaner
solution anyway that will continue to work if any other generate commands are added to git-lfs.