### PR TITLE
Use GitHub Actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  build-default:
+    name: Build with default Git
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@master
+    - run: script/cibuild
+  build-windows:
+    name: Build on Windows
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@master
+    - run: mkdir -p "$HOME/go/bin"
+      shell: bash
+    - run: set GOPATH=%HOME%\go
+    - run: set PATH=%GOPATH%\bin;%PATH%
+    - run: cinst InnoSetup -y
+    - run: cinst strawberryperl -y
+    - run: refreshenv
+    - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" go get github.com/josephspurrier/goversioninfo/cmd/goversioninfo
+      shell: bash
+    - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" script/cibuild
+      shell: bash
+    - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" make GOARCH=386 -B
+      shell: bash
+    - run: mv bin\git-lfs.exe git-lfs-x86.exe
+    - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" make GOARCH=amd64 -B
+      shell: bash
+    - run: mv bin\git-lfs.exe git-lfs-x64.exe
+    - run: iscc script\windows-installer\inno-setup-git-lfs-installer.iss
+  build-latest:
+    name: Build with latest Git
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@master
+    - run: git clone -b master https://github.com/git/git.git "$HOME/git"
+    - run: script/build-git "$HOME/git"
+    - run: script/cibuild
+  build-earliest:
+    name: Build with earliest Git
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@master
+    - run: git clone -b v2.0.0 https://github.com/git/git.git "$HOME/git"
+    - run: script/build-git "$HOME/git"
+    - run: script/cibuild

--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/git-lfs/git-lfs/git"
 	"github.com/git-lfs/git-lfs/lfs"
+	"github.com/git-lfs/git-lfs/tools"
 	"github.com/spf13/cobra"
 )
 
@@ -54,6 +55,8 @@ func statusCommand(cmd *cobra.Command, args []string) {
 
 	wd, _ := os.Getwd()
 	repo := cfg.LocalWorkingDir()
+
+	wd = tools.ResolveSymlinks(wd)
 
 	Print("\nGit LFS objects to be committed:\n")
 	for _, entry := range staged {

--- a/script/build-git
+++ b/script/build-git
@@ -1,0 +1,26 @@
+#!/bin/sh -ex
+
+DIR="$1"
+
+case $(uname -s) in
+  Darwin)
+    brew install curl zlib pcre2 gettext openssl
+    brew link --force zlib pcre2 gettext openssl;;
+  Linux)
+    export DEBIAN_FRONTEND=noninteractive
+    sed -e 's/^deb/deb-src/' /etc/apt/sources.list | sudo tee /etc/apt/sources.list.d/src.list
+    sudo apt-get update
+    sudo apt-get install build-essential
+    sudo apt-get -y build-dep git;;
+esac
+
+cd "$DIR"
+printf "%s\n" \
+  "NO_OPENSSL=YesPlease" \
+  "prefix=/usr/local" \
+  > config.mak
+make -j2
+sudo make install
+
+echo "Git version:"
+git --version

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,10 +1,19 @@
 #!/usr/bin/env bash
 set -e
 
-GOIMPORTS="goimports"
-if [ "appveyor" = "$USERNAME" ]; then
-  GOIMPORTS="C:\\Users\\appveyor\\go\\bin\\goimports"
+# Strip out CI environment variables which cause tests to fail.
+unset $(env | grep -E '^GIT(HUB)?_' | sed -e 's/=.*$//')
+
+UNAME=$(uname -s)
+X=""
+if [[ $UNAME == MINGW* || $UNAME == MSYS* || $UNAME == CYGWIN* ]]; then
+  X=".exe"
+  WINDOWS=1
+  export GIT_LFS_NO_TEST_COUNT=1
+  export GIT_LFS_LOCK_ACQUIRE_DISABLED=1
 fi
+
+GOIMPORTS="goimports"
 
 make GOIMPORTS="$GOIMPORTS" && make GOIMPORTS="$GOIMPORTS" test
 
@@ -12,15 +21,9 @@ make GOIMPORTS="$GOIMPORTS" && make GOIMPORTS="$GOIMPORTS" test
 GIT_TRACE=1 make GOIMPORTS="$GOIMPORTS" PKGS=git test
 
 pushd t >/dev/null
-  UNAME=$(uname -s)
-  X=""
-  if [[ $UNAME == MINGW* || $UNAME == MSYS* || $UNAME == CYGWIN* ]]; then
-    X=".exe"
-  fi
-
   PROVE="prove"
   PROVE_EXTRA_ARGS="-j9"
-  if [ "appveyor" = "$USERNAME" ]; then
+  if [ "$WINDOWS" ]; then
     export PATH="/c/Strawberry/perl/bin:.:$PATH"
     PROVE="prove.bat"
     PROVE_EXTRA_ARGS="$PROVE_EXTRA_ARGS --exec bash"

--- a/t/Makefile
+++ b/t/Makefile
@@ -16,6 +16,7 @@ TEST_CMDS += ../bin/lfs-ssh-proxy-test$X
 TEST_CMDS += ../bin/lfstest-count-tests$X
 TEST_CMDS += ../bin/lfstest-customadapter$X
 TEST_CMDS += ../bin/lfstest-gitserver$X
+TEST_CMDS += ../bin/lfstest-realpath$X
 TEST_CMDS += ../bin/lfstest-standalonecustomadapter$X
 TEST_CMDS += ../bin/lfstest-testutils$X
 

--- a/t/cmd/git-credential-lfstest.go
+++ b/t/cmd/git-credential-lfstest.go
@@ -118,6 +118,9 @@ func credsFromFilename(file string) (string, string, error) {
 		return "", "", fmt.Errorf("Error opening %q: %s", file, err)
 	}
 	credsPieces := strings.SplitN(strings.TrimSpace(string(userPass)), ":", 2)
+	if len(credsPieces) != 2 {
+		return "", "", fmt.Errorf("Invalid data %q while reading %q", string(userPass), file)
+	}
 	return credsPieces[0], credsPieces[1], nil
 }
 

