### PR TITLE
Pass standard input to ssh

### DIFF
--- a/lfshttp/ssh.go
+++ b/lfshttp/ssh.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -87,6 +88,7 @@ func (c *sshAuthClient) Resolve(e Endpoint, method string) (sshAuthResponse, err
 
 	// Save stdout and stderr in separate buffers
 	var outbuf, errbuf bytes.Buffer
+	cmd.Stdin = os.Stdin
 	cmd.Stdout = &outbuf
 	cmd.Stderr = &errbuf
 


### PR DESCRIPTION
Some people have SSH prompt them for their passphrase when a key is used. In such a situation, the user needs to be able to enter a password on standard input so that they can use their key. When invoking ssh, pass our standard input through to the ssh process so that it can prompt the user if needed.