### PR TITLE
Sign and notarize binaries on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     name: Build with specific Go
     strategy:
       matrix:
-        go: ['1.12.x', '1.13.x']
+        go: ['1.12.x', '1.13.x', '1.14.x']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,21 +43,38 @@ jobs:
       shell: bash
     - uses: actions/upload-artifact@v1
       with:
-        name: assets
+        name: windows-assets
+        path: bin/releases
+  build-macos:
+    name: Build macOS Assets
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-ruby@v1
+    - run: make release
+    - uses: actions/upload-artifact@v1
+      with:
+        name: macos-assets
         path: bin/releases
   build-main:
     name: Main Release Assets
-    needs: build-windows
+    needs:
+      - build-windows
+      - build-macos
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
     - uses: actions/download-artifact@v1
       with:
-        name: assets
+        name: windows-assets
+    - uses: actions/download-artifact@v1
+      with:
+        name: macos-assets
     - run: CGO_ENABLED=0 make release
-    - run: rm -f bin/releases/*windows*
-    - run: find assets -name "*windows*" | xargs -L1 -I{} mv {} bin/releases
+    - run: rm -f bin/releases/*windows* bin/releases/*darwin*
+    - run: 'find windows-assets -name "*windows*" -type f | xargs -L1 -I{} mv {} bin/releases'
+    - run: 'find macos-assets -name "*darwin*" -type f | xargs -L1 -I{} mv {} bin/releases'
     - run: script/upload --skip-verify $(git describe)
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,19 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
+    - run: brew install mitchellh/gon/gon
     - run: make release
+    - run: CERT_FILE="$HOME/cert.p12" make release-write-certificate
+      env:
+        CERT_CONTENTS: ${{secrets.MACOS_CERT_BASE64}}
+    - run: CERT_FILE="$HOME/cert.p12" make release-import-certificate
+      env:
+        CERT_PASS: ${{secrets.MACOS_CERT_PASS}}
+    - run: make release-darwin
+      env:
+        DARWIN_DEV_USER: ${{secrets.MACOS_DEV_USER}}
+        DARWIN_DEV_PASS: ${{secrets.MACOS_DEV_PASS}}
+        DARWIN_CERT_ID: ${{secrets.MACOS_CERT_ID}}
     - uses: actions/upload-artifact@v1
       with:
         name: macos-assets

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,6 @@ BUILD = GOOS=$(1) GOARCH=$(2) \
 # built for.
 BUILD_TARGETS = \
 	bin/git-lfs-darwin-amd64 \
-	bin/git-lfs-darwin-386 \
 	bin/git-lfs-linux-arm \
 	bin/git-lfs-linux-arm64 \
 	bin/git-lfs-linux-amd64 \
@@ -206,8 +205,6 @@ all build : $(BUILD_TARGETS)
 # embeds the versioninfo into the binary.
 bin/git-lfs-darwin-amd64 : $(SOURCES) mangen
 	$(call BUILD,darwin,amd64,-darwin-amd64)
-bin/git-lfs-darwin-386 : $(SOURCES) mangen
-	$(call BUILD,darwin,386,-darwin-386)
 bin/git-lfs-linux-arm : $(SOURCES) mangen
 	GOARM=5 $(call BUILD,linux,arm,-linux-arm)
 bin/git-lfs-linux-arm64 : $(SOURCES) mangen
@@ -272,7 +269,6 @@ script/windows-installer/git-lfs-wizard-image.bmp
 # 	make VERSION=my-version bin/releases/git-lfs-darwin-amd64-my-version.tar.gz
 RELEASE_TARGETS = \
 	bin/releases/git-lfs-darwin-amd64-$(VERSION).tar.gz \
-	bin/releases/git-lfs-darwin-386-$(VERSION).tar.gz \
 	bin/releases/git-lfs-linux-arm-$(VERSION).tar.gz \
 	bin/releases/git-lfs-linux-arm64-$(VERSION).tar.gz \
 	bin/releases/git-lfs-linux-amd64-$(VERSION).tar.gz \

--- a/Makefile
+++ b/Makefile
@@ -268,7 +268,7 @@ script/windows-installer/git-lfs-wizard-image.bmp
 #
 # 	make VERSION=my-version bin/releases/git-lfs-darwin-amd64-my-version.tar.gz
 RELEASE_TARGETS = \
-	bin/releases/git-lfs-darwin-amd64-$(VERSION).tar.gz \
+	bin/releases/git-lfs-darwin-amd64-$(VERSION).zip \
 	bin/releases/git-lfs-linux-arm-$(VERSION).tar.gz \
 	bin/releases/git-lfs-linux-arm64-$(VERSION).tar.gz \
 	bin/releases/git-lfs-linux-amd64-$(VERSION).tar.gz \
@@ -296,7 +296,7 @@ release : $(RELEASE_TARGETS)
 	shasum -a 256 $(RELEASE_TARGETS)
 
 # bin/releases/git-lfs-%-$(VERSION).tar.gz generates a gzip-compressed TAR of
-# the non-Windows release artifacts.
+# the non-Windows and non-macOS release artifacts.
 #
 # It includes all of RELEASE_INCLUDES, as well as script/install.sh.
 bin/releases/git-lfs-%-$(VERSION).tar.gz : \
@@ -304,12 +304,24 @@ $(RELEASE_INCLUDES) bin/git-lfs-% script/install.sh
 	@mkdir -p bin/releases
 	tar $(TAR_XFORM_ARG) '$(TAR_XFORM_CMD)!bin/git-lfs-.*!git-lfs!' $(TAR_XFORM_ARG) '$(TAR_XFORM_CMD)!script/!!' -czf $@ $^
 
-# bin/releases/git-lfs-%-$(VERSION).zip generates a ZIP compression of all of
-# the Windows release artifacts.
+# bin/releases/git-lfs-darwin-$(VERSION).zip generates a ZIP compression of all
+# of the macOS release artifacts.
+#
+# It includes all of the RELEASE_INCLUDES, as well as script/install.sh.
+bin/releases/git-lfs-darwin-%-$(VERSION).zip : \
+$(RELEASE_INCLUDES) bin/git-lfs-darwin-% script/install.sh
+	dir=bin/releases/darwin-$* && \
+	mkdir -p $$dir && \
+	cp $^ $$dir && mv $$dir/git-lfs-darwin-$* $$dir/git-lfs && \
+	zip -j $@ $$dir/* && \
+	$(RM) -r $$dir
+
+# bin/releases/git-lfs-windows-$(VERSION).zip generates a ZIP compression of all
+# of the Windows release artifacts.
 #
 # It includes all of the RELEASE_INCLUDES, and converts LF-style line endings to
 # CRLF in the non-binary components of the artifact.
-bin/releases/git-lfs-%-$(VERSION).zip : $(RELEASE_INCLUDES) bin/git-lfs-%.exe
+bin/releases/git-lfs-windows-%-$(VERSION).zip : $(RELEASE_INCLUDES) bin/git-lfs-windows-%.exe
 	@mkdir -p bin/releases
 	zip -j -l $@ $^
 

--- a/docs/man/mangen.go
+++ b/docs/man/mangen.go
@@ -63,8 +63,8 @@ func main() {
 		os.Exit(2)
 	}
 	out.WriteString("package commands\n\nfunc init() {\n")
-	out.WriteString("// THIS FILE IS GENERATED, DO NOT EDIT\n")
-	out.WriteString("// Use 'go generate ./commands' to update\n")
+	out.WriteString("\t// THIS FILE IS GENERATED, DO NOT EDIT\n")
+	out.WriteString("\t// Use 'go generate ./commands' to update\n")
 	fileregex := regexp.MustCompile(`git-lfs(?:-([A-Za-z\-]+))?.\d.ronn`)
 	headerregex := regexp.MustCompile(`^###?\s+([A-Za-z0-9 ]+)`)
 	// only pick up caps in links to avoid matching optional args
@@ -80,7 +80,7 @@ func main() {
 				// This is git-lfs.1.ronn
 				cmd = "git-lfs"
 			}
-			out.WriteString("ManPages[\"" + cmd + "\"] = `")
+			out.WriteString("\tManPages[\"" + cmd + "\"] = `")
 			contentf, err := os.Open(filepath.Join(manDir, f.Name()))
 			if err != nil {
 				warnf(os.Stderr, "Failed to open %v: %v\n", f.Name(), err)

--- a/script/macos/manifest.json
+++ b/script/macos/manifest.json
@@ -1,0 +1,10 @@
+{
+  "apple_id": {
+    "password": "@env:DARWIN_DEV_PASS"
+  },
+  "notarize": {
+    "path": ["git-lfs"],
+    "bundle_id": "com.github.git-lfs",
+    "staple": false
+  }
+}


### PR DESCRIPTION
Apple complains if a binary is downloaded from the Internet but has not been signed and notarized as of macOS Catalina.  Because this is an impediment for users, let's fix that.

This series contains several different patches:
1. We now build with Go 1.14 in CI in addition to other versions.
2. We no longer build i386 Darwin binaries since we can't notarize those.
3. We build the Darwin release assets as a zip file, since we can't notarize a tarball.
4. We build Darwin binaries on Darwin instead of Linux for releases.
5. We sign and notarize binaries.

Each patch contains a description of what it does and why it's valuable.

Currently we use my (GitHub) Apple ID as the actor for notarization plus an app password.  This value will be stored in the secret store for Git LFS so it can be changed out without further code changes if I should be hit by a bus (or just move on to other projects).

This has been tested in a private repo in the git-lfs organization and appears to work there.

Fixes #3714.