### PR TITLE
Support DragonFly BSD

### DIFF
--- a/lfshttp/certs_dragonfly.go
+++ b/lfshttp/certs_dragonfly.go
@@ -1,0 +1,8 @@
+package lfshttp
+
+import "crypto/x509"
+
+func appendRootCAsForHostFromPlatform(pool *x509.CertPool, host string) *x509.CertPool {
+	// Do nothing, use golang default
+	return pool
+}


### PR DESCRIPTION
I've tested this patch on the latest DragonFly BSD (development version as of 2019-09-17) and git-lfs works well.

The added `lfshttp/certs_dragonfly.go` is the same as `lfshttp/certs_freebsd.go`.

Please review this patch.  Thanks.