### PR TITLE
README: explain how to verify releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,23 @@ running:
 $ git lfs install
 ```
 
+#### Verifying releases
+
+Releases are signed with the OpenPGP key of one of the core team members.  To
+get these keys, you can run the following command, which will print them to
+standard output:
+
+```ShellSession
+$ curl -L https://api.github.com/repos/git-lfs/git-lfs/tarball/core-gpg-keys | tar -Ozxf -
+```
+
+Once you have the keys, you can download the `sha256sums.asc` file and verify
+the file you want like so:
+
+```ShellSession
+$ gpg -d sha256sums.asc | grep git-lfs-linux-amd64-v2.10.0.tar.gz | shasum -a 256 -c
+```
+
 ## Example Usage
 
 To begin using Git LFS within a Git repository that is not already configured


### PR DESCRIPTION
Some folks aren't familiar with the signed SHA-256 sums file we use, or aren't sure how to get the keys to verify releases.  To help them, point them to the tag we've created that contains the keys (similar to the way Git does this) and add an explanation to the README to help them verify the releases.

Currently, I'm the only core team member with keys, so I'm the only one with keys in the tree.  If other folks add keys to their GitHub profile, ping me and I'll rewrite the tag.  I've opted to use a tree instead of the blob that Git uses (git/git's `junio-gpg-pub`) because I can't find a way to let people download a tagged blob from GitHub, while tagged trees do work.

Fixes #4018