### PR TITLE
fix upload retry 'file already closed' issue'

### DIFF
--- a/t/t-upload-redirect.sh
+++ b/t/t-upload-redirect.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+. "$(dirname "$0")/testlib.sh"
+
+begin_test "redirect upload"
+(
+  set -e
+
+  reponame="redirect-storage-upload"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" redirect-repo-upload
+
+  contents="redirect-storage-upload"
+  oid="$(calc_oid "$contents")"
+  printf "%s" "$contents" > a.dat
+
+  git lfs track "*.dat"
+  git add .gitattributes a.dat
+  git commit -m "initial commit"
+
+  GIT_TRACE=1 git push origin master 2>&1 | tee push.log
+  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected \`git push origin master\` to succeed ..."
+    exit 1
+  fi
+
+  grep "api: redirect" push.log
+
+  assert_server_object "$reponame" "$oid"
+)
+end_test

--- a/tools/copycallback.go
+++ b/tools/copycallback.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"bytes"
 	"io"
+	"os"
 )
 
 type CopyCallback func(totalSize int64, readSoFar int64, readSinceLast int) error
@@ -16,6 +17,10 @@ type BodyWithCallback struct {
 
 func NewByteBodyWithCallback(by []byte, totalSize int64, cb CopyCallback) *BodyWithCallback {
 	return NewBodyWithCallback(NewByteBody(by), totalSize, cb)
+}
+
+func NewFileBodyWithCallback(f *os.File, totalSize int64, cb CopyCallback) *BodyWithCallback {
+	return NewBodyWithCallback(NewFileBody(f), totalSize, cb)
 }
 
 func NewBodyWithCallback(body ReadSeekCloser, totalSize int64, cb CopyCallback) *BodyWithCallback {
@@ -97,5 +102,17 @@ type closingByteReader struct {
 }
 
 func (r *closingByteReader) Close() error {
+	return nil
+}
+
+func NewFileBody(f *os.File) ReadSeekCloser {
+	return &closingFileReader{File: f}
+}
+
+type closingFileReader struct {
+	*os.File
+}
+
+func (r *closingFileReader) Close() error {
 	return nil
 }

--- a/tq/basic_upload.go
+++ b/tq/basic_upload.go
@@ -86,7 +86,7 @@ func (a *basicUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb Progres
 		return nil
 	}
 
-	cbr := tools.NewBodyWithCallback(f, t.Size, ccb)
+	cbr := tools.NewFileBodyWithCallback(f, t.Size, ccb)
 	var reader lfsapi.ReadSeekCloser = cbr
 
 	// Signal auth was ok on first read; this frees up other workers to start


### PR DESCRIPTION
In our infra, there is this peculiar situation where lfs upload request would be redirected to our lfs server. 
Even though redirect requests are handled by git-lfs by rewinding request body and creating a new http request for retry, the underlying http module closes the file handle upon request completion. 
So, retry would always fail with error like
`
< HTTP/1.1 307 Temporary Redirect
< Content-Length: 0
< Authorization: dontcare
< Content-Type: application/octet-stream
< Cookie: hadoop.auth="u=git-lfs&p=git-lfs@kerberos.gerrit.inc&t=kerberos-dt&e=1582650048997&s=N9xsabgxNkzMjXH0lWKuzK8646A="
< Date: Tue, 25 Feb 2020 07:13:38 GMT
< Location: http://ubuntu:14000/webhdfs/v1/user/git-lfs/a9/e0/a9e064317304049e503f0a7906d573695d4cbf7c89e7b2059117e72eae3fac77/?op=CREATE&data=true&replication=1&delegation=IgAHZ2l0LWxmcwdnaXQtbGZzAIoBcHsl8X2KAXCfMnV9FRMUgHVxD2f3eu37cDeUJ2egsLnsNbAHd2ViaGRmcxMxOTIuMTY4LjAuMTA5OjE0MDAw
< Set-Cookie: hadoop.auth="u=git-lfs&p=git-lfs@kerberos.gerrit.inc&t=kerberos-dt&e=1582650048997&s=N9xsabgxNkzMjXH0lWKuzK8646A="
<
15:13:38.674821 trace git-lfs: api: redirect PUT http://localhost:9080/plugins/git-lfs/lfs-test/objects/a9e064317304049e503f0a7906d573695d4cbf7c89e7b2059117e72eae3fac77 to http://ubuntu:14000/webhdfs/v1/user/git-lfs/a9/e0/a9e064317304049e503f0a7906d573695d4cbf7c89e7b2059117e72eae3fac77/
15:13:38.674846 trace git-lfs: HTTP: PUT http://ubuntu:14000/webhdfs/v1/user/git-lfs/a9/e0/a9e064317304049e503f0a7906d573695d4cbf7c89e7b2059117e72eae3fac77/
> PUT /webhdfs/v1/user/git-lfs/a9/e0/a9e064317304049e503f0a7906d573695d4cbf7c89e7b2059117e72eae3fac77/?op=CREATE&data=true&replication=1&delegation=IgAHZ2l0LWxmcwdnaXQtbGZzAIoBcHsl8X2KAXCfMnV9FRMUgHVxD2f3eu37cDeUJ2egsLnsNbAHd2ViaGRmcxMxOTIuMTY4LjAuMTA5OjE0MDAw HTTP/1.1
> Host: ubuntu:14000
> Content-Length: 3000
> Content-Type: application/octet-stream
> User-Agent: git-lfs/2.10.0 (GitHub; linux amd64; go 1.12.6; git 043dddc5)
>
15:13:38.678552 trace git-lfs: xfer: adapter "basic" worker 0 finished job for "a9e064317304049e503f0a7906d573695d4cbf7c89e7b2059117e72eae3fac77"
15:13:38.678760 trace git-lfs: tq: retrying object a9e064317304049e503f0a7906d573695d4cbf7c89e7b2059117e72eae3fac77: LFS: Put http://ubuntu:14000/webhdfs/v1/user/git-lfs/a9/e0/a9e064317304049e503f0a7906d573695d4cbf7c89e7b2059117e72eae3fac77/?op=CREATE&data=true&replication=1&delegation=IgAHZ2l0LWxmcwdnaXQtbGZzAIoBcHsl8X2KAXCfMnV9FRMUgHVxD2f3eu37cDeUJ2egsLnsNbAHd2ViaGRmcxMxOTIuMTY4LjAuMTA5OjE0MDAw: read /projects/temp/lfs-test/.git/lfs/objects/a9/e0/a9e064317304049e503f0a7906d573695d4cbf7c89e7b2059117e72eae3fac77: file already closed

`

So, this fix is to intercept the close of the file handle and let whoever directly open the file closes it.
