### PR TITLE
install: don't print error if run outside repository

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -672,9 +672,12 @@ func RootDir() (string, error) {
 
 func GitDir() (string, error) {
 	cmd := gitNoLFS("rev-parse", "--git-dir")
+	buf := &bytes.Buffer{}
+	cmd.Stderr = buf
 	out, err := cmd.Output()
+
 	if err != nil {
-		return "", fmt.Errorf("failed to call git rev-parse --git-dir: %v %v", err, string(out))
+		return "", fmt.Errorf("failed to call git rev-parse --git-dir: %v %v: %v", err, string(out), buf.String())
 	}
 	path := strings.TrimSpace(string(out))
 	path, err = tools.TranslateCygwinPath(path)
@@ -694,8 +697,10 @@ func GitCommonDir() (string, error) {
 
 	cmd := gitNoLFS("rev-parse", "--git-common-dir")
 	out, err := cmd.Output()
+	buf := &bytes.Buffer{}
+	cmd.Stderr = buf
 	if err != nil {
-		return "", fmt.Errorf("failed to call git rev-parse --git-dir: %v %v", err, string(out))
+		return "", fmt.Errorf("failed to call git rev-parse --git-common-dir: %v %v: %v", err, string(out), buf.String())
 	}
 	path := strings.TrimSpace(string(out))
 	path, err = tools.TranslateCygwinPath(path)

--- a/t/t-install.sh
+++ b/t/t-install.sh
@@ -163,7 +163,7 @@ begin_test "install outside repository directory"
     exit 1
   fi
 
-  git lfs install 2>&1 > check.log
+  git lfs install > check.log 2>&1
 
   if [ -d "hooks" ]; then
     ls -al
@@ -175,6 +175,7 @@ begin_test "install outside repository directory"
 
   # doesn't print this because being in a git repo is not necessary for install
   [ "$(grep -c "Not in a git repository" check.log)" = "0" ]
+  [ "$(grep -c "Error" check.log)" = "0" ]
 )
 end_test
 


### PR DESCRIPTION
As of 2.9.2, if run outside of a repository, Git LFS will produce an error if `git lfs install` is run outside of a repository.  This occurs because we look for a specific string in the error message to detect if the directory is not a repository, but that message was no longer included since the standard output of `git rev-parse` is not included.

Include the standard error output in the message so that we correctly detect whether the directory is a repository or not and avoid printing an error message in this case if it is not.

Fixes #3964.