### PR TITLE
Detect Cygwin-style pipe TTYs as TTYs

### DIFF
--- a/tasklog/log.go
+++ b/tasklog/log.go
@@ -98,7 +98,7 @@ type hasFd interface {
 // tty returns true if the writer is connected to a tty
 func tty(writer io.Writer) bool {
 	if v, ok := writer.(hasFd); ok {
-		return isatty.IsTerminal(v.Fd())
+		return isatty.IsTerminal(v.Fd()) || isatty.IsCygwinTerminal(v.Fd())
 	}
 	return false
 }

--- a/tasklog/log.go
+++ b/tasklog/log.go
@@ -252,7 +252,7 @@ func (l *Logger) logTask(task Task) {
 
 	var update *Update
 	for update = range task.Updates() {
-		if !isatty.IsTerminal(os.Stdout.Fd()) && !l.forceProgress {
+		if !tty(os.Stdout) && !l.forceProgress {
 			continue
 		}
 		if logAll || l.throttle == 0 || !update.Throttled(last.Add(l.throttle)) {


### PR DESCRIPTION
Some Unix emulation layers for Windows, such as Cygwin and MSYS, use pipes to create their Unix-style TTYs. These TTYs are not detected as such by Windows, which sees them as pipes. However, our isatty module has a way to detect them, and they will function just like a TTY for our purposes, so check for them as well and handle them as TTYs if present.

I haven't added tests for this since I don't think we can just install Cygwin or MSYS in CI, and even if we could, we'd still have to somehow allocate a TTY for the tests in such an environment. If someone thinks of a way to test this, I'm all ears.

Fixes #3575
/cc @kristjanvalur as reporter