### PR TITLE
fail dedup command with explanation when LFS extensions configured

### DIFF
--- a/commands/command_dedup.go
+++ b/commands/command_dedup.go
@@ -33,6 +33,10 @@ func dedupTestCommand(*cobra.Command, []string) {
 		Exit("This system does not support deduplication. %s", err)
 	}
 
+	if len(cfg.Extensions()) > 0 {
+		Exit("This platform supports file de-duplication, however, Git LFS extensions are configured and therefore de-duplication can not be used.")
+	}
+
 	Print("OK: This platform and repository support file de-duplication.")
 }
 
@@ -47,6 +51,10 @@ func dedupCommand(cmd *cobra.Command, args []string) {
 		ExitWithError(err)
 	} else if supported, err := tools.CheckCloneFileSupported(gitDir); err != nil || !supported {
 		Exit("This system does not support deduplication.")
+	}
+
+	if len(cfg.Extensions()) > 0 {
+		Exit("This platform supports file de-duplication, however, Git LFS extensions are configured and therefore de-duplication can not be used.")
 	}
 
 	if dirty, err := git.IsWorkingCopyDirty(); err != nil {

--- a/docs/man/git-lfs-dedup.1.ronn
+++ b/docs/man/git-lfs-dedup.1.ronn
@@ -12,6 +12,11 @@ using the operating system's copy-on-write file creation functionality.
 
 If the operating system or file system don't support copy-on-write file creation, this command exits unsuccessfully.
 
+This command will also exit without success if any Git LFS extensions are
+configured, as these will typically be used to alter the file contents
+before they are written to the Git LFS storage directory, and therefore the
+working tree files should not be copy-on-write clones of the LFS object files.
+
 ## SEE ALSO
 
 Part of the git-lfs(1) suite.


### PR DESCRIPTION
We add checks to the `git lfs dedup` command and its `-t` test option variant which cause the command to exit immediately with an explanatory message if any Git LFS extensions are configured.

This is because extensions normally cause the LFS storage object files to be altered in some way (for example, by compressing them), and so the object storage files can not be used as one-to-one copy-on-write clones (via filesystem reflinks) in the working tree, or else users would see unexpected file contents.

Fixes #4043.
/cc @swisspol as reporter