### PR TITLE
make Go tests run consistently using local binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -406,7 +406,7 @@ test-race : GO_TEST_EXTRA_ARGS=-race
 # And so on.
 test : fmt
 	(unset GIT_DIR; unset GIT_WORK_TREE; \
-	$(GO) test $(GO_TEST_EXTRA_ARGS) $(addprefix ./,$(PKGS)))
+	$(GO) test -count=1 $(GO_TEST_EXTRA_ARGS) $(addprefix ./,$(PKGS)))
 
 # integration is a shorthand for running 'make' in the 't' directory.
 .PHONY : integration

--- a/Makefile
+++ b/Makefile
@@ -404,7 +404,7 @@ test-race : GO_TEST_EXTRA_ARGS=-race
 # 		make PKGS="config lfsapi tools/kv" test-race
 #
 # And so on.
-test : fmt
+test : fmt $(.DEFAULT_GOAL)
 	(unset GIT_DIR; unset GIT_WORK_TREE; \
 	$(GO) test -count=1 $(GO_TEST_EXTRA_ARGS) $(addprefix ./,$(PKGS)))
 

--- a/lfshttp/endpoint.go
+++ b/lfshttp/endpoint.go
@@ -125,7 +125,7 @@ func EndpointFromLocalPath(path string) Endpoint {
 	} else {
 		gitpath = filepath.Join(path, ".git")
 	}
-	if file, err := os.Lstat(gitpath); err == nil && file.IsDir() {
+	if _, err := os.Stat(gitpath); err == nil {
 		path = gitpath
 	}
 	return Endpoint{Url: fmt.Sprintf("file://%s%s", slash, filepath.ToSlash(path))}

--- a/lfshttp/standalone/standalone.go
+++ b/lfshttp/standalone/standalone.go
@@ -101,6 +101,11 @@ func gitDirAtPath(path string) (string, error) {
 	}
 	env = env[:n]
 
+	// Trim any trailing .git path segment.
+	if filepath.Base(path) == ".git" {
+		path = filepath.Dir(path)
+	}
+
 	curdir, err := os.Getwd()
 	if err != nil {
 		return "", err

--- a/t/cmd/util/testutils.go
+++ b/t/cmd/util/testutils.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -26,6 +27,34 @@ import (
 	"github.com/git-lfs/git-lfs/git"
 	"github.com/git-lfs/git-lfs/lfs"
 )
+
+func init() {
+	path := os.Getenv("PATH")
+	sep := ""
+	if path != "" {
+		if runtime.GOOS == "windows" {
+			sep = ";"
+		} else {
+			sep = ":"
+		}
+	}
+
+	// Strip the trailing "t/cmd/util/testutils.go" from the path to this
+	// source file to create a path to the working tree's "bin" directory,
+	// then prepend that to the PATH environment variable to ensure our
+	// "git-lfs" binary is used in preference to any installed versions when
+	// executing the Go tests.
+	_, srcdir, _, _ := runtime.Caller(0)
+	for i := 0; i < 4; i++ {
+		srcdir = filepath.Dir(srcdir)
+	}
+	var err error
+	srcdir, err = filepath.Abs(srcdir)
+	if err != nil {
+		panic(err)
+	}
+	os.Setenv("PATH", filepath.Join(srcdir, "bin")+sep+path)
+}
 
 type RepoType int
 


### PR DESCRIPTION
The PR attempts to refine a number of related issues with the Go test suite and the `make test` Makefile target.

The `make test` target is adjusted so that it depends on the local `bin/git-lfs[.exe]` binary being built first, and then the Go tests are run with `-count=1` so no caching of results is done between invocations.  (A developer wishing for Go's default caching of package list results can use `go test ./...` instead of `make test`.)

The common test utility package in `t/cmd/util/testutils.go` is given an `init()` function which attempts to ensure that the first path in the `PATH` environment variable's list is an absolute path to the working tree's `bin` directory.  This prevents the tests, when they run `git-lfs` as a system command, from accidentally using whatever `git-lfs` binary happens to be installed on the system instead, which obviously can produce inconsistent or unexpected test results.

Finally, the standalone transfer adapter's logic for running `git rev-parse --git-dir` when setting up a new handler based on a file path is refined so that it first removes any trailing `/.git` path segment.  This ensures the logic succeeds when presented with the path to a bare repository (which lacks a `.git` directory) even when the path has had `/.git` appended by [`EndpointFromLocalPath()`](https://github.com/git-lfs/git-lfs/blob/e8be7992b1c42956a351abf876e7c137b2254d83/lfshttp/endpoint.go#L112).

As [discussed](https://github.com/git-lfs/git-lfs/issues/4046#issuecomment-604649900) in #4046, we might be able to change `EndpointFromLocalPath()` as well, or instead, of changing `gitDirAtPath()`.  I chose this approach primarily because I was concerned that I didn't fully understand the potential use cases for custom transfer adapters, such as were described in #2912, and whether users might have configurations which depended on the existing behaviour of the `EndpointFromLocalPath()` function.

I believe the CI test failures are due to the issue addressed by #4082.

Fixes #4046.