### PR TITLE
release: v2.9.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
     - run: script/cibuild
     - run: make release
     - run: mkdir -p bin/assets
@@ -22,7 +22,7 @@ jobs:
     name: Build on Windows
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
     - run: mkdir -p "$HOME/go/bin"
       shell: bash
     - run: set GOPATH=%HOME%\go
@@ -57,7 +57,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
     - run: git clone -b master https://github.com/git/git.git "$HOME/git"
     - run: script/build-git "$HOME/git"
     - run: script/cibuild
@@ -68,7 +68,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
     - run: git clone -b v2.0.0 https://github.com/git/git.git "$HOME/git"
     - run: script/build-git "$HOME/git"
     - run: script/cibuild
@@ -76,7 +76,7 @@ jobs:
     name: Build Linux packages
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
     - run: git clone https://github.com/git-lfs/build-dockers.git "$HOME/build-dockers"
     - run: (cd "$HOME/build-dockers" && ./build_dockers.bsh)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,3 +72,12 @@ jobs:
     - run: git clone -b v2.0.0 https://github.com/git/git.git "$HOME/git"
     - run: script/build-git "$HOME/git"
     - run: script/cibuild
+  build-docker:
+    name: Build Linux packages
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions/setup-ruby@v1
+    - run: git clone https://github.com/git-lfs/build-dockers.git "$HOME/build-dockers"
+    - run: (cd "$HOME/build-dockers" && ./build_dockers.bsh)
+    - run: DOCKER_AUTOPULL=0 ./docker/run_dockers.bsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
     name: Build Windows Assets
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
     - run: mkdir -p "$HOME/go/bin"
       shell: bash
@@ -46,7 +46,7 @@ jobs:
     needs: build-windows
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
     - uses: actions/download-artifact@v1
       with:
@@ -61,7 +61,7 @@ jobs:
     name: Build Linux Packages
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
     - run: gem install packagecloud-ruby
     - run: git clone https://github.com/git-lfs/build-dockers.git "$HOME/build-dockers"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,7 @@ jobs:
     - run: git clone https://github.com/git-lfs/build-dockers.git "$HOME/build-dockers"
     - run: (cd "$HOME/build-dockers" && ./build_dockers.bsh)
     - run: DOCKER_AUTOPULL=0 ./docker/run_dockers.bsh
