### PR TITLE
Makefile: ensure temp Go modules can be deleted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -473,6 +473,7 @@ test : fmt $(.DEFAULT_GOAL)
 		export GIT_CONFIG_NOSYSTEM=1; \
 		$(GO) test -count=1 $(GO_TEST_EXTRA_ARGS) $(addprefix ./,$(PKGS)); \
 		RET=$$?; \
+		chmod -R u+w "$$tempdir"; \
 		rm -fr "$$tempdir"; \
 		exit $$RET; \
 	)


### PR DESCRIPTION
As a followup to commit 1d4e46b311a3 in PR #4132, we ensure any files created during the `make test` build can be fully deleted by setting the user write permission bit.  Otherwise, at least on macOS, some Go modules' files are installed in directories with read-only permissions, and the final `rm -fr` cleanup is then unable to remove those files, leading to lots of spurious error messages.