### PR TITLE
Make 'locked_at' required in JSON schema

### DIFF
--- a/locking/schemas/http-lock-create-response-schema.json
+++ b/locking/schemas/http-lock-create-response-schema.json
@@ -24,7 +24,7 @@
           }
         }
       },
-      "required": ["id", "path"]
+      "required": ["id", "path", "locked_at"]
     },
     "message": {
       "type": "string"


### PR DESCRIPTION
This commit fixes discrepancy between LFS locking spec and JSON schema.

Per discussion in #3652, spec has higher priority here.