### PR TITLE
Support for file URLs

### DIFF
--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -124,7 +124,7 @@ func smudge(gf *lfs.GitFilter, to io.Writer, from io.Reader, filename string, sk
 		download = filter.Allows(filename)
 	}
 
-	n, err := gf.Smudge(to, ptr, filename, download, getTransferManifest(), cb)
+	n, err := gf.Smudge(to, ptr, filename, download, getTransferManifestOperationRemote("download", cfg.Remote()), cb)
 	if file != nil {
 		file.Close()
 	}

--- a/commands/command_standalone_file.go
+++ b/commands/command_standalone_file.go
@@ -1,0 +1,21 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/git-lfs/git-lfs/lfshttp/standalone"
+	"github.com/spf13/cobra"
+)
+
+func standaloneFileCommand(cmd *cobra.Command, args []string) {
+	err := standalone.ProcessStandaloneData(cfg, os.Stdin, os.Stdout)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(2)
+	}
+}
+
+func init() {
+	RegisterCommand("standalone-file", standaloneFileCommand, nil)
+}

--- a/docs/man/git-lfs-standalone-file.1.ronn
+++ b/docs/man/git-lfs-standalone-file.1.ronn
@@ -1,0 +1,22 @@
+git-lfs-standalone-file(1) -- Standalone transfer adapter for file URLs
+=======================================================================
+
+## SYNOPSIS
+
+`git lfs standalone-file`
+
+## DESCRIPTION
+
+Provides a standalone transfer adapter for file URLs (local paths).
+
+By default, Git LFS requires the support of an HTTP server to implement the Git
+LFS protocol. However, this tool allows the use of URLs starting with `file:///`
+(that is, those representing local paths) in addition. Configuration is not
+necessary; Git LFS handles this internally.
+
+When invoked, this tool speaks JSON on input and output as a standalone transfer
+adapter. It is not intended for use by end users.
+
+## SEE ALSO
+
+Part of the git-lfs(1) suite.

--- a/git/git.go
+++ b/git/git.go
@@ -439,7 +439,7 @@ func ValidateRemoteURL(remote string) error {
 	}
 
 	switch u.Scheme {
-	case "ssh", "http", "https", "git":
+	case "ssh", "http", "https", "git", "file":
 		return nil
 	default:
 		return fmt.Errorf("Invalid remote url protocol %q in %q", u.Scheme, remote)

--- a/lfsapi/endpoint_finder.go
+++ b/lfsapi/endpoint_finder.go
@@ -175,6 +175,10 @@ func (e *endpointGitFinder) NewEndpointFromCloneURL(operation, rawurl string) lf
 		ep.Url = rawurl[0 : len(rawurl)-1]
 	}
 
+	if strings.HasPrefix(rawurl, "file://") {
+		return ep
+	}
+
 	// When using main remote URL for HTTP, append info/lfs
 	if path.Ext(ep.Url) == ".git" {
 		ep.Url += "/info/lfs"

--- a/lfsapi/endpoint_finder.go
+++ b/lfsapi/endpoint_finder.go
@@ -202,6 +202,8 @@ func (e *endpointGitFinder) NewEndpoint(operation, rawurl string) lfshttp.Endpoi
 		return lfshttp.EndpointFromHttpUrl(u)
 	case "git":
 		return endpointFromGitUrl(u, e)
+	case "file":
+		return lfshttp.EndpointFromFileUrl(u)
 	case "":
 		return lfshttp.EndpointFromBareSshUrl(u.String())
 	default:

--- a/lfshttp/endpoint.go
+++ b/lfshttp/endpoint.go
@@ -112,3 +112,9 @@ func EndpointFromLocalPath(path string) Endpoint {
 	}
 	return Endpoint{Url: fmt.Sprintf("file://%s", path)}
 }
+
+// Construct a new endpoint from a file URL
+func EndpointFromFileUrl(u *url.URL) Endpoint {
+	// just pass this straight through
+	return Endpoint{Url: u.String()}
+}

