### PR TITLE
Honor lfs.url when deciding on transfer adapters

### DIFF
--- a/t/t-standalone-file.sh
+++ b/t/t-standalone-file.sh
@@ -252,3 +252,159 @@ begin_test "standalone-file-clone"
   grep "xfer: started custom adapter process" clonecustom.log
 )
 end_test
+
+begin_test "standalone-file-lfs.url file URL"
+(
+  set -e
+
+  # setup a git repo to be used as a local repo, not remote
+  reponame="standalone-file-lfsurl"
+  setup_remote_repo "$reponame"
+
+  # clone directly, not through lfstest-gitserver
+  clone_repo_url "$REMOTEDIR/$reponame.git" $reponame
+
+  otherrepo="$(pwd)/$reponame-2.git"
+  git init --bare "$otherrepo"
+
+  wrongrepo="$(pwd)/$reponame-3.git"
+  git init --bare "$wrongrepo"
+
+  git remote set-url origin "file://$(urlify "$wrongrepo")"
+  git config lfs.url "file://$(urlify "$otherrepo")"
+
+  git lfs track "*.dat" 2>&1 | tee track.log
+  grep "Tracking \"\*.dat\"" track.log
+  git add .gitattributes
+  git commit -m "Tracking"
+
+  git checkout -b test
+
+  # set up a decent amount of data so that there's work for multiple concurrent adapters
+  echo "[
+  {
+    \"CommitDate\":\"$(get_date -10d)\",
+    \"Files\":[
+      {\"Filename\":\"verify.dat\",\"Size\":18,\"Data\":\"send-verify-action\"},
+      {\"Filename\":\"file1.dat\",\"Size\":1024},
+      {\"Filename\":\"file2.dat\",\"Size\":750}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -7d)\",
+    \"Files\":[
+      {\"Filename\":\"file1.dat\",\"Size\":1050},
+      {\"Filename\":\"file3.dat\",\"Size\":660},
+      {\"Filename\":\"file4.dat\",\"Size\":230}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -5d)\",
+    \"Files\":[
+      {\"Filename\":\"file5.dat\",\"Size\":1200},
+      {\"Filename\":\"file6.dat\",\"Size\":300}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -2d)\",
+    \"Files\":[
+      {\"Filename\":\"file3.dat\",\"Size\":120},
+      {\"Filename\":\"file5.dat\",\"Size\":450},
+      {\"Filename\":\"file7.dat\",\"Size\":520},
+      {\"Filename\":\"file8.dat\",\"Size\":2048}]
+  }
+  ]" | lfstest-testutils addcommits
+
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git push origin test 2>&1 | tee pushcustom.log
+  # use PIPESTATUS otherwise we get exit code from tee
+  [ ${PIPESTATUS[0]} = "0" ]
+
+  # Make sure the lock verification is not attempted.
+  grep "locks/verify$" pushcustom.log && false
+
+  grep "xfer: started custom adapter process" pushcustom.log
+  grep "Uploading LFS objects: 100% (12/12)" pushcustom.log
+
+  # Make sure we didn't write to the wrong repo.
+  objectlist=$(find "$wrongrepo/lfs/objects" -type f || true)
+  [ -z "$objectlist" ]
+
+  # Make sure we uploaded the expected number of objects.
+  objectlist=$(find "$otherrepo/lfs/objects" -type f || true)
+  [ "$(echo "$objectlist" | wc -l)" -eq 12 ]
+)
+end_test
+
+begin_test "standalone-file-lfs.url http URL"
+(
+  set -e
+
+  reponame="standalone-file-lfsurl-http"
+  setup_remote_repo "$reponame"
+
+  # clone directly, not through lfstest-gitserver
+  clone_repo "$reponame" "$reponame"
+
+  wrongrepo="$(pwd)/$reponame-2.git"
+  git init --bare "$wrongrepo"
+
+  git remote set-url origin "file://$(urlify "$wrongrepo")"
+  git config lfs.url "$(repo_endpoint "$GITSERVER" "$reponame")"
+
+  git lfs track "*.dat" 2>&1 | tee track.log
+  grep "Tracking \"\*.dat\"" track.log
+  git add .gitattributes
+  git commit -m "Tracking"
+
+  git checkout -b test
+
+  # set up a decent amount of data so that there's work for multiple concurrent adapters
+  echo "[
+  {
+    \"CommitDate\":\"$(get_date -10d)\",
+    \"Files\":[
+      {\"Filename\":\"verify.dat\",\"Size\":18,\"Data\":\"send-verify-action\"},
+      {\"Filename\":\"file1.dat\",\"Size\":1024},
+      {\"Filename\":\"file2.dat\",\"Size\":750}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -7d)\",
+    \"Files\":[
+      {\"Filename\":\"file1.dat\",\"Size\":1050},
+      {\"Filename\":\"file3.dat\",\"Size\":660},
+      {\"Filename\":\"file4.dat\",\"Size\":230}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -5d)\",
+    \"Files\":[
+      {\"Filename\":\"file5.dat\",\"Size\":1200},
+      {\"Filename\":\"file6.dat\",\"Size\":300}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -2d)\",
+    \"Files\":[
+      {\"Filename\":\"file3.dat\",\"Size\":120},
+      {\"Filename\":\"file5.dat\",\"Size\":450},
+      {\"Filename\":\"file7.dat\",\"Size\":520},
+      {\"Filename\":\"file8.dat\",\"Size\":2048}]
+  }
+  ]" | lfstest-testutils addcommits
+
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git push origin test 2>&1 | tee push.log
+  # use PIPESTATUS otherwise we get exit code from tee
+  [ ${PIPESTATUS[0]} = "0" ]
+
+  # We should not use the custom adapter process here.
+  ! grep "xfer: started custom adapter process" push.log
+  grep -F "$GITSERVER/$reponame" push.log
+
+  # Make sure we didn't write to the wrong repo.
+  objectlist=$(find "$wrongrepo/lfs/objects" -type f || true)
+  [ -z "$objectlist" ]
+
+  rm -fr .git/lfs/objects
+
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git lfs fetch --all 2>&1 | tee fetch.log
+  ! grep "xfer: started custom adapter process" fetch.log
+  grep -F "$GITSERVER/$reponame" fetch.log
+
+  git lfs fsck
+)
+end_test

--- a/tq/manifest.go
+++ b/tq/manifest.go
@@ -118,10 +118,11 @@ func findStandaloneTransfer(client *lfsapi.Client, operation, remote string) str
 	}
 
 	ep := client.Endpoints.RemoteEndpoint(operation, remote)
+	aep := client.Endpoints.Endpoint(operation, remote)
 	uc := config.NewURLConfig(client.GitEnv())
 	v, ok := uc.Get("lfs", ep.Url, "standalonetransferagent")
 	if !ok {
-		return findDefaultStandaloneTransfer(ep.Url)
+		return findDefaultStandaloneTransfer(aep.Url)
 	}
 
 	return v


### PR DESCRIPTION
Currently, if you have a remote with a file URL but have `lfs.url` set to point to a non-file URL, your transfers will fail.  This occurs because we look up whether to use a transfer adapter based on the remote URL, but we also look up whether to default to the built-in transfer adapter based on the remote URL, not the endpoint URL.  We then attempt to pass the HTTP URL to the standalone transfer adapter, which doesn't work.

Look up the endpoint URL as well and pass that to the code which determines whether we should use the builtin transfer adapter.  If the actual endpoint is not a file URL, then we won't suggest the builtin transfer adapter.

As a note to the harried reviewer, the `Endpoint` function looks up all LFS endpoints and is more complete than the `RemoteEndpoint` function, which only looks up the endpoint based on the remote.  We want to look up options in the config based on the remote (to work more like Git), but synthesize our own based only on the actual endpoint.

Fixes #3893.
/cc @ulilaube as reporter