--- a/t/cmd/lfstest-realpath.go
+++ b/t/cmd/lfstest-realpath.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func canonicalize(path string) (string, error) {
+	left := path
+	right := ""
+
+	for {
+		canon, err := filepath.EvalSymlinks(left)
+		if err != nil && !os.IsNotExist(err) {
+			return "", err
+		}
+		if err == nil {
+			if right == "" {
+				return canon, nil
+			}
+			return filepath.Join(canon, right), nil
+		}
+		// One component of our path is missing.  Let's walk up a level
+		// and canonicalize that and then append the remaining piece.
+		full := filepath.Join(left, right)
+		if right == "" {
+			full = left
+		}
+		newleft := filepath.Clean(fmt.Sprintf("%s%c..", left, os.PathSeparator))
+		newright, err := filepath.Rel(newleft, full)
+		if err != nil {
+			return "", err
+		}
+		left = newleft
+		right = newright
+	}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "Usage: %s PATH\n", os.Args[0])
+		os.Exit(2)
+	}
+
+	path, err := filepath.Abs(os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating absolute path: %v", err)
+		os.Exit(3)
+	}
+
+	fullpath, err := canonicalize(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error canonicalizing: %v", err)
+		os.Exit(4)
+	}
+
+	fmt.Println(fullpath)
+}

--- a/t/t-credentials.sh
+++ b/t/t-credentials.sh
@@ -437,7 +437,7 @@ begin_test "credentials from lfs.url"
   # No 401 should occur as we've already set an access mode for the
   # storage endpoint during the push
   [ ! "$(grep "HTTP: 401" fetch.log)" ]
-  grep "Downloading LFS objects: 100% (1/1), 7 B" fetch.log
+  git lfs fsck
 
   echo "good fetch, setting access mode"
   rm -rf .git/lfs/objects
@@ -451,7 +451,8 @@ begin_test "credentials from lfs.url"
   # Ensure we didn't make a second batch request, which means the request
   # was successfully retried internally
   [ ! "$(grep "tq: retrying object" fetch.log)" ]
-  grep "Downloading LFS objects: 100% (1/1), 7 B" fetch.log
+
+  git lfs fsck
 )
 end_test
 
@@ -502,7 +503,7 @@ begin_test "credentials from remote.origin.url"
   # No 401 should occur as we've already set an access mode for the
   # storage endpoint during the push
   [ ! "$(grep "HTTP: 401" fetch.log)" ]
-  grep "Downloading LFS objects: 100% (1/1), 7 B" fetch.log
+  git lfs fsck
 
   echo "good fetch, setting access mode"
   rm -rf .git/lfs/objects
@@ -516,6 +517,7 @@ begin_test "credentials from remote.origin.url"
   # Ensure we didn't make a second batch request, which means the request
   # was successfully retried internally
   [ ! "$(grep "tq: retrying object" fetch.log)" ]
-  grep "Downloading LFS objects: 100% (1/1), 7 B" fetch.log
+
+  git lfs fsck
 )
 end_test

--- a/t/t-custom-transfers.sh
+++ b/t/t-custom-transfers.sh
@@ -184,7 +184,6 @@ begin_test "custom-transfer-standalone"
 
   grep "xfer: started custom adapter process" fetchcustom.log
   grep "xfer\[lfstest-standalonecustomadapter\]:" fetchcustom.log
-  grep "Downloading LFS objects: 100% (12/12)" fetchcustom.log
 
   grep "Terminating test custom adapter gracefully" fetchcustom.log
 
@@ -195,6 +194,8 @@ begin_test "custom-transfer-standalone"
 
   objectlist=`find .git/lfs/objects -type f`
   [ "$(echo "$objectlist" | wc -l)" -eq 12 ]
+
+  git lfs fsck
 )
 end_test
 
@@ -275,11 +276,12 @@ begin_test "custom-transfer-standalone-urlmatch"
 
   grep "xfer: started custom adapter process" fetchcustom.log
   grep "xfer\[lfstest-standalonecustomadapter\]:" fetchcustom.log
-  grep "Downloading LFS objects: 100% (12/12)" fetchcustom.log
 
   grep "Terminating test custom adapter gracefully" fetchcustom.log
 
   objectlist=`find .git/lfs/objects -type f`
   [ "$(echo "$objectlist" | wc -l)" -eq 12 ]
+
+  git lfs fsck
 )
 end_test

--- a/t/t-env.sh
+++ b/t/t-env.sh
@@ -6,10 +6,16 @@ envInitConfig='git config filter.lfs.process = "git-lfs filter-process"
 git config filter.lfs.smudge = "git-lfs smudge -- %f"
 git config filter.lfs.clean = "git-lfs clean -- %f"'
 
