### PR TITLE
very rough stab at h2c/ssh, alternative to pkt-line ssh solution

### DIFF
--- a/lfsapi/endpoint_finder.go
+++ b/lfsapi/endpoint_finder.go
@@ -22,6 +22,7 @@ const (
 	PrivateAccess   AccessMode = "private"
 	NegotiateAccess AccessMode = "negotiate"
 	NTLMAccess      AccessMode = "ntlm"
+	H2SSHAccess     AccessMode = "h2ssh"
 	emptyAccess     AccessMode = ""
 	defaultRemote              = "origin"
 )


### PR DESCRIPTION
Adding this PR as a related discussion to https://github.com/git-lfs/git-lfs/issues/1044#issuecomment-478816962

It's rough and probably doesn't work well in all situations.

In a world where `git-lfs-tunnel` exists on the remote host, you could enable it by setting the lfs 'access' to `h2ssh`.

The `git-lfs-tunnel` command called on the remote server would be implemented with something like this https://gist.github.com/saracen/0e38a648f7804c6cff40141da21882ad - but not this, because it relies on a hard-coded upstream server and only supports proxying the API server and not also the batch object downloads/uploads.

A better solution for `git-lfs-tunnel` is located here: https://github.com/saracen/git-lfs-tunnel - it supports multiple upstream servers and handles object downloads/uploads.

---

#### testing

It can be tested on localhost, against a remote LFS server, by modifying your LFS URL of a current github repository and changing the access to h2ssh. Something like:
```
git config -f .lfsconfig lfs.url $(git config --get remote.origin.url | sed 's/github.com/localhost/' | sed "s/git@/$USER@/" | sed 's/\.git$//')
git config -f .lfsconfig lfs.https://localhost/$(git config --get remote.origin.url | sed 's/git@github.com://' | sed 's/\.git$//').access h2ssh
```

With the assumption that `git-lfs-tunnel` and `git-lfs-authenticate` are in your PATH. You can use this as your `git-lfs-authenticate` script:
```
#!/bin/bash
ssh -- git@github.com git-lfs-authenticate $1 $2
```