### PR TITLE
Make Travis run tests on the proper version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
     - GIT_LFS_SRC_DIR="$HOME/src/git-lfs"
     - GIT_LFS_TEST_DIR="$HOME/git-lfs-tests"
     - GIT_SOURCE_REPO="https://github.com/git/git.git"
-    - GIT_EARLIEST_SUPPORTED_VERSION="v2.0.0
+    - GIT_EARLIEST_SUPPORTED_VERSION="v2.0.0"
     - GIT_LATEST_SOURCE_BRANCH="master"
     - GIT_ASKPASS=""
 


### PR DESCRIPTION
Because the quotation mark was missing for the variable `GIT_EARLIEST_SUPPORTED_VERSION`, we never checked out the older version and built it. Instead, we always checked out the latest master and built it twice, resulting in us never testing version 2.0.0 as we had wanted.