-    - run: ./script/packagecloud.rb
+    # If this is a pre-release tag, don't upload anything to packagecloud.
+    - run: '[ -z "${GITHUB_REF%%refs/tags/*-pre*}" ] || ./script/packagecloud.rb'
       env:
         PACKAGECLOUD_TOKEN: ${{secrets.PACKAGECLOUD_TOKEN}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Git LFS Changelog
 
+## 2.9.2 (12 December 2019)
+
+This release fixes a few regressions, such as a possible nil pointer
+dereference, a failure to retry batch requests, and a bug where repositories
+could fail to be detected on Windows.
+
+We would like to extend a special thanks to the following open-source
+contributors:
+
+* @exceed-alae for fixing a possible nil pointer dereference
+
+### Bugs
+
+* Add nil-check on defer block of DoTransfer() #3936 (@exceed-alae)
+* Retry batch failures #3930 (@bk2204)
+* rpm: use old setup code on CentOS 7 #3938 (@bk2204)
+* Handle missing cygpath gracefully #3910 (@bk2204)
+
+### Misc
+
+* Don't abort with newer Git when in a bare repo #3940 (@bk2204)
+* Fix more Linux package issues #3932 (@bk2204)
+
 ## 2.9.1 (25 November 2019)
 
 This release fixes a few regressions, such as the ability to use HTTP/1.1 when

--- a/config/version.go
+++ b/config/version.go
@@ -13,7 +13,7 @@ var (
 )
 
 const (
-	Version = "2.9.1"
+	Version = "2.9.2"
 )
 
 func init() {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+git-lfs (2.9.2) stable; urgency=low
+
+  * New upstream version
+
+ -- brian m. carlson <bk2204@github.com>  Thu, 12 Dec 2019 14:29:00 -0000
+
 git-lfs (2.9.1) stable; urgency=low
 
   * New upstream version

--- a/rpm/SPECS/git-lfs.spec
+++ b/rpm/SPECS/git-lfs.spec
@@ -1,5 +1,5 @@
 Name:           git-lfs
-Version:        2.9.1
+Version:        2.9.2
 Release:        1%{?dist}
 Summary:        Git extension for versioning large files
 

--- a/rpm/SPECS/rubygem-hpricot.spec
+++ b/rpm/SPECS/rubygem-hpricot.spec
@@ -18,7 +18,7 @@ Requires:       ruby
 a swift, liberal HTML parser with a fantastic library
 
 %prep
-%if 0%{?el6}
+%if 0%{?el6}%{?el7}
 %setup -q -c -T
 %else
 %setup -q -n %{gem_name}-%{version}

--- a/rpm/SPECS/rubygem-mustache.spec
+++ b/rpm/SPECS/rubygem-mustache.spec
@@ -20,7 +20,7 @@ BuildArch:      noarch
 Inspired by ctemplate, Mustache is a framework-agnostic way to render logic-free views. As ctemplates says, "It emphasizes separating logic from presentation: it is impossible to embed application logic in this template language. Think of Mustache as a replacement for your views. Instead of views consisting of ERB or HAML with random helpers and arbitrary logic, your views are broken into two parts: a Ruby class and an HTML template.
 
 %prep
-%if 0%{?el6}
+%if 0%{?el6}%{?el7}
 %setup -q -c -T
 %else
 %setup -q -n %{gem_name}-%{version}

--- a/rpm/SPECS/rubygem-rdiscount.spec
+++ b/rpm/SPECS/rubygem-rdiscount.spec
@@ -18,7 +18,7 @@ Requires:       ruby > 1.9.2
 Fast Implementation of Gruber's Markdown in C
 
 %prep
-%if 0%{?el6}
+%if 0%{?el6}%{?el7}
 %setup -q -c -T
 %else
 %setup -q -n %{gem_name}-%{version}

--- a/rpm/SPECS/rubygem-ronn.spec
+++ b/rpm/SPECS/rubygem-ronn.spec
@@ -23,7 +23,7 @@ BuildArch:      noarch
 Builds Manuals
 
 %prep
-%if 0%{?el6}
+%if 0%{?el6}%{?el7}
 %setup -q -c -T
 %else
 %setup -q -n %{gem_name}-%{version}

--- a/rpm/build_rpms.bsh
+++ b/rpm/build_rpms.bsh
@@ -160,7 +160,7 @@ rm -rf ${CURDIR}/tmptar
 mkdir -p ${CURDIR}/tmptar/git-lfs-${LFS_VERSION}
 pushd ${CURDIR}/..
   #I started running out of space in the docker, so I needed to copy a little less waste
-  tar -c . --exclude tmptar --exclude repos | tar -x -C ${CURDIR}/tmptar/git-lfs-${LFS_VERSION}/
+  tar -c --exclude tmptar --exclude repos . | tar -x -C ${CURDIR}/tmptar/git-lfs-${LFS_VERSION}/
 popd
 pushd ${CURDIR}/tmptar
   tar -zcf ${CURDIR}/SOURCES/git-lfs-${LFS_VERSION}.tar.gz git-lfs-${LFS_VERSION}

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -1,3 +1,4 @@
+#!/usr/bin/env ruby
 # Pushes all deb and rpm files from ./repos to PackageCloud.
 
 packagecloud_user = ENV["PACKAGECLOUD_USER"] || "github"

--- a/tools/os_tools.go
+++ b/tools/os_tools.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/git-lfs/git-lfs/subprocess"
@@ -33,7 +34,12 @@ func translateCygwinPath(path string) (string, error) {
 	out, err := cmd.Output()
 	output := strings.TrimSpace(string(out))
 	if err != nil {
-		return path, fmt.Errorf("Failed to translate path from cygwin to windows: %s", buf.String())
+		// If cygpath doesn't exist, that's okay: just return the paths
+		// as we got it.
+		if _, ok := err.(*exec.Error); ok {
+			return path, nil
+		}
+		return path, fmt.Errorf("failed to translate path from cygwin to windows: %s", buf.String())
 	}
 	return output, nil
 }

--- a/tq/basic_download.go
+++ b/tq/basic_download.go
@@ -47,13 +47,17 @@ func (a *basicDownloadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb Progr
 	if err != nil {
 		return err
 	}
+	tmpName := f.Name()
 	defer func() {
-		f.Close()
+		// Fail-safe: Most implementation of os.File.Close() does nil check
+		if f != nil {
+			f.Close()
+		}
 		// This will delete temp file if:
 		// - we failed to fully download file and move it to final location including the case when final location already
 		//   exists because other parallel git-lfs processes downloaded file
 		// - we also failed to move it to a partially-downloaded location
-		os.Remove(f.Name())
+		os.Remove(tmpName)
 	}()
 
 	// Close file because we will attempt to move partially-downloaded one on top of it

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -442,7 +442,7 @@ func (q *TransferQueue) collectBatches() {
 		// don't process further batches.  Abort the wait queue so that
 		// we don't deadlock waiting for objects to complete when they
 		// never will.
-		if err != nil {
+		if err != nil && !errors.IsRetriableError(err) {
 			q.wait.Abort()
 			break
 		}
@@ -538,7 +538,7 @@ func (q *TransferQueue) enqueueAndCollectRetriesFor(batch batch) (batch, error) 
 				}
 			}
 
-			return next, err
+			return next, errors.NewRetriableError(err)
 		}
 	}
 

--- a/versioninfo.json
+++ b/versioninfo.json
@@ -4,7 +4,7 @@
 		"FileVersion": {
 			"Major": 2,
 			"Minor": 9,
-			"Patch": 1,
+			"Patch": 2,
 			"Build": 0
 		}
 	},
