### PR TITLE
lfshttp: allow renegotiation

### DIFF
--- a/lfshttp/client.go
+++ b/lfshttp/client.go
@@ -449,7 +449,9 @@ func (c *Client) Transport(u *url.URL, access creds.AccessMode) (http.RoundTripp
 		tr.DialContext = dialer.DialContext
 	}
 
-	tr.TLSClientConfig = &tls.Config{}
+	tr.TLSClientConfig = &tls.Config{
+		Renegotiation: tls.RenegotiateFreelyAsClient,
+	}
 
 	if isClientCertEnabledForHost(c, host) {
 		tracerx.Printf("http: client cert for %s", host)


### PR DESCRIPTION
There are some TLS servers that want to perform a renegotiation to request users use a client certificate.  Allow us to use renegotiation as a client when making a TLS connection.  The DoS potential for this is low, since the server must not only perform another key exchange, but must re-sign the request, leading to a larger performance impact on the server than the client.

Fixes #4062 

@manishgo, can you please test this commit and see if it works for you?  If you need binaries, they should be available for download from the CI builds.