### PR TITLE
Build artifacts during CI for easier testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,14 @@ jobs:
       shell: bash
     - run: mv bin\git-lfs.exe git-lfs-x64.exe
     - run: iscc script\windows-installer\inno-setup-git-lfs-installer.iss
+    - run: mkdir -p bin/assets
+      shell: bash
+    - run: mv *.exe bin/assets
+      shell: bash
+    - uses: actions/upload-artifact@v1
+      with:
+        name: windows-latest
+        path: bin/assets
   build-latest:
     name: Build with latest Git
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,13 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - run: script/cibuild
+    - run: make release
+    - run: mkdir -p bin/assets
+    - run: find bin/releases -name "*$(uname -s | tr A-Z a-z)*" | xargs -I{} cp {} bin/assets
+    - uses: actions/upload-artifact@v1
+      with:
+        name: ${{ matrix.os }}
+        path: bin/assets
   build-windows:
     name: Build on Windows
     runs-on: windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,10 +31,6 @@ jobs:
       shell: bash
     - run: PATH="$HOME/go/bin:$PATH" make bin/releases/git-lfs-windows-386-$(git describe).zip
       shell: bash
-    - run: echo "$PATH"
-      shell: bash
-    - run: find "/c/Program Files (x86)/Windows Kits/10/bin/x86"
-      shell: bash
     - run: PATH="$HOME/go/bin:/c/Program Files (x86)/Windows Kits/10/bin/x86:$PATH" CERT_FILE="$HOME/cert.pfx" make release-windows
       shell: bash
       env:


### PR DESCRIPTION
When proposing a PR that purports to fix a user problem, it's helpful if we can provide test binaries that they can use to see if the PR fixes their issue.  To do so, build binaries as part of the CI process and upload them as artifacts.