### PR TITLE
Let git-lfs HTTPS transport send cookies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,12 @@ module github.com/git-lfs/git-lfs
 
 require (
 	github.com/alexbrainman/sspi v0.0.0-20180125232955-4729b3d4d858
+	github.com/fsnotify/fsnotify v1.4.7 // indirect
 	github.com/git-lfs/gitobj v1.4.1
 	github.com/git-lfs/go-netrc v0.0.0-20180525200031-e0e9ca483a18
 	github.com/git-lfs/go-ntlm v0.0.0-20190401175752-c5056e7fa066
 	github.com/git-lfs/wildmatch v1.0.4
+	github.com/google/slothfs v0.0.0-20190417171004-6b42407d9230
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/mattn/go-isatty v0.0.4
 	github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/alexbrainman/sspi v0.0.0-20180125232955-4729b3d4d858 h1:OZQyEhf4Bviyd
 github.com/alexbrainman/sspi v0.0.0-20180125232955-4729b3d4d858/go.mod h1:976q2ETgjT2snVCf2ZaBnyBbVoPERGjUz+0sofzEfro=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
+github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/git-lfs/gitobj v1.4.1 h1:6nH5d1QP7GJjZfBqaBXpS7mDzT4plXQLqUjPbcbtRpw=
 github.com/git-lfs/gitobj v1.4.1/go.mod h1:B+djgKTnUoJHbg4uDvnC/+6xPcfEJNFbZd/YunEJRtA=
 github.com/git-lfs/go-netrc v0.0.0-20180525200031-e0e9ca483a18 h1:7Th0eBA4rT8WJNiM1vppjaIv9W5WJinhpbCJvRJxloI=
@@ -10,6 +12,8 @@ github.com/git-lfs/go-ntlm v0.0.0-20190401175752-c5056e7fa066 h1:f5UyyCnv3o2EHy+
 github.com/git-lfs/go-ntlm v0.0.0-20190401175752-c5056e7fa066/go.mod h1:YnCP1lAyul0ITv9nT/OqXseZmGeaqvMVa2uvl8ssQvE=
 github.com/git-lfs/wildmatch v1.0.4 h1:Mj6LPnNZ6QSHLAAPDCH596pu6A/Z1xVm2Vk0+s3CtkY=
 github.com/git-lfs/wildmatch v1.0.4/go.mod h1:SdHAGnApDpnFYQ0vAxbniWR0sn7yLJ3QXo9RRfhn2ew=
+github.com/google/slothfs v0.0.0-20190417171004-6b42407d9230 h1:iBLrJ79cF90CZmpskySqhPvzrWr9njBYEsOZubXLZlc=
+github.com/google/slothfs v0.0.0-20190417171004-6b42407d9230/go.mod h1:kzvK/MFjZSNdFgc1tCZML3E1nVvnB4/npSKEuvMoECU=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs=

--- a/lfshttp/client.go
+++ b/lfshttp/client.go
@@ -447,8 +447,11 @@ func (c *Client) HttpClient(host string) *http.Client {
 
 	if isCookieJarEnabledForHost(c, host) {
 		tracerx.Printf("http: cookieFile for %s", host)
-		cookieJar, _ := getCookieJarForHost(c, host)
-		httpClient.Jar = cookieJar
+		if cookieJar, err := getCookieJarForHost(c, host); err == nil {
+			httpClient.Jar = cookieJar
+		} else {
+			tracerx.Printf("http: error while reading cookieFile: %s", err.Error())
+		}
 	}
 
 	c.hostClients[host] = httpClient

--- a/lfshttp/client.go
+++ b/lfshttp/client.go
@@ -445,6 +445,12 @@ func (c *Client) HttpClient(host string) *http.Client {
 		},
 	}
 
+	if isCookieJarEnabledForHost(c, host) {
+		tracerx.Printf("http: cookieFile for %s", host)
+		cookieJar, _ := getCookieJarForHost(c, host)
+		httpClient.Jar = cookieJar
+	}
+
 	c.hostClients[host] = httpClient
 	if c.VerboseOut == nil {
 		c.VerboseOut = os.Stderr

--- a/lfshttp/cookies.go
+++ b/lfshttp/cookies.go
@@ -14,7 +14,7 @@ func isCookieJarEnabledForHost(c *Client, host string) bool {
 }
 
 func getCookieJarForHost(c *Client, host string) (http.CookieJar, error) {
-cookieFile, _ := c.uc.Get("http", fmt.Sprintf("https://%v", host), "cookieFile")
+	cookieFile, _ := c.uc.Get("http", fmt.Sprintf("https://%v", host), "cookieFile")
 
 	return cookie.NewJar(cookieFile)
 }

--- a/lfshttp/cookies.go
+++ b/lfshttp/cookies.go
@@ -1,0 +1,20 @@
+package lfshttp
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/google/slothfs/cookie"
+)
+
+func isCookieJarEnabledForHost(c *Client, host string) bool {
+	_, cookieFileOk := c.uc.Get("http", fmt.Sprintf("https://%v", host), "cookieFile")
+
+	return cookieFileOk
+}
+
+func getCookieJarForHost(c *Client, host string) (http.CookieJar, error) {
+cookieFile, _ := c.uc.Get("http", fmt.Sprintf("https://%v", host), "cookieFile")
+
+	return cookie.NewJar(cookieFile)
+}

--- a/lfshttp/cookies.go
+++ b/lfshttp/cookies.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/git-lfs/git-lfs/tools"
 	"github.com/google/slothfs/cookie"
 )
 
