### PR TITLE
Use default line endings for core.autocrlf=input

### DIFF
--- a/commands/path.go
+++ b/commands/path.go
@@ -5,7 +5,7 @@ import "strings"
 func gitLineEnding(git env) string {
 	value, _ := git.Get("core.autocrlf")
 	switch strings.ToLower(value) {
-	case "input", "true", "t", "1":
+	case "true", "t", "1":
 		return "\r\n"
 	default:
 		return osLineEnding()

--- a/t/t-track.sh
+++ b/t/t-track.sh
@@ -212,9 +212,12 @@ begin_test "track with autocrlf=input"
   [ "*.mov filter=lfs -text" = "$(cat .gitattributes)" ]
 
   git lfs track "*.gif"
-  expected="*.mov filter=lfs -text^M$
-*.gif filter=lfs diff=lfs merge=lfs -text^M$"
-  [ "$expected" = "$(cat -e .gitattributes)" ]
+  if [ $IS_WINDOWS -eq 1 ]
+  then
+      cat -e .gitattributes | grep '\^M\$'
+  else
+      cat -e .gitattributes | grep -v '\^M'
+  fi
 )
 end_test
 


### PR DESCRIPTION
We currently use core.autocrlf to guess what line endings a user might want to have for the .gitattributes file if it lacks line endings already. When the user has specified core.autocrlf=input, they have specified that they don't want line endings to be changed. This isn't explicitly an indication that they want to use CRLF line endings, especially if they are on a non-Windows system.

Therefore, if we need to guess what line endings to use with `core.autocrlf=input`, guess the system line endings, not CRLF.

Fixes #3702.