### PR TITLE
Fix 'owner' lock field not documented as optional

### DIFF
--- a/docs/api/locking.md
+++ b/docs/api/locking.md
@@ -62,7 +62,7 @@ as long as it's returned as a string.
 * `path` - String path name of the locked file. This should be relative to the
 root of the repository working directory.
 * `locked_at` - The timestamp the lock was created, as an ISO 8601 formatted string.
-* `owner` - The name of the user that created the Lock. This should be set from
+* `owner` - Optional name of the user that created the Lock. This should be set from
 the user credentials posted when creating the lock.
 
 ```js


### PR DESCRIPTION
According to `locking/schemas/http-lock-create-response-schema.json`, `owner` field is not required,
so fix locking API documentation to match schema.

In fact, GitHub LFS implementation does NOT provide 'owner' field in response to lock creation request.