### PR TITLE
Revert "ci: force Windows Git version to 2.22.0"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,6 @@ jobs:
     - run: set GOPATH=%HOME%\go
     - run: cinst InnoSetup -y
     - run: cinst strawberryperl -y
-    - run: choco uninstall git.install -y --force
-    - run: cinst git --version 2.22.0 -y --force
     - run: refreshenv
     - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" go get github.com/josephspurrier/goversioninfo/cmd/goversioninfo
       shell: bash


### PR DESCRIPTION
Now that Git for Windows 2.24.0 is available with a fixed version of bash, we can revert the changes to CI that pinned it to 2.22.0 and have things work properly.

This reverts commit 52257344da89a7ba0891d49ac4d60a8e04563aad.
