### PR TITLE
add man page for the post-commit hook command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -469,6 +469,7 @@ MAN_ROFF_TARGETS = man/git-lfs-checkout.1 \
   man/git-lfs-migrate.1 \
   man/git-lfs-pointer.1 \
   man/git-lfs-post-checkout.1 \
+  man/git-lfs-post-commit.1 \
   man/git-lfs-post-merge.1 \
   man/git-lfs-pre-push.1 \
   man/git-lfs-prune.1 \
@@ -501,6 +502,7 @@ MAN_HTML_TARGETS = man/git-lfs-checkout.1.html \
   man/git-lfs-migrate.1.html \
   man/git-lfs-pointer.1.html \
   man/git-lfs-post-checkout.1.html \
+  man/git-lfs-post-commit.1.html \
   man/git-lfs-post-merge.1.html \
   man/git-lfs-pre-push.1.html \
   man/git-lfs-prune.1.html \

--- a/docs/man/git-lfs-post-commit.1.ronn
+++ b/docs/man/git-lfs-post-commit.1.ronn
@@ -1,0 +1,23 @@
+git-lfs-post-commit(1) -- Git post-commit hook implementation
+=================================================================
+
+## SYNOPSIS
+
+`git lfs post-commit`
+
+## DESCRIPTION
+
+Responds to Git post-commit events. It makes sure that any files which are
+marked as lockable by `git lfs track` are read-only in the working copy, if
+not currently locked by the local user.
+
+Where the `git lfs post-merge` command, which has a similar purpose, must
+examine all files in the working copy, `git lfs post-commit` can limit
+itself checking only those files which have changed in `HEAD`.  It primarily
+handles newly added lockable files which have not yet been made read-only.
+
+## SEE ALSO
+
+git-lfs-post-merge(1), git-lfs-track(1)
+
+Part of the git-lfs(1) suite.

--- a/docs/man/git-lfs.1.ronn
+++ b/docs/man/git-lfs.1.ronn
@@ -33,6 +33,10 @@ commands and low level ("plumbing") commands.
     Display the Git LFS environment.
 * git-lfs-checkout(1):
     Populate working copy with real content from Git LFS files.
+* git-lfs-dedup(1):
+    De-duplicate Git LFS files.
+* git-lfs-ext(1):
+    Display Git LFS extension details.
 * git-lfs-fetch(1):
     Download Git LFS files from a remote.
 * git-lfs-fsck(1):
@@ -77,12 +81,20 @@ commands and low level ("plumbing") commands.
     Git clean filter that converts large files to pointers.
 * git-lfs-pointer(1):
     Build and compare pointers.
+* git-lfs-post-checkout(1):
+    Git post-checkout hook implementation.
+* git-lfs-post-commit(1):
+    Git post-commit hook implementation.
+* git-lfs-post-merge(1):
+    Git post-merge hook implementation.
 * git-lfs-pre-push(1):
     Git pre-push hook implementation.
 * git-lfs-filter-process(1):
     Git process filter that converts between large files and pointers.
 * git-lfs-smudge(1):
     Git smudge filter that converts pointer in blobs to the actual content.
+* git-lfs-standalone-file(1):
+    Git LFS standalone transfer adapter for file URLs (local paths).
 
 ## EXAMPLES
 

--- a/docs/man/git-lfs.1.ronn
+++ b/docs/man/git-lfs.1.ronn
@@ -79,6 +79,8 @@ commands and low level ("plumbing") commands.
 
 * git-lfs-clean(1):
     Git clean filter that converts large files to pointers.
+* git-lfs-filter-process(1):
+    Git process filter that converts between large files and pointers.
 * git-lfs-pointer(1):
     Build and compare pointers.
 * git-lfs-post-checkout(1):
@@ -89,8 +91,6 @@ commands and low level ("plumbing") commands.
     Git post-merge hook implementation.
 * git-lfs-pre-push(1):
     Git pre-push hook implementation.
-* git-lfs-filter-process(1):
-    Git process filter that converts between large files and pointers.
 * git-lfs-smudge(1):
     Git smudge filter that converts pointer in blobs to the actual content.
 * git-lfs-standalone-file(1):


### PR DESCRIPTION
Add a man page for `git-lfs-post-commit(1)` which largely parallels the `git-lfs-post-merge(1)` one, as they have similar purposes for Git LFS, namely, to ensure all tracked lockable files are marked read-only in the working copy.

This PR also updates the list of porcelain and plumbing commands in the main Git LFS man page, adding those which were missing (except for the deprecated `git-lfs-clone(1)`), including the `git-lfs-post-commit(1)` command.

Fixes #4048.
/cc @swisspol as reporter.