### PR TITLE
Check for code formatting in CI

### DIFF
--- a/git/attribs.go
+++ b/git/attribs.go
@@ -183,7 +183,7 @@ func findAttributeFiles(workingDir, gitDir string) []attrFile {
 		for _, f := range gitattributesFiles {
 			tracerx.Printf("findAttributeFiles: located %s", f.FullPath)
 			paths = append(paths, attrFile{
-				path: filepath.Join(workingDir, f.FullPath),
+				path:       filepath.Join(workingDir, f.FullPath),
 				readMacros: f.FullPath == ".gitattributes", // Read macros from the top-level attributes
 			})
 		}

--- a/git/ls_files.go
+++ b/git/ls_files.go
@@ -2,9 +2,9 @@ package git
 
 import (
 	"bufio"
-	"strings"
-	"path"
 	"io/ioutil"
+	"path"
+	"strings"
 
 	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/tools"
@@ -16,7 +16,7 @@ type lsFileInfo struct {
 	FullPath string
 }
 type LsFiles struct {
-	Files map[string]*lsFileInfo
+	Files       map[string]*lsFileInfo
 	FilesByName map[string][]*lsFileInfo
 }
 
@@ -35,8 +35,8 @@ func NewLsFiles(workingDir string, standardExclude bool) (*LsFiles, error) {
 	cmd := gitNoLFS(args...)
 	cmd.Dir = workingDir
 
-    tracerx.Printf("NewLsFiles: running in %s git %s",
-			workingDir, strings.Join(args, " "))
+	tracerx.Printf("NewLsFiles: running in %s git %s",
+		workingDir, strings.Join(args, " "))
 
 	// Capture stdout and stderr
 	stdout, err := cmd.StdoutPipe()
@@ -55,8 +55,8 @@ func NewLsFiles(workingDir string, standardExclude bool) (*LsFiles, error) {
 		return nil, err
 	}
 
-	rv := &LsFiles {
-		Files: make(map[string]*lsFileInfo),
+	rv := &LsFiles{
+		Files:       make(map[string]*lsFileInfo),
 		FilesByName: make(map[string][]*lsFileInfo),
 	}
 
@@ -71,7 +71,7 @@ func NewLsFiles(workingDir string, standardExclude bool) (*LsFiles, error) {
 	// Read all files
 	for scanner.Scan() {
 		base := path.Base(scanner.Text())
-		finfo := &lsFileInfo {
+		finfo := &lsFileInfo{
 			BaseName: base,
 			FullPath: scanner.Text(),
 		}

--- a/script/cibuild
+++ b/script/cibuild
@@ -13,7 +13,11 @@ if [[ $UNAME == MINGW* || $UNAME == MSYS* || $UNAME == CYGWIN* ]]; then
   export GIT_LFS_LOCK_ACQUIRE_DISABLED=1
 fi
 
-GOIMPORTS="goimports"
+# Set GOPATH if it isn't already set.
+eval "$(go env | grep GOPATH)"
+go get golang.org/x/tools/cmd/goimports
+
+GOIMPORTS="$GOPATH/bin/goimports"
 
 make GOIMPORTS="$GOIMPORTS" && make GOIMPORTS="$GOIMPORTS" test
 
@@ -36,3 +40,13 @@ popd >/dev/null
 echo "Looking for trailing whitespace..."
 ! git grep -lE '[[:space:]]+$' | \
   grep -vE '(^vendor/|\.git/(objects/|index)|\.bat$)'
+
+echo "Formatting files..."
+# Building and installing goimports and goversioninfo will have modified go.mod
+# and go.sum, so reset the branch before formatting.
+git reset --hard
+make GOIMPORTS="$GOIMPORTS" fmt
+
+echo "Looking for files that are not formatted correctly..."
+git status -s
+[ -z "$(git status --porcelain)" ]

--- a/tools/filetools.go
+++ b/tools/filetools.go
@@ -272,11 +272,11 @@ type fastWalkInfo struct {
 }
 
 type fastWalker struct {
-	rootDir         string
-	ch              chan fastWalkInfo
-	limit           int32
-	cur             *int32
-	wg              *sync.WaitGroup
+	rootDir string
+	ch      chan fastWalkInfo
+	limit   int32
+	cur     *int32
+	wg      *sync.WaitGroup
 }
 
 // fastWalkWithExcludeFiles walks the contents of a dir, respecting
@@ -296,11 +296,11 @@ func fastWalkWithExcludeFiles(rootDir string) *fastWalker {
 
 	c := int32(0)
 	w := &fastWalker{
-		rootDir:         rootDir,
-		limit:           int32(limit),
-		cur:             &c,
-		ch:              make(chan fastWalkInfo, 256),
-		wg:              &sync.WaitGroup{},
+		rootDir: rootDir,
+		limit:   int32(limit),
+		cur:     &c,
+		ch:      make(chan fastWalkInfo, 256),
+		wg:      &sync.WaitGroup{},
 	}
 
 	go func() {

--- a/tools/iotools.go
+++ b/tools/iotools.go
@@ -146,11 +146,10 @@ func Spool(to io.Writer, from io.Reader, dir string) (n int64, err error) {
 
 // Split the input on the NUL character. Usable with bufio.Scanner.
 func SplitOnNul(data []byte, atEOF bool) (advance int, token []byte, err error) {
-	for i:= 0; i < len(data); i++ {
+	for i := 0; i < len(data); i++ {
 		if data[i] == '\x00' {
-			return i+1, data[:i], nil
+			return i + 1, data[:i], nil
 		}
 	}
 	return 0, nil, nil
 }
-


### PR DESCRIPTION
Sometimes we get contributions from folks who aren't very familiar with Go.  This is great, but since they aren't familiar with Go, they don't know to use go fmt or goimports to tidy files.  This leads to files that are misformatted, which then causes problems when users who do have these tools are doing development.

Let's help people check formatting automatically by running it as part of the CI job.  We already check for trailing whitespace, which is complementary (since it looks at non-Go files as well), and that check has been effective, so likely this one will be as well.

There is one potential downside: sometimes output changes between versions of Go.  This is unfortunate, but we'll need to just pin to whatever version GitHub Actions uses.
