### PR TITLE
Include ppc64le and s390x Linux builds in releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,8 @@ BUILD_TARGETS = \
 	bin/git-lfs-darwin-386 \
 	bin/git-lfs-linux-arm64 \
 	bin/git-lfs-linux-amd64 \
+	bin/git-lfs-linux-ppc64le \
+	bin/git-lfs-linux-s390x \
 	bin/git-lfs-linux-386 \
 	bin/git-lfs-freebsd-amd64 \
 	bin/git-lfs-freebsd-386 \
@@ -209,6 +211,10 @@ bin/git-lfs-linux-arm64 : $(SOURCES) mangen
 	$(call BUILD,linux,arm64,-linux-arm64)
 bin/git-lfs-linux-amd64 : $(SOURCES) mangen
 	$(call BUILD,linux,amd64,-linux-amd64)
+bin/git-lfs-linux-ppc64le : $(SOURCES) mangen
+	$(call BUILD,linux,ppc64le,-linux-ppc64le)
+bin/git-lfs-linux-s390x : $(SOURCES) mangen
+	$(call BUILD,linux,s390x,-linux-s390x)
 bin/git-lfs-linux-386 : $(SOURCES) mangen
 	$(call BUILD,linux,386,-linux-386)
 bin/git-lfs-freebsd-amd64 : $(SOURCES) mangen
@@ -266,6 +272,8 @@ RELEASE_TARGETS = \
 	bin/releases/git-lfs-darwin-386-$(VERSION).tar.gz \
 	bin/releases/git-lfs-linux-arm64-$(VERSION).tar.gz \
 	bin/releases/git-lfs-linux-amd64-$(VERSION).tar.gz \
+	bin/releases/git-lfs-linux-ppc64le-$(VERSION).tar.gz \
+	bin/releases/git-lfs-linux-s390x-$(VERSION).tar.gz \
 	bin/releases/git-lfs-linux-386-$(VERSION).tar.gz \
 	bin/releases/git-lfs-freebsd-amd64-$(VERSION).tar.gz \
 	bin/releases/git-lfs-freebsd-386-$(VERSION).tar.gz \

--- a/script/upload
+++ b/script/upload
@@ -44,7 +44,12 @@ categorize_os () {
 categorize_arch () {
   local arch="$1"
 
-  echo "$arch" | tr a-z A-Z
+  if [ "$arch" = "ppc64le" ]
+  then
+    echo "Little-endian 64-bit PowerPC"
+  else
+    echo "$arch" | tr a-z A-Z
+  fi
 }
 
 # Categorize a release asset and print its human readable name to standard


### PR DESCRIPTION
These have been requested and it's trivial to build them.  In addition, they're supported by Debian, so presumably they have a reasonable number of users.  Let's build them.

/cc #3982
/cc @james-crowley as reporter