### PR TITLE
Properly handle config options for URLs with upper case letters

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"github.com/git-lfs/git-lfs/fs"
 	"github.com/git-lfs/git-lfs/git"
@@ -155,6 +156,15 @@ func NewFrom(v Values) *Configuration {
 			}
 
 			for key, values := range v.Git {
+				parts := strings.Split(key, ".")
+				isCaseSensitive := len(parts) >= 3
+				hasUpper := strings.IndexFunc(key, unicode.IsUpper) > -1
+
+				// This branch should only ever trigger in
+				// tests, and only if they'd be broken.
+				if !isCaseSensitive && hasUpper {
+					panic(fmt.Sprintf("key %q has uppercase, shouldn't", key))
+				}
 				for _, value := range values {
 					fmt.Printf("Config: %s=%s\n", key, value)
 					source.Lines = append(source.Lines, fmt.Sprintf("%s=%s", key, value))

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -13,7 +13,7 @@ func TestRemoteDefault(t *testing.T) {
 	cfg := NewFrom(Values{
 		Git: map[string][]string{
 			"branch.unused.remote":     []string{"a"},
-			"branch.unused.pushRemote": []string{"b"},
+			"branch.unused.pushremote": []string{"b"},
 		},
 	})
 	assert.Equal(t, "origin", cfg.Remote())
@@ -24,7 +24,7 @@ func TestRemoteBranchConfig(t *testing.T) {
 	cfg := NewFrom(Values{
 		Git: map[string][]string{
 			"branch.master.remote":    []string{"a"},
-			"branch.other.pushRemote": []string{"b"},
+			"branch.other.pushremote": []string{"b"},
 		},
 	})
 	cfg.ref = &git.Ref{Name: "master"}
@@ -37,8 +37,8 @@ func TestRemotePushDefault(t *testing.T) {
 	cfg := NewFrom(Values{
 		Git: map[string][]string{
 			"branch.master.remote":    []string{"a"},
-			"remote.pushDefault":      []string{"b"},
-			"branch.other.pushRemote": []string{"c"},
+			"remote.pushdefault":      []string{"b"},
+			"branch.other.pushremote": []string{"c"},
 		},
 	})
 	cfg.ref = &git.Ref{Name: "master"}
@@ -51,8 +51,8 @@ func TestRemoteBranchPushDefault(t *testing.T) {
 	cfg := NewFrom(Values{
 		Git: map[string][]string{
 			"branch.master.remote":     []string{"a"},
-			"remote.pushDefault":       []string{"b"},
-			"branch.master.pushRemote": []string{"c"},
+			"remote.pushdefault":       []string{"b"},
+			"branch.master.pushremote": []string{"c"},
 		},
 	})
 	cfg.ref = &git.Ref{Name: "master"}

--- a/config/git_fetcher_test.go
+++ b/config/git_fetcher_test.go
@@ -1,0 +1,25 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetCanonicalization(t *testing.T) {
+	vals := map[string][]string{
+		"user.name":                   []string{"Pat Doe"},
+		"branch.MixedCase.pushremote": []string{"Somewhere"},
+		"http.https://example.com/BIG-TEXT.git.extraheader": []string{"X-Foo: Bar"},
+	}
+
+	fetcher := GitFetcher{vals: vals}
+	assert.Equal(t, []string{"Somewhere"}, fetcher.GetAll("bRanch.MixedCase.pushRemote"))
+	assert.Equal(t, []string{"Somewhere"}, fetcher.GetAll("branch.MixedCase.pushremote"))
+	assert.Equal(t, []string(nil), fetcher.GetAll("branch.mixedcase.pushremote"))
+	assert.Equal(t, []string{"Pat Doe"}, fetcher.GetAll("user.name"))
+	assert.Equal(t, []string{"Pat Doe"}, fetcher.GetAll("User.Name"))
+	assert.Equal(t, []string{"X-Foo: Bar"}, fetcher.GetAll("http.https://example.com/BIG-TEXT.git.extraheader"))
+	assert.Equal(t, []string{"X-Foo: Bar"}, fetcher.GetAll("http.https://example.com/BIG-TEXT.git.extraHeader"))
+	assert.Equal(t, []string(nil), fetcher.GetAll("http.https://example.com/big-text.git.extraHeader"))
+}


### PR DESCRIPTION
Git configuration options have a complicated situation with regard to case. For the most part, they are case-insensitive: you may write any case into the file, but Git interprets it as lower case. However, there are exceptions.

Because the middle component of a three-component option can be a URL, branch name, or remote name, this component (and only this component) is treated as case sensitive. Since this component can be a URL, which may (and, due to the ".git" portion, usually does) contain a dot, the first component of the config option is read up until the first dot, and the last component is read from the end to the last dot.

When git config writes a value into the file, it preserves the case the user has provided, and when it prints the config values, it canonicalizes the keys by folding the case-insensitive portions to lowercase. Git LFS then reads this canonicalized form in as our source of config options, relieving us from having to parse the files ourselves.

However, when we read this data in, we forced the key to lowercase, and when we looked up a key, we also forced the key we were looking up to lowercase. While this behavior was wrong (since URLs, at least, are case-sensitive), it did happen to mostly work if the configuration didn't contain settings for two URLs differing in case.

In the 2.7.0 cycle, we changed the way we did URL config lookups to match the way Git does them. Previously, we performed configuration lookups on several possible keys (forcing them to lower case, URL portion included) and took the first that matched. Now, we directly compare the URL we're connecting to (which may be in mixed case) to the values we got in the configuration (which we've forced to lowercase). Consequently, we will fail to find configuration options for a mixed-case URL, resulting in things like "http.extraHeader" not being used.

Fix this issue by letting Git do the canonicalization of configuration keys for us instead of lowercasing them ourselves and then canonicalizing the key when looking it up in the table. Add tests for this behavior with "http.extraHeader" in the integration suite and several canonicalization assertions in the unit tests. Update several tests to use the canonical version of the data in their test data stores.

Fixes #3571
/cc @mitesch and @arche89 as reporters