### PR TITLE
Allow migrate export to handle non-pointer files gracefully

### DIFF
--- a/lfs/pointer.go
+++ b/lfs/pointer.go
@@ -253,7 +253,7 @@ func decodeKVData(data []byte) (kvps map[string]string, exts map[string]string, 
 
 		parts := strings.SplitN(text, " ", 2)
 		if len(parts) < 2 {
-			err = fmt.Errorf("error reading line %d: %s", line, text)
+			err = errors.NewNotAPointerError(fmt.Errorf("error reading line %d: %s", line, text))
 			return
 		}
 
@@ -261,7 +261,7 @@ func decodeKVData(data []byte) (kvps map[string]string, exts map[string]string, 
 		value := parts[1]
 
 		if numKeys <= line {
-			err = fmt.Errorf("extra line: %s", text)
+			err = errors.NewNotAPointerError(fmt.Errorf("extra line: %s", text))
 			return
 		}
 

--- a/t/t-migrate-export.sh
+++ b/t/t-migrate-export.sh
@@ -442,3 +442,26 @@ begin_test "migrate export (invalid --remote)"
   grep "fatal: invalid remote zz provided" migrate.log
 )
 end_test
+
+begin_test "migrate export (invalid pointer)"
+(
+  set -e
+
+  git init repo1
+  git init repo2
+
+  cd repo1
+  echo "git-lfs" > problematic_file
+  git add .
+  git commit -m "create repo"
+
+  git lfs migrate export --include="*" --everything --yes
+
+  cd ../repo2
+  echo "not git-lfs" > problematic_file
+  git add .
+  git commit -m "create repo"
+
+  git lfs migrate export --include="*" --everything --yes
+)
+end_test


### PR DESCRIPTION
If a file that was being handled by git lfs migrate export contained the text "git-lfs", but was not a pointer file, we would abort.  This occurred because the error was not of a type that indicated that the file was not a pointer, so we treated it as an unrecoverable error instead of a recoverable one.

Wrap the error in an appropriate type so that we can recover from this and treat it as not being a pointer.  Add tests for both error branches in the function to ensure we recover from them.

Fixes #3908.
/cc @benblo as reporter