### PR TITLE
Update gitobj to v1.3.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/git-lfs/git-lfs
 
 require (
 	github.com/alexbrainman/sspi v0.0.0-20180125232955-4729b3d4d858
-	github.com/git-lfs/gitobj v1.3.0
+	github.com/git-lfs/gitobj v1.3.1
 	github.com/git-lfs/go-netrc v0.0.0-20180525200031-e0e9ca483a18
 	github.com/git-lfs/go-ntlm v0.0.0-20190307203151-c5056e7fa066
 	github.com/git-lfs/wildmatch v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/alexbrainman/sspi v0.0.0-20180125232955-4729b3d4d858 h1:OZQyEhf4Bviyd
 github.com/alexbrainman/sspi v0.0.0-20180125232955-4729b3d4d858/go.mod h1:976q2ETgjT2snVCf2ZaBnyBbVoPERGjUz+0sofzEfro=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/git-lfs/gitobj v1.3.0 h1:XRdf5COrTYPfmCUwZlNY3TKjWqOPrjRWQb4QOqB6ZJc=
-github.com/git-lfs/gitobj v1.3.0/go.mod h1:EdPNGHVxXe1jTuNXzZT1+CdJCuASoDSLPQuvNOo9nGM=
+github.com/git-lfs/gitobj v1.3.1 h1:Nni8wnRfvT3x91rDl3V397LjKOUoiaEK6vyIcA92aM8=
+github.com/git-lfs/gitobj v1.3.1/go.mod h1:EdPNGHVxXe1jTuNXzZT1+CdJCuASoDSLPQuvNOo9nGM=
 github.com/git-lfs/go-netrc v0.0.0-20180525200031-e0e9ca483a18 h1:7Th0eBA4rT8WJNiM1vppjaIv9W5WJinhpbCJvRJxloI=
 github.com/git-lfs/go-netrc v0.0.0-20180525200031-e0e9ca483a18/go.mod h1:70O4NAtvWn1jW8V8V+OKrJJYcxDLTmIozfi2fmSz5SI=
 github.com/git-lfs/go-ntlm v0.0.0-20190307203151-c5056e7fa066 h1:j7JwIEwLNQ/kBdKpHO3U1jjMXIPjSq7eCFvQIF3e8Fs=

--- a/vendor/github.com/git-lfs/gitobj/object_db.go
+++ b/vendor/github.com/git-lfs/gitobj/object_db.go
@@ -158,7 +158,7 @@ func (o *ObjectDatabase) WriteBlob(b *Blob) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer os.Remove(buf.Name())
+	defer o.cleanup(buf)
 
 	sha, _, err := o.encodeBuffer(b, buf)
 	if err != nil {
@@ -236,7 +236,7 @@ func (d *ObjectDatabase) encodeBuffer(object Object, buf io.ReadWriter) (sha []b
 	if err != nil {
 		return nil, 0, err
 	}
-	defer os.Remove(tmp.Name())
+	defer d.cleanup(tmp)
 
 	to := NewObjectWriter(tmp)
 	if _, err = to.WriteHeader(object.Type(), int64(cn)); err != nil {
@@ -322,4 +322,9 @@ func (o *ObjectDatabase) decode(r *ObjectReader, into Object) error {
 		return nil
 	}
 	return r.Close()
+}
+
+func (o *ObjectDatabase) cleanup(f *os.File) {
+	f.Close()
+	os.Remove(f.Name())
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -3,7 +3,7 @@ github.com/alexbrainman/sspi
 github.com/alexbrainman/sspi/ntlm
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/git-lfs/gitobj v1.3.0
+# github.com/git-lfs/gitobj v1.3.1
 github.com/git-lfs/gitobj
 github.com/git-lfs/gitobj/errors
 github.com/git-lfs/gitobj/pack


### PR DESCRIPTION
Update gitobj to v1.3.1, which fixes a file descriptor leak.

Fixes #3696.