### PR TITLE
Add support for Debian 10

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: git-lfs
 Section: vcs
 Priority: optional
 Maintainer: Stephen Gelman <gelman@getbraintree.com>
-Build-Depends: debhelper (>= 9), dh-golang, golang-go:native (>= 1.3.0), git (>= 1.8.2), ruby-ronn
+Build-Depends: debhelper (>= 9), dh-golang, golang-go:native (>= 1.3.0), git (>= 1.8.2), ruby-ronn, ronn | ruby-ronn (<< 0.8.0-1)
 Standards-Version: 3.9.6
 
 Package: git-lfs

--- a/debian/rules
+++ b/debian/rules
@@ -1,7 +1,6 @@
 #!/usr/bin/make -f
 
 export DH_OPTIONS
-export GO111MODULE=on
 
 #dh_golang doesn't do this for you
 ifeq ($(DEB_HOST_ARCH), i386)
@@ -25,7 +24,8 @@ export PATH := $(CURDIR)/$(BUILD_DIR)/bin:$(PATH)
 export DH_GOLANG_INSTALL_ALL := 1
 
 %:
-	dh $@ --buildsystem=golang --with=golang
+	mkdir -p /tmp/gocache
+	GO111MODULE=on GOFLAGS=-mod=vendor GOCACHE=/tmp/gocache dh $@ --buildsystem=golang --with=golang
 
 override_dh_clean:
 	rm -f debian/debhelper.log
@@ -37,7 +37,6 @@ override_dh_auto_build:
 	#dh_golang doesn't do anything here in deb 8, and it's needed in both
 	if [ "$(DEB_HOST_GNU_TYPE)" != "$(DEB_BUILD_GNU_TYPE)" ]; then\
 		cp -rf $(BUILD_DIR)/bin/*/* $(BUILD_DIR)/bin/; \
-		cp -rf $(BUILD_DIR)/pkg/*/* $(BUILD_DIR)/pkg/; \
 	fi
 	rm $(BUILD_DIR)/bin/script
 	rm $(BUILD_DIR)/bin/man

