### PR TITLE
script/build-git: compile without gettext on macOS

### DIFF
--- a/script/build-git
+++ b/script/build-git
@@ -4,9 +4,9 @@ DIR="$1"
 
 case $(uname -s) in
   Darwin)
-    brew install curl zlib pcre2 gettext openssl
-    brew reinstall curl zlib pcre2 gettext openssl
-    for i in curl zlib pcre2 gettext openssl
+    brew install curl zlib pcre2 openssl
+    brew reinstall curl zlib pcre2 openssl
+    for i in curl zlib pcre2 openssl
     do
       brew unlink $i || true;
       brew link --force $i || true
@@ -21,6 +21,7 @@ esac
 
 cd "$DIR"
 printf "%s\n" \
+  "NO_GETTEXT=YesPlease" \
   "NO_OPENSSL=YesPlease" \
   "prefix=/usr/local" \
   > config.mak


### PR DESCRIPTION
Due to recent Homebrew changes, our CI builds of Git [failed](https://github.com/git-lfs/git-lfs/pull/4109#issuecomment-619814598) with a [missing](https://github.com/git-lfs/git-lfs/runs/621615779) `gettext` dependency.  While the upstream [issue](https://github.com/Homebrew/homebrew-core/issues/53485) may have been [resolved](https://github.com/Homebrew/homebrew-core/pull/53489), we can simply avoid the problem entirely by building Git without `gettext`.

See also https://lore.kernel.org/git/20200426200932.3769-1-tboegi@web.de/