### PR TITLE
Accept legacy Git SSH URLs

### DIFF
--- a/lfsapi/endpoint_finder.go
+++ b/lfsapi/endpoint_finder.go
@@ -196,7 +196,7 @@ func (e *endpointGitFinder) NewEndpoint(operation, rawurl string) lfshttp.Endpoi
 	}
 
 	switch u.Scheme {
-	case "ssh":
+	case "ssh", "git+ssh", "ssh+git":
 		return lfshttp.EndpointFromSshUrl(u)
 	case "http", "https":
 		return lfshttp.EndpointFromHttpUrl(u)

--- a/lfsapi/endpoint_finder_test.go
+++ b/lfsapi/endpoint_finder_test.go
@@ -166,6 +166,54 @@ func TestSSHCustomPortEndpointAddsLfsSuffix(t *testing.T) {
 	assert.Equal(t, "9000", e.SshPort)
 }
 
+func TestGitSSHEndpointAddsLfsSuffix(t *testing.T) {
+	finder := NewEndpointFinder(lfshttp.NewContext(nil, nil, map[string]string{
+		"remote.origin.url": "git+ssh://git@example.com/foo/bar",
+	}))
+
+	e := finder.Endpoint("download", "")
+	assert.Equal(t, "https://example.com/foo/bar.git/info/lfs", e.Url)
+	assert.Equal(t, "git@example.com", e.SshUserAndHost)
+	assert.Equal(t, "foo/bar", e.SshPath)
+	assert.Equal(t, "", e.SshPort)
+}
+
+func TestGitSSHCustomPortEndpointAddsLfsSuffix(t *testing.T) {
+	finder := NewEndpointFinder(lfshttp.NewContext(nil, nil, map[string]string{
+		"remote.origin.url": "git+ssh://git@example.com:9000/foo/bar",
+	}))
+
+	e := finder.Endpoint("download", "")
+	assert.Equal(t, "https://example.com/foo/bar.git/info/lfs", e.Url)
+	assert.Equal(t, "git@example.com", e.SshUserAndHost)
+	assert.Equal(t, "foo/bar", e.SshPath)
+	assert.Equal(t, "9000", e.SshPort)
+}
+
+func TestSSHGitEndpointAddsLfsSuffix(t *testing.T) {
+	finder := NewEndpointFinder(lfshttp.NewContext(nil, nil, map[string]string{
+		"remote.origin.url": "ssh+git://git@example.com/foo/bar",
+	}))
+
+	e := finder.Endpoint("download", "")
+	assert.Equal(t, "https://example.com/foo/bar.git/info/lfs", e.Url)
+	assert.Equal(t, "git@example.com", e.SshUserAndHost)
+	assert.Equal(t, "foo/bar", e.SshPath)
+	assert.Equal(t, "", e.SshPort)
+}
+
+func TestSSHGitCustomPortEndpointAddsLfsSuffix(t *testing.T) {
+	finder := NewEndpointFinder(lfshttp.NewContext(nil, nil, map[string]string{
+		"remote.origin.url": "ssh+git://git@example.com:9000/foo/bar",
+	}))
+
+	e := finder.Endpoint("download", "")
+	assert.Equal(t, "https://example.com/foo/bar.git/info/lfs", e.Url)
+	assert.Equal(t, "git@example.com", e.SshUserAndHost)
+	assert.Equal(t, "foo/bar", e.SshPath)
+	assert.Equal(t, "9000", e.SshPort)
+}
+
 func TestBareSSHEndpointAddsLfsSuffix(t *testing.T) {
 	finder := NewEndpointFinder(lfshttp.NewContext(nil, nil, map[string]string{
 		"remote.origin.url": "git@example.com:foo/bar.git",


### PR DESCRIPTION
For a long time, the preferred way to write an SSH URL for use with Git has been with the "ssh" scheme. However, Git still accepts the "git+ssh" and "ssh+git" schemes for remotes as well, despite marking them as deprecated in the code. For compatibility with Git, accept these schemes as an alias for the "ssh" scheme.

Addresses behavior reported in #3695.