### PR TITLE
Provide an option to track to handle paths literally

### DIFF
--- a/docs/man/git-lfs-track.1.ronn
+++ b/docs/man/git-lfs-track.1.ronn
@@ -31,6 +31,11 @@ to match paths.
 
   Disabled by default.
 
+* `--filename`
+  Treat the arguments as literal filenames, not as patterns. Any special glob
+  characters in the filename will be escaped when writing the `.gitattributes`
+  file.
+
 * `--lockable` `-l`
   Make the paths 'lockable', meaning they should be locked to edit them, and
   will be made read-only in the working copy when not locked.

--- a/t/t-track.sh
+++ b/t/t-track.sh
@@ -653,3 +653,31 @@ begin_test "track: escaped pattern in .gitattributes"
   fi
 )
 end_test
+
+begin_test "track: escaped glob pattern in .gitattributes"
+(
+  set -e
+
+  # None of these characters are valid in the Win32 subsystem.
+  [ "$IS_WINDOWS" -eq 1 ] && exit 0
+
+  reponame="track-escaped-glob"
+  git init "$reponame"
+  cd "$reponame"
+
+  filename='*[foo]bar?.txt'
+  contents='I need escaping'
+  contents_oid=$(calc_oid "$contents")
+
+  git lfs track --filename "$filename"
+  git add .
+  cat .gitattributes
+
+  printf "%s" "$contents" > "$filename"
+  git add .
+  git commit -m 'Add unusually named file'
+
+  # If Git understood our escaping, we'll have a pointer. Otherwise, we won't.
+  assert_pointer "master" "$filename" "$contents_oid" 15
+)
+end_test

--- a/t/testhelpers.sh
+++ b/t/testhelpers.sh
@@ -14,7 +14,7 @@ assert_pointer() {
     while read -r -d $'\0' x; do
       echo $x
     done |
-    grep "$path" | cut -f 3 -d " ")
+    grep -F "$path" | cut -f 3 -d " ")
 
   actual=$(git cat-file -p $gitblob)
   expected=$(pointer $oid $size)


### PR DESCRIPTION
Normally, the arguments to `git lfs track` are taken as glob patterns. This is generally useful, but sometimes there are filenames that contain special characters. Add a `--filename` option that forces arguments to be taken as literal paths instead of glob patterns to make handling these files easier.

In the test helpers, pass -F to grep so that our unusual file names don't trigger undesired pattern matching. This has no effect on other tests, as they all pass a literal filename here.

Fixes #3506.