@@ -16,5 +17,10 @@ func isCookieJarEnabledForHost(c *Client, host string) bool {
 func getCookieJarForHost(c *Client, host string) (http.CookieJar, error) {
 	cookieFile, _ := c.uc.Get("http", fmt.Sprintf("https://%v", host), "cookieFile")
 
-	return cookie.NewJar(cookieFile)
+	cookieFilePath, err := tools.ExpandPath(cookieFile, false)
+	if err != nil {
+		return nil, err
+	}
+
+	return cookie.NewJar(cookieFilePath)
 }

--- a/t/t-clone.sh
+++ b/t/t-clone.sh
@@ -671,7 +671,6 @@ begin_test "clone (HTTP server/proxy require cookies)"
   set -e
 
   # golang net.http.Cookie ignores cookies with IP instead of domain/hostname
-  GITSERVER_SAVED="$GITSERVER"
   GITSERVER=$(echo "$GITSERVER" | sed 's/127\.0\.0\.1/localhost/')
   cp "$CREDSDIR/127.0.0.1" "$CREDSDIR/localhost"
   printf "localhost\tTRUE\t/\tFALSE\t2145916800\tCOOKIE_GITLFS\tsecret\n" >> "$REMOTEDIR/cookies.txt"
@@ -752,7 +751,6 @@ begin_test "clone (HTTP server/proxy require cookies)"
     assert_clean_status
   popd
 
-  GITSERVER="$GITSERVER_SAVED"
   rm "$CREDSDIR/localhost"
 )
 end_test

--- a/t/t-clone.sh
+++ b/t/t-clone.sh
@@ -751,6 +751,7 @@ begin_test "clone (HTTP server/proxy require cookies)"
     assert_clean_status
   popd
 
+  # to avoid breaking t-credentials.sh
   rm "$CREDSDIR/localhost"
 )
 end_test

--- a/t/t-clone.sh
+++ b/t/t-clone.sh
@@ -665,3 +665,94 @@ begin_test "clone bare empty repository"
   fi
 )
 end_test
+
+begin_test "clone (HTTP server/proxy require cookies)"
+(
+  set -e
+
+  # golang net.http.Cookie ignores cookies with IP instead of domain/hostname
+  GITSERVER_SAVED="$GITSERVER"
+  GITSERVER=$(echo "$GITSERVER" | sed 's/127\.0\.0\.1/localhost/')
+  cp "$CREDSDIR/127.0.0.1" "$CREDSDIR/localhost"
+  printf "localhost\tTRUE\t/\tFALSE\t2145916800\tCOOKIE_GITLFS\tsecret\n" >> "$REMOTEDIR/cookies.txt"
+  git config --global http.cookieFile "$REMOTEDIR/cookies.txt"
+
+  reponame="require-cookie-test"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.dat" 2>&1 | tee track.log
+  grep "Tracking \"\*.dat\"" track.log
+
+  # generate some test data & commits with random LFS data
+  echo "[
+  {
+    \"CommitDate\":\"$(get_date -10d)\",
+    \"Files\":[
+      {\"Filename\":\"file1.dat\",\"Size\":100},
+      {\"Filename\":\"file2.dat\",\"Size\":75}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -7d)\",
+    \"Files\":[
+      {\"Filename\":\"file1.dat\",\"Size\":110},
+      {\"Filename\":\"file3.dat\",\"Size\":66},
+      {\"Filename\":\"file4.dat\",\"Size\":23}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -10d)\",
+    \"Files\":[
+      {\"Filename\":\"file5.dat\",\"Size\":120},
+      {\"Filename\":\"file6.dat\",\"Size\":30}]
+  }
+  ]" | lfstest-testutils addcommits
+
+  git push origin master
+
+  # Now clone again, test specific clone dir
+  cd "$TRASHDIR"
+
+  newclonedir="require-cookie-test1"
+  git lfs clone "$GITSERVER/$reponame" "$newclonedir" 2>&1 | tee lfsclone.log
+  grep "Cloning into" lfsclone.log
+  grep "Downloading LFS objects:" lfsclone.log
+  # should be no filter errors
+  [ ! $(grep "filter" lfsclone.log) ]
+  [ ! $(grep "error" lfsclone.log) ]
+  # should be cloned into location as per arg
+  [ -d "$newclonedir" ]
+
+  # check a few file sizes to make sure pulled
+  pushd "$newclonedir"
+    [ $(wc -c < "file1.dat") -eq 110 ]
+    [ $(wc -c < "file2.dat") -eq 75 ]
+    [ $(wc -c < "file3.dat") -eq 66 ]
+    assert_hooks "$(dot_git_dir)"
+    [ ! -e "lfs" ]
+    assert_clean_status
+  popd
+
+  # Now check clone with implied dir
+  rm -rf "$reponame"
+  git lfs clone "$GITSERVER/$reponame" 2>&1 | tee lfsclone.log
+  grep "Cloning into" lfsclone.log
+  grep "Downloading LFS objects:" lfsclone.log
+  # should be no filter errors
+  [ ! $(grep "filter" lfsclone.log) ]
+  [ ! $(grep "error" lfsclone.log) ]
+  # clone location should be implied
+  [ -d "$reponame" ]
+
+  pushd "$reponame"
+    [ $(wc -c < "file1.dat") -eq 110 ]
+    [ $(wc -c < "file2.dat") -eq 75 ]
+    [ $(wc -c < "file3.dat") -eq 66 ]
+    assert_hooks "$(dot_git_dir)"
+    [ ! -e "lfs" ]
+    assert_clean_status
+  popd
+
+  GITSERVER="$GITSERVER_SAVED"
+  rm "$CREDSDIR/localhost"
+)
+end_test


### PR DESCRIPTION
This allows Git LFS to use the same cookies as configured for Git
(http.cookieFile). Those cookies may be needed for e.g. Gcloud Identity-Aware
Proxy.

Cookies are sent only over HTTPS.

Fixes #3824 