### PR TITLE
Add support for local paths

### DIFF
--- a/lfsapi/endpoint_finder_test.go
+++ b/lfsapi/endpoint_finder_test.go
@@ -1,6 +1,7 @@
 package lfsapi
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/git-lfs/git-lfs/lfshttp"
@@ -312,19 +313,31 @@ func TestBareGitEndpointAddsLfsSuffix(t *testing.T) {
 }
 
 func TestLocalPathEndpointAddsDotGitDir(t *testing.T) {
+	// Windows will add a drive letter to the paths below since we
+	// canonicalize them.
+	if runtime.GOOS == "windows" {
+		return
+	}
+
 	finder := NewEndpointFinder(lfshttp.NewContext(nil, nil, map[string]string{
 		"remote.origin.url": "/local/path",
 	}))
 	e := finder.Endpoint("download", "")
-	assert.Equal(t, "file:///local/path/.git/info/lfs", e.Url)
+	assert.Equal(t, "file:///local/path/.git", e.Url)
 }
 
 func TestLocalPathEndpointPreservesDotGit(t *testing.T) {
+	// Windows will add a drive letter to the paths below since we
+	// canonicalize them.
+	if runtime.GOOS == "windows" {
+		return
+	}
+
 	finder := NewEndpointFinder(lfshttp.NewContext(nil, nil, map[string]string{
 		"remote.origin.url": "/local/path.git",
 	}))
 	e := finder.Endpoint("download", "")
-	assert.Equal(t, "file:///local/path.git/info/lfs", e.Url)
+	assert.Equal(t, "file:///local/path.git", e.Url)
 }
 
 func TestAccessConfig(t *testing.T) {

--- a/lfshttp/endpoint.go
+++ b/lfshttp/endpoint.go
@@ -3,6 +3,7 @@ package lfshttp
 import (
 	"fmt"
 	"net/url"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -110,7 +111,15 @@ func EndpointFromLocalPath(path string) Endpoint {
 	if !strings.HasSuffix(path, ".git") {
 		path = fmt.Sprintf("%s/.git", path)
 	}
-	return Endpoint{Url: fmt.Sprintf("file://%s", path)}
+	var slash string
+	if abs, err := filepath.Abs(path); err == nil {
+		// Required for Windows paths to work.
+		if !strings.HasPrefix(abs, "/") {
+			slash = "/"
+		}
+		path = abs
+	}
+	return Endpoint{Url: fmt.Sprintf("file://%s%s", slash, filepath.ToSlash(path))}
 }
 
 // Construct a new endpoint from a file URL

--- a/t/t-standalone-file.sh
+++ b/t/t-standalone-file.sh
@@ -253,6 +253,78 @@ begin_test "standalone-file-clone"
 )
 end_test
 
+begin_test "standalone-file-local-path"
+(
+  set -e
+
+  # setup a git repo to be used as a local repo, not remote
+  reponame="standalone-file-local-path"
+  setup_remote_repo "$reponame"
+
+  # clone directly, not through lfstest-gitserver
+  clone_repo_url "$REMOTEDIR/$reponame.git" $reponame
+
+  git lfs track "*.dat" 2>&1 | tee track.log
+  grep "Tracking \"\*.dat\"" track.log
+  git add .gitattributes
+  git commit -m "Tracking"
+
+  git checkout -b test
+
+  # set up a decent amount of data so that there's work for multiple concurrent adapters
+  echo "[
+  {
+    \"CommitDate\":\"$(get_date -10d)\",
+    \"Files\":[
+      {\"Filename\":\"verify.dat\",\"Size\":18,\"Data\":\"send-verify-action\"},
+      {\"Filename\":\"file1.dat\",\"Size\":1024},
+      {\"Filename\":\"file2.dat\",\"Size\":750}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -7d)\",
+    \"Files\":[
+      {\"Filename\":\"file1.dat\",\"Size\":1050},
+      {\"Filename\":\"file3.dat\",\"Size\":660},
+      {\"Filename\":\"file4.dat\",\"Size\":230}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -5d)\",
+    \"Files\":[
+      {\"Filename\":\"file5.dat\",\"Size\":1200},
+      {\"Filename\":\"file6.dat\",\"Size\":300}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -2d)\",
+    \"Files\":[
+      {\"Filename\":\"file3.dat\",\"Size\":120},
+      {\"Filename\":\"file5.dat\",\"Size\":450},
+      {\"Filename\":\"file7.dat\",\"Size\":520},
+      {\"Filename\":\"file8.dat\",\"Size\":2048}]
+  }
+  ]" | lfstest-testutils addcommits
+
+  testdir="$(pwd)"
+
+  cd "$TRASHDIR"
+
+  # Check a clone using an absolute Unix-style path.
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git clone "$testdir" "$reponame-repo1"  2>&1 | tee clonecustom.log
+  (cd "$reponame-repo1" && git lfs fsck)
+  grep "xfer: started custom adapter process" clonecustom.log
+
+  # Check a clone using a relative path.
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git clone "$reponame-repo1" "$reponame-repo2"  2>&1 | tee clonecustom.log
+  (cd "$reponame-repo2" && git lfs fsck)
+  grep "xfer: started custom adapter process" clonecustom.log
+
+  # Check a clone using an absolute native-style path.
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git clone "$(native_path "$testdir")" "$reponame-repo3"  2>&1 | tee clonecustom.log
+  (cd "$reponame-repo3" && git lfs fsck)
+  grep "xfer: started custom adapter process" clonecustom.log
+
+)
+end_test
+
 begin_test "standalone-file-lfs.url file URL"
 (
   set -e


### PR DESCRIPTION
Currently, we only support local remotes using file URLs, but not local paths.  This is a highly requested feature, however, so implement support for local paths as remotes.

First, fix the handling of local paths we already have: the handling of absolute Unix-style paths.  Instead of checking for the remote to contain a file URL to determine whether to append "info/lfs" to the URL, look to see if the URL we're using is a file URL, which will catch local paths which will have been rewritten as such by this point.

If we get something that looks like it's not a URL, check if it's a file on the file system, and if so, don't attempt to interpret it as an SSH URL.  This fixes the confusion with Windows paths, which resemble SSH-style locations with a single-letter alias as the host name.

Finally, when turning a local path into a file URL, turn the path into an absolute one if possible and rewrite it using slashes, which is required for file URLs.  Add several tests for the various cases: one for Unix-style paths, one for native paths, and one for relative paths.

Fixes #3914.