### PR TITLE
Don't abort with newer Git when in a bare repo

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -12,6 +12,7 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -604,6 +605,13 @@ func GitAndRootDirs() (string, string, error) {
 	out, err := cmd.Output()
 	output := string(out)
 	if err != nil {
+		// If we got a fatal error, it's possible we're on a newer
+		// (2.24+) Git and we're not in a worktree, so fall back to just
+		// looking up the repo directory.
+		if e, ok := err.(*exec.ExitError); ok && e.ProcessState.ExitCode() == 128 {
+			absGitDir, err := GitDir()
+			return absGitDir, "", err
+		}
 		return "", "", fmt.Errorf("failed to call git rev-parse --git-dir --show-toplevel: %q", buf.String())
 	}
 


### PR DESCRIPTION
In Git 2.25, git rev-parse --show-toplevel will fail when not in a work tree.  This currently causes our test suite to abort because there are myriad places that we use bare repositories, in addition to the user impact.  Fix this by adjusting our code to fall back to querying just the Git directory if we get an exit code of 128 from Git, which indicates that Git called die().

The alternative would be to inspect the error message, which should theoretically be stable, since it comes from die() (it will at least not be localized), but that is potentially brittle.  We can revisit this decision in a few Git releases if it remains stable.

Fixes #3939.