### PR TITLE
Allow specifying HTTP version to use

### DIFF
--- a/lfsapi/auth.go
+++ b/lfsapi/auth.go
@@ -93,7 +93,12 @@ func (c *Client) doWithCreds(req *http.Request, credWrapper creds.CredentialHelp
 
 	req.Header.Set("User-Agent", lfshttp.UserAgent)
 
-	redirectedReq, res, err := c.client.DoWithRedirect(c.client.HttpClient(req.Host), req, "", via)
+	client, err := c.client.HttpClient(req.URL)
+	if err != nil {
+		return nil, err
+	}
+
+	redirectedReq, res, err := c.client.DoWithRedirect(client, req, "", via)
 	if err != nil || res != nil {
 		return res, err
 	}


### PR DESCRIPTION
There are some servers that cannot speak HTTP/2 in all cases and demand to fall back to HTTP/1.1 with a `HTTP_1_1_REQUIRED`.  Notably, this happens with IIS 10 when using NTLM.  Go's HTTP library doesn't seem to like this response and aborts the transfer, leading to a failure.

Fortunately, Git has an option (`http.version`) to control the protocol used when speaking HTTP to a remote server.  Implement this option to allow users to set the protocol to use when speaking HTTP and work around these servers.

/cc @YawJatah as reporter