### PR TITLE
Add CI link to CI badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Git Large File Storage
 
-![CI status][1]
+[![CI status][ci_badge]][ci_url]
 
-[1]: https://github.com/git-lfs/git-lfs/workflows/CI/badge.svg
+[ci_badge]: https://github.com/git-lfs/git-lfs/workflows/CI/badge.svg
+[ci_url]: https://github.com/git-lfs/git-lfs/actions?query=workflow%3ACI
 
 [Git LFS](https://git-lfs.github.com) is a command line extension and
 [specification](docs/spec.md) for managing large files with Git.


### PR DESCRIPTION
Before this commit, clicking on a CI badge would just open badge image.
Instead, now it will navigate user to CI page.