### PR TITLE
docs: explain shell metacharacters better

### DIFF
--- a/docs/man/git-lfs-track.1.ronn
+++ b/docs/man/git-lfs-track.1.ronn
@@ -13,7 +13,10 @@ currently-tracked paths.
 
 The [gitattributes documentation](https://git-scm.com/docs/gitattributes) states
 that patterns use the [gitignore pattern rules](https://git-scm.com/docs/gitignore)
-to match paths.
+to match paths. This means that patterns which contain asterisk (`*`), question
+mark (`?`), and the bracket characters (`[` and `]`) are treated specially; to
+disable this behavior and treat them literally instead, use `--filename` or
+escape the character with a backslash.
 
 ## OPTIONS
 
@@ -65,6 +68,10 @@ to match paths.
 * Configure Git LFS to track PSD files and make them read-only unless locked:
 
     `git lfs track --lockable "*.psd"`
+
+* Configure Git LFS to track the file named `project [1].psd`:
+
+    `git lfs track --filename "project [1].psd"`
 
 ## SEE ALSO
 


### PR DESCRIPTION
It's a surprise to many users that bracket characters are treated specially in the shell, especially Windows users or other users who are not intimately familiar with the various peculiarities of shell.  As a consequence, users are also surprised when putting brackets into a `git lfs track` pattern doesn't work as expected.

Let's help these users out by explaining exactly what characters are special and what are ignored, since folks don't always dive into the Git attribute documentation.  Let's also provide an example of tracking a file with brackets in the name to reinforce the use of the `--filename` option as well.

Fixes #3784.