### PR TITLE
debian: bump version of golang-go

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: git-lfs
 Section: vcs
 Priority: optional
 Maintainer: Stephen Gelman <gelman@getbraintree.com>
-Build-Depends: debhelper (>= 9), dh-golang, golang-go:native (>= 1.3.0), git (>= 1.8.2), ruby-ronn, ronn | ruby-ronn (<< 0.8.0-1)
+Build-Depends: debhelper (>= 9), dh-golang, golang-go:native (>= 1.12.0), git (>= 1.8.2), ruby-ronn, ronn | ruby-ronn (<< 0.8.0-1)
 Standards-Version: 3.9.6
 
 Package: git-lfs


### PR DESCRIPTION
Since we now require Go 1.12 to build, let's bump the version in the debian/control file so that others using our packages have their dependencies properly satisfied.