### PR TITLE
Fix 'locked_at' lock field not documented as optional

### DIFF
--- a/docs/api/locking.md
+++ b/docs/api/locking.md
@@ -61,7 +61,7 @@ Successful responses return the created lock:
 as long as it's returned as a string.
 * `path` - String path name of the locked file. This should be relative to the
 root of the repository working directory.
-* `locked_at` - The timestamp the lock was created, as an ISO 8601 formatted string.
+* `locked_at` - Optional timestamp the lock was created, as an ISO 8601 formatted string.
 * `owner` - Optional name of the user that created the Lock. This should be set from
 the user credentials posted when creating the lock.
 


### PR DESCRIPTION
According to `locking/schemas/http-lock-create-response-schema.json`, `locked_at` field is not required,
so fix locking API documentation to match schema.