### PR TITLE
Do not fail when multiple processes download the same lfs file

### DIFF
--- a/tq/basic_download.go
+++ b/tq/basic_download.go
@@ -242,7 +242,12 @@ func (a *basicDownloadAdapter) download(t *Transfer, cb ProgressCallback, authOk
 		return fmt.Errorf("Expected OID %s, got %s after %d bytes written", t.Oid, actual, written)
 	}
 
-	return tools.RenameFileCopyPermissions(dlfilename, t.Path)
+	err = tools.RenameFileCopyPermissions(dlfilename, t.Path)
+	if _, err2 := os.Stat(t.Path); err2 == nil {
+		// Target file already exists, possibly was downloaded by other git-lfs process
+		return nil
+	}
+	return err
 }
 
 func configureBasicDownloadAdapter(m *Manifest) {


### PR DESCRIPTION
When several git-lfs processes use the same LFS storage simultaneously,
there's a race condition between checking whether LFS file exists and renaming temporary
file to final name in LFS storage. When rename fails, check that target file exists.
If it does, pretend that download has finished successfully.

Fixes #2825

----

I'm not sure how to write a test for this.