### PR TITLE
Removed lfs.extension.* from list of supported keys for .lfsconfig

### DIFF
--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -379,9 +379,6 @@ including and limited to:
 - lfs.locksverify
 - lfs.pushurl
 - lfs.url
-- lfs.extension.{name}.clean
-- lfs.extension.{name}.smudge
-- lfs.extension.{name}.priority
 - remote.{name}.lfsurl
 - lfs.{*}.access
 


### PR DESCRIPTION
The LFS extension keys are not considered safe by Git LFS so attempting to put them in `.lfsconfig` results in such warnings:
```
WARNING: These unsafe lfsconfig keys were ignored:

  lfs.extension.gzip.clean
  lfs.extension.gzip.smudge
```