### PR TITLE
Add support for CentOS 8

### DIFF
--- a/docker/run_dockers.bsh
+++ b/docker/run_dockers.bsh
@@ -55,7 +55,7 @@ done
 
 if [[ ${#IMAGES[@]} == 0 ]]; then
   # If you change this list, change script/upload as well.
-  IMAGES=(centos_6 centos_7 debian_8 debian_9 debian_10)
+  IMAGES=(centos_6 centos_7 centos_8 debian_8 debian_9 debian_10)
 fi
 
 mkdir -p "${PACKAGE_DIR}"

--- a/rpm/SPECS/rubygem-hpricot.spec
+++ b/rpm/SPECS/rubygem-hpricot.spec
@@ -18,14 +18,19 @@ Requires:       ruby
 a swift, liberal HTML parser with a fantastic library
 
 %prep
-%setup -q -c -T
+%setup -q -n %{gem_name}-%{version}
+%if ! 0%{?el8}
 gem install -V --local --force --install-dir ./%{gemdir} %{SOURCE0}
+%endif
 #mv ./%{gemdir}/bin ./usr/local
 
 %build
+%if 0%{?el8}
+gem build ../%{gem_name}-%{version}.gemspec
+%gem_install
+%endif
 
 %install
-[ "$RPM_BUILD_ROOT" != "/" ] && rm -rf $RPM_BUILD_ROOT
 mkdir -p ${RPM_BUILD_ROOT}
 cp -a ./usr ${RPM_BUILD_ROOT}/usr
 
@@ -34,7 +39,16 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
+%if 0%{?el8}
+%dir %{gem_instdir}
+%{gem_extdir_mri}
+%{gem_libdir}
+%exclude %{gem_cache}
+%{gem_spec}
+/usr/share/gems
+%else
 %{gemdir}
+%endif
 
 %changelog
 * Wed May 20 2015 Andrew Neff <andyneff@users.noreply.github.com> - 2.1.8

--- a/rpm/SPECS/rubygem-mustache.spec
+++ b/rpm/SPECS/rubygem-mustache.spec
@@ -20,14 +20,19 @@ BuildArch:      noarch
 Inspired by ctemplate, Mustache is a framework-agnostic way to render logic-free views. As ctemplates says, "It emphasizes separating logic from presentation: it is impossible to embed application logic in this template language. Think of Mustache as a replacement for your views. Instead of views consisting of ERB or HAML with random helpers and arbitrary logic, your views are broken into two parts: a Ruby class and an HTML template.
 
 %prep
-%setup -q -c -T
+%setup -q -n %{gem_name}-%{version}
+%if ! 0%{?el8}
 gem install -V --local --force --install-dir ./%{gemdir} %{SOURCE0}
 mv ./%{gemdir}/bin ./usr/local
+%endif
 
 %build
+%if 0%{?el8}
+gem build ../%{gem_name}-%{version}.gemspec
+%gem_install
+%endif
 
 %install
-[ "$RPM_BUILD_ROOT" != "/" ] && rm -rf $RPM_BUILD_ROOT
 mkdir -p ${RPM_BUILD_ROOT}
 cp -a ./usr ${RPM_BUILD_ROOT}/usr
 
@@ -36,8 +41,16 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
+%if 0%{?el8}
+%dir %{gem_instdir}
+%{gem_libdir}
+%exclude %{gem_cache}
+/usr/share/gems
+/usr/bin/%{gem_name}
+%else
 %{gemdir}
 /usr/local/bin/%{gem_name}
+%endif
 
 %changelog
 * Wed May 20 2015 Andrew Neff <andyneff@users.noreply.github.com> - 2.1.8

--- a/rpm/SPECS/rubygem-rdiscount.spec
+++ b/rpm/SPECS/rubygem-rdiscount.spec
@@ -18,14 +18,19 @@ Requires:       ruby > 1.9.2
 Fast Implementation of Gruber's Markdown in C
 
 %prep
-%setup -q -c -T
+%setup -q -n %{gem_name}-%{version}
+%if ! 0%{?el8}
 gem install -V --local --force --install-dir ./%{gemdir} %{SOURCE0}
 mv ./%{gemdir}/bin ./usr/local
+%endif
 
 %build
+%if 0%{?el8}
+gem build ../%{gem_name}-%{version}.gemspec
+%gem_install
+%endif
 
 %install
-[ "$RPM_BUILD_ROOT" != "/" ] && rm -rf $RPM_BUILD_ROOT
 mkdir -p ${RPM_BUILD_ROOT}
 cp -a ./usr ${RPM_BUILD_ROOT}/usr
 
@@ -34,8 +39,18 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
+%if 0%{?el8}
+%dir %{gem_instdir}
+%{gem_extdir_mri}
+%{gem_libdir}
+%exclude %{gem_cache}
+/usr/share/gems
+/usr/bin/%{gem_name}
+%{gem_spec}
+%else
 %{gemdir}
 /usr/local/bin/%{gem_name}
+%endif
 
 %changelog
 * Wed May 20 2015 Andrew Neff <andyneff@users.noreply.github.com> - 2.1.8

--- a/rpm/SPECS/rubygem-ronn.spec
+++ b/rpm/SPECS/rubygem-ronn.spec
@@ -23,14 +23,19 @@ BuildArch:      noarch
 Builds Manuals
 
 %prep
-%setup -q -c -T
+%setup -q -n %{gem_name}-%{version}
+%if ! 0%{?el8}
 gem install -V --local --force --install-dir ./%{gemdir} %{SOURCE0}
 mv ./%{gemdir}/bin ./usr/local
+%endif
 
 %build
+%if 0%{?el8}
+gem build ../%{gem_name}-%{version}.gemspec
+%gem_install
+%endif
 
 %install
-[ "$RPM_BUILD_ROOT" != "/" ] && rm -rf $RPM_BUILD_ROOT
 mkdir -p ${RPM_BUILD_ROOT}
 cp -a ./usr ${RPM_BUILD_ROOT}/usr
 
@@ -39,8 +44,17 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
+%if 0%{?el8}
+%dir %{gem_instdir}
+%{gem_libdir}
+%exclude %{gem_cache}
+%{gem_spec}
+/usr/share/gems
+/usr/bin/%{gem_name}
+%else
 %{gemdir}
 /usr/local/bin/%{gem_name}
+%endif
 
 %changelog
 * Wed May 20 2015 Andrew Neff <andyneff@users.noreply.github.com> - 2.1.8

--- a/rpm/build_rpms.bsh
+++ b/rpm/build_rpms.bsh
@@ -119,6 +119,10 @@ if [[ ${RUBY_VERSION[0]} < 2 ]]; then
   fi
 fi
 
+if [[ ${VERSION_ID[0]} == 8 ]]; then
+  $SUDO yum install -y rubygems-devel
+fi
+
 if ! which ronn; then
   echo "Downloading some ruby gems..."
   pushd ${CURDIR}/SOURCES

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -56,6 +56,9 @@ $distro_name_map = {
     "sles/12.3", # LTSS ends 30 Jun 2022
     "sles/15.0"  # Current
   ],
+  "centos/8" => [
+    "el/8",
+  ],
   # Debian EOL https://wiki.debian.org/LTS/
   # Ubuntu EOL https://wiki.ubuntu.com/Releases
   # Mint EOL https://linuxmint.com/download_all.php

--- a/script/upload
+++ b/script/upload
@@ -178,6 +178,7 @@ Up to date packages are available on [PackageCloud](https://packagecloud.io/gith
 
 [RPM RHEL 6/CentOS 6](https://packagecloud.io/github/git-lfs/packages/el/6/git-lfs-VERSION-1.el6.x86_64.rpm/download)
 [RPM RHEL 7/CentOS 7](https://packagecloud.io/github/git-lfs/packages/el/7/git-lfs-VERSION-1.el7.x86_64.rpm/download)
+[RPM RHEL 8/CentOS 8](https://packagecloud.io/github/git-lfs/packages/el/8/git-lfs-VERSION-1.el8.x86_64.rpm/download)
 [Debian 8](https://packagecloud.io/github/git-lfs/packages/debian/jessie/git-lfs_VERSION_amd64.deb/download)
 [Debian 9](https://packagecloud.io/github/git-lfs/packages/debian/stretch/git-lfs_VERSION_amd64.deb/download)
 [Debian 10](https://packagecloud.io/github/git-lfs/packages/debian/buster/git-lfs_VERSION_amd64.deb/download)


### PR DESCRIPTION
Build packages for CentOS 8.  Add it to the list of containers we build for and the list of packages we have downloads available for.

In the gem spec files, use a different tooling on CentOS 8, since the old method no longer works there.  Build using a more standard gem build process so that RPM does the abstraction for us now that it's capable of it.  Stop deleting the root in the install step since we may have installed things there by that point, and RPM has handled this properly for many versions.

Since the syntax "%{?el8}" expands to "1" on CentOS 8 and nothing on earlier versions, add a 0 in front of it any time we use the macro so that we don't end up with an empty conditional on earlier versions. "01" is still true and "0" is false, so the logic works out.

It's been verified that the packages still build on CentOS 7 as well as CentOS 8.
