### PR TITLE
Clarify output shown by `git lfs status`

### DIFF
--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -58,7 +58,7 @@ func statusCommand(cmd *cobra.Command, args []string) {
 
 	wd = tools.ResolveSymlinks(wd)
 
-	Print("\nGit LFS objects to be committed:\n")
+	Print("\nObjects to be committed:\n")
 	for _, entry := range staged {
 		// Find a path from the current working directory to the
 		// absolute path of each side of the entry.
@@ -73,7 +73,7 @@ func statusCommand(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	Print("\nGit LFS objects not staged for commit:\n")
+	Print("\nObjects not staged for commit:\n")
 	for _, entry := range unstaged {
 		src := relativize(wd, filepath.Join(repo, entry.SrcName))
 
@@ -246,7 +246,7 @@ func statusScanRefRange(ref *git.Ref) {
 	})
 	defer gitscanner.Close()
 
-	Print("Git LFS objects to be pushed to %s:\n", remoteRef.Name)
+	Print("Objects to be pushed to %s:\n", remoteRef.Name)
 	if err := gitscanner.ScanRefRange(ref.Sha, remoteRef.Sha, nil); err != nil {
 		Panic(err, "Could not scan for Git LFS objects")
 	}

--- a/t/t-status.sh
+++ b/t/t-status.sh
@@ -42,12 +42,12 @@ begin_test "status"
 
   expected="On branch master
 
-Git LFS objects to be committed:
+Objects to be committed:
 
 	file2.dat (LFS: $file_2_oid_short)
 	file3.dat (LFS: $file_3_oid_short)
 
-Git LFS objects not staged for commit:
+Objects not staged for commit:
 
 	file1.dat (LFS: $file_1_oid_short -> File: $file_1_new_oid_short)
 	file3.dat (File: $file_3_new_oid_short)"
@@ -137,10 +137,10 @@ begin_test "status in a sub-directory"
 
   expected="On branch master
 
-Git LFS objects to be committed:
+Objects to be committed:
 
 
-Git LFS objects not staged for commit:
+Objects not staged for commit:
 
 	../file.dat (LFS: f0e4c2f -> File: 99b3bcf)"
 
@@ -183,11 +183,11 @@ begin_test "status - before initial commit"
   git add file1.dat
 
   expected="
-Git LFS objects to be committed:
+Objects to be committed:
 
 	file1.dat (LFS: $contents_oid_short)
 
-Git LFS objects not staged for commit:"
+Objects not staged for commit:"
 
   [ "$expected" = "$(git lfs status)" ]
 )
@@ -245,11 +245,11 @@ begin_test "status shows multiple copies of partially staged files"
 
   expected="On branch master
 
-Git LFS objects to be committed:
+Objects to be committed:
 
 	a.dat (LFS: $contents_1_oid_short)
 
-Git LFS objects not staged for commit:
+Objects not staged for commit:
 
 	a.dat (File: $contents_2_oid_short)"
   actual="$(git lfs status)"
@@ -287,11 +287,11 @@ begin_test "status: LFS to LFS change"
 
   expected="On branch master
 
-Git LFS objects to be committed:
+Objects to be committed:
 
 	a.dat (LFS: $contents_oid_short -> LFS: $contents_new_oid_short)
 
-Git LFS objects not staged for commit:"
+Objects not staged for commit:"
   actual="$(git lfs status)"
 
   [ "$expected" = "$actual" ]
@@ -327,11 +327,11 @@ begin_test "status: Git to LFS change"
 
   expected="On branch master
 
-Git LFS objects to be committed:
+Objects to be committed:
 
 	a.dat (Git: $contents_oid_short -> LFS: $contents_new_oid_short)
 
-Git LFS objects not staged for commit:"
+Objects not staged for commit:"
   actual="$(git lfs status)"
 
   [ "$expected" = "$actual" ]
@@ -372,14 +372,14 @@ begin_test "status: Git to LFS conversion"
     fi
 
     expected="On branch master
-Git LFS objects to be pushed to origin/master:
+Objects to be pushed to origin/master:
 
 
-Git LFS objects to be committed:
+Objects to be committed:
 
 	a.dat (Git: $contents_oid_short -> LFS: $contents_oid_short)
 
-Git LFS objects not staged for commit:"
+Objects not staged for commit:"
     actual="$(cat status.log)"
 
     [ "$expected" = "$actual" ]
@@ -436,14 +436,14 @@ begin_test "status (unpushed objects)"
   git commit -m "add a large file"
 
   expected="On branch master
-Git LFS objects to be pushed to origin/master:
+Objects to be pushed to origin/master:
 
 	a.dat ($oid)
 
-Git LFS objects to be committed:
+Objects to be committed:
 
 
-Git LFS objects not staged for commit:"
+Objects not staged for commit:"
 
   [ "$expected" = "$(git lfs status)" ]
 )
@@ -490,15 +490,15 @@ begin_test "status (deleted files)"
   git rm a.dat
 
   expected="On branch master
-Git LFS objects to be pushed to origin/master:
+Objects to be pushed to origin/master:
 
 	a.dat ($oid)
 
-Git LFS objects to be committed:
+Objects to be committed:
 
 	a.dat (LFS: $oid_short -> File: deleted)
 
-Git LFS objects not staged for commit:"
+Objects not staged for commit:"
 
   [ "$expected" = "$(git lfs status)" ]
 )
@@ -538,12 +538,12 @@ begin_test "status (file to dir)"
 
   expected="On branch master
 
-Git LFS objects to be committed:
+Objects to be committed:
 
 	test (Git: $obj -> File: deleted)
 	test/a.dat (LFS: $oid_short)
 
-Git LFS objects not staged for commit:"
+Objects not staged for commit:"
 
   [ "$expected" = "$(git lfs status)" ]
 )
@@ -584,10 +584,10 @@ begin_test "status: permission change"
 
   expected="On branch master
 
-Git LFS objects to be committed:
+Objects to be committed:
 
 
-Git LFS objects not staged for commit:"
+Objects not staged for commit:"
   actual="$(cat status.log)"
 
   [ "$expected" = "$actual" ]


### PR DESCRIPTION
Resolve git-lfs/git-lfs#3552
The `git lfs status` command shows objects that pertain to both
`git lfs` as well as regular `git` objects. This commit modifies
the output of `git lfs status` to better reflect that