### PR TITLE
Optimize pushes for multiple refs

### DIFF
--- a/lfs/gitscanner.go
+++ b/lfs/gitscanner.go
@@ -95,6 +95,25 @@ func (s *GitScanner) ScanRangeToRemote(left, right string, cb GitScannerFoundPoi
 	return scanLeftRightToChan(s, callback, left, right, s.cfg.OSEnv(), s.opts(ScanRangeToRemoteMode))
 }
 
+// ScanMultiRangeToRemote scans through all commits starting at the left ref but
+// not including the right ref (if given) that the given remote does not have.
+// See RemoteForPush().
+func (s *GitScanner) ScanMultiRangeToRemote(left string, rights []string, cb GitScannerFoundPointer) error {
+	callback, err := firstGitScannerCallback(cb, s.FoundPointer)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	if len(s.remote) == 0 {
+		s.mu.Unlock()
+		return fmt.Errorf("unable to scan starting at %q: no remote set", left)
+	}
+	s.mu.Unlock()
+
+	return scanMultiLeftRightToChan(s, callback, left, rights, s.cfg.OSEnv(), s.opts(ScanRangeToRemoteMode))
+}
+
 // ScanRefs through all commits reachable by refs contained in "include" and
 // not reachable by any refs included in "excluded"
 func (s *GitScanner) ScanRefs(include, exclude []string, cb GitScannerFoundPointer) error {

--- a/lfs/gitscanner_refs.go
+++ b/lfs/gitscanner_refs.go
@@ -100,6 +100,14 @@ func scanLeftRightToChan(scanner *GitScanner, pointerCb GitScannerFoundPointer, 
 	return scanRefsToChan(scanner, pointerCb, []string{refLeft}, []string{refRight}, osEnv, opt)
 }
 
+// scanMultiLeftRightToChan takes a ref and a set of bases and returns a channel
+// of WrappedPointer objects for all Git LFS pointers it finds for that ref.
+// Reports unique oids once only, not multiple times if >1 file uses the same
+// content
+func scanMultiLeftRightToChan(scanner *GitScanner, pointerCb GitScannerFoundPointer, refLeft string, bases []string, osEnv config.Environment, opt *ScanRefsOptions) error {
+	return scanRefsToChan(scanner, pointerCb, []string{refLeft}, bases, osEnv, opt)
+}
+
 // revListShas uses git rev-list to return the list of object sha1s
 // for the given ref. If all is true, ref is ignored. It returns a
 // channel from which sha1 strings can be read.


### PR DESCRIPTION
This PR optimizes pushes for multiple refs by using all the remote sides as bases for crawling `git rev-list`.

Fixes #3976.