### PR TITLE
Interpret relative hook paths as relative to working tree

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -324,7 +324,14 @@ func (c *Configuration) HookDir() (string, error) {
 	if git.IsGitVersionAtLeast("2.9.0") {
 		hp, ok := c.Git.Get("core.hooksPath")
 		if ok {
-			return tools.ExpandPath(hp, false)
+			path, err := tools.ExpandPath(hp, false)
+			if err != nil {
+				return "", err
+			}
+			if filepath.IsAbs(path) {
+				return path, nil
+			}
+			return filepath.Join(c.LocalWorkingDir(), path), nil
 		}
 	}
 	return filepath.Join(c.LocalGitStorageDir(), "hooks"), nil

--- a/t/t-install-custom-hooks-path.sh
+++ b/t/t-install-custom-hooks-path.sh
@@ -19,6 +19,14 @@ assert_hooks() {
   [ ! -e ".git/post-merge" ]
 }
 
+refute_hooks() {
+  local hooks_dir="$1"
+  [ ! -e "$hooks_dir/pre-push" ]
+  [ ! -e "$hooks_dir/post-checkout" ]
+  [ ! -e "$hooks_dir/post-commit" ]
+  [ ! -e "$hooks_dir/post-merge" ]
+}
+
 begin_test "install with supported core.hooksPath"
 (
   set -e
@@ -36,6 +44,28 @@ begin_test "install with supported core.hooksPath"
   grep "Updated git hooks" install.log
 
   assert_hooks "$hooks_dir"
+)
+end_test
+
+begin_test "install with supported core.hooksPath in subdirectory"
+(
+  set -e
+
+  repo_name="supported-custom-hooks-path-subdir"
+  git init "$repo_name"
+  cd "$repo_name"
+
+  hooks_dir="custom_hooks_dir"
+
+  mkdir subdir
+
+  git config --local core.hooksPath "$hooks_dir"
+
+  (cd subdir && git lfs install 2>&1 | tee install.log)
+  grep "Updated git hooks" subdir/install.log
+
+  assert_hooks "$hooks_dir"
+  refute_hooks "subdir/$hooks_dir"
 )
 end_test
 


### PR DESCRIPTION
Git specifies that relative hook paths are specified relative to the working tree in a non-bare repository.  However, we were interpreting it relative to the working directory, which meant that we could install hooks in an undesired place if the user was in a subdirectory of the repository.  Fix this by installing relative to the root of the working tree as Git does.

Fixes #3802