### PR TITLE
Fix remote autoselection when not on a branch

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -230,12 +230,7 @@ func (c *Configuration) Remote() string {
 	defer c.loading.Unlock()
 
 	if c.currentRemote == nil {
-		if len(ref.Name) == 0 {
-			c.currentRemote = &defaultRemote
-			return defaultRemote
-		}
-
-		if remote, ok := c.Git.Get(fmt.Sprintf("branch.%s.remote", ref.Name)); ok {
+		if remote, ok := c.Git.Get(fmt.Sprintf("branch.%s.remote", ref.Name)); len(ref.Name) != 0 && ok {
 			// try tracking remote
 			c.currentRemote = &remote
 		} else if remotes := c.Remotes(); len(remotes) == 1 {


### PR DESCRIPTION
We currently have code that determines which remote to us automatically. For example, if there is only one remote, we want to use it, no matter what it's named, because there's no other logical choice.

However, if we were not on any branch, we'd always end up picking "origin", even if that remote didn't exist. This appears to have been because we wanted to avoid a lookup with an empty branch name in the configuration. Doing so is harmless, though, so let's simply check that the branch name isn't empty before we execute that condition, and fall back to the rest of the checks if it is. This ensures that we always pick the only remote when there's just one.

Fixes #3730.
/cc @flokli and @gwerbin as reporters