### PR TITLE
tq/adapterbase: support rewriting href

### DIFF
--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -162,6 +162,13 @@ be scoped inside the configuration for a remote.
   not an integer, is less than one, or is not given, a default value of three
   will be used instead.
 
+* `lfs.transfer.enablehrefrewrite`
+
+  If set to true, this enables rewriting href of LFS objects using
+  `url.*.insteadof/pushinsteadof` config. `pushinsteadof` is used only for
+  uploading, and `insteadof` is used for downloading and for uploading when
+  `pushinsteadof` is not set.
+
 ### Push settings
 
 * `lfs.allowincompletepush`

--- a/t/t-pull.sh
+++ b/t/t-pull.sh
@@ -289,3 +289,29 @@ begin_test "pull: outside git repository"
   grep "Not in a git repository" pull.log
 )
 end_test
+
+begin_test "pull with invalid insteadof"
+(
+  set -e
+  mkdir insteadof
+  cd insteadof
+  git init
+  git lfs install --local --skip-smudge
+
+  git remote add origin "$GITSERVER/t-pull"
+  git pull origin master
+
+  # set insteadOf to rewrite the href of downloading LFS object.
+  git config url."$GITSERVER/storage/invalid".insteadOf "$GITSERVER/storage/"
+
+  set +e
+  git lfs pull > pull.log 2>&1
+  res=$?
+
+  set -e
+  [ "$res" = "2" ]
+
+  # check rewritten href is used to download LFS object.
+  grep "LFS: Repository or object not found: $GITSERVER/storage/invalid" pull.log
+)
+end_test

--- a/t/t-pull.sh
+++ b/t/t-pull.sh
@@ -248,6 +248,38 @@ begin_test "pull with multiple remotes"
 )
 end_test
 
+begin_test "pull with invalid insteadof"
+(
+  set -e
+  mkdir insteadof
+  cd insteadof
+  git init
+  git lfs install --local --skip-smudge
+
+  git remote add origin "$GITSERVER/t-pull"
+  git pull origin master
+
+  # set insteadOf to rewrite the href of downloading LFS object.
+  git config url."$GITSERVER/storage/invalid".insteadOf "$GITSERVER/storage/"
+  # Enable href rewriting explicitly.
+  git config lfs.transfer.enablehrefrewrite true
+
+  set +e
+  git lfs pull > pull.log 2>&1
+  res=$?
+
+  set -e
+  [ "$res" = "2" ]
+
+  # check rewritten href is used to download LFS object.
+  grep "LFS: Repository or object not found: $GITSERVER/storage/invalid" pull.log
+
+  # lfs-pull succeed after unsetting enableHrefRerite config
+  git config --unset lfs.transfer.enablehrefrewrite
+  git lfs pull
+)
+end_test
+
 begin_test "pull: with missing object"
 (
   set -e
@@ -287,31 +319,5 @@ begin_test "pull: outside git repository"
   fi
   [ "$res" = "128" ]
   grep "Not in a git repository" pull.log
-)
-end_test
-
-begin_test "pull with invalid insteadof"
-(
-  set -e
-  mkdir insteadof
-  cd insteadof
-  git init
-  git lfs install --local --skip-smudge
-
-  git remote add origin "$GITSERVER/t-pull"
-  git pull origin master
-
-  # set insteadOf to rewrite the href of downloading LFS object.
-  git config url."$GITSERVER/storage/invalid".insteadOf "$GITSERVER/storage/"
-
-  set +e
-  git lfs pull > pull.log 2>&1
-  res=$?
-
-  set -e
-  [ "$res" = "2" ]
-
-  # check rewritten href is used to download LFS object.
-  grep "LFS: Repository or object not found: $GITSERVER/storage/invalid" pull.log
 )
 end_test

--- a/t/t-push.sh
+++ b/t/t-push.sh
@@ -676,6 +676,8 @@ begin_test "push with invalid pushInsteadof"
 
   # set pushInsteadOf to rewrite the href of uploading LFS object.
   git config url."$GITSERVER/storage/invalid".pushInsteadOf "$GITSERVER/storage/"
+  # Enable href rewriting explicitly.
+  git config lfs.transfer.enablehrefrewrite true
 
   set +e
   git lfs push origin master > push.log 2>&1
@@ -686,5 +688,9 @@ begin_test "push with invalid pushInsteadof"
 
   # check rewritten href is used to upload LFS object.
   grep "LFS: Authorization error: $GITSERVER/storage/invalid" push.log
+
+  # lfs-push succeed after unsetting enableHrefRerite config
+  git config --unset lfs.transfer.enablehrefrewrite
+  git lfs push origin master
 )
 end_test

--- a/t/t-push.sh
+++ b/t/t-push.sh
@@ -667,3 +667,24 @@ begin_test "push with deprecated _links"
   assert_server_object "$reponame" "$contents_oid"
 )
 end_test
+
+begin_test "push with invalid pushInsteadof"
+(
+  set -e
+
+  push_repo_setup "push-invalid-pushinsteadof"
+
+  # set pushInsteadOf to rewrite the href of uploading LFS object.
+  git config url."$GITSERVER/storage/invalid".pushInsteadOf "$GITSERVER/storage/"
+
+  set +e
+  git lfs push origin master > push.log 2>&1
+  res=$?
+
+  set -e
+  [ "$res" = "2" ]
+
+  # check rewritten href is used to upload LFS object.
+  grep "LFS: Authorization error: $GITSERVER/storage/invalid" push.log
+)
+end_test

--- a/tq/adapterbase.go
+++ b/tq/adapterbase.go
@@ -194,12 +194,14 @@ func (a *adapterBase) worker(workerNum int, ctx interface{}) {
 var httpRE = regexp.MustCompile(`\Ahttps?://`)
 
 func (a *adapterBase) newHTTPRequest(method string, rel *Action) (*http.Request, error) {
-	if !httpRE.MatchString(rel.Href) {
-		urlfragment := strings.SplitN(rel.Href, "?", 2)[0]
+	href := a.apiClient.Endpoints.NewEndpoint(a.direction.String(), rel.Href).Url
+
+	if !httpRE.MatchString(href) {
+		urlfragment := strings.SplitN(href, "?", 2)[0]
 		return nil, fmt.Errorf("missing protocol: %q", urlfragment)
 	}
 
-	req, err := http.NewRequest(method, rel.Href, nil)
+	req, err := http.NewRequest(method, href, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Use insteadOf/pushInsteadOf aliases to rewrite href to upload/download LFS objects.
This is useful in situations such like you need to access the LFS server via a reverse proxy.