### PR TITLE
Use GitHub Actions for release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: Release
+on:
+  push:
+    tags: '*'
+
+jobs:
+  build-windows:
+    name: Build Windows Assets
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions/setup-ruby@v1
+    - run: mkdir -p "$HOME/go/bin"
+      shell: bash
+    - run: set GOPATH=%HOME%\go
+    - run: set PATH=%GOPATH%\bin;%PATH%
+    - run: cinst InnoSetup -y
+    - run: cinst strawberryperl -y
+    - run: cinst zip -y
+    - run: cinst jq -y
+    - run: cinst windows-sdk-10.0 -y
+    - run: refreshenv
+    - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" go get github.com/josephspurrier/goversioninfo/cmd/goversioninfo
+      shell: bash
+    - run: mkdir -p bin/releases
+      shell: bash
+    - run: CERT_FILE="$HOME/cert.pfx" make release-write-certificate
+      shell: bash
+      env:
+        CERT_CONTENTS: ${{secrets.WINDOWS_CERT_BASE64}}
+    - run: PATH="$HOME/go/bin:$PATH" make bin/releases/git-lfs-windows-amd64-$(git describe).zip
+      shell: bash
+    - run: PATH="$HOME/go/bin:$PATH" make bin/releases/git-lfs-windows-386-$(git describe).zip
+      shell: bash
+    - run: echo "$PATH"
+      shell: bash
+    - run: find "/c/Program Files (x86)/Windows Kits/10/bin/x86"
+      shell: bash
+    - run: PATH="$HOME/go/bin:/c/Program Files (x86)/Windows Kits/10/bin/x86:$PATH" CERT_FILE="$HOME/cert.pfx" make release-windows
+      shell: bash
+      env:
+        CERT_PASS: ${{secrets.WINDOWS_CERT_PASS}}
+    - run: make release-windows-rebuild
+      shell: bash
+    - uses: actions/upload-artifact@v1
+      with:
+        name: assets
+        path: bin/releases
+  build-main:
+    name: Main Release Assets
+    needs: build-windows
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions/setup-ruby@v1
+    - uses: actions/download-artifact@v1
+      with:
+        name: assets
+    - run: make release
+    - run: rm -f bin/releases/*windows*
+    - run: find assets -name "*windows*" | xargs -L1 -I{} mv {} bin/releases
+    - run: script/upload --skip-verify $(git describe)
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+  build-docker:
+    name: Build Linux Packages
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions/setup-ruby@v1
+    - run: git clone https://github.com/git-lfs/build-dockers.git "$HOME/build-dockers"
+    - run: (cd "$HOME/build-dockers" && ./build_dockers.bsh)
+    - run: DOCKER_AUTOPULL=0 ./docker/run_dockers.bsh
+    - run: ./script/packagecloud.rb
+      env:
+        PACKAGECLOUD_TOKEN: ${{secrets.PACKAGECLOUD_TOKEN}}

--- a/Makefile
+++ b/Makefile
@@ -344,7 +344,7 @@ bin/releases/git-lfs-windows-assets-$(VERSION).tar.gz :
 	mv git-lfs-x64.exe git-lfs-windows-amd64.exe
 	mv git-lfs-x86.exe git-lfs-windows-386.exe
 	@# We use tar because Git Bash doesn't include zip.
-	tar -cf $@ git-lfs-windows-amd64.exe git-lfs-windows-386.exe git-lfs-windows.exe
+	tar -czf $@ git-lfs-windows-amd64.exe git-lfs-windows-386.exe git-lfs-windows.exe
 	$(RM) git-lfs-windows-amd64.exe git-lfs-windows-386.exe git-lfs-windows.exe
 
 # release-windows-rebuild takes the archive produced by release-windows and

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,9 @@ CERT_PASS ?=
 
 # CERT_ARGS are additional arguments to pass when signing Windows binaries.
 ifneq ("$(CERT_FILE)$(CERT_PASS)","")
-CERT_ARGS ?= /f "$(CERT_FILE)" /p "$(CERT_PASS)"
+CERT_ARGS ?= -f "$(CERT_FILE)" -p "$(CERT_PASS)"
+else
+CERT_ARGS ?= -sha1 $(CERT_SHA1)
 endif
 
 # SOURCES is a listing of all .go files in this and child directories, excluding
@@ -330,15 +332,15 @@ bin/releases/git-lfs-windows-assets-$(VERSION).tar.gz :
 	$(MAKE) -B GOARCH=amd64 && cp ./bin/git-lfs.exe ./git-lfs-x64.exe
 	$(MAKE) -B GOARCH=386 && cp ./bin/git-lfs.exe ./git-lfs-x86.exe
 	@echo Signing git-lfs-x64.exe
-	@signtool.exe sign /sha1 $(CERT_SHA1) /fd sha256 /tr http://timestamp.digicert.com /td sha256 /v $(CERT_ARGS) git-lfs-x64.exe
+	@signtool.exe sign -debug -fd sha256 -tr http://timestamp.digicert.com -td sha256 $(CERT_ARGS) -v git-lfs-x64.exe
 	@echo Signing git-lfs-x86.exe
-	@signtool.exe sign /sha1 $(CERT_SHA1) /fd sha256 /tr http://timestamp.digicert.com /td sha256 /v $(CERT_ARGS) git-lfs-x86.exe
+	@signtool.exe sign -debug -fd sha256 -tr http://timestamp.digicert.com -td sha256 $(CERT_ARGS) -v git-lfs-x86.exe
 	iscc.exe script/windows-installer/inno-setup-git-lfs-installer.iss
 	@# This file will be named according to the version number in the
 	@# versioninfo.json, not according to $(VERSION).
 	mv git-lfs-windows-*.exe git-lfs-windows.exe
 	@echo Signing git-lfs-windows.exe
-	@signtool.exe sign /sha1 $(CERT_SHA1) /fd sha256 /tr http://timestamp.digicert.com /td sha256 /v $(CERT_ARGS) git-lfs-windows.exe
+	@signtool.exe sign -debug -fd sha256 -tr http://timestamp.digicert.com -td sha256 $(CERT_ARGS) -v git-lfs-windows.exe
 	mv git-lfs-x64.exe git-lfs-windows-amd64.exe
 	mv git-lfs-x86.exe git-lfs-windows-386.exe
 	@# We use tar because Git Bash doesn't include zip.

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,10 @@ GC_FLAGS = $(BUILTIN_GC_FLAGS) $(EXTRA_GC_FLAGS)
 
 ASM_FLAGS ?= all=-trimpath="$$HOME"
 
+# TRIMPATH contains arguments to be passed to go to strip paths on Go 1.13 and
+# newer.
+TRIMPATH ?= $(shell [ "$$($(GO) version | awk '{print $$3}' | sed -e 's/^[^.]*\.//;s/\..*$$//;')" -ge 13 ] && echo -trimpath)
+
 # RONN is the name of the 'ronn' program used to generate man pages.
 RONN ?= ronn
 # RONN_EXTRA_ARGS are extra arguments given to the $(RONN) program when invoked.
@@ -143,6 +147,7 @@ BUILD = GOOS=$(1) GOARCH=$(2) \
 	-ldflags="$(LD_FLAGS)" \
 	-gcflags="$(GC_FLAGS)" \
 	-asmflags="$(ASM_FLAGS)" \
+	$(TRIMPATH) \
 	-o ./bin/git-lfs$(3) $(BUILD_MAIN)
 
 # BUILD_TARGETS is the set of all platforms and architectures that Git LFS is

--- a/docker/run_dockers.bsh
+++ b/docker/run_dockers.bsh
@@ -69,7 +69,11 @@ for IMAGE_NAME in "${IMAGES[@]}"; do
   fi
 
   #It CAN'T be empty () with set -u... So I put some defaults in here
-  OTHER_OPTIONS=("-it")
+  OTHER_OPTIONS=("-t")
+
+  if tty >/dev/null; then
+    OTHER_OPTIONS+=("-i")
+  fi
 
   if [ "${AUTO_REMOVE-1}" == "1" ]; then
     OTHER_OPTIONS+=("--rm")

--- a/script/upload
+++ b/script/upload
@@ -282,6 +282,28 @@ EOM
   exit $status
 }
 
+# Check that this script has the prerequisites to continue.
+sanity_check () {
+  local version="$1"
+
+  say "Checking that you've got some release artifacts..."
+  [ -n "$(release_files "$version")" ] || \
+    abort "I couldn't find any release files for $version."
+
+  if [ -n "$GITHUB_TOKEN" ]
+  then
+    say "Found a token in the GITHUB_TOKEN environment variable."
+  else
+    say "Looking for the necessary entries in .netrc..."
+    grep -qsF api.github.com "$HOME/.netrc" || \
+      abort "I couldn't find api.github.com in your .netrc."
+    grep -qsF uploads.github.com "$HOME/.netrc" || \
+      abort "I couldn't find uploads.github.com in your .netrc."
+  fi
+
+  say "Okay, everything looks good."
+}
+
 # The main program.
 main () {
   while [ -n "$1" ]
@@ -304,22 +326,7 @@ main () {
 
   [ -z "$version" ] && usage 1 >&2
 
-  say "Checking that you've got some release artifacts..."
-  [ -n "$(release_files "$version")" ] || \
-    abort "I couldn't find any release files for $version."
-
-  if [ -n "$GITHUB_TOKEN" ]
-  then
-    say "Found a token in the GITHUB_TOKEN environment variable."
-  else
-    say "Looking for the necessary entries in .netrc..."
-    grep -qsF api.github.com "$HOME/.netrc" || \
-      abort "I couldn't find api.github.com in your .netrc."
-    grep -qsF uploads.github.com "$HOME/.netrc" || \
-      abort "I couldn't find uploads.github.com in your .netrc."
-  fi
-
-  say "Okay, everything looks good."
+  sanity_check "$version"
 
   say "Formatting the body of the GitHub release now..."
 

--- a/script/upload
+++ b/script/upload
@@ -252,11 +252,25 @@ verify_assets () {
   say "\nAssets look good!"
 }
 
+# Extract the changelog for the given version from the history and save it in a
+# file.  Print the filename of the changelog to standard output.
+extract_changelog () {
+  local version="$1"
+
+  git cat-file blob "$version:CHANGELOG.md" | \
+  ruby -ne "version=%Q($version)[1..-1]; state ||= :silent; text ||= [];" \
+    -e 'if state == :print && $_.start_with?("## "); puts text.join.strip; exit; end;' \
+    -e 'text << $_ if state == :print;' \
+    -e 'state = :print if $_.start_with?("## #{version}")' \
+    > "$WORKDIR/changelog"
+  echo "$WORKDIR/changelog"
+}
+
 # Provide a helpful usage message and exit.
 usage () {
   local status="$1"
   cat <<EOM
-Usage: $0 VERSION CHANGELOG
+Usage: $0 VERSION
 
 Create a draft GitHub release for Git LFS using the tag specified by VERSION and
 the changelog specified in the file CHANGELOG. Before running this script, the
@@ -287,9 +301,8 @@ main () {
   done
 
   local version="$1"
-  local changelog="$2"
 
-  [ -z "$changelog" ] && usage 1 >&2
+  [ -z "$version" ] && usage 1 >&2
 
   say "Checking that you've got some release artifacts..."
   [ -n "$(release_files "$version")" ] || \
@@ -310,6 +323,7 @@ main () {
 
   say "Formatting the body of the GitHub release now..."
 
+  local changelog=$(extract_changelog "$version")
   local bodyfile=$(finalize_body_message "$version" "$changelog")
 
   say "Creating a GitHub release for %s..." "$version"

--- a/script/upload
+++ b/script/upload
@@ -22,7 +22,12 @@ abort () {
 }
 
 curl () {
-  command curl -nfSs "$@"
+  if [ -n "$GITHUB_TOKEN" ]
+  then
+    command curl -u "token:$GITHUB_TOKEN" -fSs "$@"
+  else
+    command curl -nfSs "$@"
+  fi
 }
 
 categorize_os () {
@@ -260,11 +265,16 @@ main () {
   [ -n "$(release_files "$version")" ] || \
     abort "I couldn't find any release files for $version."
 
-  say "Looking for the necessary entries in .netrc..."
-  grep -qsF api.github.com "$HOME/.netrc" || \
-    abort "I couldn't find api.github.com in your .netrc."
-  grep -qsF uploads.github.com "$HOME/.netrc" || \
-    abort "I couldn't find uploads.github.com in your .netrc."
+  if [ -n "$GITHUB_TOKEN" ]
+  then
+    say "Found a token in the GITHUB_TOKEN environment variable."
+  else
+    say "Looking for the necessary entries in .netrc..."
+    grep -qsF api.github.com "$HOME/.netrc" || \
+      abort "I couldn't find api.github.com in your .netrc."
+    grep -qsF uploads.github.com "$HOME/.netrc" || \
+      abort "I couldn't find uploads.github.com in your .netrc."
+  fi
 
   say "Okay, everything looks good."
 

--- a/script/upload
+++ b/script/upload
@@ -214,28 +214,40 @@ upload_assets () {
     download=$(jq -r '.url' "$WORKDIR/response")
   done
 
+  say "Assets uploaded."
+}
+
+# Download assets from GitHub to the specified directory.
+download_assets () {
+  local version="$1"
+  local dir="$2"
+
   curl https://api.github.com/repos/$REPO/releases | \
     jq -rc '.[] | select(.name == "'"$version"'") | .assets | .[] | [.name,.url]' | \
     ruby -rjson -ne 'puts JSON.parse($_).join(" ")' \
     > "$WORKDIR/assets"
 
-  say "Assets uploaded."
-}
-
-verify_assets () {
   cat "$WORKDIR/assets" | (while read base url
   do
     say "\tDownloading %s for verification..." "$base"
     (
-      cd "$WORKDIR/downloads" &&
+      cd "$dir" &&
       curl -Lo "$base" -H"Accept: application/octet-stream" "$url"
     )
   done)
+}
+
+# Download the assets and verify the signature made on them.
+verify_assets () {
+  local version="$1"
+  local dir="$WORKDIR/verify"
+  mkdir "$dir"
+  download_assets "$version" "$dir"
 
   # If the OpenPGP data is not valid, gpg -d will output nothing to stdout, and
   # shasum will then fail.
   say "Checking assets for integrity..."
-  (cd "$WORKDIR/downloads" && gpg -d sha256sums.asc | shasum -a 256 -c)
+  (cd "$dir" && gpg -d sha256sums.asc | shasum -a 256 -c)
 
   say "\nAssets look good!"
 }
@@ -310,7 +322,7 @@ main () {
   if [ -z "$SKIP_VERIFY" ]
   then
     say "Verifying assets..."
-    verify_assets
+    verify_assets "$version"
   fi
 
   say "Okay, done. Sanity-check the release and publish it."

--- a/script/upload
+++ b/script/upload
@@ -220,8 +220,9 @@ upload_assets () {
     > "$WORKDIR/assets"
 
   say "Assets uploaded."
-  say "Verifying assets..."
+}
 
+verify_assets () {
   cat "$WORKDIR/assets" | (while read base url
   do
     say "\tDownloading %s for verification..." "$base"
@@ -257,10 +258,25 @@ EOM
 
 # The main program.
 main () {
+  while [ -n "$1" ]
+  do
+    case "$1" in
+      --help)
+        usage 0;;
+      --skip-verify)
+        SKIP_VERIFY=1
+        shift;;
+      --)
+        shift
+        break;;
+      *)
+        break;;
+    esac
+  done
+
   local version="$1"
   local changelog="$2"
 
-  [ "$version" = "--help" ] && usage 0
   [ -z "$changelog" ] && usage 1 >&2
 
   say "Checking that you've got some release artifacts..."
@@ -290,6 +306,12 @@ main () {
 
   say "Uploading assets to GitHub..."
   upload_assets "$version" "$upload_url"
+
+  if [ -z "$SKIP_VERIFY" ]
+  then
+    say "Verifying assets..."
+    verify_assets
+  fi
 
   say "Okay, done. Sanity-check the release and publish it."
 }

--- a/script/upload
+++ b/script/upload
@@ -59,6 +59,8 @@ categorize_asset () {
       echo "Source";;
     git-lfs-windows-v*.*.*.exe)
       echo "Windows Installer";;
+    sha256sums)
+      echo "Unsigned SHA-256 Hashes";;
     sha256sums.asc)
       echo "Signed SHA-256 Hashes";;
     *)
@@ -77,7 +79,7 @@ content_type () {
       echo "application/gzip";;
     *.exe)
       echo "application/octet-stream";;
-    *.asc)
+    *.asc|sha256sums*)
       echo "text/plain";;
   esac
 }

--- a/script/upload
+++ b/script/upload
@@ -123,13 +123,36 @@ create_release () {
     sed -e 's/{.*}//g'
 }
 
+# Update the draft release with a new body and print the upload URL for release assets to the
+# standard output.  A release with the given version must already exist.
+patch_release () {
+  local version="$1"
+  local bodyfile="$2"
+
+  # Find the URL of this release.
+  local url=$(curl https://api.github.com/repos/$REPO/releases | \
+    jq -r '.[] | select(.name == "'"$version"'") | .url')
+
+  [ -n "$url" ] || abort "No existing release found for version $version."
+  say "Found the existing release for this version."
+
+  # This can be large, so pass it in a file.
+  format_release_json "$version" "$bodyfile" >> "$WORKDIR/release-json"
+
+  curl -XPATCH -H'Content-Type: application/json' -d"@$WORKDIR/release-json" \
+    $url | \
+    jq -r '.upload_url' |
+    sed -e 's/{.*}//g'
+}
+
 # Find the release files for the given version.
 release_files () {
   local version="$1"
+  local assets="${2:-bin/releases}"
 
   [ -n "$version" ] || return 1
 
-  find bin/releases -name '*.tar.gz' -o -name '*386*.zip' -o \
+  find "$assets" -name '*.tar.gz' -o -name '*386*.zip' -o \
     -name '*amd64*.zip' -o -name '*.exe' -o -name 'sha256sums.asc' | \
     grep -E "$version|sha256sums.asc" | \
     grep -v "assets" | \
@@ -141,6 +164,7 @@ release_files () {
 finalize_body_message () {
   local version="$1"
   local changelog="$2"
+  local assets="$3"
 
   version=$(echo "$version" | sed -e 's/^v//')
 
@@ -161,7 +185,7 @@ Up to date packages are available on [PackageCloud](https://packagecloud.io/gith
 ## SHA-256 hashes:
 EOM
 
-  shasum -a256 $(release_files "$version") | \
+  shasum -a256 $(release_files "$version" "$assets") | \
     ruby -pe '$_.chomp!' \
     -e '$_.gsub!(/^([0-9a-f]+)\s+.*\/([^\/]+)$/, "**\\2**\n\\1\n\n")' | \
     ruby -0777 -pe '$_.gsub!(/\n+\z/, "\n")' >> "$WORKDIR/body-template"
@@ -197,8 +221,6 @@ upload_assets () {
     jq -r '.[] | select(.name == "'"$version"'") | .assets | .[] | .name' \
     > "$WORKDIR/existing-assets"
 
-  mkdir "$WORKDIR/downloads"
-
   for file in $(release_files "$version" | filter_files "$WORKDIR/existing-assets")
   do
     base=$(basename "$file")
@@ -229,7 +251,7 @@ download_assets () {
 
   cat "$WORKDIR/assets" | (while read base url
   do
-    say "\tDownloading %s for verification..." "$base"
+    say "\tDownloading %s..." "$base"
     (
       cd "$dir" &&
       curl -Lo "$base" -H"Accept: application/octet-stream" "$url"
@@ -266,6 +288,49 @@ extract_changelog () {
   echo "$WORKDIR/changelog"
 }
 
+# Perform the final steps to verify a release
+finalize () {
+  local version="$1"
+  local inspect="$2"
+  local downloads="$WORKDIR/finalize"
+
+  say "Finalizing the release process..."
+  say "Downloading assets..."
+
+  mkdir "$downloads"
+  download_assets "$version" "$downloads"
+
+  if [ -n "$inspect" ]
+  then
+    say "Dropping you to a shell to inspect the assets."
+    say "Type 'exit 0' to continue, or 'exit 1' to abort."
+
+    (cd "$downloads" && $SHELL)
+  fi
+
+  say "Signing asset manifest..."
+  (
+    cd "$downloads" && \
+    shasum -a256 -b * | grep -vE '(assets|sha256sums)' | \
+        gpg --digest-algo SHA256 --clearsign >sha256sums.asc
+  )
+
+  say "Formatting the final body of the GitHub release now..."
+
+  local changelog=$(extract_changelog "$version")
+  local bodyfile=$(finalize_body_message "$version" "$changelog" "$downloads")
+
+  say "Uploading final release body..."
+
+  local upload_url=$(patch_release "$version" "$bodyfile")
+
+  say "Uploading final versions of assets..."
+  cp "$downloads/sha256sums.asc" bin/releases
+  upload_assets "$version" "$upload_url"
+
+  # Verification occurs in caller below.
+}
+
 # Provide a helpful usage message and exit.
 usage () {
   local status="$1"
@@ -277,7 +342,7 @@ the changelog specified in the file CHANGELOG. Before running this script, the
 release assets should be built and ready for upload, including the signed
 sha256sums.asc file.
 
-This script requires ruby, curl, shasum, and jq.
+This script requires ruby, gpg, curl, shasum, and jq.
 EOM
   exit $status
 }
@@ -285,10 +350,15 @@ EOM
 # Check that this script has the prerequisites to continue.
 sanity_check () {
   local version="$1"
+  local finalize="$2"
 
   say "Checking that you've got some release artifacts..."
-  [ -n "$(release_files "$version")" ] || \
-    abort "I couldn't find any release files for $version."
+  if [ -n "$(release_files "$version")" ]
+  then
+    [ -z "$finalize" ] || abort "You'll need an empty bin/releases directory to continue."
+  else
+    [ -n "$finalize" ] || abort "I couldn't find any release files for $version."
+  fi
 
   if [ -n "$GITHUB_TOKEN" ]
   then
@@ -306,13 +376,21 @@ sanity_check () {
 
 # The main program.
 main () {
+  local inspect=""
+
   while [ -n "$1" ]
   do
     case "$1" in
       --help)
         usage 0;;
+      --inspect)
+        inspect=1
+        shift;;
       --skip-verify)
         SKIP_VERIFY=1
+        shift;;
+      --finalize)
+        FINALIZE=1
         shift;;
       --)
         shift
@@ -326,19 +404,24 @@ main () {
 
   [ -z "$version" ] && usage 1 >&2
 
-  sanity_check "$version"
+  sanity_check "$version" "$FINALIZE"
 
-  say "Formatting the body of the GitHub release now..."
+  if [ -n "$FINALIZE" ]
+  then
+    finalize "$version" "$inspect"
+  else
+    say "Formatting the body of the GitHub release now..."
 
-  local changelog=$(extract_changelog "$version")
-  local bodyfile=$(finalize_body_message "$version" "$changelog")
+    local changelog=$(extract_changelog "$version")
+    local bodyfile=$(finalize_body_message "$version" "$changelog")
 
-  say "Creating a GitHub release for %s..." "$version"
+    say "Creating a GitHub release for %s..." "$version"
 
-  local upload_url=$(create_release "$version" "$bodyfile")
+    local upload_url=$(create_release "$version" "$bodyfile")
 
-  say "Uploading assets to GitHub..."
-  upload_assets "$version" "$upload_url"
+    say "Uploading assets to GitHub..."
+    upload_assets "$version" "$upload_url"
+  fi
 
   if [ -z "$SKIP_VERIFY" ]
   then

--- a/t/cmd/lfstest-realpath.go
+++ b/t/cmd/lfstest-realpath.go
@@ -1,3 +1,5 @@
+// +build testtools
+
 package main
 
 import (


### PR DESCRIPTION
Currently, our release process is highly manual and doing a release can consume a significant amount of a maintainer's day.  Automate the process of doing a release by building and uploading assets on GitHub Actions.

There's a lot of code here; the series is best explained by reading the commit messages, which cover the changes better than this summary ever could.