### PR TITLE
release: v2.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Git LFS Changelog
 
+## 2.7.2 (8 April 2019)
+
+This release is a bugfix release to address some build problems and a regression
+in handling URLs with uppercase letters.
+
+We would like to extend a special thanks to the following open-source
+contributors:
+
+* @andyneff for updating our release targets
+* @ssgelm for improving the Debian package manpage geeneration
+* @hartzell for work on the build system
+
+### Bugs
+
+* Don't set -extldflags unless LDFLAGS has a value #3545 (@hartzell)
+* Switch from manually running go generate to using dh-golang to run it #3549 (@ssgelm)
+* Properly handle config options for URLs with upper case letters #3584 (@bk2204)
+
+### Misc
+
+* Update packagecloud.rb #3546 (@andyneff)
+
 ## 2.7.1 (26 February 2019)
 
 This release is a bugfix release to address panics that could occur when certain

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,9 @@ BUILTIN_LD_FLAGS += -w
 endif
 # EXTRA_LD_FLAGS are given by the caller, and are passed to the Go linker after
 # BUILTIN_LD_FLAGS are processed. By default the system LDFLAGS are passed.
+ifdef LDFLAGS
 EXTRA_LD_FLAGS ?= -extldflags ${LDFLAGS}
+endif
 # LD_FLAGS is the union of the above two BUILTIN_LD_FLAGS and EXTRA_LD_FLAGS.
 LD_FLAGS = $(BUILTIN_LD_FLAGS) $(EXTRA_LD_FLAGS)
 

--- a/config/config.go
+++ b/config/config.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"github.com/git-lfs/git-lfs/fs"
 	"github.com/git-lfs/git-lfs/git"
