### PR TITLE
Support fetching entire history of specific refs

### DIFF
--- a/docs/man/git-lfs-fetch.1.ronn
+++ b/docs/man/git-lfs-fetch.1.ronn
@@ -25,10 +25,11 @@ This does not update the working copy.
   that would otherwise be downloaded. See [RECENT CHANGES]
 
 * `--all`:
-  Download all objects referenced by any commit that is reachable; this is
-  primarily for backup / migration purposes. Cannot be combined with --recent or
-  --include/--exclude. Ignores any globally configured include and exclude paths
-  to ensure that all objects are downloaded.
+  Download all objects that are referenced by any commit reachable from the refs
+  provided as arguments. If no refs are provided, then all refs are pushed. This
+  is primarily for backup and migration purposes. Cannot be combined with
+  --recent or --include/--exclude. Ignores any globally configured include and
+  exclude paths to ensure that all objects are downloaded.
 
 * `--prune` `-p`:
   Prune old and unreferenced objects after fetching, equivalent to running
@@ -125,6 +126,11 @@ What changes are considered 'recent' is based on a number of gitconfig options:
 * Fetch the LFS objects for the current ref from a secondary remote 'upstream'
 
   `git lfs fetch upstream`
+
+* Fetch all the LFS objects from the default remote that are referenced by any
+  commit in the `master` and `develop` branches
+
+  `git lfs fetch --all master develop`
 
 * Fetch the LFS objects for a branch from origin
 

--- a/docs/man/git-lfs-fetch.1.ronn
+++ b/docs/man/git-lfs-fetch.1.ronn
@@ -26,8 +26,8 @@ This does not update the working copy.
 
 * `--all`:
   Download all objects that are referenced by any commit reachable from the refs
-  provided as arguments. If no refs are provided, then all refs are pushed. This
-  is primarily for backup and migration purposes. Cannot be combined with
+  provided as arguments. If no refs are provided, then all refs are fetched.
+  This is primarily for backup and migration purposes. Cannot be combined with
   --recent or --include/--exclude. Ignores any globally configured include and
   exclude paths to ensure that all objects are downloaded.
 
@@ -130,7 +130,7 @@ What changes are considered 'recent' is based on a number of gitconfig options:
 * Fetch all the LFS objects from the default remote that are referenced by any
   commit in the `master` and `develop` branches
 
-  `git lfs fetch --all master develop`
+  `git lfs fetch --all origin master develop`
 
 * Fetch the LFS objects for a branch from origin
 

--- a/t/t-fetch.sh
+++ b/t/t-fetch.sh
@@ -371,6 +371,7 @@ begin_test "fetch-all"
   git push origin branch3
   git push origin remote_branch_only
   git push origin tag_only
+  git push origin tag1
   for ((a=0; a < NUMFILES ; a++))
   do
     assert_server_object "$reponame" "${oid[$a]}"
@@ -391,6 +392,32 @@ begin_test "fetch-all"
     assert_local_object "${oid[$a]}" "${#content[$a]}"
   done
 
+  rm -rf .git/lfs/objects
+
+  # fetch all objects reachable from the master branch only
+  git lfs fetch --all origin master
+  for a in 0 1 3 5 7 9 10 11
+  do
+    assert_local_object "${oid[$a]}" "${#content[$a]}"
+  done
+  for a in 2 4 6 8
+  do
+    refute_local_object "${oid[$a]}"
+  done
+
+  rm -rf .git/lfs/objects
+
+  # fetch all objects reachable from branch1 and tag1 only
+  git lfs fetch --all origin branch1 tag1
+  for a in 0 1 2 3 5 6
+  do
+    assert_local_object "${oid[$a]}" "${#content[$a]}"
+  done
+  for a in 4 7 8 9 10 11
+  do
+    refute_local_object "${oid[$a]}"
+  done
+
   # Make a bare clone of the repository
   cd ..
   git clone --bare "$GITSERVER/$reponame" "$reponame-bare"
@@ -401,6 +428,32 @@ begin_test "fetch-all"
   for ((a=0; a < NUMFILES ; a++))
   do
     assert_local_object "${oid[$a]}" "${#content[$a]}"
+  done
+
+  rm -rf lfs/objects
+
+  # fetch all objects reachable from the master branch only
+  git lfs fetch --all origin master
+  for a in 0 1 3 5 7 9 10 11
+  do
+    assert_local_object "${oid[$a]}" "${#content[$a]}"
+  done
+  for a in 2 4 6 8
+  do
+    refute_local_object "${oid[$a]}"
+  done
+
+  rm -rf lfs/objects
+
+  # fetch all objects reachable from branch1 and tag1 only
+  git lfs fetch --all origin branch1 tag1
+  for a in 0 1 2 3 5 6
+  do
+    assert_local_object "${oid[$a]}" "${#content[$a]}"
+  done
+  for a in 4 7 8 9 10 11
+  do
+    refute_local_object "${oid[$a]}"
   done
 )
 end_test

--- a/t/t-fetch.sh
+++ b/t/t-fetch.sh
@@ -398,7 +398,8 @@ begin_test "fetch-all"
 
   # Preform the same assertion as above, on the same data
   git lfs fetch --all origin
-  for ((a=0; a < NUMFILES ; a++)); do
+  for ((a=0; a < NUMFILES ; a++))
+  do
     assert_local_object "${oid[$a]}" "${#content[$a]}"
   done
 )


### PR DESCRIPTION
### Motivation

I’m currently working on an automation that synchronizes Git repositories between remotes, some of which use Git LFS. Compared to `git lfs fetch --all`, I’d like to fetch all objects referenced in the entire commit history but, and here comes the difference, not for all refs but *only a specific set of refs.*

For this reason, I’d like extend `git lfs fetch` to support downloading all objects referenced by any commit reachable from a user-defined set of refs.

### Design

I suggest allowing `git lfs fetch` to accept a combination of the `--all` option and a list of refs specified as positional command-line arguments. This would then instruct Git LFS to download all objects referenced by any commit reachable from any of the specified refs (but no other objects).

For example, the call
```sh
$ git lfs fetch --all origin master develop v1.0.0
```
would download all objects referenced by *any commit* in the `master` and `develop` branches as well as the `v1.0.0` tag—not just the tips of those branches and tags. However, objects stemming from a `sandbox` branch or a `v0.1.0` tag would not be downloaded if they aren’t contained in `master`, `develop`, or `v1.0.0`.

In contrast,
```sh
$ git lfs fetch origin master develop v1.0.0
```
only downloads objects referenced by the tips of `master`, `develop`, and `v1.0.0` but none of the objects from earlier commits.

### Implementation

I based the implementation off the preexisting functions used when providing the `--all` option and when providing just a list of refs without `--all`. I’ve added tests covering the new usage of the `--all` option to show that indeed only objects referenced by commits reachable from the requested refs (but none aside from those) will be fetched.