--- a/lfshttp/standalone/standalone.go
+++ b/lfshttp/standalone/standalone.go
@@ -1,0 +1,285 @@
+package standalone
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+
+	"github.com/git-lfs/git-lfs/config"
+	"github.com/git-lfs/git-lfs/errors"
+	"github.com/git-lfs/git-lfs/lfs"
+	"github.com/git-lfs/git-lfs/lfsapi"
+	"github.com/git-lfs/git-lfs/subprocess"
+	"github.com/git-lfs/git-lfs/tools"
+	"github.com/rubyist/tracerx"
+)
+
+// inputMessage represents a message from Git LFS to the standalone transfer
+// agent. Not all fields will be filled in on all requests.
+type inputMessage struct {
+	Event     string `json:"event"`
+	Operation string `json:"operation"`
+	Remote    string `json:"remote"`
+	Oid       string `json:"oid"`
+	Size      int64  `json:"size"`
+	Path      string `json:"path"`
+}
+
+// errorMessage represents an optional error message that may occur in a
+// completion response.
+type errorMessage struct {
+	Message string `json:"message"`
+}
+
+// completeMessage represents a completion response.
+type completeMessage struct {
+	Event string        `json:"event"`
+	Oid   string        `json:"oid"`
+	Path  string        `json:"path,omitempty"`
+	Error *errorMessage `json:"error,omitempty"`
+}
+
+type fileHandler struct {
+	remotePath   string
+	remoteConfig *config.Configuration
+	output       *os.File
+	config       *config.Configuration
+}
+
+// fileUrlFromRemote looks up the URL depending on the remote. The remote can be
+// a literal URL or the name of a remote.
+//
+// In this situation, we only accept file URLs.
+func fileUrlFromRemote(cfg *config.Configuration, name string, direction string) (*url.URL, error) {
+	if strings.HasPrefix(name, "file://") {
+		if url, err := url.Parse(name); err == nil {
+			return url, nil
+		}
+	}
+
+	apiClient, err := lfsapi.NewClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, remote := range cfg.Remotes() {
+		if remote != name {
+			continue
+		}
+		remoteEndpoint := apiClient.Endpoints.Endpoint(direction, remote)
+		if !strings.HasPrefix(remoteEndpoint.Url, "file://") {
+			return nil, nil
+		}
+		return url.Parse(remoteEndpoint.Url)
+	}
+	return nil, nil
+}
+
+// gitDirAtPath finds the .git directory corresponding to the given path, which
+// may be the .git directory itself, the working tree, or the root of a bare
+// repository.
+//
+// We filter out the GIT_DIR environment variable to ensure we get the expected
+// result, and we change directories to ensure that we can make use of
+// filepath.Abs. Using --absolute-git-dir instead of --git-dir is not an option
+// because we support Git versions that don't have --absolute-git-dir.
+func gitDirAtPath(path string) (string, error) {
+	// Filter out all the GIT_* environment variables.
+	env := os.Environ()
+	n := 0
+	for _, val := range env {
+		if !strings.HasPrefix(val, "GIT_") {
+			env[n] = val
+			n++
+		}
+	}
+	env = env[:n]
+
+	curdir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	err = os.Chdir(path)
+	if err != nil {
+		return "", err
+	}
+
+	cmd := subprocess.ExecCommand("git", "rev-parse", "--git-dir")
+	cmd.Cmd.Env = env
+	out, err := cmd.Output()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to call git rev-parse --git-dir")
+	}
+
+	gitdir, err := tools.TranslateCygwinPath(strings.TrimRight(string(out), "\n"))
+	if err != nil {
+		return "", errors.Wrap(err, "unable to translate path")
+	}
+
+	gitdir, err = filepath.Abs(gitdir)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to canonicalize path")
+	}
+
+	err = os.Chdir(curdir)
+	if err != nil {
+		return "", err
+	}
+	return filepath.EvalSymlinks(gitdir)
+}
+
+func fixUrlPath(path string) string {
+	if runtime.GOOS != "windows" {
+		return path
+	}
+
+	// When parsing a file URL, Go produces a path starting with a slash. If
+	// it looks like there's a Windows drive letter at the beginning, strip
+	// off the beginning slash. If this is a Unix-style path from a
+	// Cygwin-like environment, we'll canonicalize it later.
+	re := regexp.MustCompile("/[A-Za-z]:/")
+	if re.MatchString(path) {
+		return path[1:]
+	}
+	return path
+}
+
+// newHandler creates a new handler for the protocol.
+func newHandler(cfg *config.Configuration, output *os.File, msg *inputMessage) (*fileHandler, error) {
+	url, err := fileUrlFromRemote(cfg, msg.Remote, msg.Operation)
+	if err != nil {
+		return nil, err
+	}
+	if url == nil {
+		return nil, errors.New("no valid file:// URLs found")
+	}
+
+	path, err := tools.TranslateCygwinPath(fixUrlPath(url.Path))
+	if err != nil {
+		return nil, err
+	}
+
+	gitdir, err := gitDirAtPath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	tracerx.Printf("using %q as remote git directory", gitdir)
+
+	return &fileHandler{
+		remotePath:   path,
+		remoteConfig: config.NewIn(gitdir, gitdir),
+		output:       output,
+		config:       cfg,
+	}, nil
+}
+
+// dispatch dispatches the event depending on the message type.
+func (h *fileHandler) dispatch(msg *inputMessage) bool {
+	switch msg.Event {
+	case "init":
+		fmt.Fprintln(h.output, "{}")
+	case "upload":
+		h.respond(h.upload(msg.Oid, msg.Size, msg.Path))
+	case "download":
+		h.respond(h.download(msg.Oid, msg.Size))
+	case "terminate":
+		return false
+	default:
+		standaloneFailure(fmt.Sprintf("unknown event %q", msg.Event), nil)
+	}
+	return true
+}
+
+// respond sends a response to an upload or download command, using the return
+// values from those functions.
+func (h *fileHandler) respond(oid string, path string, err error) {
+	response := &completeMessage{
+		Event: "complete",
+		Oid:   oid,
+		Path:  path,
+	}
+	if err != nil {
+		response.Error = &errorMessage{Message: err.Error()}
+	}
+	json.NewEncoder(h.output).Encode(response)
+}
+
+// upload performs the upload action for the given OID, size, and path. It
+// returns arguments suitable for the respond method.
+func (h *fileHandler) upload(oid string, size int64, path string) (string, string, error) {
+	if h.remoteConfig.LFSObjectExists(oid, size) {
+		// Already there, nothing to do.
+		return oid, "", nil
+	}
+	dest, err := h.remoteConfig.Filesystem().ObjectPath(oid)
+	if err != nil {
+		return oid, "", err
+	}
+	return oid, "", lfs.LinkOrCopy(h.remoteConfig, path, dest)
+}
+
+// download performs the download action for the given OID and size. It returns
+// arguments suitable for the respond method.
+func (h *fileHandler) download(oid string, size int64) (string, string, error) {
+	if !h.remoteConfig.LFSObjectExists(oid, size) {
+		tracerx.Printf("missing object in %q (%s)", h.remotePath, oid)
+		return oid, "", errors.Errorf("remote missing object %s", oid)
+	}
+
+	src, err := h.remoteConfig.Filesystem().ObjectPath(oid)
+	if err != nil {
+		return oid, "", err
+	}
+
+	tmp, err := lfs.TempFile(h.config, "download")
+	if err != nil {
+		return oid, "", err
+	}
+	tmp.Close()
+	os.Remove(tmp.Name())
+	path := tmp.Name()
+	return oid, path, lfs.LinkOrCopy(h.config, src, path)
+}
+
+// standaloneFailure reports a fatal error.
+func standaloneFailure(msg string, err error) {
+	fmt.Fprintf(os.Stderr, "%s: %s\n", msg, err)
+	os.Exit(2)
+}
+
+// ProcessStandaloneData is the primary endpoint for processing data with a
+// standalone transfer agent. It reads input from the specified input file and
+// produces output to the specified output file.
+func ProcessStandaloneData(cfg *config.Configuration, input *os.File, output *os.File) error {
+	var handler *fileHandler
+
+	scanner := bufio.NewScanner(input)
+	for scanner.Scan() {
+		var msg inputMessage
+		if err := json.NewDecoder(strings.NewReader(scanner.Text())).Decode(&msg); err != nil {
+			return errors.Wrapf(err, "error decoding json")
+		}
+		if handler == nil {
+			var err error
+			handler, err = newHandler(cfg, output, &msg)
+			if err != nil {
+				return errors.Wrapf(err, "error creating handler")
+			}
+		}
+		if !handler.dispatch(&msg) {
+			break
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return errors.Wrapf(err, "error reading input")
+	}
+	return nil
+}

--- a/t/t-env.sh
+++ b/t/t-env.sh
@@ -45,8 +45,8 @@ PruneRemoteName=origin
 LfsStorageDir=%s
 AccessDownload=none
 AccessUpload=none
-DownloadTransfers=basic
-UploadTransfers=basic
+DownloadTransfers=basic,lfs-standalone-file
+UploadTransfers=basic,lfs-standalone-file
 %s
 %s
 ' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")
@@ -97,8 +97,8 @@ PruneRemoteName=origin
 LfsStorageDir=%s
 AccessDownload=none
 AccessUpload=none
-DownloadTransfers=basic
-UploadTransfers=basic
+DownloadTransfers=basic,lfs-standalone-file
+UploadTransfers=basic,lfs-standalone-file
 %s
 %s
 ' "$(git lfs version)" "$(git version)" "$endpoint" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")
@@ -156,8 +156,8 @@ PruneRemoteName=origin
 LfsStorageDir=%s
 AccessDownload=none
 AccessUpload=none
-DownloadTransfers=basic
-UploadTransfers=basic
+DownloadTransfers=basic,lfs-standalone-file
+UploadTransfers=basic,lfs-standalone-file
 %s
 %s
 ' "$(git lfs version)" "$(git version)" "$endpoint" "$endpoint2" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")
@@ -213,8 +213,8 @@ PruneRemoteName=origin
 LfsStorageDir=%s
 AccessDownload=none
 AccessUpload=none
-DownloadTransfers=basic
-UploadTransfers=basic
+DownloadTransfers=basic,lfs-standalone-file
+UploadTransfers=basic,lfs-standalone-file
 %s
 %s
 ' "$(git lfs version)" "$(git version)" "$endpoint" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")
@@ -271,8 +271,8 @@ PruneRemoteName=origin
 LfsStorageDir=%s
 AccessDownload=none
 AccessUpload=none
-DownloadTransfers=basic
-UploadTransfers=basic
+DownloadTransfers=basic,lfs-standalone-file
+UploadTransfers=basic,lfs-standalone-file
 %s
 %s
 ' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")
@@ -331,8 +331,8 @@ PruneRemoteName=origin
 LfsStorageDir=%s
 AccessDownload=none
 AccessUpload=none
-DownloadTransfers=basic
-UploadTransfers=basic
+DownloadTransfers=basic,lfs-standalone-file
+UploadTransfers=basic,lfs-standalone-file
 %s
 %s
 ' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")
@@ -391,8 +391,8 @@ PruneRemoteName=origin
 LfsStorageDir=%s
 AccessDownload=none
 AccessUpload=none
-DownloadTransfers=basic
-UploadTransfers=basic
+DownloadTransfers=basic,lfs-standalone-file
+UploadTransfers=basic,lfs-standalone-file
 %s
 %s
 ' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")
@@ -459,8 +459,8 @@ PruneRemoteName=origin
 LfsStorageDir=%s
 AccessDownload=none
 AccessUpload=none
-DownloadTransfers=basic
-UploadTransfers=basic
+DownloadTransfers=basic,lfs-standalone-file
+UploadTransfers=basic,lfs-standalone-file
 %s
 %s
 ' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")
@@ -514,8 +514,8 @@ PruneRemoteName=origin
 LfsStorageDir=%s
 AccessDownload=none
 AccessUpload=none
-DownloadTransfers=basic
-UploadTransfers=basic
+DownloadTransfers=basic,lfs-standalone-file
+UploadTransfers=basic,lfs-standalone-file
 %s
 %s
 ' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")
@@ -568,8 +568,8 @@ PruneRemoteName=origin
 LfsStorageDir=lfs
 AccessDownload=none
 AccessUpload=none
-DownloadTransfers=basic
-UploadTransfers=basic
+DownloadTransfers=basic,lfs-standalone-file
+UploadTransfers=basic,lfs-standalone-file
 %s
 git config filter.lfs.process = ""
 git config filter.lfs.smudge = ""
@@ -604,8 +604,8 @@ PruneRemoteName=origin
 LfsStorageDir=%s
 AccessDownload=none
 AccessUpload=none
-DownloadTransfers=basic
-UploadTransfers=basic
+DownloadTransfers=basic,lfs-standalone-file
+UploadTransfers=basic,lfs-standalone-file
 %s
 %s
 ' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")
@@ -637,8 +637,8 @@ PruneRemoteName=origin
 LfsStorageDir=%s
 AccessDownload=none
 AccessUpload=none
-DownloadTransfers=basic
-UploadTransfers=basic
+DownloadTransfers=basic,lfs-standalone-file
+UploadTransfers=basic,lfs-standalone-file
 %s
 %s
 ' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")
@@ -682,8 +682,8 @@ PruneRemoteName=origin
 LfsStorageDir=%s
 AccessDownload=none
 AccessUpload=none
-DownloadTransfers=basic
-UploadTransfers=basic
+DownloadTransfers=basic,lfs-standalone-file
+UploadTransfers=basic,lfs-standalone-file
 %s
 %s
 " "$(git lfs version)" "$(git version)" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")
