### PR TITLE
commands: print help output with --help

### DIFF
--- a/commands/run.go
+++ b/commands/run.go
@@ -124,6 +124,9 @@ func usageCommand(cmd *cobra.Command) error {
 }
 
 func printHelp(commandName string) {
+	if commandName == "--help" {
+		commandName = "git-lfs"
+	}
 	if txt, ok := ManPages[commandName]; ok {
 		fmt.Fprintf(os.Stdout, "%s\n", strings.TrimSpace(txt))
 	} else {

--- a/commands/run.go
+++ b/commands/run.go
@@ -69,6 +69,12 @@ Simply type ` + root.Name() + ` help [path to command] for full details.`,
 
 		Run: func(c *cobra.Command, args []string) {
 			cmd, _, e := c.Root().Find(args)
+			// In the case of "git lfs help config", pretend the
+			// last arg was "help" so our command lookup succeeds,
+			// since cmd will be ignored in helpCommand().
+			if e != nil && args[0] == "config" {
+				cmd, _, e = c.Root().Find([]string{"help"})
+			}
 			if cmd == nil || e != nil {
 				c.Printf("Unknown help topic %#q\n", args)
 				c.Root().Usage()


### PR DESCRIPTION
If the user invokes "git-lfs --help", we tell them that there's no usage text found for "--help".  This isn't very helpful.  Since what the user probably wanted was to invoke the general help output, let's do that by rewriting the command to "git-lfs", which is the topic for the general help output.

Fixes #4057
/cc @austintraver as reporter
