### PR TITLE
Fix several causes of CI problems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
     - run: mkdir -p "$HOME/go/bin"
       shell: bash
     - run: set GOPATH=%HOME%\go
-    - run: set PATH=%GOPATH%\bin;%PATH%
     - run: cinst InnoSetup -y
     - run: cinst strawberryperl -y
     - run: choco uninstall git.install -y --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,6 @@ jobs:
     - run: mkdir -p "$HOME/go/bin"
       shell: bash
     - run: set GOPATH=%HOME%\go
-    - run: set PATH=%GOPATH%\bin;%PATH%
     - run: cinst InnoSetup -y
     - run: cinst strawberryperl -y
     - run: cinst zip -y

--- a/script/build-git
+++ b/script/build-git
@@ -5,7 +5,12 @@ DIR="$1"
 case $(uname -s) in
   Darwin)
     brew install curl zlib pcre2 gettext openssl
-    brew link --force zlib pcre2 gettext openssl;;
+    brew reinstall curl zlib pcre2 gettext openssl
+    for i in curl zlib pcre2 gettext openssl
+    do
+      brew unlink $i || true;
+      brew link --force $i || true
+    done;;
   Linux)
     export DEBIAN_FRONTEND=noninteractive
     sed -e 's/^deb/deb-src/' /etc/apt/sources.list | sudo tee /etc/apt/sources.list.d/src.list


### PR DESCRIPTION
For an unknown reason, sometimes libintl.h is missing on macOS when it should not be.  Try harder to fix this by reinstalling the packages which are already allegedly installed and forcing an unlink and re-link.

In addition, address a problem in Windows CI where `%PATH%` is for some reason no longer recognized.  Since it's not strictly necessary to set the path in such a case, stop setting it.
