### PR TITLE
git: avoid trying to rewrite remote tags as remote branches

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -31,6 +31,7 @@ const (
 	RefTypeLocalBranch  = RefType(iota)
 	RefTypeRemoteBranch = RefType(iota)
 	RefTypeLocalTag     = RefType(iota)
+	RefTypeRemoteTag    = RefType(iota)
 	RefTypeHEAD         = RefType(iota) // current checkout
 	RefTypeOther        = RefType(iota) // stash or unknown
 
@@ -1042,7 +1043,7 @@ func Fetch(remotes ...string) error {
 }
 
 // RemoteRefs returns a list of branches & tags for a remote by actually
-// accessing the remote vir git ls-remote
+// accessing the remote via git ls-remote.
 func RemoteRefs(remoteName string) ([]*Ref, error) {
 	var ret []*Ref
 	cmd := gitNoLFS("ls-remote", "--heads", "--tags", "-q", remoteName)
@@ -1064,7 +1065,11 @@ func RemoteRefs(remoteName string) ([]*Ref, error) {
 			}
 
 			sha := match[1]
-			ret = append(ret, &Ref{name, RefTypeRemoteBranch, sha})
+			typ := RefTypeRemoteBranch
+			if match[2] == "tags" {
+				typ = RefTypeRemoteTag
+			}
+			ret = append(ret, &Ref{name, typ, sha})
 		}
 	}
 	return ret, cmd.Wait()

--- a/t/t-migrate-fixup.sh
+++ b/t/t-migrate-fixup.sh
@@ -100,3 +100,32 @@ begin_test "migrate import (--fixup, --no-rewrite)"
   grep -q "fatal: --no-rewrite and --fixup cannot be combined" migrate.log
 )
 end_test
+
+begin_test "migrate import (--fixup with remote tags)"
+(
+  set -e
+
+  setup_single_local_branch_tracked_corrupt
+
+  git lfs uninstall
+
+  base64 < /dev/urandom | head -c 120 > b.txt
+  git add b.txt
+  git commit -m "b.txt"
+
+  git tag -m tag1 -a tag1
+  git reset --hard HEAD^
+
+  git lfs install
+
+  cwd=$(pwd)
+  cd "$TRASHDIR"
+
+  git clone "$cwd" "$reponame-2"
+  cd "$reponame-2"
+
+  # We're checking here that this succeeds even though it does nothing in this
+  # case.
+  git lfs migrate import --fixup --yes master
+)
+end_test


### PR DESCRIPTION
When invoking "git lfs migrate import --fixup", we call Git to fetch the remote branches and tags.  However, we mark both as having the type remote branch, so when we look up the local copies for them, we try to use the tag name as the name of a remote tracking branch, which fails.

Instead, let's mark them as remote tags, which means we won't try to rewrite them into branches at all.  This ensures the operation can succeed.

Fixes #3818 