### PR TITLE
Improve error handling in git lfs install

### DIFF
--- a/commands/command_install.go
+++ b/commands/command_install.go
@@ -41,7 +41,10 @@ func cmdInstallOptions() *lfs.FilterOptions {
 		Exit("Only one of --local and --system options can be specified.")
 	}
 
-	if systemInstall && os.Geteuid() != 0 {
+	// This call will return -1 on Windows; don't warn about this there,
+	// since we can't detect it correctly.
+	uid := os.Geteuid()
+	if systemInstall && uid != 0 && uid != -1 {
 		Print("WARNING: current user is not root/admin, system install is likely to fail.")
 	}
 

--- a/commands/command_install.go
+++ b/commands/command_install.go
@@ -20,7 +20,7 @@ func installCommand(cmd *cobra.Command, args []string) {
 	if err := cmdInstallOptions().Install(); err != nil {
 		Print("WARNING: %s", err.Error())
 		Print("Run `git lfs install --force` to reset git config.")
-		return
+		os.Exit(2)
 	}
 
 	if !skipRepoInstall && (localInstall || cfg.InRepo()) {


### PR DESCRIPTION
This series introduces two improvements to git lfs install. The first is to return unsuccessfully (exit code 2) when the operation fails, so that scripting users can easily detect the failure. The second is to avoid printing the warning about the lack of root privileges on Windows, where we will always be unable to detect these privileges properly.

/cc r0nw as reporter
Fixes #3622