### PR TITLE
Fix Remote Name Parsing Bug

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -330,3 +330,13 @@ func TestCurrentTimestamp(t *testing.T) {
 		}
 	}
 }
+
+func TestRemoteNameWithDotDefault(t *testing.T) {
+        cfg := NewFrom(Values{
+                Git: map[string][]string{
+			"remote.name.with.dot.url":       []string{"http://remote.url/repo"},
+                },
+        })
+
+        assert.Equal(t, "name.with.dot", cfg.Remote())
+}

--- a/config/git_fetcher.go
+++ b/config/git_fetcher.go
@@ -85,7 +85,7 @@ func readGitConfig(configs ...*git.ConfigurationSource) (gf *GitFetcher, extensi
 				}
 
 				allowed = true
-				remote := parts[1]
+				remote := strings.Join(parts[1:len(parts)-1],".")
 				uniqRemotes[remote] = remote == "origin"
 			} else if len(parts) > 2 && parts[len(parts)-1] == "access" {
 				allowed = true


### PR DESCRIPTION
git config allows "." in subsection name but not in key name.
while splitting key with "." into parts, config key name should be the last part and subsection name should be parts from the second to the second-to-last joint by ".".
