### PR TITLE
t: fix flaky tests in CI

### DIFF
--- a/t/t-clone.sh
+++ b/t/t-clone.sh
@@ -625,7 +625,8 @@ begin_test "clone in current directory"
     mkdir "$reponame-clone"
     cd "$reponame-clone"
 
-    git lfs clone $GITSERVER/$reponame "." 2>&1 | grep "Downloading LFS objects: 100% (1/1), 8 B"
+    git lfs clone $GITSERVER/$reponame "."
+    git lfs fsck
 
     assert_local_object "$contents_oid" 8
     assert_hooks "$(dot_git_dir)"

--- a/t/t-fetch.sh
+++ b/t/t-fetch.sh
@@ -63,7 +63,7 @@ begin_test "fetch"
   cd clone
   rm -rf .git/lfs/objects
 
-  git lfs fetch 2>&1 | grep "Downloading LFS objects: 100% (1/1), 1 B"
+  git lfs fetch
   assert_local_object "$contents_oid" 1
 
   git lfs fsck 2>&1 | tee fsck.log
@@ -92,7 +92,7 @@ begin_test "fetch with remote"
   cd clone
   rm -rf .git/lfs/objects
 
-  git lfs fetch origin 2>&1 | grep "Downloading LFS objects: 100% (1/1), 1 B"
+  git lfs fetch origin
   assert_local_object "$contents_oid" 1
   refute_local_object "$b_oid" 1
 

--- a/t/t-pull.sh
+++ b/t/t-pull.sh
@@ -72,22 +72,24 @@ begin_test "pull"
   echo "lfs pull"
   rm -r a.dat á.dat dir # removing files makes the status dirty
   rm -rf .git/lfs/objects
-  git lfs pull 2>&1 | grep "Downloading LFS objects: 100% (3/3), 5 B"
+  git lfs pull
   ls -al
   [ "a" = "$(cat a.dat)" ]
   [ "A" = "$(cat "á.dat")" ]
   assert_local_object "$contents_oid" 1
   assert_local_object "$contents2_oid" 1
+  git lfs fsck
 
   echo "lfs pull with remote"
   rm -r a.dat á.dat dir
   rm -rf .git/lfs/objects
-  git lfs pull origin 2>&1 | grep "Downloading LFS objects: 100% (3/3), 5 B"
+  git lfs pull origin
   [ "a" = "$(cat a.dat)" ]
   [ "A" = "$(cat "á.dat")" ]
   assert_local_object "$contents_oid" 1
   assert_local_object "$contents2_oid" 1
   assert_clean_status
+  git lfs fsck
 
   echo "lfs pull with local storage"
   rm a.dat á.dat


### PR DESCRIPTION
When we download objects, it's possible that one or more messages may not be printed because the transfer meter is paused.  This is not normally a problem for production use, since we'll print a later update out, but in our tests, we check for specific success messages, which leads to flaky tests when those exact messages happen to be skipped. Since our CI hosts are very fast and good at triggering race conditions, we see this frequently there.

Instead of checking for these exact messages, let's instead check that the objects we want to have downloaded have in fact been downloaded and that git lfs fsck passes, which are more reliable indicators of a successful download.  In many cases, we're already doing one or more of these, so we already have confidence that everything's working correctly.

As a note, we've done this same thing in other tests when porting from our other CI providers to Actions, and it has been effective with no downsides.

Fixes #3891.