### PR TITLE
release: v2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,76 @@
 # Git LFS Changelog
 
+## 2.9.0 (17 October 2019)
+
+This release adds support for DragonFly BSD, adds a new `git lfs dedup` command
+to save space if the file system supports it, adds support for file URLs,
+improves the performance when walking the repository, contains improvements
+to use HTTP/2 when available and cookies when required, and numerous other bug
+fixes, features, and modifications.
+
+We would like to extend a special thanks to the following open-source
+contributors:
+
+* @pluehne for adding support for fetching the history of specific refs
+* @kupson for adding cookie support
+* @liweitianux for adding Dragonfly BSD support
+* @kazuki-ma for implementing de-duplication support
+* @dvdveer for adding range support to ls-files
+* @dyrone, @pmeerw, @yamiacat, and @kittenking for cleaning up some documentation issues
+* @slonopotamus for improving concurrent downloads
+* @nataliechen1 for fixing remote names with dots
+* @jw3 for removing excessive logging
+* @SeamusConnor for significantly improving performance when walking the repository
+
+### Features
+
+* Support fetching entire history of specific refs #3849 (@pluehne)
+* Add support for CentOS 8 #3854 (@bk2204)
+* Let git-lfs HTTPS transport send cookies #3825 (@kupson)
+* Support DragonFly BSD #3837 (@liweitianux)
+* HTTP/2 protocol support #3793 (@PastelMobileSuit)
+* Add clonefile on Windows over ReFS support. #3790 (@kazuki-ma)
+* Add new command `git lfs dedup` for file system level de-duplication. #3753 (@kazuki-ma)
+* Support GIT_ALTERNATE_OBJECT_DIRECTORIES #3765 (@bk2204)
+* ls-files: add support for reference range #3764 (@dvdveer)
+* Add several additional distros for packagecloud.io #3751 (@bk2204)
+* Provide an option to track to handle paths literally #3756 (@bk2204)
+* Optimize traversal of Git objects with URL remotes #3755 (@bk2204)
+* Support for file URLs #3748 (@bk2204)
+* Add clone file on MacOS X (darwin). #3745 (@kazuki-ma)
+
+### Bugs
+
+* Fix JSON comma problems in docs #3851 (@dyrone)
+* Remove redundant comma in batch.md #3841 (@dyrone)
+* More robust handling of parallel attempts to download the same file #3826 (@slonopotamus)
+* Update wildmatch to v1.0.4 #3820 (@bk2204)
+* Update to gitobj v1.4.1 #3815 (@bk2204)
+* Fix build error when cross-compiling #3817 (@bk2204)
+* Do not fail when multiple processes download the same lfs file #3813 (@slonopotamus)
+* Fix Remote Name Parsing Bug #3812 (@nataliechen1)
+* status: gracefully handle files replaced by directories #3768 (@bk2204)
+* Avoid deadlock when transfer queue fails #3800 (@bk2204)
+* Avoid a hang when Git is slow to provide us data #3806 (@bk2204)
+* tasklog/log.go: print "done" messages with a trailing period #3789 (@ttaylorr)
+* track: make --filename work with spaces #3785 (@bk2204)
+* Fix couple of 'the the' typos #3786 (@pmeerw)
+* Use an absolute path for smudging #3780 (@bk2204)
+* Fix URL parsing with Go 1.12.8 #3771 (@bk2204)
+* Fix remote autoselection when not on a branch #3759 (@bk2204)
+* Replace deprecated SEEK_SET, SEEK_CUR usage. #3739 (@kazuki-ma)
+* Do not log skipped checkouts to file #3736 (@jw3)
+* Fix typos across git-lfs repository #3728 (@kittenking)
+* Accept legacy Git SSH URLs #3713 (@bk2204)
+
+### Misc
+
+* ls-files --all man patch #3859 (@yamiacat)
+* Reworked to use git ls-files in some circumstances instead of FastWalkGitRepo #3823 (@SeamusConnor)
+* Clean up go.mod for Go 1.13 #3807 (@bk2204)
+* Use FICLONE instead of BTRFS_IOC_CLONE. #3796 (@kazuki-ma)
+* Remove unused pty code #3737 (@bk2204)
+
 ## 2.8.0 (23 July 2019)
 
 This release adds support for SOCKS proxies and Windows junctions, adds native

