### PR TITLE
Add an option to control warning about files larger than 4 GiB

### DIFF
--- a/commands/command_filter_process.go
+++ b/commands/command_filter_process.go
@@ -201,7 +201,7 @@ func filterCommand(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	if len(malformedOnWindows) > 0 {
+	if len(malformedOnWindows) > 0 && cfg.Git.Bool("lfs.largefilewarning", true) {
 		fmt.Fprintf(os.Stderr, "Encountered %d file(s) that may not have been copied correctly on Windows:\n", len(malformedOnWindows))
 
 		for _, m := range malformedOnWindows {

--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -83,6 +83,12 @@ be scoped inside the configuration for a remote.
 
   Default: `lfs` in Git repository directory (usually `.git/lfs`).
 
+* `lfs.largefilewarning`
+
+  Warn when a file is 4 GiB or larger. Such files will be corrupted when using
+  Windows (unless smudging is disabled) due to a limitation in Git.  Default:
+  true.
+
 ### Transfer (upload / download) settings
 
   These settings control how the upload and download of LFS content occurs.


### PR DESCRIPTION
Git on Windows is currently incapable of handling files larger than 4 GiB in size.  This is because Git uses "unsigned long" for numerous types of variables representing files, which on a Unix system is an appropriate way to specify a pointer-sized integer, since Unix systems are either ILP32 or LP64.  However, Windows is LLP64, meaning that a variable of type unsigned long is always 32 bits.

We warn about this case to help alert users to potential corruption when they're working across platforms.  However, there are some users and projects who don't use Windows and therefore don't have this problem. For those users and projects, this warning is not helpful.  Let's add an option to control that warning so folks who don't wish to see it can disable it.
