### PR TITLE
commands: don't honor lfs.fetch* for ls-files

### DIFF
--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -79,7 +79,7 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 
 	if ref, err := git.CurrentRef(); err == nil {
 		includeArg, excludeArg := getIncludeExcludeArgs(cmd)
-		filter := buildFilepathFilter(cfg, includeArg, excludeArg)
+		filter := buildFilepathFilter(cfg, includeArg, excludeArg, true)
 		if cloneFlags.NoCheckout || cloneFlags.Bare {
 			// If --no-checkout or --bare then we shouldn't check out, just fetch instead
 			fetchRef(ref.Name, filter)

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -88,7 +88,7 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 		}
 
 	} else { // !all
-		filter := buildFilepathFilter(cfg, include, exclude)
+		filter := buildFilepathFilter(cfg, include, exclude, true)
 
 		// Fetch refs sequentially per arg order; duplicates in later refs will be ignored
 		for _, ref := range refs {

--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -107,7 +107,7 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 	defer gitscanner.Close()
 
 	includeArg, excludeArg := getIncludeExcludeArgs(cmd)
-	gitscanner.Filter = buildFilepathFilter(cfg, includeArg, excludeArg)
+	gitscanner.Filter = buildFilepathFilter(cfg, includeArg, excludeArg, false)
 
 	if len(args) == 0 {
 		// Only scan the index when "git lfs ls-files" was invoked with

--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -303,7 +303,7 @@ func currentRefToMigrate() (*git.Ref, error) {
 // filter given by the --include and --exclude arguments.
 func getHistoryRewriter(cmd *cobra.Command, db *gitobj.ObjectDatabase, l *tasklog.Logger) *githistory.Rewriter {
 	include, exclude := getIncludeExcludeArgs(cmd)
-	filter := buildFilepathFilter(cfg, include, exclude)
+	filter := buildFilepathFilter(cfg, include, exclude, false)
 
 	return githistory.NewRewriter(db,
 		githistory.WithFilter(filter), githistory.WithLogger(l))

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -27,7 +27,7 @@ func pullCommand(cmd *cobra.Command, args []string) {
 	}
 
 	includeArg, excludeArg := getIncludeExcludeArgs(cmd)
-	filter := buildFilepathFilter(cfg, includeArg, excludeArg)
+	filter := buildFilepathFilter(cfg, includeArg, excludeArg, true)
 	pull(filter)
 }
 

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -126,8 +126,8 @@ func currentRemoteRef() *git.Ref {
 	return git.NewRefUpdate(cfg.Git, cfg.PushRemote(), cfg.CurrentRef(), nil).Right()
 }
 
-func buildFilepathFilter(config *config.Configuration, includeArg, excludeArg *string) *filepathfilter.Filter {
-	inc, exc := determineIncludeExcludePaths(config, includeArg, excludeArg)
+func buildFilepathFilter(config *config.Configuration, includeArg, excludeArg *string, useFetchOptions bool) *filepathfilter.Filter {
+	inc, exc := determineIncludeExcludePaths(config, includeArg, excludeArg, useFetchOptions)
 	return filepathfilter.New(inc, exc)
 }
 
@@ -449,14 +449,22 @@ func logPanicToWriter(w io.Writer, loggedError error, le string) {
 	}
 }
 
-func determineIncludeExcludePaths(config *config.Configuration, includeArg, excludeArg *string) (include, exclude []string) {
+func determineIncludeExcludePaths(config *config.Configuration, includeArg, excludeArg *string, useFetchOptions bool) (include, exclude []string) {
 	if includeArg == nil {
-		include = config.FetchIncludePaths()
+		if useFetchOptions {
+			include = config.FetchIncludePaths()
+		} else {
+			include = []string{}
+		}
 	} else {
 		include = tools.CleanPaths(*includeArg, ",")
 	}
 	if excludeArg == nil {
-		exclude = config.FetchExcludePaths()
+		if useFetchOptions {
+			exclude = config.FetchExcludePaths()
+		} else {
+			exclude = []string{}
+		}
 	} else {
 		exclude = tools.CleanPaths(*excludeArg, ",")
 	}

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -19,7 +19,7 @@ var (
 func TestDetermineIncludeExcludePathsReturnsCleanedPaths(t *testing.T) {
 	inc := "/some/include"
 	exc := "/some/exclude"
-	i, e := determineIncludeExcludePaths(testcfg, &inc, &exc)
+	i, e := determineIncludeExcludePaths(testcfg, &inc, &exc, true)
 
 	assert.Equal(t, []string{"/some/include"}, i)
 	assert.Equal(t, []string{"/some/exclude"}, e)
@@ -28,15 +28,22 @@ func TestDetermineIncludeExcludePathsReturnsCleanedPaths(t *testing.T) {
 func TestDetermineIncludeExcludePathsReturnsEmptyPaths(t *testing.T) {
 	inc := ""
 	exc := ""
-	i, e := determineIncludeExcludePaths(testcfg, &inc, &exc)
+	i, e := determineIncludeExcludePaths(testcfg, &inc, &exc, true)
 
 	assert.Empty(t, i)
 	assert.Empty(t, e)
 }
 
 func TestDetermineIncludeExcludePathsReturnsDefaultsWhenAbsent(t *testing.T) {
-	i, e := determineIncludeExcludePaths(testcfg, nil, nil)
+	i, e := determineIncludeExcludePaths(testcfg, nil, nil, true)
 
 	assert.Equal(t, []string{"/default/include"}, i)
 	assert.Equal(t, []string{"/default/exclude"}, e)
+}
+
+func TestDetermineIncludeExcludePathsReturnsNothingWhenAbsent(t *testing.T) {
+	i, e := determineIncludeExcludePaths(testcfg, nil, nil, false)
+
+	assert.Empty(t, i)
+	assert.Empty(t, e)
 }

--- a/t/t-ls-files.sh
+++ b/t/t-ls-files.sh
@@ -498,3 +498,21 @@ begin_test "ls-files: history with reference range"
   [ 0 -eq $(grep -c "c\.dat" ls-files.log) ]
 )
 end_test
+
+begin_test "ls-files: not affected by lfs.fetchexclude"
+(
+  set -e
+
+  mkdir repo-fetchexclude
+  cd repo-fetchexclude
+  git init
+  git lfs track "*.dat" | grep "Tracking \"\*.dat\""
+  echo "some data" > some.dat
+  echo "some text" > some.txt
+  echo "missing" > missing.dat
+  git add missing.dat
+  git commit -m "add missing file"
+  git config lfs.fetchexclude '*'
+  [ "6bbd052ab0 * missing.dat" = "$(git lfs ls-files)" ]
+)
+end_test


### PR DESCRIPTION
Currently, if a user runs `git lfs ls-files` with lfs.fetchexclude set to `*`, then all files are excluded from the output.  This doesn't make much sense, since the lfs.fetchinclude and lfs.fetchexclude options are documented to work only on fetches.  Let's ensure that we don't load the fetch filters by default when performing a non-fetch operation so that `git lfs ls-files` isn't affected by these exclusions.

I'm leaving this as a draft for the moment because our CI is temporarily broken on Windows; I'll rebase onto `master` once the PR fixing it is merged.

Fixes #4081
/cc @billsacks as reporter