### PR TITLE
Make API documentation lock creation example less confusing

### DIFF
--- a/docs/api/locking.md
+++ b/docs/api/locking.md
@@ -71,7 +71,7 @@ the user credentials posted when creating the lock.
 {
   "lock": {
     "id": "some-uuid",
-    "path": "/path/to/file",
+    "path": "foo/bar.zip",
     "locked_at": "2016-05-17T15:49:06+00:00",
     "owner": {
       "name": "Jane Doe"


### PR DESCRIPTION
Our locking API docs say that the path for a lock should be relative to the repository root, but we then use an absolute path in the JSON example, which is confusing. Improve this by using the same relative path for the example response as we do for the example request, so that the example is less confusing.

Fixes #3647.