### PR TITLE
Fall back if there are no system Windows credentials when using NTLM

### DIFF
--- a/lfsapi/ntlm.go
+++ b/lfsapi/ntlm.go
@@ -36,12 +36,12 @@ func (c *Client) ntlmReAuth(req *http.Request, credWrapper creds.CredentialHelpe
 	// Try SSPI first.
 	if c.ntlmSupportsSSPI() == true {
 		res, err := c.ntlmAuthenticateRequest(req, nil)
-		if err != nil && !errors.IsAuthError(err) {
+		if err != nil && !errors.IsAuthError(err) && !IsSystemCredentialError(err) {
 			return res, err
 		}
 
 		// If SSPI succeeded, then we can move on.
-		if res.StatusCode < 300 && res.StatusCode > 199 {
+		if res != nil && res.StatusCode < 300 && res.StatusCode > 199 {
 			return res, nil
 		}
 	}

--- a/lfsapi/ntlm_auth_nix.go
+++ b/lfsapi/ntlm_auth_nix.go
@@ -10,6 +10,10 @@ import (
 	"github.com/git-lfs/go-ntlm/ntlm"
 )
 
+func IsSystemCredentialError(err error) bool {
+	return false
+}
+
 func (c *Client) ntlmSupportsSSPI() bool {
 	return false
 }

--- a/lfsapi/ntlm_auth_windows.go
+++ b/lfsapi/ntlm_auth_windows.go
@@ -4,10 +4,20 @@ package lfsapi
 
 import (
 	"net/http"
+	"syscall"
 
 	"github.com/alexbrainman/sspi"
 	"github.com/alexbrainman/sspi/ntlm"
 )
+
+const systemCredentialError = 0x8009030E
+
+func IsSystemCredentialError(err error) bool {
+	if e, ok := err.(syscall.Errno); ok {
+		return uintptr(e) == systemCredentialError
+	}
+	return false
+}
 
 func (c *Client) ntlmSupportsSSPI() bool {
 	return true


### PR DESCRIPTION
On Windows, we attempt to use the system credentials when authenticating using NTLM if they exist.  However, in some cases, the system is not appropriately configured and we get an error, which causes the push attempt to abort.

If we get such an error, fall back to prompting for credentials like we did before 2.8.0.

This is a shot in the dark.  It may or may not work, but this is the best attempt I can give things without having a Windows system with AD set up.