### PR TITLE
Avoid hang when using git hash-object --stdin --path

### DIFF
--- a/git/pkt_line_reader.go
+++ b/git/pkt_line_reader.go
@@ -10,12 +10,18 @@ type pktlineReader struct {
 	pl *pktline
 
 	buf []byte
+
+	eof bool
 }
 
 var _ io.Reader = new(pktlineReader)
 
 func (r *pktlineReader) Read(p []byte) (int, error) {
 	var n int
+
+	if r.eof {
+		return 0, io.EOF
+	}
 
 	if len(r.buf) > 0 {
 		// If there is data in the buffer, shift as much out of it and
@@ -40,6 +46,7 @@ func (r *pktlineReader) Read(p []byte) (int, error) {
 			// reached the end of processing for this particular
 			// packet, so let's terminate.
 
+			r.eof = true
 			return n, io.EOF
 		}
 

--- a/lfs/gitfilter_clean.go
+++ b/lfs/gitfilter_clean.go
@@ -70,7 +70,7 @@ func (f *GitFilter) copyToTemp(reader io.Reader, fileSize int64, cb tools.CopyCa
 	oidHash := sha256.New()
 	writer := io.MultiWriter(oidHash, tmp)
 
-	if fileSize == 0 {
+	if fileSize <= 0 {
 		cb = nil
 	}
 


### PR DESCRIPTION
When we use git hash-object --stdin with the --path option, Git applies filters to the object, so Git LFS is invoked.  However, if the object provided is less than 1024 bytes in size, we would hang.  This occurred because of our packet reader didn't quite implement the io.Reader interface completely: if it returned a non-zero value and io.EOF, the next call to Read would not return 0 and io.EOF.  Instead, it would try to read from stdin, which would not be sending us more data until we provided a response, so we would hang.

To solve this, keep track of the EOF and always return it on subsequent Read calls.  In addition, don't process the callback to write the file in this case, since we don't actually want to write into the working tree.

Fixes #3884.
/cc @rivuonna as reporter