+unset_vars() {
+    # If set, these will cause the test to fail.
+    unset GIT_LFS_NO_TEST_COUNT GIT_LFS_LOCK_ACQUIRE_DISABLED
+}
+
 begin_test "env with no remote"
 (
   set -e
   reponame="env-no-remote"
+  unset_vars
   mkdir $reponame
   cd $reponame
   git init
@@ -60,6 +66,7 @@ begin_test "env with origin remote"
 (
   set -e
   reponame="env-origin-remote"
+  unset_vars
   mkdir $reponame
   cd $reponame
   git init
@@ -116,6 +123,7 @@ begin_test "env with multiple remotes"
 (
   set -e
   reponame="env-multiple-remotes"
+  unset_vars
   mkdir $reponame
   cd $reponame
   git init
@@ -175,6 +183,7 @@ begin_test "env with other remote"
 (
   set -e
   reponame="env-other-remote"
+  unset_vars
   mkdir $reponame
   cd $reponame
   git init
@@ -232,6 +241,7 @@ begin_test "env with multiple remotes and lfs.url config"
 (
   set -e
   reponame="env-multiple-remotes-with-lfs-url"
+  unset_vars
   mkdir $reponame
   cd $reponame
   git init
@@ -290,6 +300,7 @@ begin_test "env with multiple remotes and lfs configs"
 (
   set -e
   reponame="env-multiple-remotes-lfs-configs"
+  unset_vars
   mkdir $reponame
   cd $reponame
   git init
@@ -350,6 +361,7 @@ begin_test "env with multiple remotes and batch configs"
 (
   set -e
   reponame="env-multiple-remotes-lfs-batch-configs"
+  unset_vars
   mkdir $reponame
   cd $reponame
   git init
@@ -410,6 +422,7 @@ begin_test "env with .lfsconfig"
 (
   set -e
   reponame="env-with-lfsconfig"
+  unset_vars
 
   git init $reponame
   cd $reponame
@@ -478,6 +491,7 @@ begin_test "env with environment variables"
 (
   set -e
   reponame="env-with-envvars"
+  unset_vars
   git init $reponame
   mkdir -p $reponame/a/b/c
 
@@ -651,6 +665,7 @@ begin_test "env with bare repo"
 (
   set -e
   reponame="env-with-bare-repo"
+  unset_vars
   git init --bare $reponame
   cd $reponame
 
@@ -697,6 +712,7 @@ begin_test "env with multiple ssh remotes"
 (
   set -e
   reponame="env-with-ssh"
+  unset_vars
   mkdir $reponame
   cd $reponame
   git init
@@ -845,6 +861,7 @@ begin_test "env with extra transfer methods"
 (
   set -e
   reponame="env-with-transfers"
+  unset_vars
   git init $reponame
   cd $reponame
 
@@ -904,6 +921,7 @@ begin_test "env with multiple remotes and ref"
 (
   set -e
   reponame="env-multiple-remotes-ref"
+  unset_vars
   mkdir $reponame
   cd $reponame
   git init

--- a/t/t-env.sh
+++ b/t/t-env.sh
@@ -20,12 +20,12 @@ begin_test "env with no remote"
   cd $reponame
   git init
 
-  localwd=$(native_path "$TRASHDIR/$reponame")
-  localgit=$(native_path "$TRASHDIR/$reponame/.git")
-  localgitstore=$(native_path "$TRASHDIR/$reponame/.git")
-  lfsstorage=$(native_path "$TRASHDIR/$reponame/.git/lfs")
-  localmedia=$(native_path "$TRASHDIR/$reponame/.git/lfs/objects")
-  tempdir=$(native_path "$TRASHDIR/$reponame/.git/lfs/tmp")
+  localwd=$(canonical_path "$TRASHDIR/$reponame")
+  localgit=$(canonical_path "$TRASHDIR/$reponame/.git")
+  localgitstore=$(canonical_path "$TRASHDIR/$reponame/.git")
+  lfsstorage=$(canonical_path "$TRASHDIR/$reponame/.git/lfs")
+  localmedia=$(canonical_path "$TRASHDIR/$reponame/.git/lfs/objects")
+  tempdir=$(canonical_path "$TRASHDIR/$reponame/.git/lfs/tmp")
   envVars=$(printf "%s" "$(env | grep "^GIT")")
 
   expected=$(printf '%s
@@ -73,12 +73,12 @@ begin_test "env with origin remote"
   git remote add origin "$GITSERVER/env-origin-remote"
 
   endpoint="$GITSERVER/$reponame.git/info/lfs (auth=none)"
-  localwd=$(native_path "$TRASHDIR/$reponame")
-  localgit=$(native_path "$TRASHDIR/$reponame/.git")
-  localgitstore=$(native_path "$TRASHDIR/$reponame/.git")
-  lfsstorage=$(native_path "$TRASHDIR/$reponame/.git/lfs")
-  localmedia=$(native_path "$TRASHDIR/$reponame/.git/lfs/objects")
-  tempdir=$(native_path "$TRASHDIR/$reponame/.git/lfs/tmp")
+  localwd=$(canonical_path "$TRASHDIR/$reponame")
+  localgit=$(canonical_path "$TRASHDIR/$reponame/.git")
+  localgitstore=$(canonical_path "$TRASHDIR/$reponame/.git")
+  lfsstorage=$(canonical_path "$TRASHDIR/$reponame/.git/lfs")
+  localmedia=$(canonical_path "$TRASHDIR/$reponame/.git/lfs/objects")
+  tempdir=$(canonical_path "$TRASHDIR/$reponame/.git/lfs/tmp")
   envVars=$(printf "%s" "$(env | grep "^GIT")")
   expected=$(printf '%s
 %s
@@ -132,12 +132,12 @@ begin_test "env with multiple remotes"
 
   endpoint="$GITSERVER/env-origin-remote.git/info/lfs (auth=none)"
   endpoint2="$GITSERVER/env-other-remote.git/info/lfs (auth=none)"
-  localwd=$(native_path "$TRASHDIR/$reponame")
-  localgit=$(native_path "$TRASHDIR/$reponame/.git")
-  localgitstore=$(native_path "$TRASHDIR/$reponame/.git")
-  lfsstorage=$(native_path "$TRASHDIR/$reponame/.git/lfs")
-  localmedia=$(native_path "$TRASHDIR/$reponame/.git/lfs/objects")
-  tempdir=$(native_path "$TRASHDIR/$reponame/.git/lfs/tmp")
+  localwd=$(canonical_path "$TRASHDIR/$reponame")
+  localgit=$(canonical_path "$TRASHDIR/$reponame/.git")
+  localgitstore=$(canonical_path "$TRASHDIR/$reponame/.git")
+  lfsstorage=$(canonical_path "$TRASHDIR/$reponame/.git/lfs")
+  localmedia=$(canonical_path "$TRASHDIR/$reponame/.git/lfs/objects")
+  tempdir=$(canonical_path "$TRASHDIR/$reponame/.git/lfs/tmp")
   envVars=$(printf "%s" "$(env | grep "^GIT")")
   expected=$(printf '%s
 %s
@@ -190,12 +190,12 @@ begin_test "env with other remote"
   git remote add other "$GITSERVER/env-other-remote"
 
   endpoint="$GITSERVER/env-other-remote.git/info/lfs (auth=none)"
-  localwd=$(native_path "$TRASHDIR/$reponame")
-  localgit=$(native_path "$TRASHDIR/$reponame/.git")
-  localgitstore=$(native_path "$TRASHDIR/$reponame/.git")
-  lfsstorage=$(native_path "$TRASHDIR/$reponame/.git/lfs")
-  localmedia=$(native_path "$TRASHDIR/$reponame/.git/lfs/objects")
-  tempdir=$(native_path "$TRASHDIR/$reponame/.git/lfs/tmp")
+  localwd=$(canonical_path "$TRASHDIR/$reponame")
+  localgit=$(canonical_path "$TRASHDIR/$reponame/.git")
+  localgitstore=$(canonical_path "$TRASHDIR/$reponame/.git")
+  lfsstorage=$(canonical_path "$TRASHDIR/$reponame/.git/lfs")
+  localmedia=$(canonical_path "$TRASHDIR/$reponame/.git/lfs/objects")
+  tempdir=$(canonical_path "$TRASHDIR/$reponame/.git/lfs/tmp")
   envVars=$(printf "%s" "$(env | grep "^GIT")")
 
   expected=$(printf '%s
@@ -249,12 +249,12 @@ begin_test "env with multiple remotes and lfs.url config"
   git remote add other "$GITSERVER/env-other-remote"
   git config lfs.url "http://foo/bar"
 
-  localwd=$(native_path "$TRASHDIR/$reponame")
-  localgit=$(native_path "$TRASHDIR/$reponame/.git")
-  localgitstore=$(native_path "$TRASHDIR/$reponame/.git")
-  lfsstorage=$(native_path "$TRASHDIR/$reponame/.git/lfs")
-  localmedia=$(native_path "$TRASHDIR/$reponame/.git/lfs/objects")
-  tempdir=$(native_path "$TRASHDIR/$reponame/.git/lfs/tmp")
+  localwd=$(canonical_path "$TRASHDIR/$reponame")
+  localgit=$(canonical_path "$TRASHDIR/$reponame/.git")
+  localgitstore=$(canonical_path "$TRASHDIR/$reponame/.git")
+  lfsstorage=$(canonical_path "$TRASHDIR/$reponame/.git/lfs")
+  localmedia=$(canonical_path "$TRASHDIR/$reponame/.git/lfs/objects")
+  tempdir=$(canonical_path "$TRASHDIR/$reponame/.git/lfs/tmp")
   envVars=$(printf "%s" "$(env | grep "^GIT")")
   expected=$(printf '%s
 %s
@@ -310,12 +310,12 @@ begin_test "env with multiple remotes and lfs configs"
   git config remote.origin.lfsurl "http://custom/origin"
   git config remote.other.lfsurl "http://custom/other"
 
-  localwd=$(native_path "$TRASHDIR/$reponame")
-  localgit=$(native_path "$TRASHDIR/$reponame/.git")
-  localgitstore=$(native_path "$TRASHDIR/$reponame/.git")
-  lfsstorage=$(native_path "$TRASHDIR/$reponame/.git/lfs")
-  localmedia=$(native_path "$TRASHDIR/$reponame/.git/lfs/objects")
-  tempdir=$(native_path "$TRASHDIR/$reponame/.git/lfs/tmp")
+  localwd=$(canonical_path "$TRASHDIR/$reponame")
+  localgit=$(canonical_path "$TRASHDIR/$reponame/.git")
+  localgitstore=$(canonical_path "$TRASHDIR/$reponame/.git")
+  lfsstorage=$(canonical_path "$TRASHDIR/$reponame/.git/lfs")
+  localmedia=$(canonical_path "$TRASHDIR/$reponame/.git/lfs/objects")
+  tempdir=$(canonical_path "$TRASHDIR/$reponame/.git/lfs/tmp")
   envVars=$(printf "%s" "$(env | grep "^GIT")")
   expected=$(printf '%s
 %s
@@ -371,12 +371,12 @@ begin_test "env with multiple remotes and batch configs"
   git config remote.origin.lfsurl "http://foo/bar"
   git config remote.other.lfsurl "http://custom/other"
 
-  localwd=$(native_path "$TRASHDIR/$reponame")
-  localgit=$(native_path "$TRASHDIR/$reponame/.git")
-  localgitstore=$(native_path "$TRASHDIR/$reponame/.git")
-  lfsstorage=$(native_path "$TRASHDIR/$reponame/.git/lfs")
-  localmedia=$(native_path "$TRASHDIR/$reponame/.git/lfs/objects")
-  tempdir=$(native_path "$TRASHDIR/$reponame/.git/lfs/tmp")
+  localwd=$(canonical_path "$TRASHDIR/$reponame")
+  localgit=$(canonical_path "$TRASHDIR/$reponame/.git")
+  localgitstore=$(canonical_path "$TRASHDIR/$reponame/.git")
+  lfsstorage=$(canonical_path "$TRASHDIR/$reponame/.git/lfs")
+  localmedia=$(canonical_path "$TRASHDIR/$reponame/.git/lfs/objects")
+  tempdir=$(canonical_path "$TRASHDIR/$reponame/.git/lfs/tmp")
   envVars=$(printf "%s" "$(env | grep "^GIT")")
   expected=$(printf '%s
 %s
@@ -441,12 +441,12 @@ lfsurl = http://foobar:5050/
 concurrenttransfers = 50
 ' > .gitconfig
 
-  localwd=$(native_path "$TRASHDIR/$reponame")
-  localgit=$(native_path "$TRASHDIR/$reponame/.git")
-  localgitstore=$(native_path "$TRASHDIR/$reponame/.git")
-  lfsstorage=$(native_path "$TRASHDIR/$reponame/.git/lfs")
-  localmedia=$(native_path "$TRASHDIR/$reponame/.git/lfs/objects")
-  tempdir=$(native_path "$TRASHDIR/$reponame/.git/lfs/tmp")
+  localwd=$(canonical_path "$TRASHDIR/$reponame")
+  localgit=$(canonical_path "$TRASHDIR/$reponame/.git")
+  localgitstore=$(canonical_path "$TRASHDIR/$reponame/.git")
+  lfsstorage=$(canonical_path "$TRASHDIR/$reponame/.git/lfs")
+  localmedia=$(canonical_path "$TRASHDIR/$reponame/.git/lfs/objects")
+  tempdir=$(canonical_path "$TRASHDIR/$reponame/.git/lfs/tmp")
   envVars=$(printf "%s" "$(env | grep "^GIT")")
   expected=$(printf '%s
 %s
@@ -495,15 +495,15 @@ begin_test "env with environment variables"
   git init $reponame
   mkdir -p $reponame/a/b/c
 
-  gitDir=$(native_path "$TRASHDIR/$reponame/.git")
-  workTree=$(native_path "$TRASHDIR/$reponame/a/b")
+  gitDir=$(canonical_path "$TRASHDIR/$reponame/.git")
+  workTree=$(canonical_path "$TRASHDIR/$reponame/a/b")
 
-  localwd=$(native_path "$TRASHDIR/$reponame/a/b")
-  localgit=$(native_path "$TRASHDIR/$reponame/.git")
-  localgitstore=$(native_path "$TRASHDIR/$reponame/.git")
-  lfsstorage=$(native_path "$TRASHDIR/$reponame/.git/lfs")
-  localmedia=$(native_path "$TRASHDIR/$reponame/.git/lfs/objects")
-  tempdir=$(native_path "$TRASHDIR/$reponame/.git/lfs/tmp")
+  localwd=$(canonical_path "$TRASHDIR/$reponame/a/b")
+  localgit=$(canonical_path "$TRASHDIR/$reponame/.git")
+  localgitstore=$(canonical_path "$TRASHDIR/$reponame/.git")
+  lfsstorage=$(canonical_path "$TRASHDIR/$reponame/.git/lfs")
+  localmedia=$(canonical_path "$TRASHDIR/$reponame/.git/lfs/objects")
+  tempdir=$(canonical_path "$TRASHDIR/$reponame/.git/lfs/tmp")
   envVars="$(GIT_DIR=$gitDir GIT_WORK_TREE=$workTree env | grep "^GIT" | sort)"
   expected=$(printf '%s
 %s
@@ -669,11 +669,11 @@ begin_test "env with bare repo"
   git init --bare $reponame
   cd $reponame
 
-  localgit=$(native_path "$TRASHDIR/$reponame")
-  localgitstore=$(native_path "$TRASHDIR/$reponame")
-  lfsstorage=$(native_path "$TRASHDIR/$reponame/lfs")
-  localmedia=$(native_path "$TRASHDIR/$reponame/lfs/objects")
-  tempdir=$(native_path "$TRASHDIR/$reponame/lfs/tmp")
+  localgit=$(canonical_path "$TRASHDIR/$reponame")
+  localgitstore=$(canonical_path "$TRASHDIR/$reponame")
+  lfsstorage=$(canonical_path "$TRASHDIR/$reponame/lfs")
+  localmedia=$(canonical_path "$TRASHDIR/$reponame/lfs/objects")
+  tempdir=$(canonical_path "$TRASHDIR/$reponame/lfs/tmp")
   envVars=$(printf "%s" "$(env | grep "^GIT")")
 
   expected=$(printf "%s\n%s\n
@@ -739,19 +739,19 @@ begin_test "env with skip download errors"
 
   git config lfs.skipdownloaderrors 1
 
-  localgit=$(native_path "$TRASHDIR/$reponame")
-  localgitstore=$(native_path "$TRASHDIR/$reponame")
-  lfsstorage=$(native_path "$TRASHDIR/$reponame/lfs")
-  localmedia=$(native_path "$TRASHDIR/$reponame/lfs/objects")
-  tempdir=$(native_path "$TRASHDIR/$reponame/lfs/tmp")
+  localgit=$(canonical_path "$TRASHDIR/$reponame")
+  localgitstore=$(canonical_path "$TRASHDIR/$reponame")
+  lfsstorage=$(canonical_path "$TRASHDIR/$reponame/lfs")
+  localmedia=$(canonical_path "$TRASHDIR/$reponame/lfs/objects")
+  tempdir=$(canonical_path "$TRASHDIR/$reponame/lfs/tmp")
   envVars=$(printf "%s" "$(env | grep "^GIT")")
 
-  localwd=$(native_path "$TRASHDIR/$reponame")
-  localgit=$(native_path "$TRASHDIR/$reponame/.git")
-  localgitstore=$(native_path "$TRASHDIR/$reponame/.git")
-  lfsstorage=$(native_path "$TRASHDIR/$reponame/.git/lfs")
-  localmedia=$(native_path "$TRASHDIR/$reponame/.git/lfs/objects")
-  tempdir=$(native_path "$TRASHDIR/$reponame/.git/lfs/tmp")
+  localwd=$(canonical_path "$TRASHDIR/$reponame")
+  localgit=$(canonical_path "$TRASHDIR/$reponame/.git")
+  localgitstore=$(canonical_path "$TRASHDIR/$reponame/.git")
+  lfsstorage=$(canonical_path "$TRASHDIR/$reponame/.git/lfs")
+  localmedia=$(canonical_path "$TRASHDIR/$reponame/.git/lfs/objects")
+  tempdir=$(canonical_path "$TRASHDIR/$reponame/.git/lfs/tmp")
   envVars=$(printf "%s" "$(env | grep "^GIT")")
 
   expectedenabled=$(printf '%s
@@ -868,19 +868,19 @@ begin_test "env with extra transfer methods"
   git config lfs.tustransfers true
   git config lfs.customtransfer.supertransfer.path /path/to/something
 
-  localgit=$(native_path "$TRASHDIR/$reponame")
-  localgitstore=$(native_path "$TRASHDIR/$reponame")
-  lfsstorage=$(native_path "$TRASHDIR/$reponame/lfs")
-  localmedia=$(native_path "$TRASHDIR/$reponame/lfs/objects")
-  tempdir=$(native_path "$TRASHDIR/$reponame/lfs/tmp")
+  localgit=$(canonical_path "$TRASHDIR/$reponame")
+  localgitstore=$(canonical_path "$TRASHDIR/$reponame")
+  lfsstorage=$(canonical_path "$TRASHDIR/$reponame/lfs")
+  localmedia=$(canonical_path "$TRASHDIR/$reponame/lfs/objects")
+  tempdir=$(canonical_path "$TRASHDIR/$reponame/lfs/tmp")
   envVars=$(printf "%s" "$(env | grep "^GIT")")
 
-  localwd=$(native_path "$TRASHDIR/$reponame")
-  localgit=$(native_path "$TRASHDIR/$reponame/.git")
-  localgitstore=$(native_path "$TRASHDIR/$reponame/.git")
-  lfsstorage=$(native_path "$TRASHDIR/$reponame/.git/lfs")
-  localmedia=$(native_path "$TRASHDIR/$reponame/.git/lfs/objects")
-  tempdir=$(native_path "$TRASHDIR/$reponame/.git/lfs/tmp")
+  localwd=$(canonical_path "$TRASHDIR/$reponame")
+  localgit=$(canonical_path "$TRASHDIR/$reponame/.git")
+  localgitstore=$(canonical_path "$TRASHDIR/$reponame/.git")
+  lfsstorage=$(canonical_path "$TRASHDIR/$reponame/.git/lfs")
+  localmedia=$(canonical_path "$TRASHDIR/$reponame/.git/lfs/objects")
+  tempdir=$(canonical_path "$TRASHDIR/$reponame/.git/lfs/tmp")
   envVars=$(printf "%s" "$(env | grep "^GIT")")
 
   expectedenabled=$(printf '%s
@@ -934,12 +934,12 @@ begin_test "env with multiple remotes and ref"
 
   endpoint="$GITSERVER/env-origin-remote.git/info/lfs (auth=none)"
   endpoint2="$GITSERVER/env-other-remote.git/info/lfs (auth=none)"
-  localwd=$(native_path "$TRASHDIR/$reponame")
-  localgit=$(native_path "$TRASHDIR/$reponame/.git")
-  localgitstore=$(native_path "$TRASHDIR/$reponame/.git")
-  lfsstorage=$(native_path "$TRASHDIR/$reponame/.git/lfs")
-  localmedia=$(native_path "$TRASHDIR/$reponame/.git/lfs/objects")
-  tempdir=$(native_path "$TRASHDIR/$reponame/.git/lfs/tmp")
+  localwd=$(canonical_path "$TRASHDIR/$reponame")
+  localgit=$(canonical_path "$TRASHDIR/$reponame/.git")
+  localgitstore=$(canonical_path "$TRASHDIR/$reponame/.git")
+  lfsstorage=$(canonical_path "$TRASHDIR/$reponame/.git/lfs")
+  localmedia=$(canonical_path "$TRASHDIR/$reponame/.git/lfs/objects")
+  tempdir=$(canonical_path "$TRASHDIR/$reponame/.git/lfs/tmp")
   envVars=$(printf "%s" "$(env | grep "^GIT")")
   expected=$(printf '%s
 %s

--- a/t/t-fsck.sh
+++ b/t/t-fsck.sh
@@ -38,7 +38,7 @@ begin_test "fsck default"
 
   echo "CORRUPTION" >> .git/lfs/objects/$aOid12/$aOid34/$aOid
 
-  moved=$(native_path "$TRASHDIR/$reponame/.git/lfs/bad")
+  moved=$(canonical_path "$TRASHDIR/$reponame/.git/lfs/bad")
   expected="$(printf 'Object a.dat (%s) is corrupt
 Moving corrupt objects to %s' "$aOid" "$moved")"
   [ "$expected" = "$(git lfs fsck)" ]

--- a/t/t-submodule.sh
+++ b/t/t-submodule.sh
@@ -42,11 +42,11 @@ begin_test "submodule env"
 
   git lfs env | tee env.log
   grep "Endpoint=$GITSERVER/$reponame.git/info/lfs (auth=none)$" env.log
-  grep "LocalWorkingDir=$(native_path_escaped "$TRASHDIR/repo$")" env.log
-  grep "LocalGitDir=$(native_path_escaped "$TRASHDIR/repo/.git$")" env.log
-  grep "LocalGitStorageDir=$(native_path_escaped "$TRASHDIR/repo/.git$")" env.log
-  grep "LocalMediaDir=$(native_path_escaped "$TRASHDIR/repo/.git/lfs/objects$")" env.log
-  grep "TempDir=$(native_path_escaped "$TRASHDIR/repo/.git/lfs/tmp$")" env.log
+  grep "LocalWorkingDir=$(canonical_path_escaped "$TRASHDIR/repo$")" env.log
+  grep "LocalGitDir=$(canonical_path_escaped "$TRASHDIR/repo/.git$")" env.log
+  grep "LocalGitStorageDir=$(canonical_path_escaped "$TRASHDIR/repo/.git$")" env.log
+  grep "LocalMediaDir=$(canonical_path_escaped "$TRASHDIR/repo/.git/lfs/objects$")" env.log
+  grep "TempDir=$(canonical_path_escaped "$TRASHDIR/repo/.git/lfs/tmp$")" env.log
 
   cd .git
 
@@ -55,31 +55,31 @@ begin_test "submodule env"
   cat env.log
   grep "Endpoint=$GITSERVER/$reponame.git/info/lfs (auth=none)$" env.log
   grep "LocalWorkingDir=$" env.log
-  grep "LocalGitDir=$(native_path_escaped "$TRASHDIR/repo/.git$")" env.log
-  grep "LocalGitStorageDir=$(native_path_escaped "$TRASHDIR/repo/.git$")" env.log
-  grep "LocalMediaDir=$(native_path_escaped "$TRASHDIR/repo/.git/lfs/objects$")" env.log
-  grep "TempDir=$(native_path_escaped "$TRASHDIR/repo/.git/lfs/tmp$")" env.log
+  grep "LocalGitDir=$(canonical_path_escaped "$TRASHDIR/repo/.git$")" env.log
+  grep "LocalGitStorageDir=$(canonical_path_escaped "$TRASHDIR/repo/.git$")" env.log
+  grep "LocalMediaDir=$(canonical_path_escaped "$TRASHDIR/repo/.git/lfs/objects$")" env.log
+  grep "TempDir=$(canonical_path_escaped "$TRASHDIR/repo/.git/lfs/tmp$")" env.log
 
   cd ../sub
 
   echo "./sub"
   git lfs env | tee env.log
   grep "Endpoint=$GITSERVER/$submodname.git/info/lfs (auth=none)$" env.log
-  grep "LocalWorkingDir=$(native_path_escaped "$TRASHDIR/repo/sub$")" env.log
-  grep "LocalGitDir=$(native_path_escaped "$TRASHDIR/repo/.git/modules/sub$")" env.log
-  grep "LocalGitStorageDir=$(native_path_escaped "$TRASHDIR/repo/.git/modules/sub$")" env.log
-  grep "LocalMediaDir=$(native_path_escaped "$TRASHDIR/repo/.git/modules/sub/lfs/objects$")" env.log
-  grep "TempDir=$(native_path_escaped "$TRASHDIR/repo/.git/modules/sub/lfs/tmp$")" env.log
+  grep "LocalWorkingDir=$(canonical_path_escaped "$TRASHDIR/repo/sub$")" env.log
+  grep "LocalGitDir=$(canonical_path_escaped "$TRASHDIR/repo/.git/modules/sub$")" env.log
+  grep "LocalGitStorageDir=$(canonical_path_escaped "$TRASHDIR/repo/.git/modules/sub$")" env.log
+  grep "LocalMediaDir=$(canonical_path_escaped "$TRASHDIR/repo/.git/modules/sub/lfs/objects$")" env.log
+  grep "TempDir=$(canonical_path_escaped "$TRASHDIR/repo/.git/modules/sub/lfs/tmp$")" env.log
 
   cd dir
 
   echo "./sub/dir"
   git lfs env | tee env.log
   grep "Endpoint=$GITSERVER/$submodname.git/info/lfs (auth=none)$" env.log
-  grep "LocalWorkingDir=$(native_path_escaped "$TRASHDIR/repo/sub$")" env.log
-  grep "LocalGitDir=$(native_path_escaped "$TRASHDIR/repo/.git/modules/sub$")" env.log
-  grep "LocalGitStorageDir=$(native_path_escaped "$TRASHDIR/repo/.git/modules/sub$")" env.log
-  grep "LocalMediaDir=$(native_path_escaped "$TRASHDIR/repo/.git/modules/sub/lfs/objects$")" env.log
-  grep "TempDir=$(native_path_escaped "$TRASHDIR/repo/.git/modules/sub/lfs/tmp$")" env.log
+  grep "LocalWorkingDir=$(canonical_path_escaped "$TRASHDIR/repo/sub$")" env.log
+  grep "LocalGitDir=$(canonical_path_escaped "$TRASHDIR/repo/.git/modules/sub$")" env.log
+  grep "LocalGitStorageDir=$(canonical_path_escaped "$TRASHDIR/repo/.git/modules/sub$")" env.log
+  grep "LocalMediaDir=$(canonical_path_escaped "$TRASHDIR/repo/.git/modules/sub/lfs/objects$")" env.log
+  grep "TempDir=$(canonical_path_escaped "$TRASHDIR/repo/.git/modules/sub/lfs/tmp$")" env.log
 )
 end_test

--- a/t/t-worktree.sh
+++ b/t/t-worktree.sh
@@ -7,10 +7,16 @@ envInitConfig='git config filter.lfs.process = "git-lfs filter-process"
 git config filter.lfs.smudge = "git-lfs smudge -- %f"
 git config filter.lfs.clean = "git-lfs clean -- %f"'
 
+unset_vars () {
+    # If set, these will cause the test to fail.
+    unset GIT_LFS_NO_TEST_COUNT GIT_LFS_LOCK_ACQUIRE_DISABLED
+}
+
 begin_test "git worktree"
 (
     set -e
     reponame="worktree-main"
+    unset_vars
     mkdir $reponame
     cd $reponame
     git init
@@ -91,6 +97,7 @@ begin_test "git worktree with hooks"
 (
     set -e
     reponame="worktree-hooks"
+    unset_vars
     mkdir $reponame
     cd $reponame
     git init

--- a/t/t-worktree.sh
+++ b/t/t-worktree.sh
@@ -27,12 +27,12 @@ begin_test "git worktree"
     git commit -m "Initial commit"
 
     expected=$(printf "%s\n%s\n
-LocalWorkingDir=$(native_path_escaped "$TRASHDIR/$reponame")
-LocalGitDir=$(native_path_escaped "$TRASHDIR/$reponame/.git")
-LocalGitStorageDir=$(native_path_escaped "$TRASHDIR/$reponame/.git")
-LocalMediaDir=$(native_path_escaped "$TRASHDIR/$reponame/.git/lfs/objects")
+LocalWorkingDir=$(canonical_path_escaped "$TRASHDIR/$reponame")
+LocalGitDir=$(canonical_path_escaped "$TRASHDIR/$reponame/.git")
+LocalGitStorageDir=$(canonical_path_escaped "$TRASHDIR/$reponame/.git")
+LocalMediaDir=$(canonical_path_escaped "$TRASHDIR/$reponame/.git/lfs/objects")
 LocalReferenceDirs=
-TempDir=$(native_path_escaped "$TRASHDIR/$reponame/.git/lfs/tmp")
+TempDir=$(canonical_path_escaped "$TRASHDIR/$reponame/.git/lfs/tmp")
 ConcurrentTransfers=3
 TusTransfers=false
 BasicTransfersOnly=false
@@ -44,7 +44,7 @@ FetchRecentRefsIncludeRemotes=true
 PruneOffsetDays=3
 PruneVerifyRemoteAlways=false
 PruneRemoteName=origin
-LfsStorageDir=$(native_path_escaped "$TRASHDIR/$reponame/.git/lfs")
+LfsStorageDir=$(canonical_path_escaped "$TRASHDIR/$reponame/.git/lfs")
 AccessDownload=none
 AccessUpload=none
 DownloadTransfers=basic,lfs-standalone-file
@@ -63,12 +63,12 @@ $(escape_path "$(env | grep "^GIT")")
     # is only for index, temp etc
     # storage of git objects and lfs objects is in the original .git
     expected=$(printf "%s\n%s\n
-LocalWorkingDir=$(native_path_escaped "$TRASHDIR/$worktreename")
-LocalGitDir=$(native_path_escaped "$TRASHDIR/$reponame/.git/worktrees/$worktreename")
-LocalGitStorageDir=$(native_path_escaped "$TRASHDIR/$reponame/.git")
-LocalMediaDir=$(native_path_escaped "$TRASHDIR/$reponame/.git/lfs/objects")
+LocalWorkingDir=$(canonical_path_escaped "$TRASHDIR/$worktreename")
+LocalGitDir=$(canonical_path_escaped "$TRASHDIR/$reponame/.git/worktrees/$worktreename")
+LocalGitStorageDir=$(canonical_path_escaped "$TRASHDIR/$reponame/.git")
+LocalMediaDir=$(canonical_path_escaped "$TRASHDIR/$reponame/.git/lfs/objects")
 LocalReferenceDirs=
-TempDir=$(native_path_escaped "$TRASHDIR/$reponame/.git/lfs/tmp")
+TempDir=$(canonical_path_escaped "$TRASHDIR/$reponame/.git/lfs/tmp")
 ConcurrentTransfers=3
 TusTransfers=false
 BasicTransfersOnly=false
@@ -80,7 +80,7 @@ FetchRecentRefsIncludeRemotes=true
 PruneOffsetDays=3
 PruneVerifyRemoteAlways=false
 PruneRemoteName=origin
-LfsStorageDir=$(native_path_escaped "$TRASHDIR/$reponame/.git/lfs")
+LfsStorageDir=$(canonical_path_escaped "$TRASHDIR/$reponame/.git/lfs")
 AccessDownload=none
 AccessUpload=none
 DownloadTransfers=basic,lfs-standalone-file

--- a/t/testhelpers.sh
+++ b/t/testhelpers.sh
@@ -744,6 +744,18 @@ native_path_list_separator() {
   fi
 }
 
+# canonical_path prints the native path name in a canonical form, as if
+# realpath(3) were called on it.
+canonical_path() {
+  printf "%s" "$(lfstest-realpath "$(native_path "$1")")"
+}
+
+# canonical_path_escaped prints the native path name in a canonical form, as if
+# realpath(3) were called on it, and then escapes it.
+canonical_path_escaped() {
+  printf "%s" "$(escape_path "$(lfstest-realpath "$(native_path "$1")")")"
+}
+
 cat_end() {
   if [ $IS_WINDOWS -eq 1 ]; then
     printf '^M$'

--- a/t/testhelpers.sh
+++ b/t/testhelpers.sh
@@ -488,6 +488,17 @@ repo_endpoint() {
   echo "$server/$repo.git/info/lfs"
 }
 
+# write_creds_file writes credentials to a file iff it doesn't exist.
+write_creds_file() {
+  local creds="$1"
+  local file="$2"
+
+  if [ ! -f "$file" ]
+  then
+    printf "%s" "$creds" > "$file"
+  fi
+}
+
 # setup initializes the clean, isolated environment for integration tests.
 setup() {
   cd "$ROOTDIR"
@@ -544,9 +555,9 @@ setup() {
   local certpath="$(echo "$LFS_CLIENT_CERT_FILE" | tr / -)"
   local keypath="$(echo "$LFS_CLIENT_KEY_FILE_ENCRYPTED" | tr / -)"
   mkdir -p "$CREDSDIR"
-  printf "user:pass" > "$CREDSDIR/127.0.0.1"
-  printf ":pass" > "$CREDSDIR/--$certpath"
-  printf ":pass" > "$CREDSDIR/--$keypath"
+  write_creds_file "user:pass" "$CREDSDIR/127.0.0.1"
+  write_creds_file ":pass" "$CREDSDIR/--$certpath"
+  write_creds_file ":pass" "$CREDSDIR/--$keypath"
 
   echo "#"
   echo "# HOME: $HOME"


### PR DESCRIPTION
Currently, we have three different CI systems that handle our CI: Travis for Linux, CircleCI for macOS, and AppVeyor for Windows.  This results in widely varying performance across systems and the need to maintain code that works differently across different CI systems.

In addition, we'd like to use GitHub Actions to automate the release process, so it makes sense to use it for CI as well.  Switch over by adding a CI workflow that runs our existing jobs.

There are several causes of flaky tests that are also fixed in this series, plus some workarounds for the fact that `cygpath` on the Windows Actions servers produces a short path (`C:\Users\RUNNER~1` instead of `C:\Users\runneradmin`).  This latter issue is heavily exacerbated by the fact that we cannot canonicalize a Windows-style path from the shell since the shell uses Unix-style MSYS paths.

This does not remove the existing CI providers, since AppVeyor falls back to trying to build a standard MSBuild project when there's no configuration file and it fails when trying to do so.  I'll follow up with an additional PR to remove them once this has merged to master to allow topics in flight to settle on the new system.