### PR TITLE
Migrate tags pointing to other tags

### DIFF
--- a/t/t-migrate-import.sh
+++ b/t/t-migrate-import.sh
@@ -578,6 +578,37 @@ begin_test "migrate import (--everything and --include with glob pattern)"
 )
 end_test
 
+begin_test "migrate import (--everything with tag pointing to tag)"
+(
+  set -e
+
+  setup_multiple_local_branches
+
+  md_master_oid="$(calc_oid "$(git cat-file -p "refs/heads/master:a.md")")"
+  txt_master_oid="$(calc_oid "$(git cat-file -p "refs/heads/master:a.txt")")"
+  md_feature_oid="$(calc_oid "$(git cat-file -p "refs/heads/my-feature:a.md")")"
+  txt_feature_oid="$(calc_oid "$(git cat-file -p "refs/heads/my-feature:a.txt")")"
+
+  git tag -a -m abc abc refs/heads/master
+  git tag -a -m def def refs/tags/abc
+
+  git lfs migrate import --verbose --everything --include='*.[mM][dD]'
+
+  assert_pointer "refs/heads/master" "a.md" "$md_master_oid" "140"
+  assert_pointer "refs/tags/abc" "a.md" "$md_master_oid" "140"
+  assert_pointer "refs/tags/def" "a.md" "$md_master_oid" "140"
+  assert_pointer "refs/heads/my-feature" "a.md" "$md_feature_oid" "30"
+
+  git tag --points-at refs/tags/abc | grep -q def
+  ! git tag --points-at refs/tags/def | grep -q abc
+
+  assert_local_object "$md_master_oid" "140"
+  assert_local_object "$md_feature_oid" "30"
+  refute_local_object "$txt_master_oid"
+  refute_local_object "$txt_feature_oid"
+)
+end_test
+
 begin_test "migrate import (nested sub-trees and --include with wildcard)"
 (
   set -e


### PR DESCRIPTION
When rewriting history, we've ignored tags pointing to other tags. This leads to problems for folks that are trying to shrink the size of their repository, since they may still have tags that point to the old history. Add additional handling for tags pointing to tags, recursively rewriting the inner tags until we reach a commit.

Fixes #3568
/cc @rcdailey as reporter