### PR TITLE
Add support for SOCKS proxies

### DIFF
--- a/lfshttp/proxy.go
+++ b/lfshttp/proxy.go
@@ -32,7 +32,7 @@ func proxyFromClient(c *Client) func(req *http.Request) (*url.URL, error) {
 		}
 
 		proxyURL, err := url.Parse(proxy)
-		if err != nil || !strings.HasPrefix(proxyURL.Scheme, "http") {
+		if err != nil || !(strings.HasPrefix(proxyURL.Scheme, "http") || strings.HasPrefix(proxyURL.Scheme, "socks")) {
 			// proxy was bogus. Try prepending "http://" to it and
 			// see if that parses correctly. If not, we fall
 			// through and complain about the original one.

--- a/lfshttp/proxy_test.go
+++ b/lfshttp/proxy_test.go
@@ -95,3 +95,18 @@ func TestProxyNoProxy(t *testing.T) {
 	assert.Nil(t, proxyURL)
 	assert.Nil(t, err)
 }
+
+func TestSocksProxyFromEnvironment(t *testing.T) {
+	c, err := NewClient(NewContext(nil, map[string]string{
+		"HTTPS_PROXY": "socks5://proxy-from-env:3128",
+	}, nil))
+	require.Nil(t, err)
+
+	req, err := http.NewRequest("GET", "https://some-host.com:123/foo/bar", nil)
+	require.Nil(t, err)
+
+	proxyURL, err := proxyFromClient(c)(req)
+	assert.Equal(t, "socks5", proxyURL.Scheme)
+	assert.Equal(t, "proxy-from-env:3128", proxyURL.Host)
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
Currently, we prepend "http://" to the proxy URL if it's not an HTTP or HTTPS URL. Unfortunately, that breaks support for SOCKS 5 proxies, which use URLs that start with "socks5://". Fix this by allowing URL schemes starting with "socks" in addition to those starting with "http".

Note that this does not introduce any support for socks5h proxies, since Go does not support them, but we will support them automatically once Go does.

Fixes #1424.