### PR TITLE
Avoid a hang when Git is slow to provide us data

### DIFF
--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -417,7 +417,7 @@ func (q *TransferQueue) collectBatches() {
 			// There are some pending that cound not be queued.
 			// Wait the requested time before resuming loop.
 			time.Sleep(minWaitTime)
-		} else if len(next) == 0 && len(pending) == 0 {
+		} else if len(next) == 0 && len(pending) == 0 && closing {
 			// There are no items remaining, it is safe to break
 			break
 		}


### PR DESCRIPTION
When we are cloning or checking out a repo, the filter-process smudge filter sends the transfer queue data by calling the Add method.  This method inserts items into the incoming channel, which is then processed by the collectBatches function.  This function accepts items, downloads a batch worth, and splits the remainder into the next and pending queues, and then, if there are any items in either of these queues, goes around again.  If there are no items, it exits the download queue.

Unfortunately, this algorithm has a problem.  If the filter-process portion is slow and does not provide us enough data, we can end up with both the next and pending queues empty, but the incoming channel still open, waiting for the filter-process end to send more data.  In such a case, we stop downloading early and the process deadlocks since there's nobody to read from the channel.

The solution, however, is simple: since we set the closing flag whenever the incoming channel is closed, we can check if that flag is set and only quit if it is.  We know that if it is not, there's more data, and the other end of the channel is just being slow (perhaps because Git is processing other filters).  Do this to avoid the deadlock and ensure that we terminate properly in all cases.

Fixes #3801.
/cc @r0nw as reporter