### PR TITLE
Reset the text attribute on export

### DIFF
--- a/commands/command_migrate_export.go
+++ b/commands/command_migrate_export.go
@@ -187,7 +187,7 @@ func trackedFromExportFilter(filter *filepathfilter.Filter) *tools.OrderedSet {
 	tracked := tools.NewOrderedSet()
 
 	for _, include := range filter.Include() {
-		tracked.Add(fmt.Sprintf("%s text !filter !merge !diff", escapeAttrPattern(include)))
+		tracked.Add(fmt.Sprintf("%s !text !filter !merge !diff", escapeAttrPattern(include)))
 	}
 
 	for _, exclude := range filter.Exclude() {

--- a/t/t-migrate-export.sh
+++ b/t/t-migrate-export.sh
@@ -49,11 +49,11 @@ begin_test "migrate export (default branch)"
   master_attrs="$(git cat-file -p "$master:.gitattributes")"
   feature_attrs="$(git cat-file -p "$feature:.gitattributes")"
 
-  echo "$master_attrs" | grep -q "*.md text !filter !merge !diff"
-  echo "$master_attrs" | grep -q "*.txt text !filter !merge !diff"
+  echo "$master_attrs" | grep -q "*.md !text !filter !merge !diff"
+  echo "$master_attrs" | grep -q "*.txt !text !filter !merge !diff"
 
-  [ ! $(echo "$feature_attrs" | grep -q "*.md text !filter !merge !diff") ]
-  [ ! $(echo "$feature_attrs" | grep -q "*.txt text !filter !merge !diff") ]
+  [ ! $(echo "$feature_attrs" | grep -q "*.md !text !filter !merge !diff") ]
+  [ ! $(echo "$feature_attrs" | grep -q "*.txt !text !filter !merge !diff") ]
 )
 end_test
 
@@ -89,8 +89,8 @@ begin_test "migrate export (with remote)"
   master="$(git rev-parse refs/heads/master)"
   master_attrs="$(git cat-file -p "$master:.gitattributes")"
 
-  echo "$master_attrs" | grep -q "*.md text !filter !merge !diff"
-  echo "$master_attrs" | grep -q "*.txt text !filter !merge !diff"
+  echo "$master_attrs" | grep -q "*.md !text !filter !merge !diff"
+  echo "$master_attrs" | grep -q "*.txt !text !filter !merge !diff"
 )
 end_test
 
@@ -118,7 +118,7 @@ begin_test "migrate export (include/exclude args)"
 
   master_attrs="$(git cat-file -p "$master:.gitattributes")"
 
-  echo "$master_attrs" | grep -q "* text !filter !merge !diff"
+  echo "$master_attrs" | grep -q "* !text !filter !merge !diff"
   echo "$master_attrs" | grep -q "a.md filter=lfs diff=lfs merge=lfs"
 )
 end_test
@@ -185,10 +185,10 @@ begin_test "migrate export (given branch)"
   master_attrs="$(git cat-file -p "$master:.gitattributes")"
   feature_attrs="$(git cat-file -p "$feature:.gitattributes")"
 
-  echo "$master_attrs" | grep -q "*.md text !filter !merge !diff"
-  echo "$master_attrs" | grep -q "*.txt text !filter !merge !diff"
-  echo "$feature_attrs" | grep -q "*.md text !filter !merge !diff"
-  echo "$feature_attrs" | grep -q "*.txt text !filter !merge !diff"
+  echo "$master_attrs" | grep -q "*.md !text !filter !merge !diff"
+  echo "$master_attrs" | grep -q "*.txt !text !filter !merge !diff"
+  echo "$feature_attrs" | grep -q "*.md !text !filter !merge !diff"
+  echo "$feature_attrs" | grep -q "*.txt !text !filter !merge !diff"
 )
 end_test
 
@@ -250,11 +250,11 @@ begin_test "migrate export (exclude remote refs)"
   master_attrs="$(git cat-file -p "$master:.gitattributes")"
   remote_attrs="$(git cat-file -p "$remote:.gitattributes")"
 
-  echo "$master_attrs" | grep -q "*.md text !filter !merge !diff"
-  echo "$master_attrs" | grep -q "*.txt text !filter !merge !diff"
+  echo "$master_attrs" | grep -q "*.md !text !filter !merge !diff"
+  echo "$master_attrs" | grep -q "*.txt !text !filter !merge !diff"
 
-  [ ! $(echo "$remote_attrs" | grep -q "*.md text !filter !merge !diff") ]
-  [ ! $(echo "$remote_attrs" | grep -q "*.txt text !filter !merge !diff") ]
+  [ ! $(echo "$remote_attrs" | grep -q "*.md !text !filter !merge !diff") ]
+  [ ! $(echo "$remote_attrs" | grep -q "*.txt !text !filter !merge !diff") ]
 )
 end_test
 
@@ -300,10 +300,10 @@ begin_test "migrate export (--skip-fetch)"
   master_attrs="$(git cat-file -p "$master:.gitattributes")"
   remote_attrs="$(git cat-file -p "$remote:.gitattributes")"
 
-  echo "$master_attrs" | grep -q "*.md text !filter !merge !diff"
-  echo "$master_attrs" | grep -q "*.txt text !filter !merge !diff"
-  echo "$remote_attrs" | grep -q "*.md text !filter !merge !diff"
-  echo "$remote_attrs" | grep -q "*.txt text !filter !merge !diff"
+  echo "$master_attrs" | grep -q "*.md !text !filter !merge !diff"
+  echo "$master_attrs" | grep -q "*.txt !text !filter !merge !diff"
+  echo "$remote_attrs" | grep -q "*.md !text !filter !merge !diff"
+  echo "$remote_attrs" | grep -q "*.txt !text !filter !merge !diff"
 )
 end_test
 
@@ -361,9 +361,9 @@ begin_test "migrate export (include/exclude ref)"
   remote_attrs="$(git cat-file -p "$remote:.gitattributes")"
   feature_attrs="$(git cat-file -p "$feature:.gitattributes")"
 
-  [ ! $(echo "$master_attrs" | grep -q "*.txt text !filter !merge !diff") ]
-  [ ! $(echo "$remote_attrs" | grep -q "*.txt text !filter !merge !diff") ]
-  echo "$feature_attrs" | grep -q "*.txt text !filter !merge !diff"
+  [ ! $(echo "$master_attrs" | grep -q "*.txt !text !filter !merge !diff") ]
+  [ ! $(echo "$remote_attrs" | grep -q "*.txt !text !filter !merge !diff") ]
+  echo "$feature_attrs" | grep -q "*.txt !text !filter !merge !diff"
 )
 end_test
 


### PR DESCRIPTION
When we export LFS files, we currently set the text attribute.  This is unhelpful if the objects we're checking out are binaries, since they'll become corrupt due to automatic EOL handling.  Since we don't want that, leave the option unspecified so that the default behavior occurs.

We could also change this to use `text=auto` if folks think that's a better option.

Fixes #3909 
/cc @benblo as reporter
