### PR TITLE
Update wildmatch to v1.0.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/git-lfs/gitobj v1.4.1
 	github.com/git-lfs/go-netrc v0.0.0-20180525200031-e0e9ca483a18
 	github.com/git-lfs/go-ntlm v0.0.0-20190401175752-c5056e7fa066
-	github.com/git-lfs/wildmatch v1.0.2
+	github.com/git-lfs/wildmatch v1.0.4
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/mattn/go-isatty v0.0.4
 	github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/git-lfs/go-netrc v0.0.0-20180525200031-e0e9ca483a18 h1:7Th0eBA4rT8WJN
 github.com/git-lfs/go-netrc v0.0.0-20180525200031-e0e9ca483a18/go.mod h1:70O4NAtvWn1jW8V8V+OKrJJYcxDLTmIozfi2fmSz5SI=
 github.com/git-lfs/go-ntlm v0.0.0-20190401175752-c5056e7fa066 h1:f5UyyCnv3o2EHy+zsqOyYa8jB5bZR/N9ZEideqeDYag=
 github.com/git-lfs/go-ntlm v0.0.0-20190401175752-c5056e7fa066/go.mod h1:YnCP1lAyul0ITv9nT/OqXseZmGeaqvMVa2uvl8ssQvE=
-github.com/git-lfs/wildmatch v1.0.2 h1:Bt8fjbL2OjfhSTsmLPXSalpXgX9twSIFSVvupY2IdbE=
-github.com/git-lfs/wildmatch v1.0.2/go.mod h1:SdHAGnApDpnFYQ0vAxbniWR0sn7yLJ3QXo9RRfhn2ew=
+github.com/git-lfs/wildmatch v1.0.4 h1:Mj6LPnNZ6QSHLAAPDCH596pu6A/Z1xVm2Vk0+s3CtkY=
+github.com/git-lfs/wildmatch v1.0.4/go.mod h1:SdHAGnApDpnFYQ0vAxbniWR0sn7yLJ3QXo9RRfhn2ew=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs=

--- a/vendor/github.com/git-lfs/wildmatch/wildmatch.go
+++ b/vendor/github.com/git-lfs/wildmatch/wildmatch.go
@@ -111,7 +111,7 @@ func slashEscape(p string) string {
 				i += 1
 			}
 		default:
-			pp += string(c)
+			pp += string([]byte{c})
 			i += 1
 		}
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/git-lfs/go-netrc/netrc
 # github.com/git-lfs/go-ntlm v0.0.0-20190401175752-c5056e7fa066
 github.com/git-lfs/go-ntlm/ntlm
 github.com/git-lfs/go-ntlm/ntlm/md4
-# github.com/git-lfs/wildmatch v1.0.2
+# github.com/git-lfs/wildmatch v1.0.4
 github.com/git-lfs/wildmatch
 # github.com/inconshreveable/mousetrap v1.0.0
 github.com/inconshreveable/mousetrap


### PR DESCRIPTION
Update wildmatch to v1.0.4 to fix an issue with matching non-ASCII patterns.

Note that the version number is v1.0.4 instead of v1.0.3 because the master branch of wildmatch contains changes which are valuable but not currently compatible with Git LFS and v1.0.3 was mistakenly tagged from these changes.  These changes would break semantic versioning, so the tag was deleted and v1.0.4 was tagged with only compatible changes.

We can adopt these incompatible changes in the future, but it's better to fix this bug now since it is causing pain for multiple users rather than wait to address these changes until the new wildmatch can be included.

Fixes #3814.