### PR TITLE
Redirect stdin from /dev/null when running ssh

### DIFF
--- a/lfshttp/ssh.go
+++ b/lfshttp/ssh.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -88,7 +87,6 @@ func (c *sshAuthClient) Resolve(e Endpoint, method string) (sshAuthResponse, err
 
 	// Save stdout and stderr in separate buffers
 	var outbuf, errbuf bytes.Buffer
-	cmd.Stdin = os.Stdin
 	cmd.Stdout = &outbuf
 	cmd.Stderr = &errbuf
 


### PR DESCRIPTION
When using SSH cloning with a ControlMaster socket and a password on a Unix system, we're unable to read from standard input and consequently the SSH process fails. The redirect from standard input was intended to fix an issue on Windows that is due to /dev/tty disappearing, but it doesn't appear to work and causes issues on Unix systems. Revert this change so we can explore other options.

Fixes #3719.
/cc @slonopotamus as submitter