### PR TITLE
track: detect duplicate patterns with --filename

### DIFF
--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -77,6 +77,16 @@ func trackCommand(cmd *cobra.Command, args []string) {
 ArgsLoop:
 	for _, unsanitizedPattern := range args {
 		pattern := trimCurrentPrefix(cleanRootPath(unsanitizedPattern))
+
+		// Generate the new / changed attrib line for merging
+		var encodedArg string
+		if trackFilenameFlag {
+			encodedArg = escapeGlobCharacters(pattern)
+			pattern = escapeGlobCharacters(pattern)
+		} else {
+			encodedArg = escapeAttrPattern(pattern)
+		}
+
 		if !trackNoModifyAttrsFlag {
 			for _, known := range knownPatterns {
 				if unescapeAttrPattern(known.Path) == filepath.Join(relpath, pattern) &&
@@ -87,15 +97,6 @@ ArgsLoop:
 					continue ArgsLoop
 				}
 			}
-		}
-
-		// Generate the new / changed attrib line for merging
-		var encodedArg string
-		if trackFilenameFlag {
-			encodedArg = escapeGlobCharacters(pattern)
-			pattern = escapeGlobCharacters(pattern)
-		} else {
-			encodedArg = escapeAttrPattern(pattern)
 		}
 
 		lockableArg := ""

--- a/t/t-track.sh
+++ b/t/t-track.sh
@@ -670,6 +670,7 @@ begin_test "track: escaped glob pattern in .gitattributes"
   contents_oid=$(calc_oid "$contents")
 
   git lfs track --filename "$filename"
+  git lfs track --filename "$filename" | grep 'already supported'
   git add .
   cat .gitattributes
 


### PR DESCRIPTION
When we add a pattern with `git lfs track`, we inform the user if the pattern is already supported.  However, we fail to do so when the `--filename` argument is passed, due to not having encoded the pattern at that point.

To solve this problem, hoist the code that encodes the filename as a pattern so it happens before we check if we already have such a pattern.

Fixes #3998.
/cc @mitar as reporter