### PR TITLE
Canonicalize common directory paths on Cygwin

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -644,6 +644,9 @@ func RootDir() (string, error) {
 
 	path := strings.TrimSpace(string(out))
 	path, err = tools.TranslateCygwinPath(path)
+	if err != nil {
+		return "", err
+	}
 	return canonicalizeDir(path)
 }
 
@@ -654,6 +657,10 @@ func GitDir() (string, error) {
 		return "", fmt.Errorf("Failed to call git rev-parse --git-dir: %v %v", err, string(out))
 	}
 	path := strings.TrimSpace(string(out))
+	path, err = tools.TranslateCygwinPath(path)
+	if err != nil {
+		return "", err
+	}
 	return canonicalizeDir(path)
 }
 
@@ -671,6 +678,10 @@ func GitCommonDir() (string, error) {
 		return "", fmt.Errorf("Failed to call git rev-parse --git-dir: %v %v", err, string(out))
 	}
 	path := strings.TrimSpace(string(out))
+	path, err = tools.TranslateCygwinPath(path)
+	if err != nil {
+		return "", err
+	}
 	return canonicalizeDir(path)
 }
 


### PR DESCRIPTION
When we look up the Git and root paths together, we canonicalize the paths on Cygwin to Windows paths. This is required because Cygwin is essentially a libc, and Go neither uses libc nor has support for Cygwin natively. Without this, we'd treat absolute Unix-style paths created by Cygwin's Git as Windows paths relative to the root of the current drive, breaking most uses of Cygwin-created repositories.

However, we do not canonicalize the paths in several other cases where we read the output from Git, such as the common directory, which is used when reading Git objects. Consequently, functionality like git lfs fsck failed on Cygwin.

To ensure things work as expected on Cygwin, canonicalize the paths in all cases where we read a directory from Git. In addition, add some error checking for several of these places as well.

Fixes #3667
/cc @brice-ruppen as reporter