### PR TITLE
Copy mode from original file when rewriting objects

### DIFF
--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -384,7 +384,8 @@ func (r *Rewriter) rewriteTree(commitOID []byte, treeOID []byte, path string,
 		}
 
 		if cached := r.uncacheEntry(entry); cached != nil {
-			entries = append(entries, copyEntry(cached))
+			entries = append(entries, copyEntryMode(cached,
+				entry.Filemode))
 			continue
 		}
 
@@ -434,6 +435,13 @@ func copyEntry(e *gitobj.TreeEntry) *gitobj.TreeEntry {
 		Name:     e.Name,
 		Oid:      oid,
 	}
+}
+
+func copyEntryMode(e *gitobj.TreeEntry, mode int32) *gitobj.TreeEntry {
+	copied := copyEntry(e)
+	copied.Filemode = mode
+
+	return copied
 }
 
 func (r *Rewriter) allows(typ gitobj.ObjectType, abs string) bool {

--- a/t/t-migrate-import.sh
+++ b/t/t-migrate-import.sh
@@ -439,6 +439,34 @@ EOF)
 )
 end_test
 
+begin_test "migrate import (identical contents, different permissions)"
+(
+  set -e
+
+  # Windows lacks POSIX permissions.
+  [ "$IS_WINDOWS" -eq 1 ] && exit 0
+
+  setup_multiple_local_branches
+  git checkout master
+
+  echo "foo" >foo.dat
+  git add .
+  git commit -m "add file"
+
+  chmod u+x foo.dat
+  git add .
+  git commit -m "make file executable"
+
+  # Verify we have executable permissions.
+  ls -la foo.dat | grep 'rwx'
+
+  git lfs migrate import --everything --include="*.dat"
+
+  # Verify we have executable permissions.
+  ls -la foo.dat | grep 'rwx'
+)
+end_test
+
 begin_test "migrate import (bare repository)"
 (
   set -e


### PR DESCRIPTION
When we rewrite a blob, we cache certain data based on the file name and the old object ID. However, we don't consider the mode, so if we have two identical blobs with the same relative name but different modes, we'll write the mode we first saw into all subsequent blobs.

Fix this by copying the mode across from the existing blob when we rewrite the new blob.

Fixes #3691 
/cc @larsxschneider as reporter