### PR TITLE
Add new command `git lfs dedup` for file system level de-duplication.

### DIFF
--- a/commands/command_dedup.go
+++ b/commands/command_dedup.go
@@ -1,0 +1,128 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"sync/atomic"
+
+	"github.com/git-lfs/git-lfs/config"
+	"github.com/git-lfs/git-lfs/errors"
+	"github.com/git-lfs/git-lfs/git"
+	"github.com/git-lfs/git-lfs/lfs"
+	"github.com/git-lfs/git-lfs/tools"
+	"github.com/spf13/cobra"
+)
+
+var (
+	dedupFlags = struct {
+		test bool
+	}{}
+	dedupStats = &struct {
+		totalProcessedCount int64
+		totalProcessedSize  int64
+	}{}
+)
+
+func dedupTestCommand(*cobra.Command, []string) {
+	requireInRepo()
+
+	if supported, err := tools.CheckCloneFileSupported(cfg.TempDir()); err != nil || !supported {
+		if err == nil {
+			err = errors.New("Unknown reason.")
+		}
+		Exit("This system does not support deduplication. %s", err)
+	}
+
+	Print("OK: This platform and repository support file de-duplication.")
+}
+
+func dedupCommand(cmd *cobra.Command, args []string) {
+	if dedupFlags.test {
+		dedupTestCommand(cmd, args)
+		return
+	}
+
+	requireInRepo()
+	if gitDir, err := git.GitDir(); err != nil {
+		ExitWithError(err)
+	} else if supported, err := tools.CheckCloneFileSupported(gitDir); err != nil || !supported {
+		Exit("This system does not support deduplication.")
+	}
+
+	if dirty, err := git.IsWorkingCopyDirty(); err != nil {
+		ExitWithError(err)
+	} else if dirty {
+		Exit("Working tree is dirty. Please commit or reset your change.")
+	}
+
+	// We assume working tree is clean.
+	gitScanner := lfs.NewGitScanner(config.New(), func(p *lfs.WrappedPointer, err error) {
+		if err != nil {
+			Exit("Could not scan for Git LFS tree: %s", err)
+			return
+		}
+
+		if success, err := dedup(p); err != nil {
+			Error("Skipped: %s (Size: %d)\n          %s", p.Name, p.Size, err)
+		} else if !success {
+			Error("Skipped: %s (Size: %d)", p.Name, p.Size)
+		} else if success {
+			Print("Success: %s (Size: %d)", p.Name, p.Size)
+
+			atomic.AddInt64(&dedupStats.totalProcessedCount, 1)
+			atomic.AddInt64(&dedupStats.totalProcessedSize, p.Size)
+		}
+	})
+	defer gitScanner.Close()
+
+	if err := gitScanner.ScanTree("HEAD"); err != nil {
+		ExitWithError(err)
+	}
+
+	Print("\n\nSuccessfully finished.\n"+
+		"  De-duplicated  size: %d bytes\n"+
+		"                count: %d",
+		dedupStats.totalProcessedSize,
+		dedupStats.totalProcessedCount)
+}
+
+// dedup executes
+// Precondition: working tree MUST clean. We can replace working tree files from mediafile safely.
+func dedup(p *lfs.WrappedPointer) (success bool, err error) {
+	// PRECONDITION, check ofs object exists or skip this file.
+	if !cfg.LFSObjectExists(p.Oid, p.Size) { // Not exists,
+		// Basically, this is not happens because executing 'git status' in `git.IsWorkingCopyDirty()` recover it.
+		return false, errors.New("mediafile is not exist")
+	}
+
+	// DO de-dup
+	// Gather original state
+	originalStat, err := os.Stat(p.Name)
+	if err != nil {
+		return false, err
+	}
+
+	// Do clone
+	srcFile := cfg.Filesystem().ObjectPathname(p.Oid)
+	dstFile := filepath.Join(cfg.LocalWorkingDir(), p.Name)
+
+	// Clone the file. This overwrites the destination if it exists.
+	if ok, err := tools.CloneFileByPath(dstFile, srcFile); err != nil {
+		return false, err
+	} else if !ok {
+		return false, errors.Errorf("unknown clone file error")
+	}
+
+	// Recover original state
+	if err := os.Chmod(dstFile, originalStat.Mode()); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func init() {
+	RegisterCommand("dedup", dedupCommand, func(cmd *cobra.Command) {
+		cmd.Flags().BoolVarP(&dedupFlags.test, "test", "t", false, "test")
+	})
+}

--- a/docs/man/git-lfs-dedup.1.ronn
+++ b/docs/man/git-lfs-dedup.1.ronn
@@ -1,0 +1,18 @@
+git-lfs-dedup(1) - Deduplicate Git LFS files
+======================================================
+
+## SYNOPSIS
+
+`git lfs dedup`
+
+## DESCRIPTION
+
+Deduplicates storage by re-creating working tree files as clones of the files in the Git LFS storage directory
+using the operating system's copy-on-write file creation functionality.
+
+If the operating system or file system don't support copy-on-write file creation, this command exits unsuccessfully.
+
+## SEE ALSO
+
+Part of the git-lfs(1) suite.
+

--- a/t/t-dedup.sh
+++ b/t/t-dedup.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+. "$(dirname "$0")/testlib.sh"
+
+begin_test "dedup"
+(
+  set -e
+
+  reponame="dedup"
+  git init $reponame
+  cd $reponame
+
+  # Create a commit with some files tracked by git-lfs
+  git lfs track *.dat
+  echo "test data" > a.dat
+  echo "test data 2" > b.dat
+  git add .gitattributes *.dat
+  git commit -m "first commit"
+
+  # Delete file b and lock directory
+  bOid=$(git log --patch b.dat | grep "^+oid" | cut -d ":" -f 2)
+  bOid12=$(echo $bOid | cut -b 1-2)
+  bOid34=$(echo $bOid | cut -b 3-4)
+  rm ".git/lfs/objects/$bOid12/$bOid34/$bOid"
+
+  # DO
+  result=$(git lfs dedup 2>&1) && true
+  if ( echo $result | grep "This system does not support deduplication." ); then
+    exit
+  fi
+
+  # VERIFY: Expected
+  #  Success: a.dat
+  #  Success: b.dat
+  echo "$result" | grep 'Success: a.dat'
+  echo "$result" | grep -E 'Success:\s+b.dat|Skipped:\s+b.dat'
+  # Sometimes mediafile of b.bat is restored by timing issue?
+)
+end_test
+
+begin_test "dedup test"
+(
+  set -e
+
+  reponame="dedup_test"
+  git init $reponame
+  cd $reponame
+
+  # DO
+  result=$(git lfs dedup --test 2>&1) && true
+  if ( echo $result | grep "This system does not support deduplication." ); then
+    exit
+  fi
+
+  # Verify: This platform and repository support file de-duplication.
+  echo "$result" | grep 'This platform and repository support file de-duplication.'
+)
+end_test
+
+begin_test "dedup dirty workdir"
+(
+  set -e
+
+  reponame="dedup_dirty_workdir"
+  git init $reponame
+  cd $reponame
+
+  # Make working tree dirty.
+  echo "test data" > a.dat
+  git add a.dat
+  git commit -m "first commit"
+  echo "modify" >> a.dat
+
+  # DO
+  result=$(git lfs dedup 2>&1) && true
+  if ( echo $result | grep "This system does not support deduplication." ); then
+    exit
+  fi
+
+  # Verify: Working tree is dirty. Please commit or reset your change.
+  echo "$result" | grep 'Working tree is dirty. Please commit or reset your change.'
+)
+end_test

--- a/tools/util_darwin_test.go
+++ b/tools/util_darwin_test.go
@@ -11,6 +11,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestCheckCloneFileSupported(t *testing.T) {
+	as := assert.New(t)
+
+	// Do
+	ok, err := CheckCloneFileSupported(os.TempDir())
+
+	// Verify
+	t.Logf("ok = %v, err = %v", ok, err) // Just logging for 1st element
+
+	if !checkCloneFileSupported() {
+		as.EqualError(err, "unsupported OS version. >= 10.12.x Sierra required")
+	}
+}
+
 func TestCloneFile(t *testing.T) {
 	as := assert.New(t)
 

--- a/tools/util_generic.go
+++ b/tools/util_generic.go
@@ -5,7 +5,13 @@ package tools
 
 import (
 	"io"
+
+	"github.com/git-lfs/git-lfs/errors"
 )
+
+func CheckCloneFileSupported(dir string) (supported bool, err error) {
+	return false, errors.New("unsupported platform")
+}
 
 func CloneFile(writer io.Writer, reader io.Reader) (bool, error) {
 	return false, nil

--- a/tools/util_test.go
+++ b/tools/util_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,6 +32,7 @@ func TestCopyWithCallback(t *testing.T) {
 
 func TestMethodExists(t *testing.T) {
 	// testing following methods exist in all platform.
+	_, _ = CheckCloneFileSupported(os.TempDir())
 	_, _ = CloneFile(io.Writer(nil), io.Reader(nil))
 	_, _ = CloneFileByPath("", "")
 }


### PR DESCRIPTION
Implements and closes https://github.com/git-lfs/git-lfs/issues/3740.
This PR depends https://github.com/git-lfs/git-lfs/pull/3745 (merged).

Formatted doc is here https://github.com/kazuki-ma/git-lfs/blob/dedup/docs/man/git-lfs-dedup.1.ronn

Request of information
=======
- [x] I'm using `lfs.NewGitScanner` with `ScanTree("HEAD")`. Is it right?
  - Fixed.
- [x] `canDedup` condition.
  - Fixed. Using `! git.IsWorkingCopyDirty()` 
- [ ] minor) after finished de-dup command, git checking all de-duped files due to file stat is changed.
 Can I skip it?