### PR TITLE
Accept all local references with git lfs push

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -347,7 +347,7 @@ func RemoteList() ([]string, error) {
 // Refs returns all of the local and remote branches and tags for the current
 // repository. Other refs (HEAD, refs/stash, git notes) are ignored.
 func LocalRefs() ([]*Ref, error) {
-	cmd := gitNoLFS("show-ref", "--heads", "--tags")
+	cmd := gitNoLFS("show-ref")
 
 	outp, err := cmd.StdoutPipe()
 	if err != nil {

--- a/t/t-push.sh
+++ b/t/t-push.sh
@@ -764,8 +764,7 @@ begin_test "push custom reference"
 
   # Create and try pushing a reference in a nonstandard namespace, that is,
   # outside of refs/heads, refs/tags, and refs/remotes.
-  mkdir -p .git/refs/custom/remote/heads
-  cp .git/refs/heads/master .git/refs/custom/remote/heads/
+  git update-ref refs/custom/remote/heads/master refs/heads/master
 
   git lfs push origin refs/custom/remote/heads/master
   assert_server_object "$reponame" "$oid"

--- a/t/t-push.sh
+++ b/t/t-push.sh
@@ -740,3 +740,34 @@ begin_test 'push with data the server already has'
   assert_server_object "$reponame" "$contents2_oid"
 )
 end_test
+
+begin_test "push custom reference"
+(
+  set -e
+
+  reponame="push-custom-reference"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.dat"
+  # generate content we'll use
+  content="filecontent"
+  oid=$(calc_oid "$content")
+
+  echo "[
+  {
+    \"CommitDate\":\"$(get_date -6m)\",
+    \"Files\":[
+      {\"Filename\":\"file.dat\",\"Size\":${#content}, \"Data\":\"$content\"}]
+  }
+  ]" | lfstest-testutils addcommits
+
+  # Create and try pushing a reference in a nonstandard namespace, that is,
+  # outside of refs/heads, refs/tags, and refs/remotes.
+  mkdir -p .git/refs/custom/remote/heads
+  cp .git/refs/heads/master .git/refs/custom/remote/heads/
+
+  git lfs push origin refs/custom/remote/heads/master
+  assert_server_object "$reponame" "$oid"
+)
+end_test


### PR DESCRIPTION
This change makes it possible to run `git lfs push` with any local reference, regardless of whether it’s stored in the conventional places (`refs/heads` and `refs/tags`) or not. This is to bring the behavior of `git lfs push` in line with `git push`, which doesn’t limit source references in refspecs to the `refs/heads` and `refs/tags` scopes either.

The other reason I’m suggesting this change is to enable usage of `git lfs push` with custom local references. I’m working on an automation that fetches tags from multiple remotes. In order to avoid collisions, I store tags from `remote-a` in a custom scope of the form `refs/custom/remote-a/tags`, whereas tags from `remote-b` would go into `refs/custom/remote-b/tags`.

Prior to this change, calls like `git lfs push remote-b refs/custom/remote-a/tags/v1.0.0` would fail with the following error message:
```
exit status 1
Error getting local refs.
```
By removing the `--heads` and `--tags` options from `git show-ref`, this problem can be avoided because `git lfs push` then takes all local references into consideration when reading the reference list provided on the command line.

As far as I can see, this change should not affect existing scripts using Git LFS in any way. Also, I’m not sure whether this change merits to be mentioned in the documentation because, at least to me, the expectation is that any reference should be supported by `git lfs push`.

Concerning testing, it looks to me that the existing testing framework (specifically, `lfstest-testutils addcommits`) doesn’t support creating nonconventional references out of the box. What would you suggest?