### PR TITLE
README: correct git lfs migrate import invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ $ git commit -m "add psd"
 > in your history to use Git LFS, use `git lfs migrate`. For example:
 >
 > ```
-> $ git lfs migrate import --include="*.psd"
+> $ git lfs migrate import --include="*.psd" --everything
 > ```
 >
 > For more information, read [`git-lfs-migrate(1)`](https://github.com/git-lfs/git-lfs/blob/master/docs/man/git-lfs-migrate.1.ronn).


### PR DESCRIPTION
git lfs migrate import does nothing when given no refs to work on.  Add a command line argument to process all refs in the README example.

Fixes #3883 
/cc @alan23273850 as reporter