@@ -13,7 +13,7 @@
 		"FileDescription": "Git LFS",
 		"LegalCopyright": "GitHub, Inc. and Git LFS contributors",
 		"ProductName": "Git Large File Storage (LFS)",
-		"ProductVersion": "2.9.1"
+		"ProductVersion": "2.9.2"
 	},
 	"IconPath": "script/windows-installer/git-lfs-logo.ico"
 }


### PR DESCRIPTION
This is an in-progress look at the next release of Git LFS, v2.9.1, which is scheduled for Thursday, December 12, 2019.

We're publishing these changes early so that folks on @git-lfs/implementers can check that things work with their various platforms.

I've attached some builds below for people to use for testing:

[git-lfs-darwin-386-v2.9.2-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/3941566/git-lfs-darwin-386-v2.9.2-pre.tar.gz)
[git-lfs-darwin-amd64-v2.9.2-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/3941567/git-lfs-darwin-amd64-v2.9.2-pre.tar.gz)
[git-lfs-freebsd-386-v2.9.2-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/3941568/git-lfs-freebsd-386-v2.9.2-pre.tar.gz)
[git-lfs-freebsd-amd64-v2.9.2-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/3941569/git-lfs-freebsd-amd64-v2.9.2-pre.tar.gz)
[git-lfs-linux-386-v2.9.2-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/3941570/git-lfs-linux-386-v2.9.2-pre.tar.gz)
[git-lfs-linux-amd64-v2.9.2-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/3941571/git-lfs-linux-amd64-v2.9.2-pre.tar.gz)
[git-lfs-linux-arm64-v2.9.2-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/3941572/git-lfs-linux-arm64-v2.9.2-pre.tar.gz)
[git-lfs-v2.9.2-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/3941573/git-lfs-v2.9.2-pre.tar.gz)
[git-lfs-windows-386-v2.9.2-pre.zip](https://github.com/git-lfs/git-lfs/files/3941574/git-lfs-windows-386-v2.9.2-pre.zip)
[git-lfs-windows-amd64-v2.9.2-pre.zip](https://github.com/git-lfs/git-lfs/files/3941575/git-lfs-windows-amd64-v2.9.2-pre.zip)

In addition, the CI system will produce artifacts for Windows, Linux, and macOS if you prefer to use those; they should be equivalent.

/cc @git-lfs/core
/cc @git-lfs/implementers
/cc @git-lfs/releases