### PR TITLE
Set push remote for pre-push

### DIFF
--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -47,7 +47,7 @@ func prePushCommand(cmd *cobra.Command, args []string) {
 	requireGitVersion()
 
 	// Remote is first arg
-	if err := cfg.SetValidRemote(args[0]); err != nil {
+	if err := cfg.SetValidPushRemote(args[0]); err != nil {
 		Exit("Invalid remote name %q: %s", args[0], err)
 	}
 


### PR DESCRIPTION
In the pre-push hook, we set the remote to the remote value that has been passed to us from Git. In most cases, this works fine. However, because we're pushing and have set a remote but not specifically a push remote, if the user has a remote.pushDefault setting, we'll use that instead of honoring the remote passed into the hook. As a result, we can end up pushing LFS objects to the wrong place.

Instead, since we're pushing, set the push remote instead of the regular remote. This has no effects other than to make us not read the pushDefault setting.

Fixes #3561
/cc @rdailey as reporter