### PR TITLE
Fix error strings to follow Go guidelines

### DIFF
--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -139,7 +139,7 @@ func whichCheckout() (stage git.IndexStage, err error) {
 	}
 
 	if seen > 1 {
-		return 0, fmt.Errorf("At most one of --base, --theirs, and --ours is allowed")
+		return 0, fmt.Errorf("at most one of --base, --theirs, and --ours is allowed")
 	}
 	return stage, nil
 }

--- a/commands/command_filter_process.go
+++ b/commands/command_filter_process.go
@@ -161,7 +161,7 @@ func filterCommand(cmd *cobra.Command, args []string) {
 			}
 			err = s.WriteList(paths)
 		default:
-			ExitWithError(fmt.Errorf("Unknown command %q", req.Header["command"]))
+			ExitWithError(fmt.Errorf("unknown command %q", req.Header["command"]))
 		}
 
 		if errors.IsNotAPointerError(err) {

--- a/commands/command_pointer.go
+++ b/commands/command_pointer.go
@@ -145,7 +145,7 @@ func pointerCommand(cmd *cobra.Command, args []string) {
 func pointerReader() (io.ReadCloser, error) {
 	if len(pointerCompare) > 0 {
 		if pointerStdin {
-			return nil, errors.New("Cannot read from STDIN and --pointer.")
+			return nil, errors.New("cannot read from STDIN and --pointer")
 		}
 
 		return os.Open(pointerCompare)

--- a/commands/command_prune.go
+++ b/commands/command_prune.go
@@ -311,7 +311,7 @@ func pruneDeleteFiles(prunableObjects []string, logger *tasklog.Logger) {
 		task.Count(1)
 	}
 	if problems.Len() > 0 {
-		LoggedError(fmt.Errorf("Failed to delete some files"), problems.String())
+		LoggedError(fmt.Errorf("failed to delete some files"), problems.String())
 		Exit("Prune failed, see errors above")
 	}
 }
@@ -416,7 +416,7 @@ func pruneTaskGetRetainedCurrentAndRecentRefs(gitscanner *lfs.GitScanner, fetchc
 			// We measure from the last commit at the ref
 			summ, err := git.GetCommitSummary(commit)
 			if err != nil {
-				errorChan <- fmt.Errorf("Couldn't scan commits at %v: %v", commit, err)
+				errorChan <- fmt.Errorf("couldn't scan commits at %v: %v", commit, err)
 				continue
 			}
 			commitsSince := summ.CommitDate.AddDate(0, 0, -pruneCommitDays)

--- a/commands/pull.go
+++ b/commands/pull.go
@@ -87,7 +87,7 @@ func (c *singleCheckout) Run(p *lfs.WrappedPointer) {
 			// acceptable error, data not local (fetch not run or include/exclude)
 			Error("Skipped checkout for %q, content not local. Use fetch to download.", p.Name)
 		} else {
-			FullError(fmt.Errorf("Could not check out %q", p.Name))
+			FullError(fmt.Errorf("could not check out %q", p.Name))
 		}
 		return
 	}

--- a/creds/creds.go
+++ b/creds/creds.go
@@ -314,7 +314,7 @@ func (h *commandCredentialHelper) exec(subcommand string, input Creds) (Creds, e
 
 	if _, ok := err.(*exec.ExitError); ok {
 		if h.SkipPrompt {
-			return nil, fmt.Errorf("Change the GIT_TERMINAL_PROMPT env var to be prompted to enter your credentials for %s://%s.",
+			return nil, fmt.Errorf("change the GIT_TERMINAL_PROMPT env var to be prompted to enter your credentials for %s://%s",
 				input["protocol"], input["host"])
 		}
 

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestChecksHandleGoErrors(t *testing.T) {
-	err := errors.New("Go Error")
+	err := errors.New("go error")
 
 	if IsFatalError(err) {
 		t.Error("go error should not be a fatal error")
@@ -14,7 +14,7 @@ func TestChecksHandleGoErrors(t *testing.T) {
 }
 
 func TestCheckHandlesWrappedErrors(t *testing.T) {
-	err := errors.New("Go error")
+	err := errors.New("go error")
 
 	fatal := NewFatalError(err)
 
@@ -24,7 +24,7 @@ func TestCheckHandlesWrappedErrors(t *testing.T) {
 }
 
 func TestBehaviorWraps(t *testing.T) {
-	err := errors.New("Go error")
+	err := errors.New("go error")
 
 	fatal := NewFatalError(err)
 	ni := NewNotImplementedError(fatal)
@@ -43,7 +43,7 @@ func TestBehaviorWraps(t *testing.T) {
 }
 
 func TestContextOnGoErrors(t *testing.T) {
-	err := errors.New("Go error")
+	err := errors.New("go error")
 
 	SetContext(err, "foo", "bar")
 
@@ -54,7 +54,7 @@ func TestContextOnGoErrors(t *testing.T) {
 }
 
 func TestContextOnWrappedErrors(t *testing.T) {
-	err := NewFatalError(errors.New("Go error"))
+	err := NewFatalError(errors.New("go error"))
 
 	SetContext(err, "foo", "bar")
 

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -67,7 +67,7 @@ func (f *Filesystem) ObjectExists(oid string, size int64) bool {
 func (f *Filesystem) ObjectPath(oid string) (string, error) {
 	dir := f.localObjectDir(oid)
 	if err := tools.MkdirAll(dir, f); err != nil {
-		return "", fmt.Errorf("Error trying to create local storage directory in %q: %s", dir, err)
+		return "", fmt.Errorf("error trying to create local storage directory in %q: %s", dir, err)
 	}
 	return filepath.Join(dir, oid), nil
 }

--- a/git/filter_process_scanner_test.go
+++ b/git/filter_process_scanner_test.go
@@ -132,7 +132,7 @@ func TestFilterProcessScannerRejectsInvalidHeaderPackets(t *testing.T) {
 	req, err := readRequest(NewFilterProcessScanner(from, nil))
 
 	require.NotNil(t, err)
-	assert.Equal(t, "Invalid packet length.", err.Error())
+	assert.Equal(t, "invalid packet length", err.Error())
 
 	assert.Nil(t, req)
 }

--- a/git/git.go
+++ b/git/git.go
@@ -201,7 +201,7 @@ func HashObject(r io.Reader) (string, error) {
 	cmd.Stdin = r
 	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("Error building Git blob OID: %s", err)
+		return "", fmt.Errorf("error building Git blob OID: %s", err)
 	}
 
 	return string(bytes.TrimSpace(out)), nil
@@ -329,7 +329,7 @@ func RemoteList() ([]string, error) {
 
 	outp, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to call git remote: %v", err)
+		return nil, fmt.Errorf("failed to call git remote: %v", err)
 	}
 	cmd.Start()
 	defer cmd.Wait()
@@ -351,7 +351,7 @@ func LocalRefs() ([]*Ref, error) {
 
 	outp, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to call git show-ref: %v", err)
+		return nil, fmt.Errorf("failed to call git show-ref: %v", err)
 	}
 
 	var refs []*Ref
@@ -419,7 +419,7 @@ func ValidateRemote(remote string) error {
 		return nil
 	}
 
-	return fmt.Errorf("Invalid remote name: %q", remote)
+	return fmt.Errorf("invalid remote name: %q", remote)
 }
 
 // ValidateRemoteURL checks that a string is a valid Git remote URL
@@ -434,7 +434,7 @@ func ValidateRemoteURL(remote string) error {
 		if strings.Contains(remote, ":") {
 			return nil
 		} else {
-			return fmt.Errorf("Invalid remote name: %q", remote)
+			return fmt.Errorf("invalid remote name: %q", remote)
 		}
 	}
 
@@ -442,7 +442,7 @@ func ValidateRemoteURL(remote string) error {
 	case "ssh", "http", "https", "git", "file":
 		return nil
 	default:
-		return fmt.Errorf("Invalid remote url protocol %q in %q", u.Scheme, remote)
+		return fmt.Errorf("invalid remote url protocol %q in %q", u.Scheme, remote)
 	}
 }
 
@@ -462,7 +462,7 @@ func RecentBranches(since time.Time, includeRemoteBranches bool, onlyRemote stri
 		"refs")
 	outp, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to call git for-each-ref: %v", err)
+		return nil, fmt.Errorf("failed to call git for-each-ref: %v", err)
 	}
 	cmd.Start()
 	defer cmd.Wait()
@@ -560,7 +560,7 @@ func GetCommitSummary(commit string) (*CommitSummary, error) {
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to call git show: %v %v", err, string(out))
+		return nil, fmt.Errorf("failed to call git show: %v %v", err, string(out))
 	}
 
 	// At most 10 substrings so subject line is not split on anything
@@ -597,7 +597,7 @@ func GitAndRootDirs() (string, string, error) {
 	out, err := cmd.Output()
 	output := string(out)
 	if err != nil {
-		return "", "", fmt.Errorf("Failed to call git rev-parse --git-dir --show-toplevel: %q", buf.String())
+		return "", "", fmt.Errorf("failed to call git rev-parse --git-dir --show-toplevel: %q", buf.String())
 	}
 
 	paths := strings.Split(output, "\n")
@@ -608,12 +608,12 @@ func GitAndRootDirs() (string, string, error) {
 	}
 
 	if pathLen == 0 {
-		return "", "", fmt.Errorf("Bad git rev-parse output: %q", output)
+		return "", "", fmt.Errorf("bad git rev-parse output: %q", output)
 	}
 
 	absGitDir, err := canonicalizeDir(paths[0])
 	if err != nil {
-		return "", "", fmt.Errorf("Error converting %q to absolute: %s", paths[0], err)
+		return "", "", fmt.Errorf("error converting %q to absolute: %s", paths[0], err)
 	}
 
 	if pathLen == 1 || len(paths[1]) == 0 {
@@ -639,7 +639,7 @@ func RootDir() (string, error) {
 	cmd := gitNoLFS("rev-parse", "--show-toplevel")
 	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("Failed to call git rev-parse --show-toplevel: %v %v", err, string(out))
+		return "", fmt.Errorf("failed to call git rev-parse --show-toplevel: %v %v", err, string(out))
 	}
 
 	path := strings.TrimSpace(string(out))
@@ -654,7 +654,7 @@ func GitDir() (string, error) {
 	cmd := gitNoLFS("rev-parse", "--git-dir")
 	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("Failed to call git rev-parse --git-dir: %v %v", err, string(out))
+		return "", fmt.Errorf("failed to call git rev-parse --git-dir: %v %v", err, string(out))
 	}
 	path := strings.TrimSpace(string(out))
 	path, err = tools.TranslateCygwinPath(path)
@@ -675,7 +675,7 @@ func GitCommonDir() (string, error) {
 	cmd := gitNoLFS("rev-parse", "--git-common-dir")
 	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("Failed to call git rev-parse --git-dir: %v %v", err, string(out))
+		return "", fmt.Errorf("failed to call git rev-parse --git-dir: %v %v", err, string(out))
 	}
 	path := strings.TrimSpace(string(out))
 	path, err = tools.TranslateCygwinPath(path)
@@ -937,7 +937,7 @@ func CloneWithoutFilters(flags CloneFlags, args []string) error {
 
 	err := cmd.Start()
 	if err != nil {
-		return fmt.Errorf("Failed to start git clone: %v", err)
+		return fmt.Errorf("failed to start git clone: %v", err)
 	}
 
 	err = cmd.Wait()
@@ -979,7 +979,7 @@ func CachedRemoteRefs(remoteName string) ([]*Ref, error) {
 
 	outp, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to call git show-ref: %v", err)
+		return nil, fmt.Errorf("failed to call git show-ref: %v", err)
 	}
 	cmd.Start()
 	scanner := bufio.NewScanner(outp)
@@ -1024,7 +1024,7 @@ func RemoteRefs(remoteName string) ([]*Ref, error) {
 
 	outp, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to call git ls-remote: %v", err)
+		return nil, fmt.Errorf("failed to call git ls-remote: %v", err)
 	}
 	cmd.Start()
 	scanner := bufio.NewScanner(outp)
@@ -1110,7 +1110,7 @@ func GetTrackedFiles(pattern string) ([]string, error) {
 
 	outp, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to call git ls-files: %v", err)
+		return nil, fmt.Errorf("failed to call git ls-files: %v", err)
 	}
 	cmd.Start()
 	scanner := bufio.NewScanner(outp)
@@ -1163,17 +1163,17 @@ func GetFilesChanged(from, to string) ([]string, error) {
 	cmd := gitNoLFS(args...)
 	outp, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to call git diff: %v", err)
+		return nil, fmt.Errorf("failed to call git diff: %v", err)
 	}
 	if err := cmd.Start(); err != nil {
-		return nil, fmt.Errorf("Failed to start git diff: %v", err)
+		return nil, fmt.Errorf("failed to start git diff: %v", err)
 	}
 	scanner := bufio.NewScanner(outp)
 	for scanner.Scan() {
 		files = append(files, strings.TrimSpace(scanner.Text()))
 	}
 	if err := cmd.Wait(); err != nil {
-		return nil, fmt.Errorf("Git diff failed: %v", err)
+		return nil, fmt.Errorf("git diff failed: %v", err)
 	}
 
 	return files, err

--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -226,7 +226,7 @@ func (r *Rewriter) Rewrite(opt *RewriteOptions) ([]byte, error) {
 	if len(opt.ObjectMapFilePath) > 0 {
 		objectMapFile, err = os.OpenFile(opt.ObjectMapFilePath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666)
 		if err != nil {
-			return nil, fmt.Errorf("Could not create object map file: %v", err)
+			return nil, fmt.Errorf("could not create object map file: %v", err)
 		}
 		defer objectMapFile.Close()
 	}

--- a/git/pkt_line.go
+++ b/git/pkt_line.go
@@ -37,7 +37,7 @@ func newPktline(r io.Reader, w io.Writer) *pktline {
 //    before an entire packet (or header) could be ingested, an
 //    io.ErrShortBuffer error will be returned.
 // 3) If there was a valid header, but no body associated with the packet, an
-//    "Invalid packet length." error will be returned.
+//    "invalid packet length" error will be returned.
 // 4) If the data in the header could not be parsed as a hexadecimal length in
 //    the Git pktline format, the parse error will be returned.
 //
@@ -61,7 +61,7 @@ func (p *pktline) readPacket() ([]byte, error) {
 		return nil, nil
 	}
 	if pktLen <= 4 {
-		return nil, errors.New("Invalid packet length.")
+		return nil, errors.New("invalid packet length")
 	}
 
 	payload, err := ioutil.ReadAll(io.LimitReader(p.r, pktLen-4))
@@ -108,7 +108,7 @@ func (p *pktline) readPacketList() ([]string, error) {
 // `writeFlush()`.
 func (p *pktline) writePacket(data []byte) error {
 	if len(data) > MaxPacketLength {
-		return errors.New("Packet length exceeds maximal length")
+		return errors.New("packet length exceeds maximal length")
 	}
 
 	if _, err := p.w.WriteString(fmt.Sprintf("%04x", len(data)+4)); err != nil {

--- a/git/pkt_line_test.go
+++ b/git/pkt_line_test.go
@@ -64,7 +64,7 @@ func TestPktLineEmptyPacket(t *testing.T) {
 			// No body (invalid)
 		},
 
-		Err: "Invalid packet length.",
+		Err: "invalid packet length",
 	}
 
 	tc.Assert(t)
@@ -128,7 +128,7 @@ func TestPktLineReadsTextWithErr(t *testing.T) {
 	str, err := rw.readPacketText()
 
 	require.NotNil(t, err)
-	assert.Equal(t, "Invalid packet length.", err.Error())
+	assert.Equal(t, "invalid packet length", err.Error())
 	assert.Equal(t, "", str)
 }
 
@@ -161,7 +161,7 @@ func TestPktLineAppendsPacketListsAndReturnsErrs(t *testing.T) {
 	str, err := rw.readPacketList()
 
 	require.NotNil(t, err)
-	assert.Equal(t, "Invalid packet length.", err.Error())
+	assert.Equal(t, "invalid packet length", err.Error())
 	assert.Empty(t, str)
 }
 
@@ -198,7 +198,7 @@ func TestPktLineDoesNotWritePacketsExceedingMaxLength(t *testing.T) {
 	err := rw.writePacket(make([]byte, MaxPacketLength+1))
 
 	require.NotNil(t, err)
-	assert.Equal(t, "Packet length exceeds maximal length", err.Error())
+	assert.Equal(t, "packet length exceeds maximal length", err.Error())
 	assert.Empty(t, buf.Bytes())
 }
 

--- a/git/rev_list_scanner_test.go
+++ b/git/rev_list_scanner_test.go
@@ -160,7 +160,7 @@ func TestRevListArgs(t *testing.T) {
 
 func TestRevListScannerCallsClose(t *testing.T) {
 	var called uint32
-	err := errors.New("Hello world")
+	err := errors.New("this is a marker error")
 
 	s := &RevListScanner{
 		closeFn: func() error {

--- a/lfs/attribute.go
+++ b/lfs/attribute.go
@@ -154,7 +154,7 @@ func (a *Attribute) set(gitConfig *git.Configuration, key, value string, upgrade
 		}
 		return err
 	} else if currentValue != value {
-		return fmt.Errorf("The %q attribute should be %q but is %q",
+		return fmt.Errorf("the %q attribute should be %q but is %q",
 			key, value, currentValue)
 	}
 

--- a/lfs/extension.go
+++ b/lfs/extension.go
@@ -142,7 +142,7 @@ func pipeExtensions(cfg *config.Configuration, request *pipeRequest) (response p
 		if err = ec.cmd.Wait(); err != nil {
 			if ec.err != nil {
 				errStr := ec.err.String()
-				err = fmt.Errorf("Extension '%s' failed with: %s", ec.result.name, errStr)
+				err = fmt.Errorf("extension '%s' failed with: %s", ec.result.name, errStr)
 			}
 			return
 		}

--- a/lfs/gitfilter_smudge.go
+++ b/lfs/gitfilter_smudge.go
@@ -30,12 +30,12 @@ func (f *GitFilter) SmudgeToFile(filename string, ptr *Pointer, download bool, m
 
 	abs, err := filepath.Abs(filename)
 	if err != nil {
-		return fmt.Errorf("Could not produce absolute path for %q", filename)
+		return fmt.Errorf("could not produce absolute path for %q", filename)
 	}
 
 	file, err := os.Create(abs)
 	if err != nil {
-		return fmt.Errorf("Could not create working directory file: %v", err)
+		return fmt.Errorf("could not create working directory file: %v", err)
 	}
 	defer file.Close()
 	if _, err := f.Smudge(file, ptr, filename, download, manifest, cb); err != nil {
@@ -45,7 +45,7 @@ func (f *GitFilter) SmudgeToFile(filename string, ptr *Pointer, download bool, m
 			ptr.Encode(file)
 			return err
 		} else {
-			return fmt.Errorf("Could not write working directory file: %v", err)
+			return fmt.Errorf("could not write working directory file: %v", err)
 		}
 	}
 	return nil
@@ -122,7 +122,7 @@ func (f *GitFilter) downloadFile(writer io.Writer, ptr *Pointer, workingfile, me
 func (f *GitFilter) readLocalFile(writer io.Writer, ptr *Pointer, mediafile string, workingfile string, cb tools.CopyCallback) (int64, error) {
 	reader, err := os.Open(mediafile)
 	if err != nil {
-		return 0, errors.Wrapf(err, "Error opening media file.")
+		return 0, errors.Wrapf(err, "error opening media file")
 	}
 	defer reader.Close()
 
@@ -138,7 +138,7 @@ func (f *GitFilter) readLocalFile(writer io.Writer, ptr *Pointer, mediafile stri
 		for _, ptrExt := range ptr.Extensions {
 			ext, ok := registeredExts[ptrExt.Name]
 			if !ok {
-				err := fmt.Errorf("Extension '%s' is not configured.", ptrExt.Name)
+				err := fmt.Errorf("extension '%s' is not configured", ptrExt.Name)
 				return 0, errors.Wrap(err, "smudge")
 			}
 			ext.Priority = ptrExt.Priority
@@ -171,18 +171,18 @@ func (f *GitFilter) readLocalFile(writer io.Writer, ptr *Pointer, mediafile stri
 		// verify name, order, and oids
 		oid := response.results[0].oidIn
 		if ptr.Oid != oid {
-			err = fmt.Errorf("Actual oid %s during smudge does not match expected %s", oid, ptr.Oid)
+			err = fmt.Errorf("actual oid %s during smudge does not match expected %s", oid, ptr.Oid)
 			return 0, errors.Wrap(err, "smudge")
 		}
 
 		for _, expected := range ptr.Extensions {
 			actual := actualExts[expected.Name]
 			if actual.name != expected.Name {
-				err = fmt.Errorf("Actual extension name '%s' does not match expected '%s'", actual.name, expected.Name)
+				err = fmt.Errorf("actual extension name '%s' does not match expected '%s'", actual.name, expected.Name)
 				return 0, errors.Wrap(err, "smudge")
 			}
 			if actual.oidOut != expected.Oid {
-				err = fmt.Errorf("Actual oid %s for extension '%s' does not match expected %s", actual.oidOut, expected.Name, expected.Oid)
+				err = fmt.Errorf("actual oid %s for extension '%s' does not match expected %s", actual.oidOut, expected.Name, expected.Oid)
 				return 0, errors.Wrap(err, "smudge")
 			}
 		}

--- a/lfs/gitscanner.go
+++ b/lfs/gitscanner.go
@@ -11,7 +11,7 @@ import (
 	"github.com/rubyist/tracerx"
 )
 
-var missingCallbackErr = errors.New("No callback given")
+var missingCallbackErr = errors.New("no callback given")
 
 // IsCallbackMissing returns a boolean indicating whether the error is reporting
 // that a GitScanner is missing a required GitScannerCallback.
@@ -68,7 +68,7 @@ func (s *GitScanner) RemoteForPush(r string) error {
 	defer s.mu.Unlock()
 
 	if len(s.remote) > 0 && s.remote != r {
-		return fmt.Errorf("Trying to set remote to %q, already set to %q", r, s.remote)
+		return fmt.Errorf("trying to set remote to %q, already set to %q", r, s.remote)
 	}
 
 	s.remote = r
@@ -88,7 +88,7 @@ func (s *GitScanner) ScanRangeToRemote(left, right string, cb GitScannerFoundPoi
 	s.mu.Lock()
 	if len(s.remote) == 0 {
 		s.mu.Unlock()
-		return fmt.Errorf("Unable to scan starting at %q: no remote set.", left)
+		return fmt.Errorf("unable to scan starting at %q: no remote set", left)
 	}
 	s.mu.Unlock()
 

--- a/lfs/gitscanner_catfilebatchcheck.go
+++ b/lfs/gitscanner_catfilebatchcheck.go
@@ -48,7 +48,7 @@ func runCatFileBatchCheck(smallRevCh chan string, lockableCh chan string, lockab
 		stderr, _ := ioutil.ReadAll(cmd.Stderr)
 		err := cmd.Wait()
 		if err != nil {
-			errCh <- fmt.Errorf("Error in git cat-file --batch-check: %v %v", err, string(stderr))
+			errCh <- fmt.Errorf("error in git cat-file --batch-check: %v %v", err, string(stderr))
 		}
 		close(smallRevCh)
 		close(errCh)

--- a/lfs/gitscanner_log.go
+++ b/lfs/gitscanner_log.go
@@ -76,7 +76,7 @@ func parseScannerLogOutput(cb GitScannerFoundPointer, direction LogDiffDirection
 		stderr, _ := ioutil.ReadAll(cmd.Stderr)
 		err := cmd.Wait()
 		if err != nil {
-			ch <- gitscannerResult{Err: fmt.Errorf("Error in git log: %v %v", err, string(stderr))}
+			ch <- gitscannerResult{Err: fmt.Errorf("error in git log: %v %v", err, string(stderr))}
 		}
 		close(ch)
 	}()

--- a/lfs/gitscanner_tree.go
+++ b/lfs/gitscanner_tree.go
@@ -121,7 +121,7 @@ func lsTreeBlobs(ref string, filter *filepathfilter.Filter) (*TreeBlobChannelWra
 		stderr, _ := ioutil.ReadAll(cmd.Stderr)
 		err := cmd.Wait()
 		if err != nil {
-			errchan <- fmt.Errorf("Error in git ls-tree: %v %v", err, string(stderr))
+			errchan <- fmt.Errorf("error in git ls-tree: %v %v", err, string(stderr))
 		}
 		close(blobs)
 		close(errchan)

--- a/lfs/pointer.go
+++ b/lfs/pointer.go
@@ -166,7 +166,7 @@ func decodeKV(data []byte) (*Pointer, error) {
 	value, ok = kvps["size"]
 	size, err := strconv.ParseInt(value, 10, 64)
 	if err != nil || size < 0 {
-		return nil, fmt.Errorf("Invalid size: %q", value)
+		return nil, fmt.Errorf("invalid size: %q", value)
 	}
 
 	var extensions []*PointerExtension
@@ -227,7 +227,7 @@ func validatePointerExtensions(exts []*PointerExtension) error {
 	m := make(map[int]struct{})
 	for _, ext := range exts {
 		if _, exist := m[ext.Priority]; exist {
-			return fmt.Errorf("Duplicate priority found: %d", ext.Priority)
+			return fmt.Errorf("duplicate priority found: %d", ext.Priority)
 		}
 		m[ext.Priority] = struct{}{}
 	}
@@ -253,7 +253,7 @@ func decodeKVData(data []byte) (kvps map[string]string, exts map[string]string, 
 
 		parts := strings.SplitN(text, " ", 2)
 		if len(parts) < 2 {
-			err = fmt.Errorf("Error reading line %d: %s", line, text)
+			err = fmt.Errorf("error reading line %d: %s", line, text)
 			return
 		}
 
@@ -261,7 +261,7 @@ func decodeKVData(data []byte) (kvps map[string]string, exts map[string]string, 
 		value := parts[1]
 
 		if numKeys <= line {
-			err = fmt.Errorf("Extra line: %s", text)
+			err = fmt.Errorf("extra line: %s", text)
 			return
 		}
 

--- a/lfs/util.go
+++ b/lfs/util.go
@@ -66,7 +66,7 @@ func (f *GitFilter) CopyCallbackFile(event, filename string, index, totalFiles i
 
 func wrapProgressError(err error, event, filename string) error {
 	if err != nil {
-		return fmt.Errorf("Error writing Git LFS %s progress to %s: %s", event, filename, err.Error())
+		return fmt.Errorf("error writing Git LFS %s progress to %s: %s", event, filename, err.Error())
 	}
 
 	return nil
@@ -176,7 +176,7 @@ func (p *currentToRepoPathConverter) Convert(filename string) string {
 func pathConverterArgs(cfg *config.Configuration) (string, string, bool, error) {
 	currDir, err := os.Getwd()
 	if err != nil {
-		return "", "", false, fmt.Errorf("Unable to get working dir: %v", err)
+		return "", "", false, fmt.Errorf("unable to get working dir: %v", err)
 	}
 	currDir = tools.ResolveSymlinks(currDir)
 	return cfg.LocalWorkingDir(), currDir, cfg.LocalWorkingDir() == currDir, nil

--- a/lfsapi/ntlm.go
+++ b/lfsapi/ntlm.go
@@ -107,7 +107,7 @@ func (c *Client) ntlmSendMessage(req *http.Request, message []byte) (*http.Respo
 func parseChallengeResponse(res *http.Response) ([]byte, error) {
 	header := res.Header.Get("Www-Authenticate")
 	if len(header) < 6 {
-		return nil, fmt.Errorf("Invalid NTLM challenge response: %q", header)
+		return nil, fmt.Errorf("invalid NTLM challenge response: %q", header)
 	}
 
 	//parse out the "NTLM " at the beginning of the response

--- a/locking/locks.go
+++ b/locking/locks.go
@@ -112,7 +112,7 @@ func (c *Client) LockFile(path string) (Lock, error) {
 		if len(lockRes.RequestID) > 0 {
 			tracerx.Printf("Server Request ID: %s", lockRes.RequestID)
 		}
-		return Lock{}, fmt.Errorf("Server unable to create lock: %s", lockRes.Message)
+		return Lock{}, fmt.Errorf("server unable to create lock: %s", lockRes.Message)
 	}
 
 	lock := *lockRes.Lock
@@ -154,7 +154,7 @@ func getAbsolutePath(p string) (string, error) {
 func (c *Client) UnlockFile(path string, force bool) error {
 	id, err := c.lockIdFromPath(path)
 	if err != nil {
-		return fmt.Errorf("Unable to get lock id: %v", err)
+		return fmt.Errorf("unable to get lock id: %v", err)
 	}
 
 	return c.UnlockFileById(id, force)
@@ -172,11 +172,11 @@ func (c *Client) UnlockFileById(id string, force bool) error {
 		if len(unlockRes.RequestID) > 0 {
 			tracerx.Printf("Server Request ID: %s", unlockRes.RequestID)
 		}
-		return fmt.Errorf("Server unable to unlock: %s", unlockRes.Message)
+		return fmt.Errorf("server unable to unlock: %s", unlockRes.Message)
 	}
 
 	if err := c.cache.RemoveById(id); err != nil {
-		return fmt.Errorf("Error caching unlock information: %v", err)
+		return fmt.Errorf("error caching unlock information: %v", err)
 	}
 
 	if unlockRes.Lock != nil {
@@ -286,7 +286,7 @@ func (c *Client) SearchLocksVerifiable(limit int, cached bool) (ourLocks, theirL
 				if len(list.RequestID) > 0 {
 					tracerx.Printf("Server Request ID: %s", list.RequestID)
 				}
-				return ourLocks, theirLocks, fmt.Errorf("Server error searching locks: %s", list.Message)
+				return ourLocks, theirLocks, fmt.Errorf("server error searching locks: %s", list.Message)
 			}
 
 			for _, l := range list.Ours {
@@ -367,7 +367,7 @@ func (c *Client) searchRemoteLocks(filter map[string]string, limit int) ([]Lock,
 			if len(list.RequestID) > 0 {
 				tracerx.Printf("Server Request ID: %s", list.RequestID)
 			}
-			return locks, fmt.Errorf("Server error searching for locks: %s", list.Message)
+			return locks, fmt.Errorf("server error searching for locks: %s", list.Message)
 		}
 
 		for _, l := range list.Locks {

--- a/subprocess/subprocess.go
+++ b/subprocess/subprocess.go
@@ -75,7 +75,7 @@ func Output(cmd *Cmd) (string, error) {
 		if len(cmd.Args) > 1 {
 			ran = fmt.Sprintf("%s %s", cmd.Path, quotedArgs(cmd.Args[1:]))
 		}
-		formattedErr := fmt.Errorf("Error running %s: '%s' '%s'", ran, errorOutput, strings.TrimSpace(exitError.Error()))
+		formattedErr := fmt.Errorf("error running %s: '%s' '%s'", ran, errorOutput, strings.TrimSpace(exitError.Error()))
 
 		// return "" as output in error case, for callers that don't care about errors but rely on "" returned, in-case stdout != ""
 		return "", formattedErr

--- a/t/git-lfs-test-server-api/testdownload.go
+++ b/t/git-lfs-test-server-api/testdownload.go
@@ -18,7 +18,7 @@ func downloadAllExist(manifest *tq.Manifest, oidsExist, oidsMissing []TestObject
 	}
 
 	if len(retobjs) != len(oidsExist) {
-		return fmt.Errorf("Incorrect number of returned objects, expected %d, got %d", len(oidsExist), len(retobjs))
+		return fmt.Errorf("incorrect number of returned objects, expected %d, got %d", len(oidsExist), len(retobjs))
 	}
 
 	var errbuf bytes.Buffer
@@ -45,7 +45,7 @@ func downloadAllMissing(manifest *tq.Manifest, oidsExist, oidsMissing []TestObje
 	}
 
 	if len(retobjs) != len(oidsMissing) {
-		return fmt.Errorf("Incorrect number of returned objects, expected %d, got %d", len(oidsMissing), len(retobjs))
+		return fmt.Errorf("incorrect number of returned objects, expected %d, got %d", len(oidsMissing), len(retobjs))
 	}
 
 	var errbuf bytes.Buffer
@@ -88,7 +88,7 @@ func downloadMixed(manifest *tq.Manifest, oidsExist, oidsMissing []TestObject) e
 
 	count := len(oidsExist) + len(oidsMissing)
 	if len(retobjs) != count {
-		return fmt.Errorf("Incorrect number of returned objects, expected %d, got %d", count, len(retobjs))
+		return fmt.Errorf("incorrect number of returned objects, expected %d, got %d", count, len(retobjs))
 	}
 
 	var errbuf bytes.Buffer

--- a/t/git-lfs-test-server-api/testupload.go
+++ b/t/git-lfs-test-server-api/testupload.go
@@ -18,7 +18,7 @@ func uploadAllMissing(manifest *tq.Manifest, oidsExist, oidsMissing []TestObject
 	}
 
 	if len(retobjs) != len(oidsMissing) {
-		return fmt.Errorf("Incorrect number of returned objects, expected %d, got %d", len(oidsMissing), len(retobjs))
+		return fmt.Errorf("incorrect number of returned objects, expected %d, got %d", len(oidsMissing), len(retobjs))
 	}
 
 	var errbuf bytes.Buffer
@@ -46,7 +46,7 @@ func uploadAllExists(manifest *tq.Manifest, oidsExist, oidsMissing []TestObject)
 	}
 
 	if len(retobjs) != len(oidsExist) {
-		return fmt.Errorf("Incorrect number of returned objects, expected %d, got %d", len(oidsExist), len(retobjs))
+		return fmt.Errorf("incorrect number of returned objects, expected %d, got %d", len(oidsExist), len(retobjs))
 	}
 
 	var errbuf bytes.Buffer
@@ -84,7 +84,7 @@ func uploadMixed(manifest *tq.Manifest, oidsExist, oidsMissing []TestObject) err
 
 	count := len(oidsExist) + len(oidsMissing)
 	if len(retobjs) != count {
-		return fmt.Errorf("Incorrect number of returned objects, expected %d, got %d", count, len(retobjs))
+		return fmt.Errorf("incorrect number of returned objects, expected %d, got %d", count, len(retobjs))
 	}
 
 	var errbuf bytes.Buffer
@@ -157,7 +157,7 @@ func uploadEdgeCases(manifest *tq.Manifest, oidsExist, oidsMissing []TestObject)
 
 	count := len(errorCases) + len(validCases)
 	if len(retobjs) != count {
-		return fmt.Errorf("Incorrect number of returned objects, expected %d, got %d", count, len(retobjs))
+		return fmt.Errorf("incorrect number of returned objects, expected %d, got %d", count, len(retobjs))
 	}
 
 	var errbuf bytes.Buffer

--- a/t/t-install.sh
+++ b/t/t-install.sh
@@ -254,7 +254,7 @@ begin_test "install --local with failed permissions"
   chmod 700 .git
 
   cat err.log
-  grep -E "Error running.*git.*config" err.log
+  grep -E "error running.*git.*config" err.log
   [ "$res" -eq 2 ]
 )
 end_test

--- a/tools/filetools.go
+++ b/tools/filetools.go
@@ -230,7 +230,7 @@ func VerifyFileHash(oid, path string) error {
 
 	calcOid := hex.EncodeToString(h.Sum(nil))
 	if calcOid != oid {
-		return fmt.Errorf("File %q has an invalid hash %s, expected %s", path, calcOid, oid)
+		return fmt.Errorf("file %q has an invalid hash %s, expected %s", path, calcOid, oid)
 	}
 
 	return nil

--- a/tools/kv/keyvaluestore.go
+++ b/tools/kv/keyvaluestore.go
@@ -144,10 +144,10 @@ func (k *Store) Save() error {
 
 	enc := gob.NewEncoder(f)
 	if err := enc.Encode(k.version); err != nil {
-		return fmt.Errorf("Error while writing version data to %v: %v", k.filename, err)
+		return fmt.Errorf("error while writing version data to %v: %v", k.filename, err)
 	}
 	if err := enc.Encode(k.db); err != nil {
-		return fmt.Errorf("Error while writing new key/value data to %v: %v", k.filename, err)
+		return fmt.Errorf("error while writing new key/value data to %v: %v", k.filename, err)
 	}
 	// Clear log now that it's saved
 	k.log = nil
@@ -189,7 +189,7 @@ func (k *Store) loadAndMergeReaderIfNeeded(f io.Reader) error {
 	dec := gob.NewDecoder(f)
 	err := dec.Decode(&versionOnDisk)
 	if err != nil {
-		return fmt.Errorf("Problem checking version of key/value data from %v: %v", k.filename, err)
+		return fmt.Errorf("problem checking version of key/value data from %v: %v", k.filename, err)
 	}
 	// Totally uninitialised Version == 0, saved versions are always >=1
 	if versionOnDisk != k.version {
@@ -197,7 +197,7 @@ func (k *Store) loadAndMergeReaderIfNeeded(f io.Reader) error {
 		var dbOnDisk map[string]interface{}
 		err = dec.Decode(&dbOnDisk)
 		if err != nil {
-			return fmt.Errorf("Problem reading updated key/value data from %v: %v", k.filename, err)
+			return fmt.Errorf("problem reading updated key/value data from %v: %v", k.filename, err)
 		}
 		k.reapplyChanges(dbOnDisk)
 		k.version = versionOnDisk

--- a/tools/os_tools.go
+++ b/tools/os_tools.go
@@ -33,7 +33,7 @@ func translateCygwinPath(path string) (string, error) {
 	out, err := cmd.Output()
 	output := strings.TrimSpace(string(out))
 	if err != nil {
-		return path, fmt.Errorf("Failed to translate path from cygwin to windows: %s", buf.String())
+		return path, fmt.Errorf("failed to translate path from cygwin to windows: %s", buf.String())
 	}
 	return output, nil
 }

--- a/tq/adapterbase.go
+++ b/tq/adapterbase.go
@@ -177,7 +177,7 @@ func (a *adapterBase) worker(workerNum int, ctx interface{}) {
 		// Actual transfer happens here
 		var err error
 		if t.Size < 0 {
-			err = fmt.Errorf("Git LFS: object %q has invalid size (got: %d)", t.Oid, t.Size)
+			err = fmt.Errorf("object %q has invalid size (got: %d)", t.Oid, t.Size)
 		} else {
 			err = a.transferImpl.DoTransfer(ctx, t, a.cb, authCallback)
 		}

--- a/tq/tus_upload.go
+++ b/tq/tus_upload.go
@@ -64,11 +64,11 @@ func (a *tusUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb ProgressC
 	//    Response will contain Upload-Offset if supported
 	offHdr := res.Header.Get("Upload-Offset")
 	if len(offHdr) == 0 {
-		return fmt.Errorf("Missing Upload-Offset header from tus.io HEAD response at %q, contact server admin", rel.Href)
+		return fmt.Errorf("missing Upload-Offset header from tus.io HEAD response at %q, contact server admin", rel.Href)
 	}
 	offset, err := strconv.ParseInt(offHdr, 10, 64)
 	if err != nil || offset < 0 {
-		return fmt.Errorf("Invalid Upload-Offset value %q in response from tus.io HEAD at %q, contact server admin", offHdr, rel.Href)
+		return fmt.Errorf("invalid Upload-Offset value %q in response from tus.io HEAD at %q, contact server admin", offHdr, rel.Href)
 	}
 	// Upload-Offset=size means already completed (skip)
 	// Batch API will probably already detect this, but handle just in case


### PR DESCRIPTION
Error strings should not be capitalized (unless beginning with proper nouns or acronyms) or end with punctuation:
https://github.com/golang/go/wiki/CodeReviewComments#error-strings