--- a/docker/run_dockers.bsh
+++ b/docker/run_dockers.bsh
@@ -55,7 +55,7 @@ done
 
 if [[ ${#IMAGES[@]} == 0 ]]; then
   # If you change this list, change script/upload as well.
-  IMAGES=(centos_6 centos_7 debian_8 debian_9)
+  IMAGES=(centos_6 centos_7 debian_8 debian_9 debian_10)
 fi
 
 mkdir -p "${PACKAGE_DIR}"

--- a/docker/run_dockers.bsh
+++ b/docker/run_dockers.bsh
@@ -55,7 +55,7 @@ done
 
 if [[ ${#IMAGES[@]} == 0 ]]; then
   # If you change this list, change script/upload as well.
-  IMAGES=(centos_6 centos_7 debian_7 debian_8 debian_9)
+  IMAGES=(centos_6 centos_7 debian_8 debian_9)
 fi
 
 mkdir -p "${PACKAGE_DIR}"

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -56,10 +56,6 @@ $distro_name_map = {
   # Debian EOL https://wiki.debian.org/LTS/
   # Ubuntu EOL https://wiki.ubuntu.com/Releases
   # Mint EOL https://linuxmint.com/download_all.php
-  "debian/7" => [
-    "debian/wheezy", # EOL 31st May 2018
-    "ubuntu/precise" # ESM April 2019
-  ],
   "debian/8" => [
     "debian/jessie",     # EOL June 30, 2020
     "linuxmint/qiana",   # EOL April 2019
@@ -129,7 +125,6 @@ package_files.each do |full_path|
   next if full_path.include?("SRPM") || full_path.include?("i386") || full_path.include?("i686")
   next unless full_path =~ /\/git-lfs[-|_]\d/
   os, distro = case full_path
-  when /debian\/7/ then ["Debian 7", "debian/wheezy"]
   when /debian\/8/ then ["Debian 8", "debian/jessie"]
   when /debian\/9/ then ["Debian 9", "debian/stretch"]
   when /centos\/5/ then ["RPM RHEL 5/CentOS 5", "el/5"]

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -68,7 +68,6 @@ $distro_name_map = {
   ],
   "debian/9" => [
     "debian/stretch",   # EOL June 2022
-    "debian/buster",    # Current
     "linuxmint/sarah",  # EOL April 2021
     "linuxmint/serena", # EOL April 2021
     "linuxmint/sonya",  # EOL April 2021
@@ -83,6 +82,9 @@ $distro_name_map = {
     "ubuntu/cosmic",    # EOL July 2019
     "ubuntu/disco",     # EOL April 2020
   ],
+  "debian/10" => [
+    "debian/buster",    # Current
+  ]
 }
 
 # caches distro id lookups
@@ -125,11 +127,12 @@ package_files.each do |full_path|
   next if full_path.include?("SRPM") || full_path.include?("i386") || full_path.include?("i686")
   next unless full_path =~ /\/git-lfs[-|_]\d/
   os, distro = case full_path
-  when /debian\/8/ then ["Debian 8", "debian/jessie"]
-  when /debian\/9/ then ["Debian 9", "debian/stretch"]
-  when /centos\/5/ then ["RPM RHEL 5/CentOS 5", "el/5"]
-  when /centos\/6/ then ["RPM RHEL 6/CentOS 6", "el/6"]
-  when /centos\/7/ then ["RPM RHEL 7/CentOS 7", "el/7"]
+  when /debian\/8/  then ["Debian 8",  "debian/jessie"]
+  when /debian\/9/  then ["Debian 9",  "debian/stretch"]
+  when /debian\/10/ then ["Debian 10", "debian/buster"]
+  when /centos\/5/  then ["RPM RHEL 5/CentOS 5", "el/5"]
+  when /centos\/6/  then ["RPM RHEL 6/CentOS 6", "el/6"]
+  when /centos\/7/  then ["RPM RHEL 7/CentOS 7", "el/7"]
   end
 
   next unless os

--- a/script/upload
+++ b/script/upload
@@ -147,7 +147,6 @@ Up to date packages are available on [PackageCloud](https://packagecloud.io/gith
 
 [RPM RHEL 6/CentOS 6](https://packagecloud.io/github/git-lfs/packages/el/6/git-lfs-VERSION-1.el6.x86_64.rpm/download)
 [RPM RHEL 7/CentOS 7](https://packagecloud.io/github/git-lfs/packages/el/7/git-lfs-VERSION-1.el7.x86_64.rpm/download)
-[Debian 7](https://packagecloud.io/github/git-lfs/packages/debian/wheezy/git-lfs_VERSION_amd64.deb/download)
 [Debian 8](https://packagecloud.io/github/git-lfs/packages/debian/jessie/git-lfs_VERSION_amd64.deb/download)
 [Debian 9](https://packagecloud.io/github/git-lfs/packages/debian/stretch/git-lfs_VERSION_amd64.deb/download)
 

--- a/script/upload
+++ b/script/upload
@@ -149,6 +149,7 @@ Up to date packages are available on [PackageCloud](https://packagecloud.io/gith
 [RPM RHEL 7/CentOS 7](https://packagecloud.io/github/git-lfs/packages/el/7/git-lfs-VERSION-1.el7.x86_64.rpm/download)
 [Debian 8](https://packagecloud.io/github/git-lfs/packages/debian/jessie/git-lfs_VERSION_amd64.deb/download)
 [Debian 9](https://packagecloud.io/github/git-lfs/packages/debian/stretch/git-lfs_VERSION_amd64.deb/download)
+[Debian 10](https://packagecloud.io/github/git-lfs/packages/debian/buster/git-lfs_VERSION_amd64.deb/download)
 
 ## SHA-256 hashes:
 EOM

--- a/t/t-install.sh
+++ b/t/t-install.sh
@@ -232,6 +232,9 @@ begin_test "install --local with failed permissions"
   # Windows lacks POSIX permissions.
   [ "$IS_WINDOWS" -eq 1 ] && exit 0
 
+  # Root is exempt from permissions.
+  [ "$(id -u)" -eq 0 ] && exit 0
+
   # old values that should be ignored by `install --local`
   git config --global filter.lfs.smudge "git lfs smudge %f"
   git config --global filter.lfs.clean "git lfs clean %f"


### PR DESCRIPTION
Add support for building with Go 1.12.6 and Debian 10. This will allow us to build Git LFS with Debian 10 as soon as it's announced. Drop support for Debian 7, which is end of life and whose packages can no longer be downloaded with APT.

In addition, fix a test failure that occurs when building on CentOS. Debian builds packages with fakeroot, which honors permissions, but in our CentOS containers, we build as root, which causes a permission-related test to fail.