### PR TITLE
More robust handling of parallel attempts to download the same file

### DIFF
--- a/lfs/util.go
+++ b/lfs/util.go
@@ -3,7 +3,6 @@ package lfs
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -233,17 +232,5 @@ func LinkOrCopy(cfg *config.Configuration, src string, dst string) error {
 // This function is designed to handle only temporary files that will be renamed
 // into place later somewhere within the Git repository.
 func TempFile(cfg *config.Configuration, pattern string) (*os.File, error) {
-	tmp, err := ioutil.TempFile(cfg.TempDir(), pattern)
-	if err != nil {
-		return nil, err
-	}
-
-	perms := cfg.RepositoryPermissions(false)
-	err = os.Chmod(tmp.Name(), perms)
-	if err != nil {
-		tmp.Close()
-		os.Remove(tmp.Name())
-		return nil, err
-	}
-	return tmp, nil
+	return tools.TempFile(cfg.TempDir(), pattern, cfg)
 }

--- a/tools/filetools.go
+++ b/tools/filetools.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -513,6 +514,29 @@ func SetFileWriteFlag(path string, writeEnabled bool) error {
 		mode = mode &^ 0222 // disable all write
 	}
 	return os.Chmod(path, os.FileMode(mode))
+}
+
+// TempFile creates a temporary file in specified directory with proper permissions for the repository.
+// On success, it returns an open, non-nil *os.File, and the caller is responsible
+// for closing and/or removing it.  On failure, the temporary file is
+// automatically cleaned up and an error returned.
+//
+// This function is designed to handle only temporary files that will be renamed
+// into place later somewhere within the Git repository.
+func TempFile(dir, pattern string, cfg repositoryPermissionFetcher) (*os.File, error) {
+	tmp, err := ioutil.TempFile(dir, pattern)
+	if err != nil {
+		return nil, err
+	}
+
+	perms := cfg.RepositoryPermissions(false)
+	err = os.Chmod(tmp.Name(), perms)
+	if err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
+		return nil, err
+	}
+	return tmp, nil
 }
 
 // ExecutablePermissions takes a set of Unix permissions (which may or may not


### PR DESCRIPTION
1. git-lfs now only writes to unique temp files created with `ioutil.TempFile`
   that are open with `O_CREATE|O_EXCL`
2. Partially-downloaded file is now atomically borrowed and returned back via `os.Rename`
3. `.part <-> .tmp` and `.tmp -> final` renames are allowed to fail and are handled appropriately

This is a continuation of #3813
Fixes #2825

There are several error codepaths where we borrow .part file but remove it instead of returning back.
I believe that it is OK and in those erroneous cases it is better to restart download from scratch
instead of attempting to use possibly-corrupt .part file.