### PR TITLE
Allow vendors to customize the version info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ GO_TEST_EXTRA_ARGS =
 # the config.GitCommit variable is always set via this variable, and
 # DWARF-stripping is enabled unless DWARF=YesPlease.
 BUILTIN_LD_FLAGS =
+ifneq ("$(VENDOR)","")
+BUILTIN_LD_FLAGS += -X github.com/git-lfs/git-lfs/config.Vendor=$(VENDOR)
+endif
 BUILTIN_LD_FLAGS += -X github.com/git-lfs/git-lfs/config.GitCommit=$(GIT_LFS_SHA)
 ifneq ("$(DWARF)","YesPlease")
 BUILTIN_LD_FLAGS += -s

--- a/config/version.go
+++ b/config/version.go
@@ -9,6 +9,7 @@ import (
 var (
 	GitCommit   string
 	VersionDesc string
+	Vendor      string
 )
 
 const (
@@ -20,8 +21,12 @@ func init() {
 	if len(GitCommit) > 0 {
 		gitCommit = "; git " + GitCommit
 	}
-	VersionDesc = fmt.Sprintf("git-lfs/%s (GitHub; %s %s; go %s%s)",
+	if len(Vendor) == 0 {
+		Vendor = "GitHub"
+	}
+	VersionDesc = fmt.Sprintf("git-lfs/%s (%s; %s %s; go %s%s)",
 		Version,
+		Vendor,
 		runtime.GOOS,
 		runtime.GOARCH,
 		strings.Replace(runtime.Version(), "go", "", 1),


### PR DESCRIPTION
It's common for vendors (such as Linux distros) to want to customize the User-Agent string and version information for software they provide. This is valuable for vendors, but it also allows troubleshooting problems with custom patches that may have been applied by the vendor. Allow vendors to set a VENDOR makefile flag to set the vendor field for the User-Agent and version information.