### PR TITLE
pre-push: find named remote for URL if possible

### DIFF
--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -47,7 +47,8 @@ func prePushCommand(cmd *cobra.Command, args []string) {
 	requireGitVersion()
 
 	// Remote is first arg
-	if err := cfg.SetValidPushRemote(args[0]); err != nil {
+	remote, _ := git.MapRemoteURL(args[0], true)
+	if err := cfg.SetValidPushRemote(remote); err != nil {
 		Exit("Invalid remote name %q: %s", args[0], err)
 	}
 


### PR DESCRIPTION
Some users use tools like JGit, which use URLs instead of named remotes when invoking the pre-push hook.  This is problematic because we use remote-tracking branches to optimize our ref walk and when a user is using a URL, we can't apply that optimization since we don't know which named remote is being used.

However, if we have a named remote with only one URL, we can apply this optimization by looking up the remote name and using that as our remote instead.  We do this only in the pre-push hook, since this is the major time that we need to walk the history.

Add some unit and integration tests for this and also update one of the existing integration tests which was relying on the previous behavior by switching it to use an equivalent URL instead of the actual remote URL.
