### PR TITLE
Be more precise about what timestamps we accept

### DIFF
--- a/docs/api/batch.md
+++ b/docs/api/batch.md
@@ -145,8 +145,9 @@ omitted.
     * `expires_in` - Whole number of seconds after local client time when
       transfer will expire. Preferred over `expires_at` if both are provided.
       Maximum of 2147483647, minimum of -2147483647.
-    * `expires_at` - String ISO 8601 formatted timestamp for when the given
-    action expires (usually due to a temporary token).
+    * `expires_at` - String uppercase RFC 3339-formatted timestamp with second
+      precision for when the given action expires (usually due to a temporary
+      token).
 
 Download operations MUST specify a `download` action, or an object error if the
 object cannot be downloaded for some reason. See "Response Errors" below.

--- a/docs/api/locking.md
+++ b/docs/api/locking.md
@@ -61,7 +61,8 @@ Successful responses return the created lock:
 as long as it's returned as a string.
 * `path` - String path name of the locked file. This should be relative to the
 root of the repository working directory.
-* `locked_at` - The timestamp the lock was created, as an ISO 8601 formatted string.
+* `locked_at` - The timestamp the lock was created, as an uppercase
+RFC 3339-formatted string with second precision.
 * `owner` - Optional name of the user that created the Lock. This should be set from
 the user credentials posted when creating the lock.
 


### PR DESCRIPTION
In a couple of places in our documentation, we specified that a timestamp should be in ISO 8601 format. However, ISO 8601 specifies a large number of variants, and Go only parses a subset of those. For example, using a timestamp without the colon in the time zone offset will cause Git LFS to fail.

Be explicit about what we want as a timestamp, which is an uppercase RFC 3339-formatted timestamp with second precision. That's what Go parses, and that's what we expect. It is, in addition, a profile of ISO 8601, so other tools that can parse the entirety of ISO 8601 will still accept these date formats.

Fixes #3660
/cc @slonopotamus as reporter