### PR TITLE
Document and test Go versions explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,18 @@ jobs:
       with:
         name: ${{ matrix.os }}
         path: bin/assets
+  build-go:
+    name: Build with specific Go
+    strategy:
+      matrix:
+        go: ['1.12.x', '1.13.x']
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-go@v1
+      with:
+        go-version: ${{ matrix.go }}
+    - run: script/cibuild
   build-windows:
     name: Build on Windows
     runs-on: windows-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,9 @@ Here are some tips for getting your question answered as quickly as possible:
 
 ### Prerequisites
 
-Git LFS depends on having a working Go 1.11.0+ environment.
+Git LFS depends on having a working Go development environment.  We officially
+support the latest version of Go, although we try not to break backwards
+compatibility with older versions if it's possible to avoid doing so.
 
 On RHEL etc. e.g. Red Hat Enterprise Linux Server release 7.2 (Maipo), you will neet the minimum packages installed to build Git LFS:
 


### PR DESCRIPTION
Our documentation was conflicting on the versions of Go we support.  Update the contributing documentation to reflect that we support the latest version of Go, although we try not to break support for older versions if it's easily avoidable.  This helps set folks' expectations for backwards compatibility.

In addition, since our CI currently depends on both Go 1.12 (the default on Ubuntu) and 1.13 (the default on macOS) working, let's explicitly specify those in the CI system.  This way, we'll make an explicit decision to change Go versions.

Fixes #3945