### PR TITLE
ls-files --all man patch

### DIFF
--- a/docs/man/git-lfs-ls-files.1.ronn
+++ b/docs/man/git-lfs-ls-files.1.ronn
@@ -28,7 +28,7 @@ LFS pointer.
   Show as much information as possible about a LFS file. This is intended
   for manual inspection; the exact format may change at any time.
 
-* `-a --all`:
+* `-a` `--all`:
   Inspects the full history of the repository, not the current HEAD (or other
   provided reference).
 

--- a/docs/man/git-lfs-ls-files.1.ronn
+++ b/docs/man/git-lfs-ls-files.1.ronn
@@ -24,11 +24,11 @@ LFS pointer.
 * `-s` `--size`:
   Show the size of the LFS object between parenthesis at the end of a line.
 
-* -d --debug:
+* `-d` `--debug`:
   Show as much information as possible about a LFS file. This is intended
   for manual inspection; the exact format may change at any time.
 
-* -a --all:
+* `-a --all`:
   Inspects the full history of the repository, not the current HEAD (or other
   provided reference).
 

--- a/docs/man/git-lfs-ls-files.1.ronn
+++ b/docs/man/git-lfs-ls-files.1.ronn
@@ -30,7 +30,8 @@ LFS pointer.
 
 * `-a` `--all`:
   Inspects the full history of the repository, not the current HEAD (or other
-  provided reference).
+  provided reference). This will include previous versions of LFS objects that
+  are no longer found in the current tree.
 
 * `--deleted`:
   Shows the full history of the given reference, including objects that have


### PR DESCRIPTION
I've fixed some minor formatting on the man page of the `git lfs ls-files --all`.

I believe it may be worth adding a sentence along the lines of "This will include previous versions of LFS objects that are no longer found in the current tree." to make its use clearer. Should I add that to this PR?



Context - I've been providing support for LFS for a while but have only just found out about the --all flag introduced in https://github.com/git-lfs/git-lfs/pull/2796 ."How do I find the object IDs of old versions of LFS files?" is a common support request.

I also plan to add that flag to the tutorial - https://github.com/git-lfs/git-lfs/wiki/Tutorial 