### PR TITLE
NON-ISSUE Replace deprecated SEEK_SET, SEEK_CUR usage.

### DIFF
--- a/lfs/gitfilter_smudge.go
+++ b/lfs/gitfilter_smudge.go
@@ -36,7 +36,7 @@ func (f *GitFilter) SmudgeToFile(filename string, ptr *Pointer, download bool, m
 	if _, err := f.Smudge(file, ptr, filename, download, manifest, cb); err != nil {
 		if errors.IsDownloadDeclinedError(err) {
 			// write placeholder data instead
-			file.Seek(0, os.SEEK_SET)
+			file.Seek(0, io.SeekStart)
 			ptr.Encode(file)
 			return err
 		} else {

--- a/tools/kv/keyvaluestore.go
+++ b/tools/kv/keyvaluestore.go
@@ -136,7 +136,7 @@ func (k *Store) Save() error {
 	if stat, _ := f.Stat(); stat.Size() > 0 {
 		k.loadAndMergeReaderIfNeeded(f)
 		// Now we overwrite the file
-		f.Seek(0, os.SEEK_SET)
+		f.Seek(0, io.SeekStart)
 		f.Truncate(0)
 	}
 

--- a/tq/tus_upload.go
+++ b/tq/tus_upload.go
@@ -122,7 +122,7 @@ func (a *tusUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb ProgressC
 	var reader lfsapi.ReadSeekCloser = tools.NewBodyWithCallback(f, t.Size, ccb)
 	reader = newStartCallbackReader(reader, func() error {
 		// seek to the offset since lfsapi.Client rewinds the body
-		if _, err := f.Seek(offset, os.SEEK_CUR); err != nil {
+		if _, err := f.Seek(offset, io.SeekCurrent); err != nil {
 			return err
 		}
 		// Signal auth was ok on first read; this frees up other workers to start


### PR DESCRIPTION
os.SEEK_XXX is now deprecated and we can use io.SeekXxx instead.

https://golang.org/pkg/os/#pkg-constants

```go
// Seek whence values.
//
// Deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.
const (
	SEEK_SET int = 0 // seek relative to the origin of the file
	SEEK_CUR int = 1 // seek relative to the current offset
	SEEK_END int = 2 // seek relative to the end
)
```

https://golang.org/pkg/io/#pkg-constants

```go
// Seek whence values.
const (
	SeekStart   = 0 // seek relative to the origin of the file
	SeekCurrent = 1 // seek relative to the current offset
	SeekEnd     = 2 // seek relative to the end
)
```