### PR TITLE
workflows/ci: delete inaccessible file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,13 @@ jobs:
       shell: bash
     - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" script/cibuild
       shell: bash
+    - run: rm -f commands/mancontent_gen.go
+      shell: bash
     - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" make GOARCH=386 -B
       shell: bash
     - run: mv bin\git-lfs.exe git-lfs-x86.exe
+    - run: rm -f commands/mancontent_gen.go
+      shell: bash
     - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" make GOARCH=amd64 -B
       shell: bash
     - run: mv bin\git-lfs.exe git-lfs-x64.exe


### PR DESCRIPTION
When we build artifacts on Windows, we invoke make with -B, which runs all targets regardless of whether they're up to date.  With the upgrade to Go 1.14 on our GitHub Actions services, it looks like for some reason that we can't overwrite the generated man page file in our generate command.  When this occurs, the output looks like so:

```
go generate github.com/git-lfs/git-lfs/commands
Failed to create go file: open ..\commands\mancontent_gen.go: Access is denied.
exit status 2
commands\commands.go:28: running "go": exit status 1
```

The exact reason for this is unknown, since it doesn't appear on a test VM.  It also didn't appear in older builds using Go 1.12.7, but it's unclear if this is due to the Go version or just an upgrade of the Actions VMs that included some other change.

However, we can work around this issue by simply removing the file and having it be regenerated, which seems to fix the problem, so let's do that.  That keeps our CI system running until someone with more intimate knowledge of Windows, Go, or Actions can address the root cause.
