### PR TITLE
commands/command_migrate.go: fix bug

### DIFF
--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -341,7 +341,7 @@ func ensureWorkingCopyClean(in io.Reader, out io.Writer) {
 			case "n", "N":
 				proceed = false
 				break L
-			case "y", "Y":
+			case "y", "Y", "":
 				proceed = true
 				break L
 			}


### PR DESCRIPTION
Default hint ([Y/n]) wasn't being honored - 'y' is now default.