### PR TITLE
Support GIT_ALTERNATE_OBJECT_DIRECTORIES

### DIFF
--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -54,7 +54,7 @@ func checkoutCommand(cmd *cobra.Command, args []string) {
 	meter.Direction = tq.Checkout
 	meter.Logger = meter.LoggerFromEnv(cfg.Os)
 	logger.Enqueue(meter)
-	chgitscanner := lfs.NewGitScanner(func(p *lfs.WrappedPointer, err error) {
+	chgitscanner := lfs.NewGitScanner(cfg, func(p *lfs.WrappedPointer, err error) {
 		if err != nil {
 			LoggedError(err, "Scanner error: %s", err)
 			return
@@ -99,7 +99,7 @@ func checkoutConflict(file string, stage git.IndexStage) {
 		Exit("Could not checkout (are you not in the middle of a merge?): %v", err)
 	}
 
-	scanner, err := git.NewObjectScanner()
+	scanner, err := git.NewObjectScanner(cfg.OSEnv())
 	if err != nil {
 		Exit("Could not create object scanner: %v", err)
 	}

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -60,7 +60,7 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 	}
 
 	success := true
-	gitscanner := lfs.NewGitScanner(nil)
+	gitscanner := lfs.NewGitScanner(cfg, nil)
 	defer gitscanner.Close()
 
 	include, exclude := getIncludeExcludeArgs(cmd)
@@ -110,7 +110,7 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 func pointersToFetchForRef(ref string, filter *filepathfilter.Filter) ([]*lfs.WrappedPointer, error) {
 	var pointers []*lfs.WrappedPointer
 	var multiErr error
-	tempgitscanner := lfs.NewGitScanner(func(p *lfs.WrappedPointer, err error) {
+	tempgitscanner := lfs.NewGitScanner(cfg, func(p *lfs.WrappedPointer, err error) {
 		if err != nil {
 			if multiErr != nil {
 				multiErr = fmt.Errorf("%v\n%v", multiErr, err)
@@ -147,7 +147,7 @@ func fetchRef(ref string, filter *filepathfilter.Filter) bool {
 func fetchPreviousVersions(ref string, since time.Time, filter *filepathfilter.Filter) bool {
 	var pointers []*lfs.WrappedPointer
 
-	tempgitscanner := lfs.NewGitScanner(func(p *lfs.WrappedPointer, err error) {
+	tempgitscanner := lfs.NewGitScanner(cfg, func(p *lfs.WrappedPointer, err error) {
 		if err != nil {
 			Panic(err, "Could not scan for Git LFS previous versions")
 			return
@@ -239,7 +239,7 @@ func scanAll() []*lfs.WrappedPointer {
 	// use temp gitscanner to collect pointers
 	var pointers []*lfs.WrappedPointer
 	var multiErr error
-	tempgitscanner := lfs.NewGitScanner(func(p *lfs.WrappedPointer, err error) {
+	tempgitscanner := lfs.NewGitScanner(cfg, func(p *lfs.WrappedPointer, err error) {
 		if err != nil {
 			if multiErr != nil {
 				multiErr = fmt.Errorf("%v\n%v", multiErr, err)

--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -34,7 +34,7 @@ func fsckCommand(cmd *cobra.Command, args []string) {
 	}
 
 	var corruptOids []string
-	gitscanner := lfs.NewGitScanner(func(p *lfs.WrappedPointer, err error) {
+	gitscanner := lfs.NewGitScanner(cfg, func(p *lfs.WrappedPointer, err error) {
 		if err == nil {
 			var pointerOk bool
 			pointerOk, err = fsckPointer(p.Name, p.Oid)

--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -62,7 +62,7 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 
 	seen := make(map[string]struct{})
 
-	gitscanner := lfs.NewGitScanner(func(p *lfs.WrappedPointer, err error) {
+	gitscanner := lfs.NewGitScanner(cfg, func(p *lfs.WrappedPointer, err error) {
 		if err != nil {
 			Exit("Could not scan for Git LFS tree: %s", err)
 			return

--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -82,7 +82,8 @@ func getObjectDatabase() (*gitobj.ObjectDatabase, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot open root")
 	}
-	return gitobj.FromFilesystem(filepath.Join(dir, "objects"), cfg.TempDir())
+	alternates, _ := cfg.OSEnv().Get("GIT_ALTERNATE_OBJECT_DIRECTORIES")
+	return gitobj.FromFilesystemWithAlternates(filepath.Join(dir, "objects"), cfg.TempDir(), alternates)
 }
 
 // rewriteOptions returns *githistory.RewriteOptions able to be passed to a

--- a/commands/command_migrate_export.go
+++ b/commands/command_migrate_export.go
@@ -121,7 +121,7 @@ func migrateExportCommand(cmd *cobra.Command, args []string) {
 	// If we have a valid remote, pre-download all objects using the Transfer Queue
 	if remoteURL != "" {
 		q := newDownloadQueue(getTransferManifestOperationRemote("Download", remote), remote)
-		gs := lfs.NewGitScanner(func(p *lfs.WrappedPointer, err error) {
+		gs := lfs.NewGitScanner(cfg, func(p *lfs.WrappedPointer, err error) {
 			if err != nil {
 				return
 			}

--- a/commands/command_prune.go
+++ b/commands/command_prune.go
@@ -91,7 +91,7 @@ func prune(fetchPruneConfig lfs.FetchPruneConfig, verifyRemote, dryRun, verbose 
 	// Now find files to be retained from many sources
 	retainChan := make(chan string, 100)
 
-	gitscanner := lfs.NewGitScanner(nil)
+	gitscanner := lfs.NewGitScanner(cfg, nil)
 	gitscanner.Filter = filepathfilter.New(nil, cfg.FetchExcludePaths())
 
 	sem := semaphore.NewWeighted(int64(runtime.NumCPU() * 2))

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -47,7 +47,7 @@ func pull(filter *filepathfilter.Filter) {
 	remote := cfg.Remote()
 	singleCheckout := newSingleCheckout(cfg.Git, remote)
 	q := newDownloadQueue(singleCheckout.Manifest(), remote, tq.WithProgress(meter))
-	gitscanner := lfs.NewGitScanner(func(p *lfs.WrappedPointer, err error) {
+	gitscanner := lfs.NewGitScanner(cfg, func(p *lfs.WrappedPointer, err error) {
 		if err != nil {
 			LoggedError(err, "Scanner error: %s", err)
 			return

--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -32,7 +32,7 @@ func statusCommand(cmd *cobra.Command, args []string) {
 		scanIndexAt = git.RefBeforeFirstCommit
 	}
 
-	scanner, err := lfs.NewPointerScanner()
+	scanner, err := lfs.NewPointerScanner(cfg.OSEnv())
 	if err != nil {
 		ExitWithError(err)
 	}
@@ -228,7 +228,7 @@ func statusScanRefRange(ref *git.Ref) {
 		return
 	}
 
-	gitscanner := lfs.NewGitScanner(func(p *lfs.WrappedPointer, err error) {
+	gitscanner := lfs.NewGitScanner(cfg, func(p *lfs.WrappedPointer, err error) {
 		if err != nil {
 			Panic(err, "Could not scan for Git LFS objects")
 			return

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -151,7 +151,7 @@ func (c *uploadContext) addScannerError(err error) {
 }
 
 func (c *uploadContext) buildGitScanner() (*lfs.GitScanner, error) {
-	gitscanner := lfs.NewGitScanner(nil)
+	gitscanner := lfs.NewGitScanner(cfg, nil)
 	gitscanner.FoundLockable = func(n string) { c.lockVerifier.LockedByThem(n) }
 	gitscanner.PotentialLockables = c.lockVerifier
 	return gitscanner, gitscanner.RemoteForPush(c.Remote)

--- a/git/config.go
+++ b/git/config.go
@@ -14,6 +14,13 @@ var (
 	ErrReadOnly = errors.New("configuration is read-only")
 )
 
+// Environment is a restricted version of config.Environment that only provides
+// a single method.
+type Environment interface {
+	// Get is shorthand for calling `e.Fetcher.Get(key)`.
+	Get(key string) (val string, ok bool)
+}
+
 // Configuration can fetch or modify the current Git config and track the Git
 // version.
 type Configuration struct {

--- a/git/object_scanner.go
+++ b/git/object_scanner.go
@@ -48,7 +48,8 @@ func NewObjectScanner(osEnv Environment) (*ObjectScanner, error) {
 		return nil, err
 	}
 
-	gitobj, err := gitobj.FromFilesystem(filepath.Join(gitdir, "objects"), "")
+	alternates, _ := osEnv.Get("GIT_ALTERNATE_OBJECT_DIRECTORIES")
+	gitobj, err := gitobj.FromFilesystemWithAlternates(filepath.Join(gitdir, "objects"), "", alternates)
 	if err != nil {
 		return nil, err
 	}

--- a/git/object_scanner.go
+++ b/git/object_scanner.go
@@ -42,7 +42,7 @@ type ObjectScanner struct {
 // command, they will be returned immediately.
 //
 // Otherwise, an `*ObjectScanner` is returned with no error.
-func NewObjectScanner() (*ObjectScanner, error) {
+func NewObjectScanner(osEnv Environment) (*ObjectScanner, error) {
 	gitdir, err := GitCommonDir()
 	if err != nil {
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/git-lfs/git-lfs
 
 require (
 	github.com/alexbrainman/sspi v0.0.0-20180125232955-4729b3d4d858
-	github.com/git-lfs/gitobj v1.3.1
+	github.com/git-lfs/gitobj v1.4.0
 	github.com/git-lfs/go-netrc v0.0.0-20180525200031-e0e9ca483a18
 	github.com/git-lfs/go-ntlm v0.0.0-20190307203151-c5056e7fa066
 	github.com/git-lfs/wildmatch v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/alexbrainman/sspi v0.0.0-20180125232955-4729b3d4d858 h1:OZQyEhf4Bviyd
 github.com/alexbrainman/sspi v0.0.0-20180125232955-4729b3d4d858/go.mod h1:976q2ETgjT2snVCf2ZaBnyBbVoPERGjUz+0sofzEfro=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/git-lfs/gitobj v1.3.1 h1:Nni8wnRfvT3x91rDl3V397LjKOUoiaEK6vyIcA92aM8=
-github.com/git-lfs/gitobj v1.3.1/go.mod h1:EdPNGHVxXe1jTuNXzZT1+CdJCuASoDSLPQuvNOo9nGM=
+github.com/git-lfs/gitobj v1.4.0 h1:F7fKUUM/OTVu0ejnBA6x0trSYM8A9Zv7VGoBTsMmhHk=
+github.com/git-lfs/gitobj v1.4.0/go.mod h1:EdPNGHVxXe1jTuNXzZT1+CdJCuASoDSLPQuvNOo9nGM=
 github.com/git-lfs/go-netrc v0.0.0-20180525200031-e0e9ca483a18 h1:7Th0eBA4rT8WJNiM1vppjaIv9W5WJinhpbCJvRJxloI=
 github.com/git-lfs/go-netrc v0.0.0-20180525200031-e0e9ca483a18/go.mod h1:70O4NAtvWn1jW8V8V+OKrJJYcxDLTmIozfi2fmSz5SI=
 github.com/git-lfs/go-ntlm v0.0.0-20190307203151-c5056e7fa066 h1:j7JwIEwLNQ/kBdKpHO3U1jjMXIPjSq7eCFvQIF3e8Fs=

--- a/go.sum
+++ b/go.sum
@@ -22,12 +22,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rubyist/tracerx v0.0.0-20170927163412-787959303086 h1:mncRSDOqYCng7jOD+Y6+IivdRI6Kzv2BLWYkWkdQfu0=
 github.com/rubyist/tracerx v0.0.0-20170927163412-787959303086/go.mod h1:YpdgDXpumPB/+EGmGTYHeiW/0QVFRzBYTNFaxWfPDk4=
-github.com/spf13/cobra v0.0.0-20150809222549-c55cdf33856a h1:pYw8mElqJwrz3T7QVT2EZw1Te6gHW+cOGsuOuRzNdRo=
-github.com/spf13/cobra v0.0.0-20150809222549-c55cdf33856a/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.3 h1:ZlrZ4XsMRm04Fr5pSFxBgfND2EBVa1nLpiy1stUsX/8=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
-github.com/spf13/pflag v0.0.0-20150814225300-580b9be06c33 h1:JZTN3XaDcPNAKb/i98hWdKD3C0wNQ8ehJRQHcg9eQ10=
-github.com/spf13/pflag v0.0.0-20150814225300-580b9be06c33/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=

--- a/lfs/gitscanner_catfilebatch.go
+++ b/lfs/gitscanner_catfilebatch.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/git-lfs/git-lfs/config"
 	"github.com/git-lfs/git-lfs/git"
 )
 
@@ -16,8 +17,8 @@ import (
 // pointerCh. If a Git Blob is not an LFS pointer, check the lockableSet to see
 // if that blob is for a locked file. Any errors are sent to errCh. An error is
 // returned if the 'git cat-file' command fails to start.
-func runCatFileBatch(pointerCh chan *WrappedPointer, lockableCh chan string, lockableSet *lockableNameSet, revs *StringChannelWrapper, errCh chan error) error {
-	scanner, err := NewPointerScanner()
+func runCatFileBatch(pointerCh chan *WrappedPointer, lockableCh chan string, lockableSet *lockableNameSet, revs *StringChannelWrapper, errCh chan error, osEnv config.Environment) error {
+	scanner, err := NewPointerScanner(osEnv)
 	if err != nil {
 		return err
 	}
@@ -69,8 +70,8 @@ type PointerScanner struct {
 	err         error
 }
 
-func NewPointerScanner() (*PointerScanner, error) {
-	scanner, err := git.NewObjectScanner()
+func NewPointerScanner(osEnv config.Environment) (*PointerScanner, error) {
+	scanner, err := git.NewObjectScanner(osEnv)
 	if err != nil {
 		return nil, err
 	}

--- a/lfs/gitscanner_index.go
+++ b/lfs/gitscanner_index.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/git-lfs/git-lfs/config"
 	"github.com/git-lfs/git-lfs/filepathfilter"
 )
 
@@ -12,7 +13,7 @@ import (
 //
 // Ref is the ref at which to scan, which may be "HEAD" if there is at least one
 // commit.
-func scanIndex(cb GitScannerFoundPointer, ref string, f *filepathfilter.Filter) error {
+func scanIndex(cb GitScannerFoundPointer, ref string, f *filepathfilter.Filter, osEnv config.Environment) error {
 	indexMap := &indexFileMap{
 		nameMap:      make(map[string][]*indexFile),
 		nameShaPairs: make(map[string]bool),
@@ -67,7 +68,7 @@ func scanIndex(cb GitScannerFoundPointer, ref string, f *filepathfilter.Filter) 
 
 	ch := make(chan gitscannerResult, chanBufSize)
 
-	barePointerCh, _, err := catFileBatch(smallShas, nil)
+	barePointerCh, _, err := catFileBatch(smallShas, nil, osEnv)
 	if err != nil {
 		return err
 	}

--- a/lfs/gitscanner_refs.go
+++ b/lfs/gitscanner_refs.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"regexp"
 
+	"github.com/git-lfs/git-lfs/config"
 	"github.com/git-lfs/git-lfs/git"
 )
 
@@ -37,7 +38,7 @@ func noopFoundLockable(name string) {}
 // "include" and not reachable by any refs included in "excluded" and returns
 // a channel of WrappedPointer objects for all Git LFS pointers it finds.
 // Reports unique oids once only, not multiple times if >1 file uses the same content
-func scanRefsToChan(scanner *GitScanner, pointerCb GitScannerFoundPointer, include, exclude []string, opt *ScanRefsOptions) error {
+func scanRefsToChan(scanner *GitScanner, pointerCb GitScannerFoundPointer, include, exclude []string, osEnv config.Environment, opt *ScanRefsOptions) error {
 	if opt == nil {
 		panic("no scan ref options")
 	}
@@ -64,7 +65,7 @@ func scanRefsToChan(scanner *GitScanner, pointerCb GitScannerFoundPointer, inclu
 		}
 	}(lockableCb, batchLockableCh)
 
-	pointers, checkLockableCh, err := catFileBatch(smallShas, lockableSet)
+	pointers, checkLockableCh, err := catFileBatch(smallShas, lockableSet, osEnv)
 	if err != nil {
 		return err
 	}
@@ -95,8 +96,8 @@ func scanRefsToChan(scanner *GitScanner, pointerCb GitScannerFoundPointer, inclu
 // scanLeftRightToChan takes a ref and returns a channel of WrappedPointer objects
 // for all Git LFS pointers it finds for that ref.
 // Reports unique oids once only, not multiple times if >1 file uses the same content
-func scanLeftRightToChan(scanner *GitScanner, pointerCb GitScannerFoundPointer, refLeft, refRight string, opt *ScanRefsOptions) error {
-	return scanRefsToChan(scanner, pointerCb, []string{refLeft}, []string{refRight}, opt)
+func scanLeftRightToChan(scanner *GitScanner, pointerCb GitScannerFoundPointer, refLeft, refRight string, osEnv config.Environment, opt *ScanRefsOptions) error {
+	return scanRefsToChan(scanner, pointerCb, []string{refLeft}, []string{refRight}, osEnv, opt)
 }
 
 // revListShas uses git rev-list to return the list of object sha1s

--- a/lfs/gitscanner_tree.go
+++ b/lfs/gitscanner_tree.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/git-lfs/git-lfs/config"
 	"github.com/git-lfs/git-lfs/filepathfilter"
 	"github.com/git-lfs/git-lfs/git"
 )
@@ -19,7 +20,7 @@ type TreeBlob struct {
 	Filename string
 }
 
-func runScanTree(cb GitScannerFoundPointer, ref string, filter *filepathfilter.Filter) error {
+func runScanTree(cb GitScannerFoundPointer, ref string, filter *filepathfilter.Filter, osEnv config.Environment) error {
 	// We don't use the nameMap approach here since that's imprecise when >1 file
 	// can be using the same content
 	treeShas, err := lsTreeBlobs(ref, filter)
@@ -27,7 +28,7 @@ func runScanTree(cb GitScannerFoundPointer, ref string, filter *filepathfilter.F
 		return err
 	}
 
-	pcw, err := catFileBatchTree(treeShas)
+	pcw, err := catFileBatchTree(treeShas, osEnv)
 	if err != nil {
 		return err
 	}
@@ -46,8 +47,8 @@ func runScanTree(cb GitScannerFoundPointer, ref string, filter *filepathfilter.F
 // of a git object, given its sha1. The contents will be decoded into
 // a Git LFS pointer. treeblobs is a channel over which blob entries
 // will be sent. It returns a channel from which point.Pointers can be read.
-func catFileBatchTree(treeblobs *TreeBlobChannelWrapper) (*PointerChannelWrapper, error) {
-	scanner, err := NewPointerScanner()
+func catFileBatchTree(treeblobs *TreeBlobChannelWrapper, osEnv config.Environment) (*PointerChannelWrapper, error) {
+	scanner, err := NewPointerScanner(osEnv)
 	if err != nil {
 		return nil, err
 	}

--- a/lfs/scanner.go
+++ b/lfs/scanner.go
@@ -1,6 +1,9 @@
 package lfs
 
-import "github.com/git-lfs/git-lfs/tools"
+import (
+	"github.com/git-lfs/git-lfs/config"
+	"github.com/git-lfs/git-lfs/tools"
+)
 
 const (
 	// blobSizeCutoff is used to determine which files to scan for Git LFS
@@ -45,11 +48,11 @@ func catFileBatchCheck(revs *StringChannelWrapper, lockableSet *lockableNameSet)
 // of a git object, given its sha1. The contents will be decoded into
 // a Git LFS pointer. revs is a channel over which strings containing Git SHA1s
 // will be sent. It returns a channel from which point.Pointers can be read.
-func catFileBatch(revs *StringChannelWrapper, lockableSet *lockableNameSet) (*PointerChannelWrapper, chan string, error) {
+func catFileBatch(revs *StringChannelWrapper, lockableSet *lockableNameSet, osEnv config.Environment) (*PointerChannelWrapper, chan string, error) {
 	pointerCh := make(chan *WrappedPointer, chanBufSize)
 	lockableCh := make(chan string, chanBufSize)
 	errCh := make(chan error, 5) // shared by 2 goroutines & may add more detail errors?
-	if err := runCatFileBatch(pointerCh, lockableCh, lockableSet, revs, errCh); err != nil {
+	if err := runCatFileBatch(pointerCh, lockableCh, lockableSet, revs, errCh, osEnv); err != nil {
 		return nil, nil, err
 	}
 	return NewPointerChannelWrapper(pointerCh, errCh), lockableCh, nil

--- a/lfs/scanner_git_test.go
+++ b/lfs/scanner_git_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/git-lfs/git-lfs/config"
 	. "github.com/git-lfs/git-lfs/lfs"
 	test "github.com/git-lfs/git-lfs/t/cmd/util"
 	"github.com/stretchr/testify/assert"
@@ -91,7 +92,7 @@ func scanUnpushed(remoteName string) ([]*WrappedPointer, error) {
 	pointers := make([]*WrappedPointer, 0, 10)
 	var multiErr error
 
-	gitscanner := NewGitScanner(func(p *WrappedPointer, err error) {
+	gitscanner := NewGitScanner(config.New(), func(p *WrappedPointer, err error) {
 		if err != nil {
 			if multiErr != nil {
 				multiErr = fmt.Errorf("%v\n%v", multiErr, err)
@@ -193,7 +194,7 @@ func TestScanPreviousVersions(t *testing.T) {
 
 func scanPreviousVersions(t *testing.T, ref string, since time.Time) ([]*WrappedPointer, error) {
 	pointers := make([]*WrappedPointer, 0, 10)
-	gitscanner := NewGitScanner(func(p *WrappedPointer, err error) {
+	gitscanner := NewGitScanner(config.New(), func(p *WrappedPointer, err error) {
 		if err != nil {
 			t.Error(err)
 			return

--- a/t/t-alternates.sh
+++ b/t/t-alternates.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "test/testlib.sh"
+. "$(dirname "$0")/testlib.sh"
 
 begin_test "alternates (single)"
 (

--- a/t/t-alternates.sh
+++ b/t/t-alternates.sh
@@ -108,6 +108,8 @@ begin_test "alternates (OS environment, single)"
   popd > /dev/null
 
   rm -rf .git/lfs/objects
+  rm -rf .git/objects/*
+  git init
 
   alternate="$(native_path "$TRASHDIR/${reponame}_alternate/.git/objects")"
 
@@ -115,6 +117,8 @@ begin_test "alternates (OS environment, single)"
   GIT_TRACE=1 \
     git lfs fetch origin master 2>&1 | tee fetch.log
   [ "0" -eq "$(grep -c "sending batch of size 1" fetch.log)" ]
+  GIT_ALTERNATE_OBJECT_DIRECTORIES="$alternate" \
+    git lfs push "$(git config remote.origin.url)" master
 )
 end_test
 
@@ -134,6 +138,8 @@ begin_test "alternates (OS environment, multiple)"
   popd > /dev/null
 
   rm -rf .git/lfs/objects
+  rm -rf .git/objects/*
+  git init
 
   alternate_stale="$(native_path "$TRASHDIR/${reponame}_alternate_stale/.git/objects")"
   alternate="$(native_path "$TRASHDIR/${reponame}_alternate/.git/objects")"
@@ -143,5 +149,7 @@ begin_test "alternates (OS environment, multiple)"
   GIT_TRACE=1 \
     git lfs fetch origin master 2>&1 | tee fetch.log
   [ "0" -eq "$(grep -c "sending batch of size 1" fetch.log)" ]
+  GIT_ALTERNATE_OBJECT_DIRECTORIES="$alternate_stale$sep$alternate" \
+    git lfs push "$(git config remote.origin.url)" master
 )
 end_test

--- a/t/t-alternates.sh
+++ b/t/t-alternates.sh
@@ -16,7 +16,7 @@ begin_test "alternates (single)"
   rm -rf .git/lfs/objects
 
   alternate="$TRASHDIR/${reponame}_alternate/.git/objects"
-  echo "$alternate" > .git/objects/info/alternates
+  echo "$(native_path "$alternate")" > .git/objects/info/alternates
 
   GIT_TRACE=1 git lfs fetch origin master 2>&1 | tee fetch.log
   [ "0" -eq "$(grep -c "sending batch of size 1" fetch.log)" ]
@@ -42,8 +42,8 @@ begin_test "alternates (multiple)"
 
   alternate_stale="$TRASHDIR/${reponame}_alternate_stale/.git/objects"
   alternate="$TRASHDIR/${reponame}_alternate/.git/objects"
-  echo "$alternate" > .git/objects/info/alternates
-  echo "$alternate_stale" >> .git/objects/info/alternates
+  echo "$(native_path "$alternate")" > .git/objects/info/alternates
+  echo "$(native_path "$alternate_stale")" >> .git/objects/info/alternates
 
   GIT_TRACE=1 git lfs fetch origin master 2>&1 | tee fetch.log
   [ "0" -eq "$(grep -c "sending batch of size 1" fetch.log)" ]
@@ -84,7 +84,11 @@ begin_test "alternates (quoted)"
 
   rm -rf .git/lfs/objects
 
-  alternate="$TRASHDIR/${reponame}_alternate/.git/objects"
+  # Normally, a plain native_path call would be sufficient here, but when we
+  # use a quoted alternate, Git interprets backslash escapes, and Windows path
+  # names look like backslash escapes. As a consequence, we switch to forward
+  # slashes to avoid misinterpretation.
+  alternate=$(native_path "$TRASHDIR/${reponame}_alternate/.git/objects" | sed -e 's,\\,/,g')
   echo "\"$alternate\"" > .git/objects/info/alternates
 
   GIT_TRACE=1 git lfs fetch origin master 2>&1 | tee fetch.log
@@ -105,7 +109,7 @@ begin_test "alternates (OS environment, single)"
 
   rm -rf .git/lfs/objects
 
-  alternate="$TRASHDIR/${reponame}_alternate/.git/objects"
+  alternate="$(native_path "$TRASHDIR/${reponame}_alternate/.git/objects")"
 
   GIT_ALTERNATE_OBJECT_DIRECTORIES="$alternate" \
   GIT_TRACE=1 \
@@ -131,8 +135,8 @@ begin_test "alternates (OS environment, multiple)"
 
   rm -rf .git/lfs/objects
 
-  alternate_stale="$TRASHDIR/${reponame}_alternate_stale/.git/objects"
-  alternate="$TRASHDIR/${reponame}_alternate/.git/objects"
+  alternate_stale="$(native_path "$TRASHDIR/${reponame}_alternate_stale/.git/objects")"
+  alternate="$(native_path "$TRASHDIR/${reponame}_alternate/.git/objects")"
   sep="$(native_path_list_separator)"
 
   GIT_ALTERNATE_OBJECT_DIRECTORIES="$alternate_stale$sep$alternate" \

--- a/vendor/github.com/git-lfs/gitobj/backend.go
+++ b/vendor/github.com/git-lfs/gitobj/backend.go
@@ -5,6 +5,9 @@ import (
 	"io"
 	"os"
 	"path"
+	"regexp"
+	"strconv"
+	"strings"
 
 	"github.com/git-lfs/gitobj/pack"
 	"github.com/git-lfs/gitobj/storage"
@@ -12,6 +15,14 @@ import (
 
 // NewFilesystemBackend initializes a new filesystem-based backend.
 func NewFilesystemBackend(root, tmp string) (storage.Backend, error) {
+	return NewFilesystemBackendWithAlternates(root, tmp, "")
+}
+
+// NewFilesystemBackendWithAlternates initializes a new filesystem-based
+// backend, optionally with additional alternates as specified in the
+// `alternates` variable. The syntax is that of the Git environment variable
+// GIT_ALTERNATE_OBJECT_DIRECTORIES.
+func NewFilesystemBackendWithAlternates(root, tmp, alternates string) (storage.Backend, error) {
 	fsobj := newFileStorer(root, tmp)
 	packs, err := pack.NewStorage(root)
 	if err != nil {
@@ -19,6 +30,11 @@ func NewFilesystemBackend(root, tmp string) (storage.Backend, error) {
 	}
 
 	storage, err := findAllBackends(fsobj, packs, root)
+	if err != nil {
+		return nil, err
+	}
+
+	storage, err = addAlternatesFromEnvironment(storage, alternates)
 	if err != nil {
 		return nil, err
 	}
@@ -45,12 +61,10 @@ func findAllBackends(mainLoose *fileStorer, mainPacked *pack.Storage, root strin
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
-		storage = append(storage, newFileStorer(scanner.Text(), ""))
-		pack, err := pack.NewStorage(scanner.Text())
+		storage, err = addAlternateDirectory(storage, scanner.Text())
 		if err != nil {
 			return nil, err
 		}
-		storage = append(storage, pack)
 	}
 
 	if err := scanner.Err(); err != nil {
@@ -58,6 +72,76 @@ func findAllBackends(mainLoose *fileStorer, mainPacked *pack.Storage, root strin
 	}
 
 	return storage, nil
+}
+
+func addAlternateDirectory(s []storage.Storage, dir string) ([]storage.Storage, error) {
+	s = append(s, newFileStorer(dir, ""))
+	pack, err := pack.NewStorage(dir)
+	if err != nil {
+		return s, err
+	}
+	s = append(s, pack)
+	return s, nil
+}
+
+func addAlternatesFromEnvironment(s []storage.Storage, env string) ([]storage.Storage, error) {
+	if len(env) == 0 {
+		return s, nil
+	}
+
+	for _, dir := range splitAlternateString(env, alternatesSeparator) {
+		var err error
+		s, err = addAlternateDirectory(s, dir)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return s, nil
+}
+
+var (
+	octalEscape  = regexp.MustCompile("\\\\[0-7]{1,3}")
+	hexEscape    = regexp.MustCompile("\\\\x[0-9a-fA-F]{2}")
+	replacements = []struct {
+		olds string
+		news string
+	}{
+		{`\a`, "\a"},
+		{`\b`, "\b"},
+		{`\t`, "\t"},
+		{`\n`, "\n"},
+		{`\v`, "\v"},
+		{`\f`, "\f"},
+		{`\r`, "\r"},
+		{`\\`, "\\"},
+		{`\"`, "\""},
+		{`\'`, "'"},
+	}
+)
+
+func splitAlternateString(env string, separator string) []string {
+	dirs := strings.Split(env, separator)
+	for i, s := range dirs {
+		if !strings.HasPrefix(s, `"`) || !strings.HasSuffix(s, `"`) {
+			continue
+		}
+
+		// Strip leading and trailing quotation marks
+		s = s[1 : len(s)-1]
+		for _, repl := range replacements {
+			s = strings.Replace(s, repl.olds, repl.news, -1)
+		}
+		s = octalEscape.ReplaceAllStringFunc(s, func(inp string) string {
+			val, _ := strconv.ParseUint(inp[1:], 8, 64)
+			return string([]byte{byte(val)})
+		})
+		s = hexEscape.ReplaceAllStringFunc(s, func(inp string) string {
+			val, _ := strconv.ParseUint(inp[2:], 16, 64)
+			return string([]byte{byte(val)})
+		})
+		dirs[i] = s
+	}
+	return dirs
 }
 
 // NewMemoryBackend initializes a new memory-based backend.

--- a/vendor/github.com/git-lfs/gitobj/backend_nix.go
+++ b/vendor/github.com/git-lfs/gitobj/backend_nix.go
@@ -1,0 +1,5 @@
+// +build !windows
+
+package gitobj
+
+const alternatesSeparator = ":"

--- a/vendor/github.com/git-lfs/gitobj/backend_windows.go
+++ b/vendor/github.com/git-lfs/gitobj/backend_windows.go
@@ -1,0 +1,5 @@
+// +build windows
+
+package gitobj
+
+const alternatesSeparator = ";"

--- a/vendor/github.com/git-lfs/gitobj/object_db.go
+++ b/vendor/github.com/git-lfs/gitobj/object_db.go
@@ -36,7 +36,16 @@ type ObjectDatabase struct {
 //
 //  /absolute/repo/path/.git/objects
 func FromFilesystem(root, tmp string) (*ObjectDatabase, error) {
-	b, err := NewFilesystemBackend(root, tmp)
+	return FromFilesystemWithAlternates(root, tmp, "")
+}
+
+// FromFilesystemWithAlternates constructs an *ObjectDatabase instance that is
+// backed by a directory on the filesystem, optionally with one or more
+// alternates. Specifically, this should point to:
+//
+//  /absolute/repo/path/.git/objects
+func FromFilesystemWithAlternates(root, tmp, alternates string) (*ObjectDatabase, error) {
+	b, err := NewFilesystemBackendWithAlternates(root, tmp, alternates)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -17,8 +17,6 @@ github.com/git-lfs/go-ntlm/ntlm/md4
 github.com/git-lfs/wildmatch
 # github.com/inconshreveable/mousetrap v1.0.0
 github.com/inconshreveable/mousetrap
-# github.com/kr/pty v0.0.0-20150511174710-5cf931ef8f76
-github.com/kr/pty
 # github.com/mattn/go-isatty v0.0.4
 github.com/mattn/go-isatty
 # github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -3,7 +3,7 @@ github.com/alexbrainman/sspi
 github.com/alexbrainman/sspi/ntlm
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/git-lfs/gitobj v1.3.1
+# github.com/git-lfs/gitobj v1.4.0
 github.com/git-lfs/gitobj
 github.com/git-lfs/gitobj/errors
 github.com/git-lfs/gitobj/pack


### PR DESCRIPTION
There are two ways to specify an alternate in Git: via the repository file or via the environment. We've long supported the former, but not the latter. Add support for the environment variable form to ensure that all the standard use cases work.

During the writing of this series, I discovered an existing integration test for alternates that wasn't being run because it was named differently than the other tests. It's been renamed and adjusted so it now runs automatically and it's the basis for the test for this series.

Fixes git-lfs/gitobj#14.
/cc @rsrchboy as reporter