@@ -761,8 +761,8 @@ PruneRemoteName=origin
 LfsStorageDir=%s
 AccessDownload=none
 AccessUpload=none
-DownloadTransfers=basic
-UploadTransfers=basic
+DownloadTransfers=basic,lfs-standalone-file
+UploadTransfers=basic,lfs-standalone-file
 %s
 %s
 ' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")
@@ -794,8 +794,8 @@ PruneRemoteName=origin
 LfsStorageDir=%s
 AccessDownload=none
 AccessUpload=none
-DownloadTransfers=basic
-UploadTransfers=basic
+DownloadTransfers=basic,lfs-standalone-file
+UploadTransfers=basic,lfs-standalone-file
 %s
 %s
 ' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")
@@ -827,8 +827,8 @@ PruneRemoteName=origin
 LfsStorageDir=%s
 AccessDownload=none
 AccessUpload=none
-DownloadTransfers=basic
-UploadTransfers=basic
+DownloadTransfers=basic,lfs-standalone-file
+UploadTransfers=basic,lfs-standalone-file
 %s
 %s
 ' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVarsEnabled" "$envInitConfig")
@@ -889,8 +889,8 @@ PruneRemoteName=origin
 LfsStorageDir=%s
 AccessDownload=none
 AccessUpload=none
-DownloadTransfers=basic,supertransfer
-UploadTransfers=basic,supertransfer,tus
+DownloadTransfers=basic,lfs-standalone-file,supertransfer
+UploadTransfers=basic,lfs-standalone-file,supertransfer,tus
 %s
 %s
 ' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")
@@ -948,8 +948,8 @@ PruneRemoteName=origin
 LfsStorageDir=%s
 AccessDownload=none
 AccessUpload=none
-DownloadTransfers=basic
-UploadTransfers=basic
+DownloadTransfers=basic,lfs-standalone-file
+UploadTransfers=basic,lfs-standalone-file
 %s
 %s
 ' "$(git lfs version)" "$(git version)" "$endpoint" "$endpoint2" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")

--- a/t/t-standalone-file.sh
+++ b/t/t-standalone-file.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+
+. "$(dirname "$0")/testlib.sh"
+
+urlify () {
+  if [ "$IS_WINDOWS" -eq 1 ]
+  then
+    echo "$1" | sed -e 's,\\,/,g' -e 's,:,%3a,g' -e 's, ,%20,g'
+  else
+    echo "$1"
+  fi
+}
+
+do_upload_download_test () {
+  git lfs track "*.dat" 2>&1 | tee track.log
+  grep "Tracking \"\*.dat\"" track.log
+  git add .gitattributes
+  git commit -m "Tracking"
+
+  git checkout -b test
+
+  # set up a decent amount of data so that there's work for multiple concurrent adapters
+  echo "[
+  {
+    \"CommitDate\":\"$(get_date -10d)\",
+    \"Files\":[
+      {\"Filename\":\"verify.dat\",\"Size\":18,\"Data\":\"send-verify-action\"},
+      {\"Filename\":\"file1.dat\",\"Size\":1024},
+      {\"Filename\":\"file2.dat\",\"Size\":750}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -7d)\",
+    \"Files\":[
+      {\"Filename\":\"file1.dat\",\"Size\":1050},
+      {\"Filename\":\"file3.dat\",\"Size\":660},
+      {\"Filename\":\"file4.dat\",\"Size\":230}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -5d)\",
+    \"Files\":[
+      {\"Filename\":\"file5.dat\",\"Size\":1200},
+      {\"Filename\":\"file6.dat\",\"Size\":300}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -2d)\",
+    \"Files\":[
+      {\"Filename\":\"file3.dat\",\"Size\":120},
+      {\"Filename\":\"file5.dat\",\"Size\":450},
+      {\"Filename\":\"file7.dat\",\"Size\":520},
+      {\"Filename\":\"file8.dat\",\"Size\":2048}]
+  }
+  ]" | lfstest-testutils addcommits
+
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git push origin test 2>&1 | tee pushcustom.log
+  # use PIPESTATUS otherwise we get exit code from tee
+  [ ${PIPESTATUS[0]} = "0" ]
+
+  ourobjects=$(cd .git && find lfs/objects -type f | sort)
+  theirobjects=$(cd $gitdir && find lfs/objects -type f | sort)
+
+  # Make sure the lock verification is not attempted.
+  grep "locks/verify$" pushcustom.log && false
+
+  grep "xfer: started custom adapter process" pushcustom.log
+  grep "Uploading LFS objects: 100% (12/12)" pushcustom.log
+  [ "$ourobjects" = "$theirobjects" ]
+
+  rm -rf .git/lfs/objects
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git lfs fetch --all  2>&1 | tee fetchcustom.log
+  [ ${PIPESTATUS[0]} = "0" ]
+
+  objectlist=$(find .git/lfs/objects -type f)
+  [ "$(echo "$objectlist" | wc -l)" -eq 12 ]
+}
+
+begin_test "standalone-file-upload-download-bare"
+(
+  set -e
+
+  # setup a git repo to be used as a local repo, not remote
+  reponame="standalone-file-upload-download-bare"
+  setup_remote_repo "$reponame"
+
+  git init --bare "$reponame-2.git"
+  gitdir="$(pwd)/$reponame-2.git"
+
+  # clone directly, not through lfstest-gitserver
+  clone_repo_url "$REMOTEDIR/$reponame.git" $reponame
+
+  git remote set-url origin "file://$(urlify "$gitdir")"
+
+  do_upload_download_test
+)
+end_test
+
+begin_test "standalone-file-upload-download-non-bare"
+(
+  set -e
+
+  # setup a git repo to be used as a local repo, not remote
+  reponame="standalone-file-upload-download-non-bare"
+  setup_remote_repo "$reponame"
+
+  git init "$reponame-2.git"
+  repo2="$(pwd)/$reponame-2.git"
+  gitdir="$(pwd)/$reponame-2.git/.git"
+
+  # clone directly, not through lfstest-gitserver
+  clone_repo_url "$REMOTEDIR/$reponame.git" $reponame
+
+  git remote set-url origin "file://$(urlify "$repo2")"
+
+  do_upload_download_test
+)
+end_test
+
+begin_test "standalone-file-download-missing-file"
+(
+  set -e
+
+  # setup a git repo to be used as a local repo, not remote
+  reponame="standalone-file-download-missing-file"
+  setup_remote_repo "$reponame"
+
+  otherrepo="$(pwd)/$reponame-2.git"
+  git init --bare "$otherrepo"
+
+  # clone directly, not through lfstest-gitserver
+  clone_repo_url "$REMOTEDIR/$reponame.git" $reponame
+
+  git remote set-url origin "file://$(urlify "$otherrepo")"
+
+  git lfs track "*.dat" 2>&1 | tee track.log
+  grep "Tracking \"\*.dat\"" track.log
+  git add .gitattributes
+  git commit -m "Tracking"
+
+  git checkout -b test
+
+  # set up a decent amount of data so that there's work for multiple concurrent adapters
+  echo "[
+  {
+    \"CommitDate\":\"$(get_date -10d)\",
+    \"Files\":[
+      {\"Filename\":\"verify.dat\",\"Size\":18,\"Data\":\"send-verify-action\"},
+      {\"Filename\":\"file1.dat\",\"Size\":1024},
+      {\"Filename\":\"file2.dat\",\"Size\":750}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -7d)\",
+    \"Files\":[
+      {\"Filename\":\"file1.dat\",\"Size\":1050},
+      {\"Filename\":\"file3.dat\",\"Size\":660},
+      {\"Filename\":\"file4.dat\",\"Size\":230}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -5d)\",
+    \"Files\":[
+      {\"Filename\":\"file5.dat\",\"Size\":1200},
+      {\"Filename\":\"file6.dat\",\"Size\":300}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -2d)\",
+    \"Files\":[
+      {\"Filename\":\"file3.dat\",\"Size\":120},
+      {\"Filename\":\"file5.dat\",\"Size\":450},
+      {\"Filename\":\"file7.dat\",\"Size\":520},
+      {\"Filename\":\"file8.dat\",\"Size\":2048}]
+  }
+  ]" | lfstest-testutils addcommits
+
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git push origin test 2>&1 | tee pushcustom.log
+  # use PIPESTATUS otherwise we get exit code from tee
+  [ ${PIPESTATUS[0]} = "0" ]
+
+  # Make sure the lock verification is not attempted.
+  grep "locks/verify$" pushcustom.log && false
+
+  grep "xfer: started custom adapter process" pushcustom.log
+  grep "Uploading LFS objects: 100% (12/12)" pushcustom.log
+
+  # Delete an object from the remote side. Any object will do.
+  rm -f $(find "$otherrepo/lfs/objects" -type f | head -n1)
+
+  rm -rf .git/lfs/objects
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git lfs fetch --all  2>&1 | tee fetchcustom.log
+  # Make sure we failed.
+  [ ${PIPESTATUS[0]} != "0" ]
+
+  # Make sure we downloaded the rest of the objects.
+  objectlist=$(find .git/lfs/objects -type f)
+  [ "$(echo "$objectlist" | wc -l)" -eq 11 ]
+)
+end_test
+
+begin_test "standalone-file-clone"
+(
+  set -e
+
+  # setup a git repo to be used as a local repo, not remote
+  reponame="standalone-file-clone"
+  setup_remote_repo "$reponame"
+
+  # clone directly, not through lfstest-gitserver
+  clone_repo_url "$REMOTEDIR/$reponame.git" $reponame
+
+  git lfs track "*.dat" 2>&1 | tee track.log
+  grep "Tracking \"\*.dat\"" track.log
+  git add .gitattributes
+  git commit -m "Tracking"
+
+  git checkout -b test
+
+  # set up a decent amount of data so that there's work for multiple concurrent adapters
+  echo "[
+  {
+    \"CommitDate\":\"$(get_date -10d)\",
+    \"Files\":[
+      {\"Filename\":\"verify.dat\",\"Size\":18,\"Data\":\"send-verify-action\"},
+      {\"Filename\":\"file1.dat\",\"Size\":1024},
+      {\"Filename\":\"file2.dat\",\"Size\":750}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -7d)\",
+    \"Files\":[
+      {\"Filename\":\"file1.dat\",\"Size\":1050},
+      {\"Filename\":\"file3.dat\",\"Size\":660},
+      {\"Filename\":\"file4.dat\",\"Size\":230}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -5d)\",
+    \"Files\":[
+      {\"Filename\":\"file5.dat\",\"Size\":1200},
+      {\"Filename\":\"file6.dat\",\"Size\":300}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -2d)\",
+    \"Files\":[
+      {\"Filename\":\"file3.dat\",\"Size\":120},
+      {\"Filename\":\"file5.dat\",\"Size\":450},
+      {\"Filename\":\"file7.dat\",\"Size\":520},
+      {\"Filename\":\"file8.dat\",\"Size\":2048}]
+  }
+  ]" | lfstest-testutils addcommits
+
+  testdir="$(pwd)"
+
+  cd "$TRASHDIR"
+
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git clone "file://$(urlify "$testdir")" repo3  2>&1 | tee clonecustom.log
+
+  grep "xfer: started custom adapter process" clonecustom.log
+)
+end_test

--- a/t/t-worktree.sh
+++ b/t/t-worktree.sh
@@ -41,8 +41,8 @@ PruneRemoteName=origin
 LfsStorageDir=$(native_path_escaped "$TRASHDIR/$reponame/.git/lfs")
 AccessDownload=none
 AccessUpload=none
-DownloadTransfers=basic
-UploadTransfers=basic
+DownloadTransfers=basic,lfs-standalone-file
+UploadTransfers=basic,lfs-standalone-file
 $(escape_path "$(env | grep "^GIT")")
 %s
 " "$(git lfs version)" "$(git version)" "$envInitConfig")
@@ -77,8 +77,8 @@ PruneRemoteName=origin
 LfsStorageDir=$(native_path_escaped "$TRASHDIR/$reponame/.git/lfs")
 AccessDownload=none
 AccessUpload=none
-DownloadTransfers=basic
-UploadTransfers=basic
+DownloadTransfers=basic,lfs-standalone-file
+UploadTransfers=basic,lfs-standalone-file
 $(escape_path "$(env | grep "^GIT")")
 %s
 " "$(git lfs version)" "$(git version)" "$envInitConfig")

--- a/tools/cygwin_windows.go
+++ b/tools/cygwin_windows.go
@@ -43,7 +43,7 @@ func isCygwin() bool {
 		return false
 	}
 
-	if bytes.Contains(out, []byte("CYGWIN")) || bytes.Contains(out, []byte("MSYS")) {
+	if bytes.Contains(out, []byte("CYGWIN")) || bytes.Contains(out, []byte("MSYS")) || bytes.Contains(out, []byte("MINGW")) {
 		cygwinState = cygwinStateEnabled
 	} else {
 		cygwinState = cygwinStateDisabled

--- a/tq/custom.go
+++ b/tq/custom.go
@@ -348,8 +348,23 @@ func newCustomAdapter(f *fs.Filesystem, name string, dir Direction, path, args s
 	return c
 }
 
+const (
+	standaloneFileName = "lfs-standalone-file"
+)
+
+func configureDefaultCustomAdapters(git Env, m *Manifest) {
+	newfunc := func(name string, dir Direction) Adapter {
+		standalone := m.standaloneTransferAgent != ""
+		return newCustomAdapter(m.fs, standaloneFileName, dir, "git-lfs", "standalone-file", false, standalone)
+	}
+	m.RegisterNewAdapterFunc(standaloneFileName, Download, newfunc)
+	m.RegisterNewAdapterFunc(standaloneFileName, Upload, newfunc)
+}
+
 // Initialise custom adapters based on current config
 func configureCustomAdapters(git Env, m *Manifest) {
+	configureDefaultCustomAdapters(git, m)
+
 	pathRegex := regexp.MustCompile(`lfs.customtransfer.([^.]+).path`)
 	for k, _ := range git.All() {
 		match := pathRegex.FindStringSubmatch(k)

--- a/tq/manifest.go
+++ b/tq/manifest.go
@@ -1,6 +1,7 @@
 package tq
 
 import (
+	"strings"
 	"sync"
 
 	"github.com/git-lfs/git-lfs/config"
@@ -103,6 +104,13 @@ func NewManifest(f *fs.Filesystem, apiClient *lfsapi.Client, operation, remote s
 	return m
 }
 
+func findDefaultStandaloneTransfer(url string) string {
+	if strings.HasPrefix(url, "file://") {
+		return standaloneFileName
+	}
+	return ""
+}
+
 func findStandaloneTransfer(client *lfsapi.Client, operation, remote string) string {
 	if operation == "" || remote == "" {
 		v, _ := client.GitEnv().Get("lfs.standalonetransferagent")
@@ -113,7 +121,7 @@ func findStandaloneTransfer(client *lfsapi.Client, operation, remote string) str
 	uc := config.NewURLConfig(client.GitEnv())
 	v, ok := uc.Get("lfs", ep.Url, "standalonetransferagent")
 	if !ok {
-		return ""
+		return findDefaultStandaloneTransfer(ep.Url)
 	}
 
 	return v


### PR DESCRIPTION
One commonly requested feature for Git LFS is support for local files. Currently, we tell users that they must use a standalone transfer adapter, which is true, but nobody has provided one yet. Since writing a simple transfer adapter is not very difficult, let's provide one ourselves.

Introduce a basic standalone transfer adapter, git lfs standalone-file, that handles uploads and downloads. Add a default configuration required for it to work, while still allowing users to override this configuration if they have a preferred implementation that is more featureful. We provide this as a transfer adapter instead of built-in because it avoids the complexity of adding a different code path to the main codebase, but also serves as a demonstration of how to write a standalone transfer adapter for others who might want to do so, much like Git demonstrates remote helpers using its HTTP helper.

Note that this doesn't introduce support for plain paths, only file URLs, but this should be sufficient for most needs.

Fixes #3742.