### PR TITLE
Reworked to use git ls-files in some circumstances instead of FastWalkGitRepo

### DIFF
--- a/fs/cleanup.go
+++ b/fs/cleanup.go
@@ -17,7 +17,7 @@ func (f *Filesystem) cleanupTmp() error {
 	}
 
 	var walkErr error
-	tools.FastWalkGitRepo(tmpdir, func(parentDir string, info os.FileInfo, err error) {
+	tools.FastWalkDir(tmpdir, func(parentDir string, info os.FileInfo, err error) {
 		if err != nil {
 			walkErr = err
 		}

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -45,7 +45,7 @@ type Filesystem struct {
 
 func (f *Filesystem) EachObject(fn func(Object) error) error {
 	var eachErr error
-	tools.FastWalkGitRepo(f.LFSObjectDir(), func(parentDir string, info os.FileInfo, err error) {
+	tools.FastWalkDir(f.LFSObjectDir(), func(parentDir string, info os.FileInfo, err error) {
 		if err != nil {
 			eachErr = err
 			return

--- a/git/ls_files.go
+++ b/git/ls_files.go
@@ -1,0 +1,90 @@
+package git
+
+import (
+	"bufio"
+	"strings"
+	"path"
+	"io/ioutil"
+
+	"github.com/git-lfs/git-lfs/errors"
+	"github.com/git-lfs/git-lfs/tools"
+	"github.com/rubyist/tracerx"
+)
+
+type lsFileInfo struct {
+	BaseName string
+	FullPath string
+}
+type LsFiles struct {
+	Files map[string]*lsFileInfo
+	FilesByName map[string][]*lsFileInfo
+}
+
+func NewLsFiles(workingDir string, standardExclude bool) (*LsFiles, error) {
+
+	args := []string{
+		"ls-files",
+		"-z", // Use a NUL separator. This also disables the escaping of special characters.
+		"--others",
+		"--cached",
+	}
+
+	if standardExclude {
+		args = append(args, "--exclude-standard")
+	}
+	cmd := gitNoLFS(args...)
+	cmd.Dir = workingDir
+
+    tracerx.Printf("NewLsFiles: running in %s git %s",
+			workingDir, strings.Join(args, " "))
+
+	// Capture stdout and stderr
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	scanner := bufio.NewScanner(stdout)
+	scanner.Split(tools.SplitOnNul)
+
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	rv := &LsFiles {
+		Files: make(map[string]*lsFileInfo),
+		FilesByName: make(map[string][]*lsFileInfo),
+	}
+
+	// Setup a goroutine to drain stderr as large amounts of error output may cause
+	// the subprocess to block.
+	errorMessages := make(chan []byte)
+	go func() {
+		msg, _ := ioutil.ReadAll(stderr)
+		errorMessages <- msg
+	}()
+
+	// Read all files
+	for scanner.Scan() {
+		base := path.Base(scanner.Text())
+		finfo := &lsFileInfo {
+			BaseName: base,
+			FullPath: scanner.Text(),
+		}
+		rv.Files[scanner.Text()] = finfo
+		rv.FilesByName[base] = append(rv.FilesByName[base], finfo)
+	}
+
+	// Check the output of the subprocess, output stderr if the command failed.
+	msg := <-errorMessages
+	if err := cmd.Wait(); err != nil {
+		return nil, errors.Errorf("Error in git %s: %v %s",
+			strings.Join(args, " "), err, msg)
+	}
+
+	return rv, nil
+}

--- a/t/t-lock.sh
+++ b/t/t-lock.sh
@@ -250,7 +250,7 @@ begin_test "lock with .gitignore"
   git add .gitignore
   git commit -m ".gitignore: ignore 'a.txt'"
   rm -f a.txt && git checkout a.txt
-  assert_file_writeable a.txt
+  refute_file_writeable a.txt
 )
 end_test
 

--- a/tools/filetools.go
+++ b/tools/filetools.go
@@ -3,7 +3,6 @@
 package tools
 
 import (
-	"bufio"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -239,7 +238,7 @@ func VerifyFileHash(oid, path string) error {
 // FastWalkCallback is the signature for the callback given to FastWalkGitRepo()
 type FastWalkCallback func(parentDir string, info os.FileInfo, err error)
 
-// FastWalkGitRepo is a more optimal implementation of filepath.Walk for a Git
+// FastWalkDir is a more optimal implementation of filepath.Walk for a Git
 // repo. The callback guaranteed to be called sequentially. The function returns
 // once all files and errors have triggered callbacks.
 // It differs in the following ways:
@@ -248,18 +247,10 @@ type FastWalkCallback func(parentDir string, info os.FileInfo, err error)
 //    there are no other guarantees. Use parentDir argument in the callback to
 //    determine absolute path rather than tracking it yourself
 //  * Automatically ignores any .git directories
-//  * Respects .gitignore contents and skips ignored files/dirs
 //
 // rootDir - Absolute path to the top of the repository working directory
-func FastWalkGitRepo(rootDir string, cb FastWalkCallback) {
-	fastWalkCallback(fastWalkWithExcludeFiles(rootDir, ".gitignore"), cb)
-}
-
-// FastWalkGitRepoAll behaves as FastWalkGitRepo, with the additional caveat
-// that it does not ignore paths and directories found in .gitignore file(s)
-// throughout the repository.
-func FastWalkGitRepoAll(rootDir string, cb FastWalkCallback) {
-	fastWalkCallback(fastWalkWithExcludeFiles(rootDir, ""), cb)
+func FastWalkDir(rootDir string, cb FastWalkCallback) {
+	fastWalkCallback(fastWalkWithExcludeFiles(rootDir), cb)
 }
 
 // fastWalkCallback calls the FastWalkCallback "cb" for all files found by the
@@ -281,7 +272,6 @@ type fastWalkInfo struct {
 
 type fastWalker struct {
 	rootDir         string
-	excludeFilename string
 	ch              chan fastWalkInfo
 	limit           int32
 	cur             *int32
@@ -289,11 +279,10 @@ type fastWalker struct {
 }
 
 // fastWalkWithExcludeFiles walks the contents of a dir, respecting
-// include/exclude patterns and also loading new exlude patterns from files
-// named excludeFilename in directories walked
+// include/exclude patterns.
 //
 // rootDir - Absolute path to the top of the repository working directory
-func fastWalkWithExcludeFiles(rootDir, excludeFilename string) *fastWalker {
+func fastWalkWithExcludeFiles(rootDir string) *fastWalker {
 	excludePaths := []filepathfilter.Pattern{
 		filepathfilter.NewPattern(".git"),
 		filepathfilter.NewPattern("**/.git"),
@@ -307,7 +296,6 @@ func fastWalkWithExcludeFiles(rootDir, excludeFilename string) *fastWalker {
 	c := int32(0)
 	w := &fastWalker{
 		rootDir:         rootDir,
-		excludeFilename: excludeFilename,
 		limit:           int32(limit),
 		cur:             &c,
 		ch:              make(chan fastWalkInfo, 256),
@@ -327,12 +315,9 @@ func fastWalkWithExcludeFiles(rootDir, excludeFilename string) *fastWalker {
 	return w
 }
 
-// Walk is the main recursive implementation of fast walk.
-// Sends the file/dir and any contents to the channel so long as it passes the
-// include/exclude filter. If a dir, parses any excludeFilename found and updates
-// the excludePaths with its content before (parallel) recursing into contents
-// Also splits large directories into multiple goroutines.
-// Increments waitg.Add(1) for each new goroutine launched internally
+// Walk is the main recursive implementation of fast walk.  Sends the file/dir
+// and any contents to the channel so long as it passes the include/exclude
+// filter.  Increments waitg.Add(1) for each new goroutine launched internally
 //
 // workDir - Relative path inside the repository
 func (w *fastWalker) Walk(isRoot bool, workDir string, itemFi os.FileInfo,
@@ -371,15 +356,6 @@ func (w *fastWalker) Walk(isRoot bool, workDir string, itemFi os.FileInfo,
 	var childWorkDir string
 	if !isRoot {
 		childWorkDir = join(workDir, itemFi.Name())
-	}
-
-	if len(w.excludeFilename) > 0 {
-		possibleExcludeFile := join(fullPath, w.excludeFilename)
-		var err error
-		excludePaths, err = loadExcludeFilename(possibleExcludeFile, childWorkDir, excludePaths)
-		if err != nil {
-			w.ch <- fastWalkInfo{Err: err}
-		}
 	}
 
 	// The absolute optimal way to scan would be File.Readdirnames but we
@@ -428,51 +404,6 @@ func (w *fastWalker) walk(children []os.FileInfo, fn func([]os.FileInfo)) {
 func (w *fastWalker) Wait() {
 	w.wg.Wait()
 	close(w.ch)
-}
-
-// loadExcludeFilename reads the given file in gitignore format and returns a
-// revised array of exclude paths if there are any changes.
-// If any changes are made a copy of the array is taken so the original is not
-// modified
-func loadExcludeFilename(filename, workDir string, excludePaths []filepathfilter.Pattern) ([]filepathfilter.Pattern, error) {
-	f, err := os.OpenFile(filename, os.O_RDONLY, 0644)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return excludePaths, nil
-		}
-		return excludePaths, err
-	}
-	defer f.Close()
-
-	retPaths := excludePaths
-	modified := false
-
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		// Skip blanks, comments and negations (not supported right now)
-		if len(line) == 0 || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "!") {
-			continue
-		}
-
-		if !modified {
-			// copy on write
-			retPaths = make([]filepathfilter.Pattern, len(excludePaths))
-			copy(retPaths, excludePaths)
-			modified = true
-		}
-
-		path := line
-		// Add pattern in context if exclude has separator, or no wildcard
-		// Allow for both styles of separator at this point
-		if strings.ContainsAny(path, "/\\") ||
-			!strings.Contains(path, "*") {
-			path = join(workDir, line)
-		}
-		retPaths = append(retPaths, filepathfilter.NewPattern(path))
-	}
-
-	return retPaths, nil
 }
 
 func join(paths ...string) string {

--- a/tools/iotools.go
+++ b/tools/iotools.go
@@ -143,3 +143,14 @@ func Spool(to io.Writer, from io.Reader, dir string) (n int64, err error) {
 
 	return io.Copy(to, spool)
 }
+
+// Split the input on the NUL character. Usable with bufio.Scanner.
+func SplitOnNul(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	for i:= 0; i < len(data); i++ {
+		if data[i] == '\x00' {
+			return i+1, data[:i], nil
+		}
+	}
+	return 0, nil, nil
+}
+


### PR DESCRIPTION
This is a rough cut of addressing #3797 by replacing FastWalkGitRepo with `git ls-files`. For my use case, it cuts post-hook execution time down from ~40 seconds, to a few hundred ms.

At this point, I am looking for a high-level review of the changes, and direction on wether I should proceed w/ completing this change.

There are a few things that need to be addressed:

1. The new code needs tests.
2. Some existing tests are failing.
3. The new behavior needs to be verified against the old behavior on more repos.

I am also requesting any feedback that anyone familiar w/ the code might have. As it stands, git-lfs is unusable for our project without this (or a similar) fix, and I would like to verify that this fix is sound before we use it internally.