### PR TITLE
ci: force Windows Git version to 2.22.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
     - run: set PATH=%GOPATH%\bin;%PATH%
     - run: cinst InnoSetup -y
     - run: cinst strawberryperl -y
+    - run: choco uninstall git.install -y --force
+    - run: cinst git --version 2.22.0 -y --force
     - run: refreshenv
     - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" go get github.com/josephspurrier/goversioninfo/cmd/goversioninfo
       shell: bash


### PR DESCRIPTION
In Git for Windows 2.23, the /dev and /dev/fd directories did not get created.  As a result, it's not possible to use a process substitution in bash, which breaks a significant portion of the test suite.  In the mean time, let's downgrade Git for Windows to 2.22.0, which is what Actions used to use and worked for us.  We can remove this hack when the next Git for Windows release occurs.

Fixes #3828.