### PR TITLE
Use a download token when searching locks

### DIFF
--- a/locking/api.go
+++ b/locking/api.go
@@ -180,7 +180,7 @@ type lockList struct {
 }
 
 func (c *lockClient) Search(remote string, searchReq *lockSearchRequest) (*lockList, *http.Response, error) {
-	e := c.Endpoints.Endpoint("upload", remote)
+	e := c.Endpoints.Endpoint("download", remote)
 	req, err := c.NewRequest("GET", e, "locks", nil)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
The locking API documentation specifies that a user need only have pull access to the repository when searching locks. However, we requested an upload token, which requires push access. Instead, ask for a download token, which requires only pull access, as documented.

Fixes #3653
/cc @slonopotamus as reporter