### PR TITLE
track: make --filename work with spaces

### DIFF
--- a/t/t-track.sh
+++ b/t/t-track.sh
@@ -681,3 +681,31 @@ begin_test "track: escaped glob pattern in .gitattributes"
   assert_pointer "master" "$filename" "$contents_oid" 15
 )
 end_test
+
+begin_test "track: escaped glob pattern with spaces in .gitattributes"
+(
+  set -e
+
+  # None of these characters are valid in the Win32 subsystem.
+  [ "$IS_WINDOWS" -eq 1 ] && exit 0
+
+  reponame="track-escaped-glob"
+  git init "$reponame"
+  cd "$reponame"
+
+  filename="*[foo] bar?.txt"
+  contents='I need escaping'
+  contents_oid=$(calc_oid "$contents")
+
+  git lfs track --filename "$filename"
+  git add .
+  cat .gitattributes
+
+  printf "%s" "$contents" > "$filename"
+  git add .
+  git commit -m 'Add unusually named file'
+
+  # If Git understood our escaping, we'll have a pointer. Otherwise, we won't.
+  assert_pointer "master" "$filename" "$contents_oid" 15
+)
+end_test


### PR DESCRIPTION
When using "git lfs track --filename" with a filename with spaces, the brackets surrounding the character class for representing spaces were also escaped, leading to the space not being interpreted correctly.  Update the escaping function we use to handle all of our escaping needs, performing the escaping in the correct order so that we can handle spaces correctly.

/cc @gdlxn-ibm as reporter