### PR TITLE
.github/workflows: temporarily fix path on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v1
+    - run: |
+        echo "::add-path::C:\Program Files\Git\mingw64\bin"
+        echo "::add-path::C:\Program Files\Git\usr\bin"
+        echo "::add-path::C:\Program Files\Git\bin"
     - run: mkdir -p "$HOME/go/bin"
       shell: bash
     - run: set GOPATH=%HOME%\go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
+    - run: |
+        echo "::add-path::C:\Program Files\Git\mingw64\bin"
+        echo "::add-path::C:\Program Files\Git\usr\bin"
+        echo "::add-path::C:\Program Files\Git\bin"
     - run: mkdir -p "$HOME/go/bin"
       shell: bash
     - run: set GOPATH=%HOME%\go


### PR DESCRIPTION
There's a bug with Actions right now that causes the path to be set incorrectly, and as a result, this causes Windows binaries to be executed in some cases instead of the binaries that come with Git Bash. This shows up in our test suite as a hang during the execution of t-credentials.sh.

Since we can't build or release software while the Actions workflows aren't working, let's adjust the path temporarily so that things work as expected.
