### PR TITLE
Various release updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ TAR_XFORM_CMD ?= $(shell tar --version | grep -q 'GNU tar' && echo 's')
 
 # CERT_SHA1 is the SHA-1 hash of the Windows code-signing cert to use.  The
 # actual signature is made with SHA-256.
-CERT_SHA1 ?= 516f21950afecd3779b8b77da92f738fec501f03
+CERT_SHA1 ?= 824455beeb23fe270e756ca04ec8e902d19c62aa
 
 # SOURCES is a listing of all .go files in this and child directories, excluding
 # that in vendor.

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -51,7 +51,6 @@ $distro_name_map = {
     "sles/12.1", # LTSS ends 31 May 2020
     "sles/12.2", # LTSS ends 31 Mar 2021
     "sles/12.3", # LTSS ends 30 Jun 2022
-    "sles/12.4", # Current
     "sles/15.0"  # Current
   ],
   # Debian EOL https://wiki.debian.org/LTS/

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -60,7 +60,7 @@ $distro_name_map = {
   "debian/7" => [
     "debian/wheezy", # EOL 31st May 2018
     "ubuntu/precise" # ESM April 2019
-  ),
+  ],
   "debian/8" => [
     "debian/jessie",     # EOL June 30, 2020
     "linuxmint/qiana",   # EOL April 2019
@@ -70,7 +70,7 @@ $distro_name_map = {
     "ubuntu/trusty",     # ESM April 2022
     "ubuntu/vivid",      # EOL February 4, 2016
     "ubuntu/wily"        # EOL July 28, 2016
-  ),
+  ],
   "debian/9" => [
     "debian/stretch",   # EOL June 2022
     "debian/buster",    # Current
@@ -87,7 +87,7 @@ $distro_name_map = {
     "ubuntu/bionic",    # ESM April 2028
     "ubuntu/cosmic"     # EOL July 2019
     #"ubuntu/disco"     # BOL ~April
-  ),
+  ],
 }
 
 # caches distro id lookups

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -114,7 +114,13 @@ package_files.each do |full_path|
     puts "pushing #{full_path} to #{$distro_id_map.key(distro_id).inspect}"
     result = $client.put_package("git-lfs", pkg, distro_id)
     result.succeeded || begin
-      raise "packagecloud put_package failed, error: #{result.response}"
+      # We've already uploaded this package in an earlier invocation of this
+      # script and our attempt to upload over the existing package failed
+      # because PackageCloud doesn't allow that. Ignore the failure since we
+      # already have the package uploaded.
+      if result.response != '{"filename":["has already been taken"]}'
+        raise "packagecloud put_package failed, error: #{result.response}"
+      end
     end
   end
 end

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -84,8 +84,8 @@ $distro_name_map = {
     "ubuntu/zesty",     # EOL January 13, 2018
     "ubuntu/artful",    # EOL July 19 2018
     "ubuntu/bionic",    # ESM April 2028
-    "ubuntu/cosmic"     # EOL July 2019
-    #"ubuntu/disco"     # BOL ~April
+    "ubuntu/cosmic",    # EOL July 2019
+    "ubuntu/disco",     # EOL April 2020
   ],
 }
 


### PR DESCRIPTION
There are several release-related issues that I discovered while releasing 2.7.2. The first of these, of course, is the nwe signing certificate, which requires an update to the Makefile. In addition, I discovered several issues with the PackageCloud upload script, including some syntax errors and a release that PackageCloud refused to accept. Finally, I hit an additional issue with attempting to upload existing package that I've seen repeatedly before but have just hacked around; this time I finally fixed it.

I've also added Ubuntu disco as a release target, which fixes #3621. Note that I didn't use this change in this release; I simply applied it so as to not forget about it for 2.8.0.