### PR TITLE
rpm: use old setup code on CentOS 7

### DIFF
--- a/rpm/SPECS/rubygem-hpricot.spec
+++ b/rpm/SPECS/rubygem-hpricot.spec
@@ -18,7 +18,7 @@ Requires:       ruby
 a swift, liberal HTML parser with a fantastic library
 
 %prep
-%if 0%{?el6}
+%if 0%{?el6}%{?el7}
 %setup -q -c -T
 %else
 %setup -q -n %{gem_name}-%{version}

--- a/rpm/SPECS/rubygem-mustache.spec
+++ b/rpm/SPECS/rubygem-mustache.spec
@@ -20,7 +20,7 @@ BuildArch:      noarch
 Inspired by ctemplate, Mustache is a framework-agnostic way to render logic-free views. As ctemplates says, "It emphasizes separating logic from presentation: it is impossible to embed application logic in this template language. Think of Mustache as a replacement for your views. Instead of views consisting of ERB or HAML with random helpers and arbitrary logic, your views are broken into two parts: a Ruby class and an HTML template.
 
 %prep
-%if 0%{?el6}
+%if 0%{?el6}%{?el7}
 %setup -q -c -T
 %else
 %setup -q -n %{gem_name}-%{version}

--- a/rpm/SPECS/rubygem-rdiscount.spec
+++ b/rpm/SPECS/rubygem-rdiscount.spec
@@ -18,7 +18,7 @@ Requires:       ruby > 1.9.2
 Fast Implementation of Gruber's Markdown in C
 
 %prep
-%if 0%{?el6}
+%if 0%{?el6}%{?el7}
 %setup -q -c -T
 %else
 %setup -q -n %{gem_name}-%{version}

--- a/rpm/SPECS/rubygem-ronn.spec
+++ b/rpm/SPECS/rubygem-ronn.spec
@@ -23,7 +23,7 @@ BuildArch:      noarch
 Builds Manuals
 
 %prep
-%if 0%{?el6}
+%if 0%{?el6}%{?el7}
 %setup -q -c -T
 %else
 %setup -q -n %{gem_name}-%{version}


### PR DESCRIPTION
We need to have different %setup invocations on CentOS 8 and older CentOS versions.  Originally, CentOS 7 was thought to behave like CentOS 8, but the fact that it behaves like CentOS 6 was hidden by the container images building the RPMs against Git LFS 2.4.0 as part of the setup process.  As a consequence, we never built the RPMs using the new versions of the spec files in master, and we never noticed that they failed in this case.

Since we're no longer building RPMs against an ancient version of Git LFS as part of the setup process, adjust the Ruby RPMs to call the correct %setup invocation on CentOS 7.  Note that like the code with `%{?el6}`, `%{?el7}` will expand to either 1 or nothing, so the condition will be true (nonzero) for CentOS 6 or 7 and false (zero) for 8.