### PR TITLE
Allow locking and unlocking non-existent files

### DIFF
--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -60,7 +60,7 @@ func lockCommand(cmd *cobra.Command, args []string) {
 // Windows path of "\foo\bar" will be normalized to "foo/bar".
 //
 // If the root directory, working directory, or file cannot be
-// determined/opened, an error will be returned. If the file in question is
+// determined, an error will be returned. If the file in question is
 // actually a directory, an error will be returned. Otherwise, the cleaned path
 // will be returned.
 //
@@ -96,15 +96,11 @@ func lockPath(file string) (string, error) {
 		return "", fmt.Errorf("lfs: unable to canonicalize path %q", path)
 	}
 
-	if stat, err := os.Stat(abs); err != nil {
-		return "", err
-	} else {
-		if stat.IsDir() {
-			return path, fmt.Errorf("lfs: cannot lock directory: %s", file)
-		}
-
-		return filepath.ToSlash(path), nil
+	if stat, err := os.Stat(abs); err == nil && stat.IsDir() {
+		return path, fmt.Errorf("lfs: cannot lock directory: %s", file)
 	}
+
+	return filepath.ToSlash(path), nil
 }
 
 func init() {

--- a/locking/locks.go
+++ b/locking/locks.go
@@ -125,9 +125,11 @@ func (c *Client) LockFile(path string) (Lock, error) {
 		return Lock{}, errors.Wrap(err, "make lockpath absolute")
 	}
 
-	// Ensure writeable on return
-	if err := tools.SetFileWriteFlag(abs, true); err != nil {
-		return Lock{}, err
+	// If the file exists, ensure that it's writeable on return
+	if tools.FileExists(abs) {
+		if err := tools.SetFileWriteFlag(abs, true); err != nil {
+			return Lock{}, errors.Wrap(err, "set file write flag")
+		}
 	}
 
 	return lock, nil

--- a/t/t-lock.sh
+++ b/t/t-lock.sh
@@ -100,6 +100,20 @@ begin_test "creating a lock (with output)"
 )
 end_test
 
+begin_test "locking a file that doesn't exist"
+(
+  set -e
+
+  reponame="lock_create_nonexistent"
+  setup_remote_repo_with_file "$reponame" "a_output.dat"
+
+  git lfs lock "b_output.dat" | tee lock.log
+  grep "Locked b_output.dat" lock.log
+  id=$(grep -oh "\((.*)\)" lock.log | tr -d \(\))
+  assert_server_lock "$reponame" "$id"
+)
+end_test
+
 begin_test "locking a previously locked file"
 (
   set -e


### PR DESCRIPTION
The lockPath sanitization was slightly amended to allow os.Stat() to fail. All other conditions, such as testing to see if it's a directory were retained.

If a lock is obtained, attempting to set it writable only occurs if the file exists.