@@ -155,6 +156,15 @@ func NewFrom(v Values) *Configuration {
 			}
 
 			for key, values := range v.Git {
+				parts := strings.Split(key, ".")
+				isCaseSensitive := len(parts) >= 3
+				hasUpper := strings.IndexFunc(key, unicode.IsUpper) > -1
+
+				// This branch should only ever trigger in
+				// tests, and only if they'd be broken.
+				if !isCaseSensitive && hasUpper {
+					panic(fmt.Sprintf("key %q has uppercase, shouldn't", key))
+				}
 				for _, value := range values {
 					fmt.Printf("Config: %s=%s\n", key, value)
 					source.Lines = append(source.Lines, fmt.Sprintf("%s=%s", key, value))

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -13,7 +13,7 @@ func TestRemoteDefault(t *testing.T) {
 	cfg := NewFrom(Values{
 		Git: map[string][]string{
 			"branch.unused.remote":     []string{"a"},
-			"branch.unused.pushRemote": []string{"b"},
+			"branch.unused.pushremote": []string{"b"},
 		},
 	})
 	assert.Equal(t, "origin", cfg.Remote())
@@ -24,7 +24,7 @@ func TestRemoteBranchConfig(t *testing.T) {
 	cfg := NewFrom(Values{
 		Git: map[string][]string{
 			"branch.master.remote":    []string{"a"},
-			"branch.other.pushRemote": []string{"b"},
+			"branch.other.pushremote": []string{"b"},
 		},
 	})
 	cfg.ref = &git.Ref{Name: "master"}
@@ -37,8 +37,8 @@ func TestRemotePushDefault(t *testing.T) {
 	cfg := NewFrom(Values{
 		Git: map[string][]string{
 			"branch.master.remote":    []string{"a"},
-			"remote.pushDefault":      []string{"b"},
-			"branch.other.pushRemote": []string{"c"},
+			"remote.pushdefault":      []string{"b"},
+			"branch.other.pushremote": []string{"c"},
 		},
 	})
 	cfg.ref = &git.Ref{Name: "master"}
@@ -51,8 +51,8 @@ func TestRemoteBranchPushDefault(t *testing.T) {
 	cfg := NewFrom(Values{
 		Git: map[string][]string{
 			"branch.master.remote":     []string{"a"},
-			"remote.pushDefault":       []string{"b"},
-			"branch.master.pushRemote": []string{"c"},
+			"remote.pushdefault":       []string{"b"},
+			"branch.master.pushremote": []string{"c"},
 		},
 	})
 	cfg.ref = &git.Ref{Name: "master"}

--- a/config/git_fetcher_test.go
+++ b/config/git_fetcher_test.go
@@ -1,0 +1,25 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetCanonicalization(t *testing.T) {
+	vals := map[string][]string{
+		"user.name":                   []string{"Pat Doe"},
+		"branch.MixedCase.pushremote": []string{"Somewhere"},
+		"http.https://example.com/BIG-TEXT.git.extraheader": []string{"X-Foo: Bar"},
+	}
+
+	fetcher := GitFetcher{vals: vals}
+	assert.Equal(t, []string{"Somewhere"}, fetcher.GetAll("bRanch.MixedCase.pushRemote"))
+	assert.Equal(t, []string{"Somewhere"}, fetcher.GetAll("branch.MixedCase.pushremote"))
+	assert.Equal(t, []string(nil), fetcher.GetAll("branch.mixedcase.pushremote"))
+	assert.Equal(t, []string{"Pat Doe"}, fetcher.GetAll("user.name"))
+	assert.Equal(t, []string{"Pat Doe"}, fetcher.GetAll("User.Name"))
+	assert.Equal(t, []string{"X-Foo: Bar"}, fetcher.GetAll("http.https://example.com/BIG-TEXT.git.extraheader"))
+	assert.Equal(t, []string{"X-Foo: Bar"}, fetcher.GetAll("http.https://example.com/BIG-TEXT.git.extraHeader"))
+	assert.Equal(t, []string(nil), fetcher.GetAll("http.https://example.com/big-text.git.extraHeader"))
+}

--- a/config/version.go
+++ b/config/version.go
@@ -12,7 +12,7 @@ var (
 )
 
 const (
-	Version = "2.7.1"
+	Version = "2.7.2"
 )
 
 func init() {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+git-lfs (2.7.2) stable; urgency=low
+
+  * New upstream version
+
+ -- brian m. carlson <bk2204@github.com>  Mon, 08 Apr 2019 14:29:00 -0000
+
 git-lfs (2.7.1) stable; urgency=low
 
   * New upstream version

--- a/debian/rules
+++ b/debian/rules
@@ -18,6 +18,7 @@ BUILD_DIR := obj-$(DEB_HOST_GNU_TYPE)
 export DH_GOPKG := github.com/git-lfs/git-lfs
 # DH_GOLANG_EXCLUDES typically incorporates vendor exclusions
 export DH_GOLANG_EXCLUDES := test github.com/olekukonko/ts/* github.com/xeipuuv/* github.com/spf13/cobra/* github.com/kr/* github.com/pkg/errors github.com/alexbrainman/sspi/*
+export DH_GOLANG_GO_GENERATE := 1
 export PATH := $(CURDIR)/$(BUILD_DIR)/bin:$(PATH)
 
 # by-default, dh_golang only copies *.go and other source - this upsets a bunch of vendor test routines
@@ -32,7 +33,6 @@ override_dh_clean:
 	dh_clean
 
 override_dh_auto_build:
-	cd ${BUILD_DIR}/src/github.com/git-lfs/git-lfs && go generate ./commands
 	dh_auto_build
 	#dh_golang doesn't do anything here in deb 8, and it's needed in both
 	if [ "$(DEB_HOST_GNU_TYPE)" != "$(DEB_BUILD_GNU_TYPE)" ]; then\

--- a/rpm/SPECS/git-lfs.spec
+++ b/rpm/SPECS/git-lfs.spec
@@ -1,5 +1,5 @@
 Name:           git-lfs
-Version:        2.7.1
+Version:        2.7.2
 Release:        1%{?dist}
 Summary:        Git extension for versioning large files
 

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -25,47 +25,68 @@ $client = Packagecloud::Client.new(credentials)
 # matches package directories built by docker to one or more packagecloud distros
 # https://packagecloud.io/docs#os_distro_version
 $distro_name_map = {
-  "centos/5" => %w(
-    el/5
+  # RHEL EOL https://access.redhat.com/support/policy/updates/errata
+  "centos/5" => [
+    "el/5" # End of Extended Support November 30, 2020
+  ],
+  "centos/6" => [
+    "el/6" # End of Extended Support June 30, 2024
+  ],
+  "centos/7" => [
+    "el/7",
+    #"el/8", # BOL ~2019-2020?
+    # Fedora EOL check https://fedoraproject.org/wiki/End_of_life
+    # or https://en.wikipedia.org/wiki/Fedora_version_history#Version_history
+    "fedora/28", # EOL ~Oct 2019
+    "fedora/29", # EOL ~2020
+    # "fedora/30", # BOL ~May 2019
+    # opensuse https://en.opensuse.org/Lifetime
+    # or https://en.wikipedia.org/wiki/OpenSUSE_version_history
+    "opensuse/42.3", # EOL 2019-06-30
+    "opensuse/15.0", # EOL 2019-11-25
+    "opensuse/15.1", # EOL 2020-11
+    # SLES EOL https://www.suse.com/lifecycle/
+    "sles/11.4", # LTSS ends 31 Mar 2022
+    "sles/12.0", # LTSS ends 01 July 2019
+    "sles/12.1", # LTSS ends 31 May 2020
+    "sles/12.2", # LTSS ends 31 Mar 2021
+    "sles/12.3", # LTSS ends 30 Jun 2022
+    "sles/12.4", # Current
+    "sles/15.0"  # Current
+  ],
+  # Debian EOL https://wiki.debian.org/LTS/
+  # Ubuntu EOL https://wiki.ubuntu.com/Releases
+  # Mint EOL https://linuxmint.com/download_all.php
+  "debian/7" => [
+    "debian/wheezy", # EOL 31st May 2018
+    "ubuntu/precise" # ESM April 2019
   ),
-  "centos/6" => %w(
-    el/6
+  "debian/8" => [
+    "debian/jessie",     # EOL June 30, 2020
+    "linuxmint/qiana",   # EOL April 2019
+    "linuxmint/rafaela", # EOL April 2019
+    "linuxmint/rebecca", # EOL April 2019
+    "linuxmint/rosa",    # EOL April 2019
+    "ubuntu/trusty",     # ESM April 2022
+    "ubuntu/vivid",      # EOL February 4, 2016
+    "ubuntu/wily"        # EOL July 28, 2016
   ),
-  "centos/7" => %w(
-    el/7
-    fedora/27
-    fedora/28
-    opensuse/42.3
-    sles/11.4
-    sles/12.3
-    sles/15.0
-  ),
-  "debian/7" => %w(
-    debian/wheezy
-    ubuntu/precise
-  ),
-  "debian/8" => %w(
-    debian/jessie
-    linuxmint/rafaela
-    linuxmint/rebecca
-    linuxmint/rosa
-    ubuntu/trusty
-    ubuntu/vivid
-    ubuntu/wily
-  ),
-  "debian/9" => %W(
-    debian/stretch
-    linuxmint/sarah
-    linuxmint/serena
-    linuxmint/sonya
-    linuxmint/sylvia
-    linuxmint/tara
-    ubuntu/xenial
-    ubuntu/yakkety
-    ubuntu/zesty
-    ubuntu/artful
-    ubuntu/bionic
-    ubuntu/cosmic
+  "debian/9" => [
+    "debian/stretch",   # EOL June 2022
+    "debian/buster",    # Current
+    "linuxmint/sarah",  # EOL April 2021
+    "linuxmint/serena", # EOL April 2021
+    "linuxmint/sonya",  # EOL April 2021
+    "linuxmint/sylvia", # EOL April 2021
+    "linuxmint/tara",   # EOL April 2023
+    "linuxmint/tessa",  # EOL April 2023
+    "ubuntu/xenial",    # ESM April 2024
+    "ubuntu/yakkety",   # EOL July 20, 2017
+    "ubuntu/zesty",     # EOL January 13, 2018
+    "ubuntu/artful",    # EOL July 19 2018
+    "ubuntu/bionic",    # ESM April 2028
+    "ubuntu/cosmic"     # EOL July 2019
+    #"ubuntu/disco"     # BOL ~April
   ),
 }
 

--- a/versioninfo.json
+++ b/versioninfo.json
@@ -4,7 +4,7 @@
 		"FileVersion": {
 			"Major": 2,
 			"Minor": 7,
-			"Patch": 1,
+			"Patch": 2,
 			"Build": 0
 		}
 	},
@@ -13,7 +13,7 @@
 		"FileDescription": "Git LFS",
 		"LegalCopyright": "GitHub, Inc. and Git LFS contributors",
 		"ProductName": "Git Large File Storage (LFS)",
-		"ProductVersion": "2.7.1"
+		"ProductVersion": "2.7.2"
 	},
 	"IconPath": "script/windows-installer/git-lfs-logo.ico"
 }


### PR DESCRIPTION
This is an in-progress look at the next release of Git LFS, v2.7.2, which is scheduled for Monday, April 8, 2019.

We're publishing these changes early so that folks on @git-lfs/implementers can check that things work with their various platforms.

I've attached some builds below for people to use for testing:

[git-lfs-darwin-386-v2.7.2-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/3045385/git-lfs-darwin-386-v2.7.2-pre.tar.gz)
[git-lfs-darwin-amd64-v2.7.2-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/3045386/git-lfs-darwin-amd64-v2.7.2-pre.tar.gz)
[git-lfs-freebsd-386-v2.7.2-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/3045387/git-lfs-freebsd-386-v2.7.2-pre.tar.gz)
[git-lfs-freebsd-amd64-v2.7.2-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/3045388/git-lfs-freebsd-amd64-v2.7.2-pre.tar.gz)
[git-lfs-linux-386-v2.7.2-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/3045389/git-lfs-linux-386-v2.7.2-pre.tar.gz)
[git-lfs-linux-amd64-v2.7.2-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/3045390/git-lfs-linux-amd64-v2.7.2-pre.tar.gz)
[git-lfs-linux-arm64-v2.7.2-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/3045391/git-lfs-linux-arm64-v2.7.2-pre.tar.gz)
[git-lfs-v2.7.2-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/3045392/git-lfs-v2.7.2-pre.tar.gz)
[git-lfs-windows-386-v2.7.2-pre.zip](https://github.com/git-lfs/git-lfs/files/3045393/git-lfs-windows-386-v2.7.2-pre.zip)
[git-lfs-windows-amd64-v2.7.2-pre.zip](https://github.com/git-lfs/git-lfs/files/3045394/git-lfs-windows-amd64-v2.7.2-pre.zip)

/cc @git-lfs/core
/cc @git-lfs/implementers
/cc @git-lfs/releases