### PR TITLE
Update index before showing status

### DIFF
--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -170,12 +170,12 @@ func blobInfo(s *lfs.PointerScanner, blobSha, name string) (sha, from string, er
 }
 
 func scanIndex(ref string) (staged, unstaged []*lfs.DiffIndexEntry, err error) {
-	uncached, err := lfs.NewDiffIndexScanner(ref, false)
+	uncached, err := lfs.NewDiffIndexScanner(ref, false, true)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	cached, err := lfs.NewDiffIndexScanner(ref, true)
+	cached, err := lfs.NewDiffIndexScanner(ref, true, false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/git/git.go
+++ b/git/git.go
@@ -178,7 +178,14 @@ func CatFile() (*subprocess.BufferedCmd, error) {
 	return gitNoLFSBuffered("cat-file", "--batch-check")
 }
 
-func DiffIndex(ref string, cached bool) (*bufio.Scanner, error) {
+func DiffIndex(ref string, cached bool, refresh bool) (*bufio.Scanner, error) {
+	if refresh {
+		_, err := gitSimple("update-index", "-q", "--refresh")
+		if err != nil {
+			return nil, lfserrors.Wrap(err, "Failed to run git update-index")
+		}
+	}
+
 	args := []string{"diff-index", "-M"}
 	if cached {
 		args = append(args, "--cached")

--- a/lfs/diff_index_scanner.go
+++ b/lfs/diff_index_scanner.go
@@ -119,11 +119,16 @@ type DiffIndexScanner struct {
 // scan for differences between the given ref and the currently checked out
 // tree.
 //
+// If "refresh" is given, the DiffIndexScanner will refresh the index.  This is
+// probably what you want in all cases except fsck, where invoking a filtering
+// operation would be undesirable due to the possibility of corruption. It can
+// also be disabled where another operation will have refreshed the index.
+//
 // If any error was encountered in starting the command or closing its `stdin`,
 // that error will be returned immediately. Otherwise, a `*DiffIndexScanner`
 // will be returned with a `nil` error.
-func NewDiffIndexScanner(ref string, cached bool) (*DiffIndexScanner, error) {
-	scanner, err := git.DiffIndex(ref, cached)
+func NewDiffIndexScanner(ref string, cached bool, refresh bool) (*DiffIndexScanner, error) {
+	scanner, err := git.DiffIndex(ref, cached, refresh)
 	if err != nil {
 		return nil, err
 	}

--- a/lfs/gitscanner_index.go
+++ b/lfs/gitscanner_index.go
@@ -110,7 +110,7 @@ func scanIndex(cb GitScannerFoundPointer, ref string, f *filepathfilter.Filter, 
 // for in the indexf. It returns a channel from which sha1 strings can be read.
 // The namMap will be filled indexFile pointers mapping sha1s to indexFiles.
 func revListIndex(atRef string, cache bool, indexMap *indexFileMap) (*StringChannelWrapper, error) {
-	scanner, err := NewDiffIndexScanner(atRef, cache)
+	scanner, err := NewDiffIndexScanner(atRef, cache, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When running `git lfs status`, we perform a `git diff-index`.  However, we don't update the index first, so any changes, such as permissions changes due to locking, cause the file to be listed as modified.  Since these changes don't represent actual changes that we're interested in, refresh the index before running diff-index so that it doesn't produce spurious output.

Fixes #3412