### PR TITLE
Support submodule.recurse = true

### DIFF
--- a/t/t-submodule-recurse.sh
+++ b/t/t-submodule-recurse.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+. "$(dirname "$0")/testlib.sh"
+reponame="submodule-recurse-test-repo"
+submodname="submodule-recurse-test-submodule"
+
+begin_test "submodule with submodule.recurse = true"
+(
+  set -e
+
+  setup_remote_repo "$reponame"
+  setup_remote_repo "$submodname"
+
+  clone_repo "$submodname" submodule
+
+  git lfs track "*.dat" 2>&1 | tee track.log
+  grep "Tracking \"\*.dat\"" track.log
+
+  echo "foo" > file.dat
+  git add .gitattributes file.dat
+  git commit -a -m "add file"
+  git push origin master
+  subcommit1=$(git rev-parse HEAD)
+
+  echo "bar" > file.dat
+  git add file.dat
+  git commit -a -m "update file"
+  git push origin master
+  subcommit2=$(git rev-parse HEAD)
+
+  clone_repo "$reponame" repo
+  git submodule add "$GITSERVER/$submodname" submodule
+  git submodule update --init --recursive
+  git -C submodule reset --hard "$subcommit1"
+  git add .gitmodules submodule
+  git commit -m "add submodule"
+  git push origin master
+
+  git checkout -b feature
+  git -C submodule reset --hard "$subcommit2"
+  git add .gitmodules submodule
+  git commit -m "update submodule"
+  git push origin feature
+
+  clone_repo "$reponame" repo-no-recurse
+  git submodule update --init --recursive
+  git checkout feature
+
+  if [[ -d "submodule/lfs/logs" ]]
+  then
+    exit 1
+  fi
+
+  clone_repo "$reponame" repo-recurse
+  git config submodule.recurse true
+  git submodule update --init --recursive
+  git checkout feature
+
+  if [[ -d "submodule/lfs/logs" ]]
+  then
+    exit 1
+  fi
+)
+end_test


### PR DESCRIPTION
## Summary

Users of the Git configuration option **`submodule.recurse = true`** currently get errors when working in repositories with **at least one Git-LFS-enabled submodule.**

I suggest fixing this by **removing the `GIT_INTERNAL_SUPER_PREFIX` environment variable** from the environment that Git LFS passes to Git child processes.

## Problem

Git’s configuration option `submodule.recurse` makes it more convenient to use submodules. If set to `true`, top-level checkouts will recurse into all submodules. Additionally, Git will pass an environment variable called `GIT_INTERNAL_SUPER_PREFIX` to the respective submodule’s path relative to its parent repository to each child process, including `git lfs filter-process`.

In turn, Git LFS spawns a couple of Git processes, for instance, when checking the minimum required Git version, reading Git configuration values, or obtaining the object name of a commit with `git rev-parse`.

In the current implementation, **Git LFS would forward the environment variable `GIT_INTERNAL_SUPER_PREFIX` to Git unchanged.** This is problematic because the presence of this environment variable will make Git behave **as if the command-line option `--super-prefix` had been passed** to the respective Git command.¹ However, **many Git commands don’t support the `--super-prefix`** command-line option. This includes `git version`, `git config`, and `git rev-parse`. Consequently, these Git processes, as spawned by Git LFS, would immediately fail with usage errors such as:

```
...
trace git-lfs: exec: git 'version'
trace git-lfs: Error getting git version: error running /usr/lib/git-core/git 'version': 'fatal: version doesn't support --super-prefix' 'exit status 128'
...
trace git-lfs: Error running 'git rev-parse': failed to call git rev-parse --git-dir: exit status 128 : fatal: rev-parse doesn't support --super-prefix

Error: failed to call git rev-parse --git-dir: exit status 128 : fatal: rev-parse doesn't support --super-prefix
...
trace git-lfs: exec: git 'config' '-l'
Error reading git config: error running /usr/lib/git-core/git 'config' '-l': 'fatal: config doesn't support --super-prefix' 'exit status 128'
...
```

## Reproducing the problem

The first commit, 3692675, adds a unit test that demonstrates the present issue when `submodule.recurse` is set to `true`. This unit test deliberately fails, as that commit doesn’t solve the issue itself.

Colleagues and I were able to reproduce this across all major platforms (Linux, macOS, Windows), and with older and newer versions of Git (2.14.0, 2.17.0, 2.21.0, 2.21.1, 2.24.1, 2.25.1) and Git LFS (2.8.0, 2.9.1, and 2.10.0).

## Suggested solution

The error messages users get refer to the fact that the command-line option `--super-prefix` isn’t available for `git version`, `git config`, and `git rev-parse`. As `--super-prefix` is set by `GIT_INTERNAL_SUPER_PREFIX`, my suggestion is to **explicitly omit that variable from the environment passed to the Git child processes spawned by Git LFS.** As far as I can tell, `GIT_INTERNAL_SUPER_PREFIX` is used by Git to inform child processes of the relative location of a submodule in its parent repository, and I don’t think that passing `GIT_INTERNAL_SUPER_PREFIX` back to Git is required for Git and Git LFS to work correctly.

## Improving Git

On another note, I’m wondering why Git forces the `--super-prefix` option upon *any* Git command as soon as `GIT_INTERNAL_SUPER_PREFIX` is present—even if the respective Git command doesn’t support `--super-prefix` at all.

I think that it would be more sensible for Git commands to only read `GIT_INTERNAL_SUPER_PREFIX` from the environment if potentially needed (rather than forcing its value through `--super-prefix`). Alternatively, it may also make sense to either not pass `--super-prefix` to commands such as `git version` in the first place or to ignore the presence of `--super-prefix` within these commands.

Do you think this is something that should be addressed upstream in Git?

---

¹ This can be verified by running
```sh
$ GIT_INTERNAL_SUPER_PREFIX=foo git version
fatal: version doesn't support --super-prefix
```