### PR TITLE
Use an absolute path for smudging

### DIFF
--- a/lfs/gitfilter_smudge.go
+++ b/lfs/gitfilter_smudge.go
@@ -28,7 +28,12 @@ func (f *GitFilter) SmudgeToFile(filename string, ptr *Pointer, download bool, m
 		defer os.Chmod(filename, stat.Mode())
 	}
 
-	file, err := os.Create(filename)
+	abs, err := filepath.Abs(filename)
+	if err != nil {
+		return fmt.Errorf("Could not produce absolute path for %q", filename)
+	}
+
+	file, err := os.Create(abs)
 	if err != nil {
 		return fmt.Errorf("Could not create working directory file: %v", err)
 	}


### PR DESCRIPTION
On Windows, paths are limited to 260 characters with two exceptions: manifested applications on Windows 10 may use long path, and all systems may use UNC paths, which must be absolute. Since we are not currently using a manifest, use an absolute path when smudging to make so that we can take advantage of UNC paths on Windows.

Fixes #3772