### PR TITLE
status: gracefully handle files replaced by directories

### DIFF
--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -156,6 +156,11 @@ func blobInfo(s *lfs.PointerScanner, blobSha, name string) (sha, from string, er
 	}
 	defer f.Close()
 
+	// We've replaced a file with a directory.
+	if fi, err := f.Stat(); err == nil && fi.Mode().IsDir() {
+		return "deleted", "File", nil
+	}
+
 	shasum := sha256.New()
 	if _, err = io.Copy(shasum, f); err != nil {
 		return "", "", err

--- a/t/t-status.sh
+++ b/t/t-status.sh
@@ -503,3 +503,48 @@ Git LFS objects not staged for commit:"
   [ "$expected" = "$(git lfs status)" ]
 )
 end_test
+
+begin_test "status (file to dir)"
+(
+  set -e
+
+  reponame="status-file-to-dir"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  printf 'file' > test
+  git add test
+  git commit -m "add test"
+
+  obj=$(calc_oid "file" | head -c 7)
+
+  git rm test
+  mkdir test
+
+  contents="a"
+  oid="$(calc_oid "$contents")"
+  oid_short="$(calc_oid "$contents" | head -c 7)"
+  printf "%s" "$contents" > test/a.dat
+
+  git add test
+  git commit -m "add files"
+
+  git reset HEAD~
+  git add test
+
+  expected="On branch master
+
+Git LFS objects to be committed:
+
+	test (Git: $obj -> File: deleted)
+	test/a.dat (LFS: $oid_short)
+
+Git LFS objects not staged for commit:"
+
+  [ "$expected" = "$(git lfs status)" ]
+)
+end_test


### PR DESCRIPTION
Currently we fail with an error when a file has been replaced by a directory. Handle this more gracefully by treating it as a normal deletion (which, in the index, it is).

Fixes #3766