### PR TITLE
Handle Windows junctions properly

### DIFF
--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/git"
@@ -91,6 +92,9 @@ func lockPath(file string) (string, error) {
 	}
 
 	path = filepath.ToSlash(path)
+	if strings.HasPrefix(path, "../") {
+		return "", fmt.Errorf("lfs: unable to canonicalize path %q", path)
+	}
 
 	if stat, err := os.Stat(abs); err != nil {
 		return "", err

--- a/commands/command_unlock.go
+++ b/commands/command_unlock.go
@@ -54,7 +54,7 @@ func unlockCommand(cmd *cobra.Command, args []string) {
 		}
 
 		// This call can early-out
-		unlockAbortIfFileModified(path, !os.IsNotExist(err))
+		unlockAbortIfFileModified(path)
 
 		err = lockClient.UnlockFile(path, unlockCmdFlags.Force)
 		if err != nil {
@@ -90,11 +90,11 @@ func unlockCommand(cmd *cobra.Command, args []string) {
 	return
 }
 
-func unlockAbortIfFileModified(path string, exists bool) {
+func unlockAbortIfFileModified(path string) {
 	modified, err := git.IsFileModified(path)
 
 	if err != nil {
-		if !exists && unlockCmdFlags.Force {
+		if unlockCmdFlags.Force {
 			// Since git/git@b9a7d55, `git-status(1)` causes an
 			// error when asked about files that don't exist,
 			// causing `err != nil`, as above.
@@ -132,7 +132,7 @@ func unlockAbortIfFileModifiedById(id string, lockClient *locking.Client) {
 		return
 	}
 
-	unlockAbortIfFileModified(locks[0].Path, true)
+	unlockAbortIfFileModified(locks[0].Path)
 }
 
 func init() {

--- a/git/git.go
+++ b/git/git.go
@@ -611,7 +611,7 @@ func GitAndRootDirs() (string, string, error) {
 		return "", "", fmt.Errorf("Bad git rev-parse output: %q", output)
 	}
 
-	absGitDir, err := filepath.Abs(paths[0])
+	absGitDir, err := canonicalizeDir(paths[0])
 	if err != nil {
 		return "", "", fmt.Errorf("Error converting %q to absolute: %s", paths[0], err)
 	}
@@ -620,8 +620,15 @@ func GitAndRootDirs() (string, string, error) {
 		return absGitDir, "", nil
 	}
 
-	absRootDir := paths[1]
-	return absGitDir, absRootDir, nil
+	absRootDir, err := canonicalizeDir(paths[1])
+	return absGitDir, absRootDir, err
+}
+
+func canonicalizeDir(path string) (string, error) {
+	if len(path) > 0 {
+		return filepath.Abs(path)
+	}
+	return "", nil
 }
 
 func RootDir() (string, error) {
@@ -633,11 +640,7 @@ func RootDir() (string, error) {
 
 	path := strings.TrimSpace(string(out))
 	path, err = tools.TranslateCygwinPath(path)
-	if len(path) > 0 {
-		return filepath.Abs(path)
-	}
-	return "", nil
-
+	return canonicalizeDir(path)
 }
 
 func GitDir() (string, error) {
@@ -647,10 +650,7 @@ func GitDir() (string, error) {
 		return "", fmt.Errorf("Failed to call git rev-parse --git-dir: %v %v", err, string(out))
 	}
 	path := strings.TrimSpace(string(out))
-	if len(path) > 0 {
-		return filepath.Abs(path)
-	}
-	return "", nil
+	return canonicalizeDir(path)
 }
 
 func GitCommonDir() (string, error) {
@@ -667,10 +667,7 @@ func GitCommonDir() (string, error) {
 		return "", fmt.Errorf("Failed to call git rev-parse --git-dir: %v %v", err, string(out))
 	}
 	path := strings.TrimSpace(string(out))
-	if len(path) > 0 {
-		return filepath.Abs(path)
-	}
-	return "", nil
+	return canonicalizeDir(path)
 }
 
 // GetAllWorkTreeHEADs returns the refs that all worktrees are using as HEADs

--- a/git/git.go
+++ b/git/git.go
@@ -626,7 +626,11 @@ func GitAndRootDirs() (string, string, error) {
 
 func canonicalizeDir(path string) (string, error) {
 	if len(path) > 0 {
-		return filepath.Abs(path)
+		path, err := filepath.Abs(path)
+		if err != nil {
+			return "", err
+		}
+		return filepath.EvalSymlinks(path)
 	}
 	return "", nil
 }


### PR DESCRIPTION
On Windows, there is a type of file system object called a junction point, which is a by-name reference from the junction point to a directory. Go's filepath.EvalSymlinks, which we use in the locking code, resolves these and provides a canonical path. However, Git for Windows, which provides the repository root, does not resolve them, resulting in the relative paths we generate against the repository root containing ".." components. As a consequence, the locks generated in this way are broken and cannot be unlocked.

To avoid this problem, we canonicalize the paths we get back from Git to ensure that all lock paths are relative. In addition, we check for locks containing ".." and reject them, and we allow users to force unlocking by ID, even if we think that will fail. If it does indeed fail, we are no worse off than before, and if it does not, then the user is able to clean up their broken locks.

Note that we have no tests for these cases because the only way to generate this issue is with junctions, which are not able to be created except with the mklink CMD built-in, which is not available in the bash-based environment we use.

/cc #3554 and git-for-windows/git#2114
/cc @JFLarvoire as reporter