### PR TITLE
Improve test suite robustness via environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -409,8 +409,16 @@ test-race : GO_TEST_EXTRA_ARGS=-race
 #
 # And so on.
 test : fmt $(.DEFAULT_GOAL)
-	(unset GIT_DIR; unset GIT_WORK_TREE; \
-	$(GO) test -count=1 $(GO_TEST_EXTRA_ARGS) $(addprefix ./,$(PKGS)))
+	( \
+		unset GIT_DIR; unset GIT_WORK_TREE; unset XDG_CONFIG_HOME; \
+		tempdir="$$(mktemp -d)"; \
+		export HOME="$$tempdir"; \
+		export GIT_CONFIG_NOSYSTEM=1; \
+		$(GO) test -count=1 $(GO_TEST_EXTRA_ARGS) $(addprefix ./,$(PKGS)); \
+		RET=$$?; \
+		rm -fr "$$tempdir"; \
+		exit $$RET; \
+	)
 
 # integration is a shorthand for running 'make' in the 't' directory.
 .PHONY : integration

--- a/t/testenv.sh
+++ b/t/testenv.sh
@@ -128,12 +128,14 @@ GIT_CONFIG_NOSYSTEM=1
 GIT_TERMINAL_PROMPT=0
 GIT_SSH=lfs-ssh-echo
 APPVEYOR_REPO_COMMIT_MESSAGE="test: env test should look for GIT_SSH too"
+LC_ALL=C
 
 export CREDSDIR
 export GIT_LFS_FORCE_PROGRESS
 export GIT_CONFIG_NOSYSTEM
 export GIT_SSH
 export APPVEYOR_REPO_COMMIT_MESSAGE
+export LC_ALL
 
 # Don't fail if run under git rebase -x.
 unset GIT_DIR


### PR DESCRIPTION
In several places in our test suite, we have behavior such that our tests fail either due to the global or system config or the locale in use.  Adjust our integration tests to run in the `C` locale and our unit tests to set the environment appropriately so that they are no longer affected by global or system config.

Fixes #4121 and fixes #4122 
/cc @slonopotamus as reporter