### PR TITLE
git: consider full refspec when determining seen refs

### DIFF
--- a/git/githistory/ref_updater.go
+++ b/git/githistory/ref_updater.go
@@ -79,10 +79,11 @@ func (r *refUpdater) updateOneRef(list *tasklog.ListTask, maxNameLen int, seen m
 		return errors.Wrapf(err, "could not decode: %q", ref.Sha)
 	}
 
-	if _, ok := seen[ref.Name]; ok {
+	refspec := ref.Refspec()
+	if _, ok := seen[refspec]; ok {
 		return nil
 	}
-	seen[ref.Name] = struct{}{}
+	seen[refspec] = struct{}{}
 
 	to, ok := r.CacheFn(sha1)
 

--- a/t/t-migrate-import.sh
+++ b/t/t-migrate-import.sh
@@ -499,6 +499,32 @@ begin_test "migrate import (identical contents, different permissions)"
 )
 end_test
 
+begin_test "migrate import (tags with same name as branches)"
+(
+  set -e
+
+  setup_multiple_local_branches
+  git checkout master
+
+  contents="hello"
+  oid=$(calc_oid "$contents")
+  printf "$contents" >hello.dat
+  git add .
+  git commit -m "add file"
+
+  git branch foo
+  git tag foo
+  git tag bar
+
+  git lfs migrate import --everything --include="*.dat"
+
+  [ "$(git rev-parse refs/heads/foo)" = "$(git rev-parse refs/tags/foo)" ]
+  [ "$(git rev-parse refs/heads/foo)" = "$(git rev-parse refs/tags/bar)" ]
+
+  assert_pointer "refs/heads/foo" hello.dat "$oid" 5
+)
+end_test
+
 begin_test "migrate import (bare repository)"
 (
   set -e


### PR DESCRIPTION
We avoid rewriting references that we've already seen, since in some cases we will need to order references to properly handle tags pointing to tags.  However, we use ref.Name for this, which is the short name, not the full refspec.  Consequently, if we've already seen a ref with the same short name (e.g., a branch when we're processing a tag), we end up skipping the second ref.

This is not what we want, so let's use the full refspec when populating the set of items we've already seen.

Fixes #4120
/cc @karlhendikse as reporter
/cc #3238, which may be fixed by this