### PR TITLE
CI: prune unused Docker images after use

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,4 +98,4 @@ jobs:
     - uses: actions/setup-ruby@v1
     - run: git clone https://github.com/git-lfs/build-dockers.git "$HOME/build-dockers"
     - run: (cd "$HOME/build-dockers" && ./build_dockers.bsh)
-    - run: DOCKER_AUTOPULL=0 ./docker/run_dockers.bsh
+    - run: DOCKER_AUTOPULL=0 ./docker/run_dockers.bsh --prune

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
     - run: gem install packagecloud-ruby
     - run: git clone https://github.com/git-lfs/build-dockers.git "$HOME/build-dockers"
     - run: (cd "$HOME/build-dockers" && ./build_dockers.bsh)
-    - run: DOCKER_AUTOPULL=0 ./docker/run_dockers.bsh
+    - run: DOCKER_AUTOPULL=0 ./docker/run_dockers.bsh --prune
     # If this is a pre-release tag, don't upload anything to packagecloud.
     - run: '[ -z "${GITHUB_REF%%refs/tags/*-pre*}" ] || ./script/packagecloud.rb'
       env:

--- a/docker/run_dockers.bsh
+++ b/docker/run_dockers.bsh
@@ -42,8 +42,11 @@ function split_image_name()
 
 # Parse Arguments
 IMAGES=()
+PRUNE=
 while [[ $# > 0 ]]; do
-  if [ "$1" == "--" ]; then
+  if [ "$1" = "--prune" ]; then
+    PRUNE=t
+  elif [ "$1" == "--" ]; then
     shift
     DOCKER_CMD="${@}"
     break
@@ -108,6 +111,10 @@ for IMAGE_NAME in "${IMAGES[@]}"; do
                    -v "${MINGW_PATCH}${IMAGE_REPO_DIR}:/repo" \
                    gitlfs/build-dockers:${IMAGE_NAME} ${DOCKER_CMD-}
 
+  if [ -n "$PRUNE" ]
+  then
+    $SUDO docker rmi -f "gitlfs/build-dockers:${IMAGE_NAME}"
+  fi
 done
 
 echo "Docker run completed successfully!"

--- a/rpm/build_rpms.bsh
+++ b/rpm/build_rpms.bsh
@@ -142,6 +142,9 @@ if ! which ronn; then
   $SUDO yum install -y --nogpgcheck $(ls ${CURDIR}/RPMS/noarch/rubygem-*.rpm ${CURDIR}/RPMS/x86_64/rubygem-*.rpm | grep -v debuginfo)
 fi
 
+rm -fr ${CURDIR}/{BUILD,BUILDROOT}
+mkdir -p ${CURDIR}/{BUILD,BUILDROOT}
+
 pushd ${CURDIR}/..
   #Yes, compile lfs before compiling lfs...
   make

--- a/rpm/build_rpms.bsh
+++ b/rpm/build_rpms.bsh
@@ -114,6 +114,7 @@ if [[ ${RUBY_VERSION[0]} < 2 ]]; then
     "${RPMBUILD[@]}" -ba ${CURDIR}/SPECS/ruby.spec
     echo "Installing ruby..."
     $SUDO yum install -y --nogpgcheck ${CURDIR}/RPMS/x86_64/ruby*.rpm
+    $SUDO yum erase -y libyaml-devel autoconf gcc-c++ readline-devel zlib-devel openssl-devel automake libtool sqlite-devel
   else
     $SUDO yum install -y ruby ruby-devel
   fi


### PR DESCRIPTION
At the moment, we're running out of disk space when building packages in Docker containers.  This is because our CI VMs have only 14 GB of storage.  To help deal with this problem, let's add an option to the run_dockers.bsh script to prune images after using them so we can free some of that disk space and let the remaining jobs complete.
