### PR TITLE
Fix more Linux package issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,3 +72,12 @@ jobs:
     - run: git clone -b v2.0.0 https://github.com/git/git.git "$HOME/git"
     - run: script/build-git "$HOME/git"
     - run: script/cibuild
+  build-docker:
+    name: Build Linux packages
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions/setup-ruby@v1
+    - run: git clone https://github.com/git-lfs/build-dockers.git "$HOME/build-dockers"
+    - run: (cd "$HOME/build-dockers" && ./build_dockers.bsh)
+    - run: DOCKER_AUTOPULL=0 ./docker/run_dockers.bsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,7 @@ jobs:
     - run: git clone https://github.com/git-lfs/build-dockers.git "$HOME/build-dockers"
     - run: (cd "$HOME/build-dockers" && ./build_dockers.bsh)
     - run: DOCKER_AUTOPULL=0 ./docker/run_dockers.bsh
-    - run: ./script/packagecloud.rb
+    # If this is a pre-release tag, don't upload anything to packagecloud.
+    - run: '[ -z "${GITHUB_REF%%refs/tags/*-pre*}" ] || ./script/packagecloud.rb'
       env:
         PACKAGECLOUD_TOKEN: ${{secrets.PACKAGECLOUD_TOKEN}}

--- a/rpm/build_rpms.bsh
+++ b/rpm/build_rpms.bsh
@@ -160,7 +160,7 @@ rm -rf ${CURDIR}/tmptar
 mkdir -p ${CURDIR}/tmptar/git-lfs-${LFS_VERSION}
 pushd ${CURDIR}/..
   #I started running out of space in the docker, so I needed to copy a little less waste
-  tar -c . --exclude tmptar --exclude repos | tar -x -C ${CURDIR}/tmptar/git-lfs-${LFS_VERSION}/
+  tar -c --exclude tmptar --exclude repos . | tar -x -C ${CURDIR}/tmptar/git-lfs-${LFS_VERSION}/
 popd
 pushd ${CURDIR}/tmptar
   tar -zcf ${CURDIR}/SOURCES/git-lfs-${LFS_VERSION}.tar.gz git-lfs-${LFS_VERSION}

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -1,3 +1,4 @@
+#!/usr/bin/env ruby
 # Pushes all deb and rpm files from ./repos to PackageCloud.
 
 packagecloud_user = ENV["PACKAGECLOUD_USER"] || "github"


### PR DESCRIPTION
Currently we only build Linux packages during the release process.  This means that there is a significant period of time during which unrelated changes could silently break the Linux package build.  This happened the other day with CentOS 8 and a tar update.

Since having this happen is a hassle resulting in the maintainer doing the release having to build the packages by hand, we should check this process during CI to ensure that any errors are caught early.  In addition, we should allow the building of prerelease tags so that any problems with the release can be caught before the main release is built.

We additionally fix the tar issue in this series, plus the lack of a shebang on the packagecloud script.

Note that the Windows build already takes longer than the newly added Linux package build should, so this should not impede the normal flow of development.  git-lfs/build-dockers#30 should also speed this up somewhat.