### PR TITLE
git/gitattr: fix dropped test errors

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -604,7 +604,12 @@ func GitAndRootDirs() (string, string, error) {
 	pathLen := len(paths)
 
 	for i := 0; i < pathLen; i++ {
-		paths[i], err = tools.TranslateCygwinPath(paths[i])
+		if paths[i] != "" {
+			paths[i], err = tools.TranslateCygwinPath(paths[i])
+			if err != nil {
+				return "", "", fmt.Errorf("error translating cygwin path: %s", err)
+			}
+		}
 	}
 
 	if pathLen == 0 {

--- a/git/gitattr/tree_test.go
+++ b/git/gitattr/tree_test.go
@@ -139,6 +139,7 @@ func TestNewDiscoversSimpleChildrenTrees(t *testing.T) {
 			Filemode: 0100644,
 		},
 	}})
+	require.NoError(t, err)
 
 	tree, err := New(db, &gitobj.Tree{Entries: []*gitobj.TreeEntry{
 		{
@@ -181,6 +182,7 @@ func TestNewDiscoversIndirectChildrenTrees(t *testing.T) {
 			Filemode: 0100644,
 		},
 	}})
+	require.NoError(t, err)
 
 	child, err := db.WriteTree(&gitobj.Tree{Entries: []*gitobj.TreeEntry{
 		{
@@ -189,6 +191,7 @@ func TestNewDiscoversIndirectChildrenTrees(t *testing.T) {
 			Filemode: 040000,
 		},
 	}})
+	require.NoError(t, err)
 
 	tree, err := New(db, &gitobj.Tree{Entries: []*gitobj.TreeEntry{
 		{
@@ -231,6 +234,7 @@ func TestNewIgnoresChildrenAppropriately(t *testing.T) {
 			Filemode: 0100644,
 		},
 	}})
+	require.NoError(t, err)
 
 	tree, err := New(db, &gitobj.Tree{Entries: []*gitobj.TreeEntry{
 		{


### PR DESCRIPTION
This PR picks up four `err` variables that were being dropped in the `git/gitattr` package.