### PR TITLE
commands/command_filter_process: cherry-pick of several commits cause panic error

### DIFF
--- a/t/t-cherry-pick-commits.sh
+++ b/t/t-cherry-pick-commits.sh
@@ -31,6 +31,6 @@ begin_test "cherry-pick two commits without lfs cache"
   git checkout secondbranch
   rm -rf .git/lfs/objects
 
-  GIT_TRACE_PACK_ACCESS=2 git cherry-pick $commit1 $commit2
+  git cherry-pick $commit1 $commit2
 )
 end_test

--- a/t/t-cherry-pick-commits.sh
+++ b/t/t-cherry-pick-commits.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+. "$(dirname "$0")/testlib.sh"
+
+begin_test "cherry-pick two commits without lfs cache"
+(
+  set -e
+
+  reponame="$(basename "$0" ".sh")-cherry-pick-commits"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" cherrypickcommits
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  git branch secondbranch
+
+  echo "smudge a" > a.dat
+  git add a.dat
+  git commit -m "add a.dat"
+  commit1=$(git log -n1 --format="%H")
+
+  echo "smudge b" > b.dat
+  git add b.dat
+  git commit -m "add a.dat"
+  commit2=$(git log -n1 --format="%H")
+
+  git push origin master
+
+  git checkout secondbranch
+  rm -rf .git/lfs/objects
+
+  GIT_TRACE_PACK_ACCESS=2 git cherry-pick $commit1 $commit2
+)
+end_test


### PR DESCRIPTION
**Describe the bug**
You can receive the `panic: send on closed channel` error while cherry-pick several commits and lfs files are not presented in the cache.

The current `filter-process` realisation assumes that when the `list_available_blobs` command is received from GIT `smudge` command won't be  issued:  
https://github.com/git-lfs/git-lfs/blob/c3b776db6ee273a6c231f9d5922e3aa3421b7b3e/commands/command_filter_process.go#L124

But cherry-picking of several commits with LFS files demonstrate different behavior. It seems that GIT creates single long running process filter which is used for the entire life of a single Git command:
https://git-scm.com/docs/gitattributes#_code_filter_code

As a result GIT LFS can receive several `smudge` commands within single `filter-process`. The panic error appears when two `smudge` commands trigger `status=delayed` reply from LFS. The first `smudge` causes GIT LFS filter process to close transfer queue, the second `smudge` attempts to write in closed queue which causes panic.

Log: [log.txt](https://github.com/git-lfs/git-lfs/files/4182891/log.txt)
 
**To Reproduce**
I've created test to reproduce this issue:
t/t-cherry-pick-commits.sh
[t-cherry-pick-commits.sh.txt](https://github.com/git-lfs/git-lfs/files/4182890/t-cherry-pick-commits.sh.txt)

**Expected behavior**
Cherry-picked commits without panic

**System environment**
I was able to reproduce this issue in different environments including Windows, OSX and Ubuntu 18.08

**Output of `git lfs env`**
```
$ git lfs env
git-lfs/2.10.0 (GitHub; darwin amd64; go 1.13.6; git 7237dd0f)
git version 2.25.0

Endpoint=https://github.com/shalashik/gitlfstest.git/info/lfs (auth=none)
  SSH=git@github.com:shalashik/gitlfstest.git
LocalWorkingDir=/Users/shalashik/repos/pets/gitlfstest
LocalGitDir=/Users/shalashik/repos/pets/gitlfstest/.git
LocalGitStorageDir=/Users/shalashik/repos/pets/gitlfstest/.git
LocalMediaDir=/Users/shalashik/repos/pets/gitlfstest/.git/lfs/objects
LocalReferenceDirs=
TempDir=/Users/shalashik/repos/pets/gitlfstest/.git/lfs/tmp
ConcurrentTransfers=8
TusTransfers=false
BasicTransfersOnly=false
SkipDownloadErrors=false
FetchRecentAlways=false
FetchRecentRefsDays=7
FetchRecentCommitsDays=0
FetchRecentRefsIncludeRemotes=true
PruneOffsetDays=3
PruneVerifyRemoteAlways=false
PruneRemoteName=origin
LfsStorageDir=/Users/shalashik/repos/pets/gitlfstest/.git/lfs
AccessDownload=none
AccessUpload=none
DownloadTransfers=basic,lfs-standalone-file
UploadTransfers=basic,lfs-standalone-file
GIT_EXEC_PATH=/usr/local/Cellar/git/2.25.0/libexec/git-core
git config filter.lfs.process = "git-lfs filter-process"
git config filter.lfs.smudge = "git-lfs smudge -- %f"
git config filter.lfs.clean = "git-lfs clean -- %f"
```