### PR TITLE
Log test server standard error to log file

### DIFF
--- a/t/cmd/lfstest-count-tests.go
+++ b/t/cmd/lfstest-count-tests.go
@@ -122,6 +122,7 @@ func main() {
 				fmt.Sprintf("LFSTEST_CLIENT_KEY=%s", os.Getenv("LFSTEST_CLIENT_KEY")),
 			)
 			cmd.Stdout = log
+			cmd.Stderr = log
 
 			// Start performs a fork/execve, hence we can abandon
 			// this process once it has started.


### PR DESCRIPTION
When there's a problem with the test server, it's helpful to see the log output to help troubleshoot the issue. However, when the Stderr member of a command struct is not set, the standard error gets redirected to/dev/null, which isn't really what we want.

Since we already have a log set up for logging standard output, send standard error there as well.

(For those who are interested in the impetus for this pull request, I had a system-wide gitconfig file which attempted to include several nonexistent files, which of course made Git unhappy. Having logging on made troubleshooting this much easier.)