### PR TITLE
Fix build error when cross-compiling

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -332,11 +332,11 @@ func TestCurrentTimestamp(t *testing.T) {
 }
 
 func TestRemoteNameWithDotDefault(t *testing.T) {
-        cfg := NewFrom(Values{
-                Git: map[string][]string{
-			"remote.name.with.dot.url":       []string{"http://remote.url/repo"},
-                },
-        })
+	cfg := NewFrom(Values{
+		Git: map[string][]string{
+			"remote.name.with.dot.url": []string{"http://remote.url/repo"},
+		},
+	})
 
-        assert.Equal(t, "name.with.dot", cfg.Remote())
+	assert.Equal(t, "name.with.dot", cfg.Remote())
 }

--- a/config/git_fetcher.go
+++ b/config/git_fetcher.go
@@ -85,7 +85,7 @@ func readGitConfig(configs ...*git.ConfigurationSource) (gf *GitFetcher, extensi
 				}
 
 				allowed = true
-				remote := strings.Join(parts[1:len(parts)-1],".")
+				remote := strings.Join(parts[1:len(parts)-1], ".")
 				uniqRemotes[remote] = remote == "origin"
 			} else if len(parts) > 2 && parts[len(parts)-1] == "access" {
 				allowed = true

--- a/tools/util_darwin.go
+++ b/tools/util_darwin.go
@@ -1,4 +1,4 @@
-// +build darwin
+// +build darwin,cgo
 
 package tools
 

--- a/tools/util_generic.go
+++ b/tools/util_generic.go
@@ -1,5 +1,5 @@
 // +build !linux !cgo
-// +build !darwin
+// +build !darwin !cgo
 // +build !windows
 
 package tools


### PR DESCRIPTION
On Darwin, we're importing "C" in the Darwin-specific file, so flag it as requiring cgo and specify the generic file for when we're not using cgo.  This ensures that cross-compilation continues to work without errors.  Since this is just a performance optimization, there's relatively little problem with not providing the CloneFile function in a non-cgo environment.

In addition, tidy some files which were not tidy.