### PR TITLE
locking: make patterns with slashes work on Windows

### DIFF
--- a/locking/lockable.go
+++ b/locking/lockable.go
@@ -44,7 +44,7 @@ func (c *Client) refreshLockablePatterns() {
 	c.lockablePatterns = make([]string, 0, len(paths))
 	for _, p := range paths {
 		if p.Lockable {
-			c.lockablePatterns = append(c.lockablePatterns, p.Path)
+			c.lockablePatterns = append(c.lockablePatterns, filepath.ToSlash(p.Path))
 		}
 	}
 	c.lockableFilter = filepathfilter.New(c.lockablePatterns, nil)

--- a/t/t-post-checkout.sh
+++ b/t/t-post-checkout.sh
@@ -116,3 +116,92 @@ begin_test "post-checkout"
 
 )
 end_test
+
+begin_test "post-checkout with subdirectories"
+(
+  set -e
+
+  reponame="post-checkout-subdirectories"
+  setup_remote_repo "$reponame"
+
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track --lockable "bin/*.dat"
+  git lfs track "*.big" # not lockable
+  git add .gitattributes
+  git commit -m "add git attributes"
+
+  echo "[
+  {
+    \"CommitDate\":\"$(get_date -10d)\",
+    \"Files\":[
+      {\"Filename\":\"bin/file1.dat\",\"Data\":\"file 1 creation\"},
+      {\"Filename\":\"bin/file2.dat\",\"Data\":\"file 2 creation\"}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -7d)\",
+    \"Files\":[
+      {\"Filename\":\"bin/file1.dat\",\"Data\":\"file 1 updated commit 2\"},
+      {\"Filename\":\"file3.big\",\"Data\":\"file 3 creation\"},
+      {\"Filename\":\"file4.big\",\"Data\":\"file 4 creation\"}],
+    \"Tags\":[\"atag\"]
+  },
+  {
+    \"CommitDate\":\"$(get_date -5d)\",
+    \"Files\":[
+      {\"Filename\":\"bin/file2.dat\",\"Data\":\"file 2 updated commit 3\"}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -3d)\",
+    \"NewBranch\":\"branch2\",
+    \"Files\":[
+      {\"Filename\":\"bin/file5.dat\",\"Data\":\"file 5 creation in branch2\"},
+      {\"Filename\":\"file6.big\",\"Data\":\"file 6 creation in branch2\"}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -1d)\",
+    \"Files\":[
+      {\"Filename\":\"bin/file2.dat\",\"Data\":\"file 2 updated in branch2\"},
+      {\"Filename\":\"file3.big\",\"Data\":\"file 3 updated in branch2\"}]
+  }
+  ]" | GIT_LFS_SET_LOCKABLE_READONLY=0 lfstest-testutils addcommits
+
+  # skipped setting read-only above to make bulk load simpler (no read-only issues)
+
+  git push -u origin master branch2
+
+  # re-clone the repo so we start fresh
+  cd ..
+  rm -rf "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  # this will be master
+
+  [ "$(cat bin/file1.dat)" == "file 1 updated commit 2" ]
+  [ "$(cat bin/file2.dat)" == "file 2 updated commit 3" ]
+  [ "$(cat file3.big)" == "file 3 creation" ]
+  [ "$(cat file4.big)" == "file 4 creation" ]
+  [ ! -e bin/file5.dat ]
+  [ ! -e file6.big ]
+  # without the post-checkout hook, any changed files would now be writeable
+  refute_file_writeable bin/file1.dat
+  refute_file_writeable bin/file2.dat
+  assert_file_writeable file3.big
+  assert_file_writeable file4.big
+
+  # checkout branch
+  git checkout branch2
+  [ -e bin/file5.dat ]
+  [ -e file6.big ]
+  refute_file_writeable bin/file1.dat
+  refute_file_writeable bin/file2.dat
+  refute_file_writeable bin/file5.dat
+  assert_file_writeable file3.big
+  assert_file_writeable file4.big
+  assert_file_writeable file6.big
+
+  # Confirm that contents of existing files were updated even though were read-only
+  [ "$(cat bin/file2.dat)" == "file 2 updated in branch2" ]
+  [ "$(cat file3.big)" == "file 3 updated in branch2" ]
+)
+end_test


### PR DESCRIPTION
When we get paths from git.GetAttributePaths, the paths are in the system native format; that is, they use the system native path separator.  However, when creating patterns, we always want to use a slash.  As things stand right now, lockable patterns that use a slash never match on Windows.

Convert the patterns to use a slash so that lockable patterns work as expected on Windows.

Fixes #3781.