### PR TITLE
Don't fail if we lack objects the server has

### DIFF
--- a/commands/command_migrate_export.go
+++ b/commands/command_migrate_export.go
@@ -136,7 +136,7 @@ func migrateExportCommand(cmd *cobra.Command, args []string) {
 			}
 
 			if _, err := os.Stat(downloadPath); os.IsNotExist(err) {
-				q.Add(p.Name, downloadPath, p.Oid, p.Size)
+				q.Add(p.Name, downloadPath, p.Oid, p.Size, false)
 			}
 		})
 		gs.ScanRefs(opts.Include, opts.Exclude, nil)

--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -59,7 +59,7 @@ func delayedSmudge(gf *lfs.GitFilter, s *git.FilterProcessScanner, to io.Writer,
 
 	if !skip && filter.Allows(filename) {
 		if _, statErr := os.Stat(path); statErr != nil {
-			q.Add(filename, path, ptr.Oid, ptr.Size)
+			q.Add(filename, path, ptr.Oid, ptr.Size, false)
 			return 0, true, ptr, nil
 		}
 

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -131,9 +131,9 @@ func buildFilepathFilter(config *config.Configuration, includeArg, excludeArg *s
 	return filepathfilter.New(inc, exc)
 }
 
-func downloadTransfer(p *lfs.WrappedPointer) (name, path, oid string, size int64) {
+func downloadTransfer(p *lfs.WrappedPointer) (name, path, oid string, size int64, missing bool) {
 	path, _ = cfg.Filesystem().ObjectPath(p.Oid)
-	return p.Name, path, p.Oid, p.Size
+	return p.Name, path, p.Oid, p.Size, false
 }
 
 // Get user-readable manual install steps for hooks

--- a/lfs/gitfilter_smudge.go
+++ b/lfs/gitfilter_smudge.go
@@ -96,7 +96,7 @@ func (f *GitFilter) downloadFile(writer io.Writer, ptr *Pointer, workingfile, me
 		tq.WithProgressCallback(cb),
 		tq.RemoteRef(f.RemoteRef()),
 	)
-	q.Add(filepath.Base(workingfile), mediafile, ptr.Oid, ptr.Size)
+	q.Add(filepath.Base(workingfile), mediafile, ptr.Oid, ptr.Size, false)
 	q.Wait()
 
 	if errs := q.Errors(); len(errs) > 0 {

--- a/t/git-lfs-test-server-api/main.go
+++ b/t/git-lfs-test-server-api/main.go
@@ -206,7 +206,7 @@ func buildTestData(repo *t.Repo, manifest *tq.Manifest) (oidsExist, oidsMissing 
 		if err != nil {
 			return nil, nil, err
 		}
-		uploadQueue.Add(t.Name, t.Path, t.Oid, t.Size)
+		uploadQueue.Add(t.Name, t.Path, t.Oid, t.Size, false)
 	}
 	uploadQueue.Wait()
 

--- a/t/t-pre-push.sh
+++ b/t/t-pre-push.sh
@@ -412,8 +412,7 @@ begin_test "pre-push reject missing pointers (lfs.allowincompletepush default)"
     exit 1
   fi
 
-  grep "no such file or directory" push.log || # unix
-    grep "cannot find the file" push.log       # windows
+  grep 'Unable to find source' push.log
 
   refute_server_object "$reponame" "$present_oid"
   refute_server_object "$reponame" "$missing_oid"

--- a/t/t-push-failures-local.sh
+++ b/t/t-push-failures-local.sh
@@ -90,9 +90,7 @@ begin_test "push reject missing objects (lfs.allowincompletepush false)"
     exit 1
   fi
 
-  grep "no such file or directory" push.log || # unix
-    grep "cannot find the file" push.log       # windows
-  grep "failed to push some refs" push.log
+  grep 'Unable to find source' push.log
 
   refute_server_object "$reponame" "$present_oid"
   refute_server_object "$reponame" "$missing_oid"

--- a/tq/api.go
+++ b/tq/api.go
@@ -55,6 +55,11 @@ func (c *tqClient) Batch(remote string, bReq *batchRequest) (*BatchResponse, err
 		bReq.TransferAdapterNames = nil
 	}
 
+	missing := make(map[string]bool)
+	for _, obj := range bReq.Objects {
+		missing[obj.Oid] = obj.Missing
+	}
+
 	bRes.endpoint = c.Endpoints.Endpoint(bReq.Operation, remote)
 	requestedAt := time.Now()
 
@@ -81,6 +86,7 @@ func (c *tqClient) Batch(remote string, bReq *batchRequest) (*BatchResponse, err
 	}
 
 	for _, obj := range bRes.Objects {
+		obj.Missing = missing[obj.Oid]
 		for _, a := range obj.Actions {
 			a.createdAt = requestedAt
 		}

--- a/tq/transfer.go
+++ b/tq/transfer.go
@@ -55,6 +55,7 @@ type Transfer struct {
 	Links         ActionSet    `json:"_links,omitempty"`
 	Error         *ObjectError `json:"error,omitempty"`
 	Path          string       `json:"path,omitempty"`
+	Missing       bool         `json:"-"`
 }
 
 func (t *Transfer) Rel(name string) (*Action, error) {


### PR DESCRIPTION
A Git LFS client may not have the entire history of the objects for the repository. However, in some situations, we traverse the entire history of a branch when pushing it, meaning that we need to process every LFS object in the history of that branch. If the objects for the entire history are not present, we currently fail to push.

Instead, let's mark objects we don't have on disk as missing and only fail when we would need to upload those objects. We'll know the server has the objects if the batch response provides no actions to take for them when we request an upload. Pass the missing flag down through the code, and always set it to false for non-uploads.

If for some reason we fail to properly flag a missing object, we will still fail later on when we cannot open the file, just in a messier and more poorly controlled way. The technique used here will attempt to abort the batch as soon as we notice a problem, which means that in the common case (less than 100 objects) we won't have transferred any objects, so the user can notice the failure as soon as possible.

Update the tests to look for a string which will occur in the error message, since we no longer produce the system error message for ENOENT.

Fixes #3468