### PR TITLE
Allow specifying multiple insteadOf aliases

### DIFF
--- a/lfsapi/endpoint_finder.go
+++ b/lfsapi/endpoint_finder.go
@@ -340,11 +340,13 @@ func initAliases(e *endpointGitFinder, git config.Environment) {
 	}
 }
 
-func storeAlias(aliases map[string]string, key string, value []string, suffix string) {
-	if _, ok := aliases[value[len(value)-1]]; ok {
-		fmt.Fprintf(os.Stderr, "WARNING: Multiple 'url.*.%s' keys with the same alias: %q\n", suffix, value)
+func storeAlias(aliases map[string]string, key string, values []string, suffix string) {
+	for _, value := range values {
+		if _, ok := aliases[value]; ok {
+			fmt.Fprintf(os.Stderr, "WARNING: Multiple 'url.*.%s' keys with the same alias: %q\n", suffix, value)
+		}
+		aliases[value] = key[len(aliasPrefix) : len(key)-len(suffix)]
 	}
-	aliases[value[len(value)-1]] = key[len(aliasPrefix) : len(key)-len(suffix)]
 }
 
 func endpointFromGitUrl(u *url.URL, e *endpointGitFinder) lfshttp.Endpoint {

--- a/t/t-config.sh
+++ b/t/t-config.sh
@@ -125,6 +125,30 @@ begin_test "ambiguous url alias"
 )
 end_test
 
+begin_test "multiple config"
+(
+  set -e
+
+  mkdir url-alias-multiple
+  cd url-alias-multiple
+
+  git init
+
+  # When more than one insteadOf strings match a given URL, the longest match is used.
+  git config url."http://wrong-url/".insteadOf alias
+  git config url."http://actual-url/".insteadOf alias:
+  git config --add url."http://actual-url/".insteadOf alias2:
+  git config lfs.url alias:rest
+  git lfs env | tee env.log
+  grep "Endpoint=http://actual-url/rest (auth=none)" env.log
+
+  git config lfs.url alias2:rest
+  git lfs env | tee env.log
+  grep "Endpoint=http://actual-url/rest (auth=none)" env.log
+)
+end_test
+
+
 begin_test "url alias must be prefix"
 (
   set -e


### PR DESCRIPTION
It's possible for a user to specify multiple insteadOf aliases and have all of the specified URLs map to the same rewritten URL. Make sure we do handle this correctly by iterating over the all values we read from the config, not just the last one.

Fixes #2298.
/cc @larsxschneider as reporter