### PR TITLE
migrate import: set text to unspecified for excluded fields

### DIFF
--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -283,7 +283,7 @@ func trackedFromFilter(filter *filepathfilter.Filter) *tools.OrderedSet {
 	}
 
 	for _, exclude := range filter.Exclude() {
-		tracked.Add(fmt.Sprintf("%s text -filter -merge -diff", escapeAttrPattern(exclude)))
+		tracked.Add(fmt.Sprintf("%s !text -filter -merge -diff", escapeAttrPattern(exclude)))
 	}
 
 	return tracked


### PR DESCRIPTION
When we specify the --exclude option to git lfs migrate import to exclude certain patterns, we currently specify the files as text. However, in many cases, the files are not text, so it doesn't make sense to set them that way.

Let's set the text attribute to unspecified instead and let Git automatically figure out whether the file should be treated as text or binary.  That's at least less likely to result in silent breakage and will likely be less surprising to the user.

Fixes #4067 
/cc @woopla as reporter
