### PR TITLE
Stop using cgo on amd64 Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - run: script/cibuild
-    - run: make release
+    - run: CGO_ENABLED=0 make release
     - run: mkdir -p bin/assets
     - run: find bin/releases -name "*$(uname -s | tr A-Z a-z)*" | xargs -I{} cp {} bin/assets
     - uses: actions/upload-artifact@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
     - uses: actions/download-artifact@v1
       with:
         name: assets
-    - run: make release
+    - run: CGO_ENABLED=0 make release
     - run: rm -f bin/releases/*windows*
     - run: find assets -name "*windows*" | xargs -L1 -I{} mv {} bin/releases
     - run: script/upload --skip-verify $(git describe)

--- a/tools/util_generic.go
+++ b/tools/util_generic.go
@@ -1,4 +1,4 @@
-// +build !linux !cgo
+// +build !linux
 // +build !darwin !cgo
 // +build !windows
 

--- a/tools/util_linux.go
+++ b/tools/util_linux.go
@@ -1,16 +1,6 @@
-// +build linux,cgo
+// +build linux
 
 package tools
-
-/*
-#include <sys/ioctl.h>
-
-#undef FICLONE
-#define FICLONE		_IOW(0x94, 9, int)
-// copy from https://github.com/torvalds/linux/blob/v5.2/include/uapi/linux/fs.h#L195 for older header files.
-// This is equal to the older BTRFS_IOC_CLONE value.
-*/
-import "C"
 
 import (
 	"io"
@@ -20,7 +10,10 @@ import (
 )
 
 const (
-	ioctlFiClone = C.FICLONE
+	// This is the FICLONE ioctl value found in linux/fs.h on a typical
+	// system.  It's equivalent to the older BTRFS_IOC_CLONE.  We hard-code
+	// the value here to avoid a dependency on cgo.
+	ioctlFiClone = 0x40049409
 )
 
 // CheckCloneFileSupported runs explicit test of clone file on supplied directory.


### PR DESCRIPTION
This series allows us to stop using cgo on amd64 Linux, which makes our binaries static and therefore portable to musl-based systems.  The commit messages explain more in detail.

The constant was generated using a throwaway C program.

Fixes #4025.