### PR TITLE
Optimize traversal of Git objects with URL remotes

### DIFF
--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -54,7 +54,12 @@ func uploadLeftOrAll(g *lfs.GitScanner, ctx *uploadContext, q *tq.TransferQueue,
 			return err
 		}
 	} else {
-		if err := g.ScanLeftToRemote(update.LeftCommitish(), cb); err != nil {
+		left := update.LeftCommitish()
+		right := update.Right().Sha
+		if left == right {
+			right = ""
+		}
+		if err := g.ScanRangeToRemote(left, right, cb); err != nil {
 			return err
 		}
 	}

--- a/git/rev_list_scanner.go
+++ b/git/rev_list_scanner.go
@@ -23,9 +23,9 @@ const (
 	ScanRefsMode ScanningMode = iota
 	// ScanAllMode will scan all history.
 	ScanAllMode
-	// ScanLeftToRemoteMode will scan the difference between any included
+	// ScanRangeToRemoteMode will scan the difference between any included
 	// SHA1s and a remote tracking ref.
-	ScanLeftToRemoteMode
+	ScanRangeToRemoteMode
 )
 
 // RevListOrder is a constant type that allows for variation in the ordering of
@@ -250,7 +250,7 @@ func revListArgs(include, exclude []string, opt *ScanRefsOptions) (io.Reader, []
 			includeExcludeShas(include, exclude), "\n"))
 	case ScanAllMode:
 		args = append(args, "--all")
-	case ScanLeftToRemoteMode:
+	case ScanRangeToRemoteMode:
 		if len(opt.SkippedRefs) == 0 {
 			args = append(args, "--not", "--remotes="+opt.Remote)
 			stdin = strings.NewReader(strings.Join(

--- a/git/rev_list_scanner_test.go
+++ b/git/rev_list_scanner_test.go
@@ -91,7 +91,7 @@ func TestRevListArgs(t *testing.T) {
 		},
 		"scan left to remote, no skipped refs": {
 			Include: []string{s1}, Opt: &ScanRefsOptions{
-				Mode:        ScanLeftToRemoteMode,
+				Mode:        ScanRangeToRemoteMode,
 				Remote:      "origin",
 				SkippedRefs: []string{},
 			},
@@ -100,7 +100,7 @@ func TestRevListArgs(t *testing.T) {
 		},
 		"scan left to remote, skipped refs": {
 			Include: []string{s1}, Exclude: []string{s2}, Opt: &ScanRefsOptions{
-				Mode:        ScanLeftToRemoteMode,
+				Mode:        ScanRangeToRemoteMode,
 				Remote:      "origin",
 				SkippedRefs: []string{"a", "b", "c"},
 			},


### PR DESCRIPTION
We have an optimization that means we avoid traversing objects that exist in the remote tracking branches of named remotes. We assume that the server already has the LFS objects referred to by those Git objects.

However, this doesn't work for URL remotes, since there are no remote tracking branches for them. Instead, let's make sure that we don't traverse Git objects that are included in the old value of the ref, which we know the server must have.

Note that this will not help the case where someone is pushing a new branch to a URL remote; in that case, the old value is the all-zeros value and we'll still have to traverse the entire history since we haven't learned anything about what the server has.

Fixes #3661