--- a/config/version.go
+++ b/config/version.go
@@ -13,7 +13,7 @@ var (
 )
 
 const (
-	Version = "2.8.0"
+	Version = "2.9.0"
 )
 
 func init() {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+git-lfs (2.9.0) stable; urgency=low
+
+  * New upstream version
+
+ -- brian m. carlson <bk2204@github.com>  Thu, 17 Oct 2019 14:29:00 -0000
+
 git-lfs (2.8.0) stable; urgency=low
 
   * New upstream version

--- a/rpm/SPECS/git-lfs.spec
+++ b/rpm/SPECS/git-lfs.spec
@@ -1,5 +1,5 @@
 Name:           git-lfs
-Version:        2.8.0
+Version:        2.9.0
 Release:        1%{?dist}
 Summary:        Git extension for versioning large files
 

--- a/script/update-version
+++ b/script/update-version
@@ -14,7 +14,7 @@ user_id () {
 update_go () {
   local version="$1"
 
-  sed -i '' -e "s/\(Version = \)\"[0-9.]*\"/\\1\"$version\"/" config/version.go
+  sed -i -e "s/\(Version = \)\"[0-9.]*\"/\\1\"$version\"/" config/version.go
 }
 
 update_debian () {

--- a/versioninfo.json
+++ b/versioninfo.json
@@ -3,7 +3,7 @@
 	{
 		"FileVersion": {
 			"Major": 2,
-			"Minor": 8,
+			"Minor": 9,
 			"Patch": 0,
 			"Build": 0
 		}
@@ -13,7 +13,7 @@
 		"FileDescription": "Git LFS",
 		"LegalCopyright": "GitHub, Inc. and Git LFS contributors",
 		"ProductName": "Git Large File Storage (LFS)",
-		"ProductVersion": "2.8.0"
+		"ProductVersion": "2.9.0"
 	},
 	"IconPath": "script/windows-installer/git-lfs-logo.ico"
 }


### PR DESCRIPTION
This is an in-progress look at the next release of Git LFS, v2.9.0, which is scheduled for Thursday, October 17, 2019.

We're publishing these changes early so that folks on @git-lfs/implementers can check that things work with their various platforms.

I've attached some builds below for people to use for testing:

[git-lfs-darwin-386-v2.9.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/3731430/git-lfs-darwin-386-v2.9.0-pre.tar.gz)
[git-lfs-darwin-amd64-v2.9.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/3731431/git-lfs-darwin-amd64-v2.9.0-pre.tar.gz)
[git-lfs-freebsd-386-v2.9.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/3731432/git-lfs-freebsd-386-v2.9.0-pre.tar.gz)
[git-lfs-freebsd-amd64-v2.9.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/3731433/git-lfs-freebsd-amd64-v2.9.0-pre.tar.gz)
[git-lfs-linux-386-v2.9.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/3731434/git-lfs-linux-386-v2.9.0-pre.tar.gz)
[git-lfs-linux-amd64-v2.9.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/3731435/git-lfs-linux-amd64-v2.9.0-pre.tar.gz)
[git-lfs-linux-arm64-v2.9.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/3731436/git-lfs-linux-arm64-v2.9.0-pre.tar.gz)
[git-lfs-v2.9.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/3731437/git-lfs-v2.9.0-pre.tar.gz)
[git-lfs-windows-386-v2.9.0-pre.zip](https://github.com/git-lfs/git-lfs/files/3731438/git-lfs-windows-386-v2.9.0-pre.zip)
[git-lfs-windows-amd64-v2.9.0-pre.zip](https://github.com/git-lfs/git-lfs/files/3731439/git-lfs-windows-amd64-v2.9.0-pre.zip)

/cc @git-lfs/core
/cc @git-lfs/implementers
/cc @git-lfs/releases