### PR TITLE
Fix typos across git-lfs repository

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -139,7 +139,7 @@ type Values struct {
 }
 
 // NewFrom returns a new `*config.Configuration` that reads both its Git
-// and Enviornment-level values from the ones provided instead of the actual
+// and Environment-level values from the ones provided instead of the actual
 // `.gitconfig` file or `os.Getenv`, respectively.
 //
 // This method should only be used during testing.

--- a/config/delayed_environment.go
+++ b/config/delayed_environment.go
@@ -7,7 +7,7 @@ import (
 // delayedEnvironment is an implementation of the Environment which wraps the legacy
 // behavior of `*config.Configuration.loadGitConfig()`.
 //
-// It is functionally equivelant to call `cfg.loadGitConfig()` before calling
+// It is functionally equivalent to call `cfg.loadGitConfig()` before calling
 // methods on the Environment type.
 type delayedEnvironment struct {
 	env      Environment

--- a/config/fetcher.go
+++ b/config/fetcher.go
@@ -1,7 +1,7 @@
 package config
 
 // Fetcher provides an interface to get typed information out of a configuration
-// "source". These sources could be the OS enviornment, a .gitconfig, or even
+// "source". These sources could be the OS environment, a .gitconfig, or even
 // just a `map`.
 type Fetcher interface {
 	// Get returns the string value associated with a given key and a bool

--- a/config/os_fetcher.go
+++ b/config/os_fetcher.go
@@ -12,7 +12,7 @@ import (
 type OsFetcher struct {
 	// vmu guards read/write access to vals
 	vmu sync.Mutex
-	// vals maintains a local cache of the system's enviornment variables
+	// vals maintains a local cache of the system's environment variables
 	// for fast repeat lookups of a given key.
 	vals map[string]*string
 }

--- a/docker/run_dockers.bsh
+++ b/docker/run_dockers.bsh
@@ -5,7 +5,7 @@
 #  ./run_dockers.bsh centos_6 centos_7 - Run only CentOS 6 & 7 image
 #  ./run_dockers.bsh centos_6 -- bash #Runs bash in the CentOS 6 docker
 #
-# Special Environmet Variables
+# Special Environments Variables
 #  REPO_HOSTNAME - Override the hostname for all the repos generated/tested
 #  DOCKER_AUTOPULL - Default 1. If set to 0, it will not build docker images
 #                before running

--- a/docs/proposals/locking.md
+++ b/docs/proposals/locking.md
@@ -364,7 +364,7 @@ type LockList struct {
         // `LockListRequest`.
         NextCursor string `json:"next_cursor,omitempty"`
         // Err populates any error that was encountered during the search. If no
-        // error was encountered and the operation was succesful, then a value
+        // error was encountered and the operation was successful, then a value
         // of nil will be passed here.
         Err error `json:"error,omitempty"`
 }

--- a/docs/proposals/locking_api.md
+++ b/docs/proposals/locking_api.md
@@ -69,7 +69,7 @@
 < }
 ```
 
-* **Bad repsonse: server error**
+* **Bad response: server error**
 ```
 < HTTP/1.1 500 Internal server error
 < Content-Type: application/vnd.git-lfs+json
@@ -93,7 +93,7 @@
 > Authorization: Basic
 ```
 
-### Repsonse
+### Response
 
 * **Success: unlocked**
 ```

--- a/docs/proposals/ntlm.md
+++ b/docs/proposals/ntlm.md
@@ -11,7 +11,7 @@ go through the ntlm auth flow.
 
 We will store NTLM credentials in the credential helper. When the user is prompted for their credentials they must use username:{DOMAIN}\{user} and password:{pass}
 
-The ntlm protocl will be handled by an ntlm.go class that hides the implementation of InitHandshake, Authenticate, and Challenge. This allows miminal changesto the existing
+The ntlm protocol will be handled by an ntlm.go class that hides the implementation of InitHandshake, Authenticate, and Challenge. This allows miminal changesto the existing
 client.go class.
 
 ### Tech

--- a/git/githistory/fixtures_test.go
+++ b/git/githistory/fixtures_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 // DatabaseFromFixture returns a *gitobj.ObjectDatabase instance that is safely
-// mutable and created from a template equivelant to the fixture that you
+// mutable and created from a template equivalent to the fixture that you
 // provided it.
 //
 // If any error was encountered, it will call t.Fatalf() immediately.

--- a/lfshttp/stats.go
+++ b/lfshttp/stats.go
@@ -43,7 +43,7 @@ func (c *Client) LogHTTPStats(w io.WriteCloser) {
 }
 
 // LogStats is intended to be called after all HTTP operations for the
-// commmand have finished. It dumps k/v logs, one line per httpTransfer into
+// command have finished. It dumps k/v logs, one line per httpTransfer into
 // a log file with the current timestamp.
 //
 // DEPRECATED: Call LogHTTPStats() before the first HTTP request.

--- a/locking/api.go
+++ b/locking/api.go
@@ -172,7 +172,7 @@ type lockList struct {
 	// `LockListRequest`.
 	NextCursor string `json:"next_cursor,omitempty"`
 	// Message populates any error that was encountered during the search. If no
-	// error was encountered and the operation was succesful, then a value
+	// error was encountered and the operation was successful, then a value
 	// of nil will be passed here.
 	Message          string `json:"message,omitempty"`
 	DocumentationURL string `json:"documentation_url,omitempty"`
@@ -238,7 +238,7 @@ type lockVerifiableList struct {
 	// `LockListRequest`.
 	NextCursor string `json:"next_cursor,omitempty"`
 	// Message populates any error that was encountered during the search. If no
-	// error was encountered and the operation was succesful, then a value
+	// error was encountered and the operation was successful, then a value
 	// of nil will be passed here.
 	Message          string `json:"message,omitempty"`
 	DocumentationURL string `json:"documentation_url,omitempty"`

--- a/locking/cache.go
+++ b/locking/cache.go
@@ -35,7 +35,7 @@ func (c *LockCache) Add(l Lock) error {
 	return nil
 }
 
-// Remove a cached lock by path becuase it's been relinquished
+// Remove a cached lock by path because it's been relinquished
 func (c *LockCache) RemoveByPath(filePath string) error {
 	ilock := c.kv.Get(filePath)
 	if lock, ok := ilock.(*Lock); ok && lock != nil {

--- a/locking/locks.go
+++ b/locking/locks.go
@@ -393,7 +393,7 @@ func (c *Client) searchRemoteLocks(filter map[string]string, limit int) ([]Lock,
 //
 // If the API call failed, an error will be returned. If multiple locks matched
 // the given path (should not happen during real-world usage), an error will be
-// returnd. If no locks matched the given path, an error will be returned.
+// returned. If no locks matched the given path, an error will be returned.
 //
 // If the API call is successful, and only one lock matches the given filepath,
 // then its ID will be returned, along with a value of "nil" for the error.

--- a/rpm/build_rpms.bsh
+++ b/rpm/build_rpms.bsh
@@ -171,7 +171,7 @@ touch ${CURDIR}/SOURCES/RPM-GPG-KEY-GITLFS
 
 echo "Build git-lfs rpm..."
 
-#--no-deps added for now so you can compile without offical rpms installed
+#--no-deps added for now so you can compile without official rpms installed
 "${RPMBUILD[@]}" --nodeps -ba ${CURDIR}/SPECS/git-lfs.spec
 
 echo "All Done!"

--- a/t/cmd/util/testutils.go
+++ b/t/cmd/util/testutils.go
@@ -439,7 +439,7 @@ func (r *Repo) AddRemote(name string) *Repo {
 	return remote
 }
 
-// Just a psuedo-random stream of bytes (not cryptographic)
+// Just a pseudo-random stream of bytes (not cryptographic)
 // Calls RNG a bit less often than using rand.Source directly
 type PlaceholderDataReader struct {
 	source    rand.Source

--- a/t/t-credentials.sh
+++ b/t/t-credentials.sh
@@ -4,7 +4,7 @@
 
 ensure_git_version_isnt $VERSION_LOWER "2.3.0"
 
-begin_test "credentails with url-specific helper skips askpass"
+begin_test "credentials with url-specific helper skips askpass"
 (
   set -e
 

--- a/t/t-duplicate-oids.sh
+++ b/t/t-duplicate-oids.sh
@@ -6,7 +6,7 @@ begin_test "multiple revs with same OID get pushed once"
 (
   set -e
 
-  reponame="mutliple-revs-one-oid"
+  reponame="multiple-revs-one-oid"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"
 

--- a/tasklog/log.go
+++ b/tasklog/log.go
@@ -57,7 +57,7 @@ func ForceProgress(v bool) Option {
 	}
 }
 
-// NewLogger retuns a new *Logger instance that logs to "sink" and uses the
+// NewLogger returns a new *Logger instance that logs to "sink" and uses the
 // current terminal width as the width of the line. Will log progress status if
 // stdout is a terminal or if forceProgress is true
 func NewLogger(sink io.Writer, options ...Option) *Logger {

--- a/tools/stringset.go
+++ b/tools/stringset.go
@@ -149,7 +149,7 @@ func (set StringSet) Iter() <-chan string {
 
 // Equal determines if two sets are equal to each other.
 // If they both are the same size and have the same items they are considered equal.
-// Order of items is not relevent for sets to be equal.
+// Order of items is not relevant for sets to be equal.
 func (set StringSet) Equal(other StringSet) bool {
 	if set.Cardinality() != other.Cardinality() {
 		return false

--- a/tq/custom.go
+++ b/tq/custom.go
@@ -120,7 +120,7 @@ func (a *customAdapter) Begin(cfg AdapterConfig, cb ProgressCallback) error {
 }
 
 func (a *customAdapter) ClearTempStorage() error {
-	// no action requred
+	// no action required
 	return nil
 }
 


### PR DESCRIPTION
:blue_heart: Fix typos across **git-lfs repository**

### Fixed files :wrench: 

<details><summary>See all fixed files</summary>
<p>

```
git-lfs/config/config.go:142:7: "Enviornment" is a misspelling of "Environment"
git-lfs/config/delayed_environment.go:10:22: "equivelant" is a misspelling of "equivalent"
git-lfs/config/fetcher.go:4:43: "enviornment" is a misspelling of "environment"
git-lfs/config/os_fetcher.go:15:49: "enviornment" is a misspelling of "environment"
git-lfs/docker/run_dockers.bsh:8:10: "Environmet" is a misspelling of "Environments"
git-lfs/docs/proposals/locking.md:367:55: "succesful" is a misspelling of "successful"
git-lfs/docs/proposals/locking_api.md:72:8: "repsonse" is a misspelling of "response"
git-lfs/docs/proposals/locking_api.md:96:4: "Repsonse" is a misspelling of "Response"
git-lfs/docs/proposals/ntlm.md:14:9: "protocl" is a misspelling of "protocol"
git-lfs/git/githistory/fixtures_test.go:19:39: "equivelant" is a misspelling of "equivalent"
git-lfs/git/githistory/fixtures_test.go:117:61: "equivelant" is a misspelling of "equivalent"
git-lfs/lfshttp/stats.go:46:3: "commmand" is a misspelling of "command"
git-lfs/locking/api.go:175:48: "succesful" is a misspelling of "successful"
git-lfs/locking/api.go:241:48: "succesful" is a misspelling of "successful"
git-lfs/locking/cache.go:38:32: "becuase" is a misspelling of "because"
git-lfs/locking/locks.go:396:3: "returnd" is a misspelling of "returned"
git-lfs/rpm/build_rpms.bsh:174:52: "offical" is a misspelling of "official"
git-lfs/t/cmd/util/testutils.go:442:10: "psuedo" is a misspelling of "pseudo"
git-lfs/t/t-credentials.sh:7:12: "credentails" is a misspelling of "credentials"
git-lfs/t/t-duplicate-oids.sh:9:12: "mutliple" is a misspelling of "multiple"
git-lfs/tasklog/log.go:60:13: "retuns" is a misspelling of "returns"
git-lfs/tools/stringset.go:152:25: "relevent" is a misspelling of "relevant"
git-lfs/tq/custom.go:123:14: "requred" is a misspelling of "required"
```

</p>
</details>

**FYI:** I used [**Go Spellchecker**](https://github.com/liamzdenek/go-spellcheck) :smile_cat: