### PR TITLE
Do not delete zero-sized file from LFS storage

### DIFF
--- a/lfs/gitfilter_smudge.go
+++ b/lfs/gitfilter_smudge.go
@@ -62,7 +62,7 @@ func (f *GitFilter) Smudge(writer io.Writer, ptr *Pointer, workingfile string, d
 	stat, statErr := os.Stat(mediafile)
 	if statErr == nil && stat != nil {
 		fileSize := stat.Size()
-		if fileSize == 0 || fileSize != ptr.Size {
+		if fileSize != ptr.Size {
 			tracerx.Printf("Removing %s, size %d is invalid", mediafile, fileSize)
 			os.RemoveAll(mediafile)
 			stat = nil


### PR DESCRIPTION
Because it:
1. Doesn't add any value
2. Introduces a source of race conditions to download logic when multiple git-lfs instances share LFS storage
3. Forces git-lfs to oscillate between two strange states when empty file is downloaded from LFS server. See #3863