### PR TITLE
Ensure we always use correct Content-Type and Accept headers

### DIFF
--- a/t/cmd/lfstest-gitserver.go
+++ b/t/cmd/lfstest-gitserver.go
@@ -215,10 +215,22 @@ func lfsHandler(w http.ResponseWriter, r *http.Request, id string) {
 		return
 	}
 
+	// Check that we're sending valid data.
+	if !strings.Contains(r.Header.Get("Accept"), "application/vnd.git-lfs+json") {
+		w.WriteHeader(406)
+		return
+	}
+
 	debug(id, "git lfs %s %s repo: %s", r.Method, r.URL, repo)
 	w.Header().Set("Content-Type", "application/vnd.git-lfs+json")
 	switch r.Method {
 	case "POST":
+		// Reject invalid data.
+		if !strings.Contains(r.Header.Get("Content-Type"), "application/vnd.git-lfs+json") {
+			w.WriteHeader(400)
+			return
+		}
+
 		if strings.HasSuffix(r.URL.String(), "batch") {
 			lfsBatchHandler(w, r, id, repo)
 		} else {

--- a/t/testhelpers.sh
+++ b/t/testhelpers.sh
@@ -119,6 +119,7 @@ refute_server_object() {
     -o http.json \
     -d "{\"operation\":\"download\",\"objects\":[{\"oid\":\"$oid\"}]}" \
     -H "Accept: application/vnd.git-lfs+json" \
+    -H "Content-Type: application/vnd.git-lfs+json" \
     -H "X-Check-Object: 1" \
     -H "X-Ignore-Retries: true" 2>&1 |
     tee http.log
@@ -157,6 +158,7 @@ assert_server_object() {
     -o http.json \
     -d "{\"operation\":\"download\",\"objects\":[{\"oid\":\"$oid\"}],\"ref\":{\"name\":\"$refspec\"}}" \
     -H "Accept: application/vnd.git-lfs+json" \
+    -H "Content-Type: application/vnd.git-lfs+json" \
     -H "X-Check-Object: 1" \
     -H "X-Ignore-Retries: true" 2>&1 |
     tee http.log

--- a/tq/verify.go
+++ b/tq/verify.go
@@ -35,10 +35,11 @@ func verifyUpload(c *lfsapi.Client, remote string, t *Transfer) error {
 		return err
 	}
 
+	req.Header.Set("Content-Type", "application/vnd.git-lfs+json")
+	req.Header.Set("Accept", "application/vnd.git-lfs+json")
 	for key, value := range action.Header {
 		req.Header.Set(key, value)
 	}
-	req.Header.Set("Content-Type", "application/vnd.git-lfs+json")
 
 	mv := c.GitEnv().Int(maxVerifiesConfigKey, defaultMaxVerifyAttempts)
 	mv = tools.MaxInt(defaultMaxVerifyAttempts, mv)


### PR DESCRIPTION
There is one place in the code and two places in the testsuite where we fail to provide the proper Content-Type and Accept headers when making a request to the server. Correct these places and adjust the test server to always check for the Accept header and check for the Content-Type header whenever we have a JSON body (i.e., when we have a POST request).

Fixes #3662
/cc @slonopotamus as reporter