### PR TITLE
NON-ISSUE Use FICLONE instead of BTRFS_IOC_CLONE.

### DIFF
--- a/tools/util_linux.go
+++ b/tools/util_linux.go
@@ -5,10 +5,10 @@ package tools
 /*
 #include <sys/ioctl.h>
 
-#undef BTRFS_IOCTL_MAGIC
-#define BTRFS_IOCTL_MAGIC 0x94
-#undef BTRFS_IOC_CLONE
-#define BTRFS_IOC_CLONE _IOW (BTRFS_IOCTL_MAGIC, 9, int)
+#undef FICLONE
+#define FICLONE		_IOW(0x94, 9, int)
+// copy from https://github.com/torvalds/linux/blob/v5.2/include/uapi/linux/fs.h#L195 for older header files.
+// This is equal to the older BTRFS_IOC_CLONE value.
 */
 import "C"
 
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	BtrfsIocClone = C.BTRFS_IOC_CLONE
+	ioctlFiClone = C.FICLONE
 )
 
 // CheckCloneFileSupported runs explicit test of clone file on supplied directory.
@@ -51,7 +51,7 @@ func CloneFile(writer io.Writer, reader io.Reader) (bool, error) {
 	fdst, fdstFound := writer.(*os.File)
 	fsrc, fsrcFound := reader.(*os.File)
 	if fdstFound && fsrcFound {
-		if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, fdst.Fd(), BtrfsIocClone, fsrc.Fd()); err != 0 {
+		if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, fdst.Fd(), ioctlFiClone, fsrc.Fd()); err != 0 {
 			return false, err
 		}
 		return true, nil


### PR DESCRIPTION
Sorry it's my miss-understanding that we should use `FICLONE` first and fallback to `BTRFS_IOC_CLONE`. Actually, `FICILONE` is equal to `BTRFS_IOC_CLONE`.

So we already support copy-on-write on XFS not only Btrfs.

In this commit, let me use standarized name `FICILONE` instead of `BTRFS_IOC_CLONE`.

FICILONE definition:
----

`#define FICLONE                _IOW(0x94, 9, int)`  in https://github.com/torvalds/linux/blob/v5.2/include/uapi/linux/fs.h#L195

BTRFS_IOC_CLONE definition:
----

`#define BTRFS_IOC_CLONE        _IOW(BTRFS_IOCTL_MAGIC, 9, int)` in https://github.com/torvalds/linux/blob/v5.2/include/uapi/linux/btrfs.h#L850

and

`#define BTRFS_IOCTL_MAGIC 0x94` in https://github.com/torvalds/linux/blob/v5.2/include/uapi/linux/btrfs.h#L25