### PR TITLE
t-duplicate-oids: use correct awk indexing

### DIFF
--- a/t/t-duplicate-oids.sh
+++ b/t/t-duplicate-oids.sh
@@ -19,7 +19,7 @@ begin_test "multiple revs with same OID get pushed once"
 
   # Stash the contents of the file that we want to commit in .git/lfs/objects.
   object_dir="$(echo $contents_oid \
-    | awk '{ print substr($0, 0, 2) "/" substr($0, 3, 2) }')"
+    | awk '{ print substr($0, 1, 2) "/" substr($0, 3, 2) }')"
   mkdir -p ".git/lfs/objects/$object_dir"
   printf "%s" "$contents" > ".git/lfs/objects/$object_dir/$contents_oid"
 


### PR DESCRIPTION
In awk, strings start at position 1, not position 0, according to POSIX. While using 0 does the right thing for some awk versions, it fails with the version of mawk in Debian unstable.  Since it's easy to invoke this in a way that works for all awk versions, let's do so.
