### PR TITLE
ls-files: add support for reference range

### DIFF
--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -239,7 +239,7 @@ func statusScanRefRange(ref *git.Ref) {
 	defer gitscanner.Close()
 
 	Print("Git LFS objects to be pushed to %s:\n", remoteRef.Name)
-	if err := gitscanner.ScanRefRange(ref.Sha, "^"+remoteRef.Sha, nil); err != nil {
+	if err := gitscanner.ScanRefRange(ref.Sha, remoteRef.Sha, nil); err != nil {
 		Panic(err, "Could not scan for Git LFS objects")
 	}
 

--- a/docs/man/git-lfs-ls-files.1.ronn
+++ b/docs/man/git-lfs-ls-files.1.ronn
@@ -3,12 +3,16 @@ git-lfs-ls-files(1) -- Show information about Git LFS files in the index and wor
 
 ## SYNOPSIS
 
-`git lfs ls-files` [<ref>]
+`git lfs ls-files` [<ref>]<br>
+`git lfs ls-files` <ref> <ref>
 
 ## DESCRIPTION
 
 Display paths of Git LFS files that are found in the tree at the given
 reference.  If no reference is given, scan the currently checked-out branch.
+If two references are given, the LFS files that are modified between the two
+references are shown; deletions are not listed.
+
 An asterisk (*) after the OID indicates a full object, a minus (-) indicates an
 LFS pointer.
 

--- a/lfs/gitscanner.go
+++ b/lfs/gitscanner.go
@@ -90,9 +90,6 @@ func (s *GitScanner) ScanRangeToRemote(left, right string, cb GitScannerFoundPoi
 	}
 	s.mu.Unlock()
 
-	if len(right) != 0 {
-		right = fmt.Sprintf("^%s", right)
-	}
 	return scanLeftRightToChan(s, callback, left, right, s.opts(ScanRangeToRemoteMode))
 }
 

--- a/lfs/gitscanner_refs.go
+++ b/lfs/gitscanner_refs.go
@@ -96,7 +96,7 @@ func scanRefsToChan(scanner *GitScanner, pointerCb GitScannerFoundPointer, inclu
 // for all Git LFS pointers it finds for that ref.
 // Reports unique oids once only, not multiple times if >1 file uses the same content
 func scanLeftRightToChan(scanner *GitScanner, pointerCb GitScannerFoundPointer, refLeft, refRight string, opt *ScanRefsOptions) error {
-	return scanRefsToChan(scanner, pointerCb, []string{refLeft, refRight}, nil, opt)
+	return scanRefsToChan(scanner, pointerCb, []string{refLeft}, []string{refRight}, opt)
 }
 
 // revListShas uses git rev-list to return the list of object sha1s

--- a/t/t-ls-files.sh
+++ b/t/t-ls-files.sh
@@ -442,3 +442,59 @@ begin_test "ls-files: --name-only"
 )
 end_test
 
+begin_test "ls-files: history with reference range"
+(
+  set -e
+
+  reponame="ls-files-history-with-range"
+  git init "$reponame"
+  cd "$reponame"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m 'intial commit'
+
+  echo "content of a-file" > a.dat
+  git add a.dat
+  git commit -m 'add a.dat'
+
+  echo "content of b-file" > b.dat
+  git add b.dat
+  git commit -m 'add b.dat'
+
+  git tag b-commit
+
+  echo "content of c-file" > c.dat
+  git add c.dat
+  git commit -m 'add c.dat'
+
+  echo "content of c-file and later modified" > c.dat
+  git add c.dat
+  git commit -m 'modify c.dat'
+
+  git tag c-commit
+
+  git rm a.dat
+  git commit -m 'remove a.dat'
+
+  git lfs ls-files --all 2>&1 | tee ls-files.log
+  [ 1 -eq $(grep -c "a\.dat" ls-files.log) ]
+  [ 1 -eq $(grep -c "b\.dat" ls-files.log) ]
+  [ 2 -eq $(grep -c "c\.dat" ls-files.log) ]
+
+  git lfs ls-files b-commit c-commit 2>&1 | tee ls-files.log
+  [ 0 -eq $(grep -c "a\.dat" ls-files.log) ]
+  [ 0 -eq $(grep -c "b\.dat" ls-files.log) ]
+  [ 2 -eq $(grep -c "c\.dat" ls-files.log) ]
+
+  git lfs ls-files c-commit~ c-commit 2>&1 | tee ls-files.log
+  [ 0 -eq $(grep -c "a\.dat" ls-files.log) ]
+  [ 0 -eq $(grep -c "b\.dat" ls-files.log) ]
+  [ 1 -eq $(grep -c "c\.dat" ls-files.log) ]
+
+  git lfs ls-files HEAD~ HEAD 2>&1 | tee ls-files.log
+  [ 0 -eq $(grep -c "a\.dat" ls-files.log) ]
+  [ 0 -eq $(grep -c "b\.dat" ls-files.log) ]
+  [ 0 -eq $(grep -c "c\.dat" ls-files.log) ]
+)
+end_test


### PR DESCRIPTION
Add an option to the `ls-files` command where the user can specify a commit range. This will return all the lfs files which changed between those two commits.

This change is based on the aborted pull request #3151 by @larsxschneider. I finished implementation and added unit tests and documentation.

As background information, the reason for this option is that I have a script that creates a git bundle. To workaround the missing bundle support in lfs (see #1755), I want to know which lfs objects were changed/created in the commit range of the bundle. Currently, in the script, I walk over all commits in the range and do a compare of the `ls-files` output. This is very slow however, so if `ls-files` has support for a commit range that would help me a lot.