### PR TITLE
Handle missing cygpath gracefully

### DIFF
--- a/tools/os_tools.go
+++ b/tools/os_tools.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/git-lfs/git-lfs/subprocess"
@@ -33,6 +34,11 @@ func translateCygwinPath(path string) (string, error) {
 	out, err := cmd.Output()
 	output := strings.TrimSpace(string(out))
 	if err != nil {
+		// If cygpath doesn't exist, that's okay: just return the paths
+		// as we got it.
+		if _, ok := err.(*exec.Error); ok {
+			return path, nil
+		}
 		return path, fmt.Errorf("failed to translate path from cygwin to windows: %s", buf.String())
 	}
 	return output, nil


### PR DESCRIPTION
It looks like there are situations in which some Git for Windows installations don't have the cygpath binary.  In that case, we end up picking an empty string, which leads us to install hooks and LFS objects in the current directory.  Fix this by looking for the cygpath binary and if it's missing, disabling Cygwin path canonicalization on Windows.

/cc #3898 
/cc @StarWars999123