### PR TITLE
Fix CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,4 @@
 version: 2
-
 jobs:
   bootstrap:
     macos:
@@ -78,7 +77,6 @@ jobs:
       - run: echo "export PATH=$HOME/bin:$GOPATH/bin:$PATH" >> $BASH_ENV
       - run: echo "export GIT_LFS_TEST_DIR=$HOME/git-lfs-tests" >> $BASH_ENV
       - run: script/cibuild
-
 workflows:
   version: 2
   build:


### PR DESCRIPTION
Our CircleCI configuration seems to be being flagged as being 1.0 instead of 2.0, preventing jobs from running. This PR is an attempt to address this issue and get things working again.