### PR TITLE
add --worktree option to install and uninstall commands

### DIFF
--- a/commands/command_uninstall.go
+++ b/commands/command_uninstall.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"github.com/git-lfs/git-lfs/git"
 	"github.com/spf13/cobra"
 )
 
@@ -10,13 +11,13 @@ func uninstallCommand(cmd *cobra.Command, args []string) {
 		Print("WARNING: %s", err.Error())
 	}
 
-	if !skipRepoInstall && (localInstall || cfg.InRepo()) {
+	if !skipRepoInstall && (localInstall || worktreeInstall || cfg.InRepo()) {
 		uninstallHooksCommand(cmd, args)
 	}
 
 	if systemInstall {
 		Print("System Git LFS configuration has been removed.")
-	} else if !localInstall {
+	} else if !(localInstall || worktreeInstall) {
 		Print("Global Git LFS configuration has been removed.")
 	}
 }
@@ -33,6 +34,9 @@ func uninstallHooksCommand(cmd *cobra.Command, args []string) {
 func init() {
 	RegisterCommand("uninstall", uninstallCommand, func(cmd *cobra.Command) {
 		cmd.Flags().BoolVarP(&localInstall, "local", "l", false, "Remove the Git LFS config for the local Git repository only.")
+		if git.IsGitVersionAtLeast("2.20.0") {
+			cmd.Flags().BoolVarP(&worktreeInstall, "worktree", "w", false, "Remove the Git LFS config for the current Git working tree, if multiple working trees are configured; otherwise, the same as --local.")
+		}
 		cmd.Flags().BoolVarP(&systemInstall, "system", "", false, "Remove the Git LFS config in system-wide scope.")
 		cmd.Flags().BoolVarP(&skipRepoInstall, "skip-repo", "", false, "Skip repo setup, just uninstall global filters.")
 		cmd.AddCommand(NewCommand("hooks", uninstallHooksCommand))

--- a/commands/command_uninstall.go
+++ b/commands/command_uninstall.go
@@ -7,7 +7,7 @@ import (
 // uninstallCmd removes any configuration and hooks set by Git LFS.
 func uninstallCommand(cmd *cobra.Command, args []string) {
 	if err := cmdInstallOptions().Uninstall(); err != nil {
-		Error(err.Error())
+		Print("WARNING: %s", err.Error())
 	}
 
 	if !skipRepoInstall && (localInstall || cfg.InRepo()) {
@@ -32,8 +32,8 @@ func uninstallHooksCommand(cmd *cobra.Command, args []string) {
 
 func init() {
 	RegisterCommand("uninstall", uninstallCommand, func(cmd *cobra.Command) {
-		cmd.Flags().BoolVarP(&localInstall, "local", "l", false, "Set the Git LFS config for the local Git repository only.")
-		cmd.Flags().BoolVarP(&systemInstall, "system", "", false, "Set the Git LFS config in system-wide scope.")
+		cmd.Flags().BoolVarP(&localInstall, "local", "l", false, "Remove the Git LFS config for the local Git repository only.")
+		cmd.Flags().BoolVarP(&systemInstall, "system", "", false, "Remove the Git LFS config in system-wide scope.")
 		cmd.Flags().BoolVarP(&skipRepoInstall, "skip-repo", "", false, "Skip repo setup, just uninstall global filters.")
 		cmd.AddCommand(NewCommand("hooks", uninstallHooksCommand))
 	})

--- a/config/config.go
+++ b/config/config.go
@@ -462,6 +462,10 @@ func (c *Configuration) FindGitLocalKey(key string) string {
 	return c.gitConfig.FindLocal(key)
 }
 
+func (c *Configuration) FindGitWorktreeKey(key string) string {
+	return c.gitConfig.FindWorktree(key)
+}
+
 func (c *Configuration) SetGitGlobalKey(key, val string) (string, error) {
 	return c.gitConfig.SetGlobal(key, val)
 }
@@ -474,6 +478,10 @@ func (c *Configuration) SetGitLocalKey(key, val string) (string, error) {
 	return c.gitConfig.SetLocal(key, val)
 }
 
+func (c *Configuration) SetGitWorktreeKey(key, val string) (string, error) {
+	return c.gitConfig.SetWorktree(key, val)
+}
+
 func (c *Configuration) UnsetGitGlobalSection(key string) (string, error) {
 	return c.gitConfig.UnsetGlobalSection(key)
 }
@@ -484,6 +492,10 @@ func (c *Configuration) UnsetGitSystemSection(key string) (string, error) {
 
 func (c *Configuration) UnsetGitLocalSection(key string) (string, error) {
 	return c.gitConfig.UnsetLocalSection(key)
+}
+
+func (c *Configuration) UnsetGitWorktreeSection(key string) (string, error) {
+	return c.gitConfig.UnsetWorktreeSection(key)
 }
 
 func (c *Configuration) UnsetGitLocalKey(key string) (string, error) {

--- a/docs/man/git-lfs-install.1.ronn
+++ b/docs/man/git-lfs-install.1.ronn
@@ -26,6 +26,16 @@ filters if they are not already set.
 * `--local`:
     Sets the "lfs" smudge and clean filters in the local repository's git
     config, instead of the global git config (~/.gitconfig).
+* `--worktree`:
+    Sets the "lfs" smudge and clean filters in the current working tree's
+    git config, instead of the global git config (~/.gitconfig) or local
+    repository's git config ($GIT_DIR/config).
+    If multiple working trees are in use, the Git config extension
+    `worktreeConfig` must be enabled to use this option.
+    If only one working tree is in use, `--worktree` has the same effect
+    as `--local`.
+    This option is only available if the installed Git version is at least
+    2.20.0 and therefore supports the "worktreeConfig" extension.
 * `--manual`:
     Print instructions for manually updating your hooks to include git-lfs
     functionality. Use this option if `git lfs install` fails because of existing
@@ -43,6 +53,6 @@ filters if they are not already set.
 
 ## SEE ALSO
 
-git-lfs-uninstall(1).
+git-lfs-uninstall(1), git-worktree(1).
 
 Part of the git-lfs(1) suite.

--- a/docs/man/git-lfs-uninstall.1.ronn
+++ b/docs/man/git-lfs-uninstall.1.ronn
@@ -17,6 +17,16 @@ Perform the following actions to remove the Git LFS configuration:
 * --local:
     Removes the "lfs" smudge and clean filters from the local repository's git
     config, instead of the global git config (~/.gitconfig).
+* --worktree:
+    Removes the "lfs" smudge and clean filters from the current working tree's
+    git config, instead of the global git config (~/.gitconfig) or local
+    repository's git config ($GIT_DIR/config).
+    If multiple working trees are in use, the Git config extension
+    `worktreeConfig` must be enabled to use this option.
+    If only one working tree is in use, `--worktree` has the same effect
+    as `--local`.
+    This option is only available if the installed Git version is at least
+    2.20.0 and therefore supports the "worktreeConfig" extension.
 * --system:
     Removes the "lfs" smudge and clean filters from the system git config,
     instead of the global git config (~/.gitconfig).
@@ -26,6 +36,6 @@ Perform the following actions to remove the Git LFS configuration:
 
 ## SEE ALSO
 
-git-lfs-install(1).
+git-lfs-install(1), git-worktree(1).
 
 Part of the git-lfs(1) suite.

--- a/git/config.go
+++ b/git/config.go
@@ -83,6 +83,12 @@ func (c *Configuration) FindLocal(key string) string {
 	return output
 }
 
+// FindWorktree returns the git config value in worktree or local scope for the key, depending on whether multiple worktrees are in use
+func (c *Configuration) FindWorktree(key string) string {
+	output, _ := c.gitConfig("--worktree", key)
+	return output
+}
+
 // SetGlobal sets the git config value for the key in the global config
 func (c *Configuration) SetGlobal(key, val string) (string, error) {
 	return c.gitConfigWrite("--global", "--replace-all", key, val)
@@ -98,6 +104,11 @@ func (c *Configuration) SetLocal(key, val string) (string, error) {
 	return c.gitConfigWrite("--replace-all", key, val)
 }
 
+// SetWorktree sets the git config value for the key in the worktree or local config, depending on whether multiple worktrees are in use
+func (c *Configuration) SetWorktree(key, val string) (string, error) {
+	return c.gitConfigWrite("--worktree", "--replace-all", key, val)
+}
+
 // UnsetGlobalSection removes the entire named section from the global config
 func (c *Configuration) UnsetGlobalSection(key string) (string, error) {
 	return c.gitConfigWrite("--global", "--remove-section", key)
@@ -111,6 +122,11 @@ func (c *Configuration) UnsetSystemSection(key string) (string, error) {
 // UnsetLocalSection removes the entire named section from the local config
 func (c *Configuration) UnsetLocalSection(key string) (string, error) {
 	return c.gitConfigWrite("--local", "--remove-section", key)
+}
+
+// UnsetWorktreeSection removes the entire named section from the worktree or local config, depending on whether multiple worktrees are in use
+func (c *Configuration) UnsetWorktreeSection(key string) (string, error) {
+	return c.gitConfigWrite("--worktree", "--remove-section", key)
 }
 
 // UnsetLocalKey removes the git config value for the key from the specified config file

--- a/git/config.go
+++ b/git/config.go
@@ -65,7 +65,7 @@ func (c *Configuration) Find(val string) string {
 	return output
 }
 
-// FindGlobal returns the git config value global scope for the key
+// FindGlobal returns the git config value in global scope for the key
 func (c *Configuration) FindGlobal(key string) string {
 	output, _ := c.gitConfig("--global", key)
 	return output
@@ -77,7 +77,7 @@ func (c *Configuration) FindSystem(key string) string {
 	return output
 }
 
-// Find returns the git config value for the key
+// FindLocal returns the git config value in local scope for the key
 func (c *Configuration) FindLocal(key string) string {
 	output, _ := c.gitConfig("--local", key)
 	return output
@@ -93,6 +93,11 @@ func (c *Configuration) SetSystem(key, val string) (string, error) {
 	return c.gitConfigWrite("--system", "--replace-all", key, val)
 }
 
+// SetLocal sets the git config value for the key in the specified config file
+func (c *Configuration) SetLocal(key, val string) (string, error) {
+	return c.gitConfigWrite("--replace-all", key, val)
+}
+
 // UnsetGlobalSection removes the entire named section from the global config
 func (c *Configuration) UnsetGlobalSection(key string) (string, error) {
 	return c.gitConfigWrite("--global", "--remove-section", key)
@@ -103,14 +108,9 @@ func (c *Configuration) UnsetSystemSection(key string) (string, error) {
 	return c.gitConfigWrite("--system", "--remove-section", key)
 }
 
-// UnsetLocalSection removes the entire named section from the system config
+// UnsetLocalSection removes the entire named section from the local config
 func (c *Configuration) UnsetLocalSection(key string) (string, error) {
 	return c.gitConfigWrite("--local", "--remove-section", key)
-}
-
-// SetLocal sets the git config value for the key in the specified config file
-func (c *Configuration) SetLocal(key, val string) (string, error) {
-	return c.gitConfigWrite("--replace-all", key, val)
 }
 
 // UnsetLocalKey removes the git config value for the key from the specified config file

--- a/lfs/attribute.go
+++ b/lfs/attribute.go
@@ -43,8 +43,7 @@ func (o *FilterOptions) Install() error {
 }
 
 func (o *FilterOptions) Uninstall() error {
-	filterAttribute().Uninstall(o)
-	return nil
+	return filterAttribute().Uninstall(o)
 }
 
 func filterAttribute() *Attribute {
@@ -162,14 +161,16 @@ func (a *Attribute) set(gitConfig *git.Configuration, key, value string, upgrade
 }
 
 // Uninstall removes all properties in the path of this property.
-func (a *Attribute) Uninstall(opt *FilterOptions) {
+func (a *Attribute) Uninstall(opt *FilterOptions) error {
+	var err error
 	if opt.Local {
-		opt.GitConfig.UnsetLocalSection(a.Section)
+		_, err = opt.GitConfig.UnsetLocalSection(a.Section)
 	} else if opt.System {
-		opt.GitConfig.UnsetSystemSection(a.Section)
+		_, err = opt.GitConfig.UnsetSystemSection(a.Section)
 	} else {
-		opt.GitConfig.UnsetGlobalSection(a.Section)
+		_, err = opt.GitConfig.UnsetGlobalSection(a.Section)
 	}
+	return err
 }
 
 // shouldReset determines whether or not a value is resettable given its current

--- a/lfs/attribute.go
+++ b/lfs/attribute.go
@@ -31,6 +31,7 @@ type FilterOptions struct {
 	GitConfig  *git.Configuration
 	Force      bool
 	Local      bool
+	Worktree   bool
 	System     bool
 	SkipSmudge bool
 }
@@ -136,6 +137,8 @@ func (a *Attribute) set(gitConfig *git.Configuration, key, value string, upgrade
 	var currentValue string
 	if opt.Local {
 		currentValue = gitConfig.FindLocal(key)
+	} else if opt.Worktree {
+		currentValue = gitConfig.FindWorktree(key)
 	} else if opt.System {
 		currentValue = gitConfig.FindSystem(key)
 	} else {
@@ -146,6 +149,8 @@ func (a *Attribute) set(gitConfig *git.Configuration, key, value string, upgrade
 		var err error
 		if opt.Local {
 			_, err = gitConfig.SetLocal(key, value)
+		} else if opt.Worktree {
+			_, err = gitConfig.SetWorktree(key, value)
 		} else if opt.System {
 			_, err = gitConfig.SetSystem(key, value)
 		} else {
@@ -165,6 +170,8 @@ func (a *Attribute) Uninstall(opt *FilterOptions) error {
 	var err error
 	if opt.Local {
 		_, err = opt.GitConfig.UnsetLocalSection(a.Section)
+	} else if opt.Worktree {
+		_, err = opt.GitConfig.UnsetWorktreeSection(a.Section)
 	} else if opt.System {
 		_, err = opt.GitConfig.UnsetSystemSection(a.Section)
 	} else {

--- a/t/t-install-worktree-unsupported.sh
+++ b/t/t-install-worktree-unsupported.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+. "$(dirname "$0")/testlib.sh"
+
+# These tests rely on behavior found in Git versions less than 2.20.0 to
+# perform themselves, specifically:
+#   - lack of worktreeConfig extension support
+ensure_git_version_isnt $VERSION_HIGHER "2.20.0"
+
+begin_test "install --worktree with unsupported worktreeConfig extension"
+(
+  set -e
+
+  reponame="$(basename "$0" ".sh")-unsupported"
+  mkdir "$reponame"
+  cd "$reponame"
+  git init
+
+  set +e
+  git lfs install --worktree 2>err.log
+  res=$?
+  set -e
+
+  cat err.log
+  grep -i "error" err.log
+  grep -- "--worktree" err.log
+  [ "0" != "$res" ]
+)
+end_test

--- a/t/t-install-worktree.sh
+++ b/t/t-install-worktree.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+
+. "$(dirname "$0")/testlib.sh"
+
+# These tests rely on behavior found in Git versions higher than 2.20.0 to
+# perform themselves, specifically:
+#   - worktreeConfig extension support
+ensure_git_version_isnt $VERSION_LOWER "2.20.0"
+
+begin_test "install --worktree outside repository"
+(
+  set -e
+
+  # If run inside the git-lfs source dir this will update its .git/config & cause issues
+  if [ "$GIT_LFS_TEST_DIR" == "" ]; then
+    echo "Skipping install --worktree because GIT_LFS_TEST_DIR is not set"
+    exit 0
+  fi
+
+  has_test_dir || exit 0
+
+  set +e
+  git lfs install --worktree >out.log
+  res=$?
+  set -e
+
+  [ "Not in a git repository." = "$(cat out.log)" ]
+  [ "0" != "$res" ]
+)
+end_test
+
+begin_test "install --worktree with single working tree"
+(
+  set -e
+
+  # old values that should be ignored by `install --worktree`
+  git config --global filter.lfs.smudge "global smudge"
+  git config --global filter.lfs.clean "global clean"
+  git config --global filter.lfs.process "global filter"
+
+  reponame="$(basename "$0" ".sh")-single-tree"
+  mkdir "$reponame"
+  cd "$reponame"
+  git init
+  git lfs install --worktree
+
+  # local configs are correct
+  [ "git-lfs smudge -- %f" = "$(git config filter.lfs.smudge)" ]
+  [ "git-lfs smudge -- %f" = "$(git config --local filter.lfs.smudge)" ]
+  [ "git-lfs smudge -- %f" = "$(git config --worktree filter.lfs.smudge)" ]
+  [ "git-lfs clean -- %f" = "$(git config filter.lfs.clean)" ]
+  [ "git-lfs clean -- %f" = "$(git config --local filter.lfs.clean)" ]
+  [ "git-lfs clean -- %f" = "$(git config --worktree filter.lfs.clean)" ]
+  [ "git-lfs filter-process" = "$(git config filter.lfs.process)" ]
+  [ "git-lfs filter-process" = "$(git config --local filter.lfs.process)" ]
+  [ "git-lfs filter-process" = "$(git config --worktree filter.lfs.process)" ]
+
+  # global configs
+  [ "global smudge" = "$(git config --global filter.lfs.smudge)" ]
+  [ "global clean" = "$(git config --global filter.lfs.clean)" ]
+  [ "global filter" = "$(git config --global filter.lfs.process)" ]
+)
+end_test
+
+begin_test "install --worktree with multiple working trees"
+(
+  set -e
+
+  reponame="$(basename "$0" ".sh")-multi-tree"
+  mkdir "$reponame"
+  cd "$reponame"
+  git init
+
+  # old values that should be ignored by `install --worktree`
+  git config --global filter.lfs.smudge "global smudge"
+  git config --global filter.lfs.clean "global clean"
+  git config --global filter.lfs.process "global filter"
+  git config --local filter.lfs.smudge "local smudge"
+  git config --local filter.lfs.clean "local clean"
+  git config --local filter.lfs.process "local filter"
+
+  touch a.txt
+  git add a.txt
+  git commit -m "initial commit"
+
+  git config extensions.worktreeConfig true
+
+  treename="../$reponame-wt"
+  git worktree add "$treename"
+  cd "$treename"
+
+  git lfs install --worktree
+
+  # worktree configs are correct
+  [ "git-lfs smudge -- %f" = "$(git config filter.lfs.smudge)" ]
+  [ "git-lfs smudge -- %f" = "$(git config --worktree filter.lfs.smudge)" ]
+  [ "git-lfs clean -- %f" = "$(git config filter.lfs.clean)" ]
+  [ "git-lfs clean -- %f" = "$(git config --worktree filter.lfs.clean)" ]
+  [ "git-lfs filter-process" = "$(git config filter.lfs.process)" ]
+  [ "git-lfs filter-process" = "$(git config --worktree filter.lfs.process)" ]
+
+  # local configs are correct
+  [ "local smudge" = "$(git config --local filter.lfs.smudge)" ]
+  [ "local clean" = "$(git config --local filter.lfs.clean)" ]
+  [ "local filter" = "$(git config --local filter.lfs.process)" ]
+
+  # global configs
+  [ "global smudge" = "$(git config --global filter.lfs.smudge)" ]
+  [ "global clean" = "$(git config --global filter.lfs.clean)" ]
+  [ "global filter" = "$(git config --global filter.lfs.process)" ]
+)
+end_test
+
+begin_test "install --worktree without worktreeConfig extension"
+(
+  set -e
+
+  reponame="$(basename "$0" ".sh")-multi-tree-no-config"
+  mkdir "$reponame"
+  cd "$reponame"
+  git init
+
+  touch a.txt
+  git add a.txt
+  git commit -m "initial commit"
+
+  treename="../$reponame-wt"
+  git worktree add "$treename"
+  cd "$treename"
+
+  set +e
+  git lfs install --worktree >out.log
+  res=$?
+  set -e
+
+  cat out.log
+  grep -E "error running.*git.*config" out.log
+  [ "$res" -eq 2 ]
+)
+end_test
+
+begin_test "install --worktree with conflicting scope"
+(
+  set -e
+
+  reponame="$(basename "$0" ".sh")-scope-conflict"
+  mkdir "$reponame"
+  cd "$reponame"
+  git init
+
+  set +e
+  git lfs install --local --worktree 2>err.log
+  res=$?
+  set -e
+
+  [ "Only one of --local and --worktree options can be specified." = "$(cat err.log)" ]
+  [ "0" != "$res" ]
+
+  set +e
+  git lfs install --worktree --system 2>err.log
+  res=$?
+  set -e
+
+  [ "Only one of --worktree and --system options can be specified." = "$(cat err.log)" ]
+  [ "0" != "$res" ]
+)
+end_test

--- a/t/t-uninstall-worktree-unsupported.sh
+++ b/t/t-uninstall-worktree-unsupported.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+. "$(dirname "$0")/testlib.sh"
+
+# These tests rely on behavior found in Git versions less than 2.20.0 to
+# perform themselves, specifically:
+#   - lack of worktreeConfig extension support
+ensure_git_version_isnt $VERSION_HIGHER "2.20.0"
+
+begin_test "uninstall --worktree with unsupported worktreeConfig extension"
+(
+  set -e
+
+  reponame="$(basename "$0" ".sh")-unsupported"
+  mkdir "$reponame"
+  cd "$reponame"
+
+  set +e
+  git lfs uninstall --worktree 2>err.log
+  res=$?
+  set -e
+
+  cat err.log
+  grep -i "error" err.log
+  grep -- "--worktree" err.log
+  [ "0" != "$res" ]
+)
+end_test

--- a/t/t-uninstall-worktree.sh
+++ b/t/t-uninstall-worktree.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+
+. "$(dirname "$0")/testlib.sh"
+
+# These tests rely on behavior found in Git versions higher than 2.20.0 to
+# perform themselves, specifically:
+#   - worktreeConfig extension support
+ensure_git_version_isnt $VERSION_LOWER "2.20.0"
+
+begin_test "uninstall --worktree outside repository"
+(
+  set -e
+
+  # If run inside the git-lfs source dir this will update its .git/config & cause issues
+  if [ "$GIT_LFS_TEST_DIR" == "" ]; then
+    echo "Skipping uninstall --worktree because GIT_LFS_TEST_DIR is not set"
+    exit 0
+  fi
+
+  has_test_dir || exit 0
+
+  set +e
+  git lfs uninstall --worktree >out.log
+  res=$?
+  set -e
+
+  [ "Not in a git repository." = "$(cat out.log)" ]
+  [ "0" != "$res" ]
+)
+end_test
+
+begin_test "uninstall --worktree with single working tree"
+(
+  set -e
+
+  # old values that should be ignored by `uninstall --worktree`
+  git config --global filter.lfs.smudge "global smudge"
+  git config --global filter.lfs.clean "global clean"
+  git config --global filter.lfs.process "global filter"
+
+  reponame="$(basename "$0" ".sh")-single-tree"
+  mkdir "$reponame"
+  cd "$reponame"
+  git init
+  git lfs install --worktree
+
+  # local configs are correct
+  [ "git-lfs smudge -- %f" = "$(git config filter.lfs.smudge)" ]
+  [ "git-lfs smudge -- %f" = "$(git config --local filter.lfs.smudge)" ]
+  [ "git-lfs smudge -- %f" = "$(git config --worktree filter.lfs.smudge)" ]
+  [ "git-lfs clean -- %f" = "$(git config filter.lfs.clean)" ]
+  [ "git-lfs clean -- %f" = "$(git config --local filter.lfs.clean)" ]
+  [ "git-lfs clean -- %f" = "$(git config --worktree filter.lfs.clean)" ]
+  [ "git-lfs filter-process" = "$(git config filter.lfs.process)" ]
+  [ "git-lfs filter-process" = "$(git config --local filter.lfs.process)" ]
+  [ "git-lfs filter-process" = "$(git config --worktree filter.lfs.process)" ]
+
+  # global configs
+  [ "global smudge" = "$(git config --global filter.lfs.smudge)" ]
+  [ "global clean" = "$(git config --global filter.lfs.clean)" ]
+  [ "global filter" = "$(git config --global filter.lfs.process)" ]
+
+  git lfs uninstall --worktree 2>&1 | tee uninstall.log
+  if [ ${PIPESTATUS[0]} -ne 0 ]; then
+    echo >&2 "fatal: expected 'git lfs uninstall --worktree' to succeed"
+    exit 1
+  fi
+  grep -v "Global Git LFS configuration has been removed." uninstall.log
+
+  # global configs
+  [ "global smudge" = "$(git config filter.lfs.smudge)" ]
+  [ "global smudge" = "$(git config --global filter.lfs.smudge)" ]
+  [ "global clean" = "$(git config filter.lfs.clean)" ]
+  [ "global clean" = "$(git config --global filter.lfs.clean)" ]
+  [ "global filter" = "$(git config filter.lfs.process)" ]
+  [ "global filter" = "$(git config --global filter.lfs.process)" ]
+
+  # local configs are empty
+  [ "" = "$(git config --local filter.lfs.smudge)" ]
+  [ "" = "$(git config --worktree filter.lfs.smudge)" ]
+  [ "" = "$(git config --local filter.lfs.clean)" ]
+  [ "" = "$(git config --worktree filter.lfs.clean)" ]
+  [ "" = "$(git config --local filter.lfs.process)" ]
+  [ "" = "$(git config --worktree filter.lfs.process)" ]
+)
+end_test
+
+begin_test "uninstall --worktree with multiple working trees"
+(
+  set -e
+
+  reponame="$(basename "$0" ".sh")-multi-tree"
+  mkdir "$reponame"
+  cd "$reponame"
+  git init
+
+  # old values that should be ignored by `uninstall --worktree`
+  git config --global filter.lfs.smudge "global smudge"
+  git config --global filter.lfs.clean "global clean"
+  git config --global filter.lfs.process "global filter"
+  git config --local filter.lfs.smudge "local smudge"
+  git config --local filter.lfs.clean "local clean"
+  git config --local filter.lfs.process "local filter"
+
+  touch a.txt
+  git add a.txt
+  git commit -m "initial commit"
+
+  git config extensions.worktreeConfig true
+
+  treename="../$reponame-wt"
+  git worktree add "$treename"
+  cd "$treename"
+
+  git lfs install --worktree
+
+  # worktree configs are correct
+  [ "git-lfs smudge -- %f" = "$(git config filter.lfs.smudge)" ]
+  [ "git-lfs smudge -- %f" = "$(git config --worktree filter.lfs.smudge)" ]
+  [ "git-lfs clean -- %f" = "$(git config filter.lfs.clean)" ]
+  [ "git-lfs clean -- %f" = "$(git config --worktree filter.lfs.clean)" ]
+  [ "git-lfs filter-process" = "$(git config filter.lfs.process)" ]
+  [ "git-lfs filter-process" = "$(git config --worktree filter.lfs.process)" ]
+
+  # local configs are correct
+  [ "local smudge" = "$(git config --local filter.lfs.smudge)" ]
+  [ "local clean" = "$(git config --local filter.lfs.clean)" ]
+  [ "local filter" = "$(git config --local filter.lfs.process)" ]
+
+  # global configs
+  [ "global smudge" = "$(git config --global filter.lfs.smudge)" ]
+  [ "global clean" = "$(git config --global filter.lfs.clean)" ]
+  [ "global filter" = "$(git config --global filter.lfs.process)" ]
+
+  git lfs uninstall --worktree 2>&1 | tee uninstall.log
+  if [ ${PIPESTATUS[0]} -ne 0 ]; then
+    echo >&2 "fatal: expected 'git lfs uninstall --worktree' to succeed"
+    exit 1
+  fi
+  grep -v "Global Git LFS configuration has been removed." uninstall.log
+
+  # global configs
+  [ "global smudge" = "$(git config --global filter.lfs.smudge)" ]
+  [ "global clean" = "$(git config --global filter.lfs.clean)" ]
+  [ "global filter" = "$(git config --global filter.lfs.process)" ]
+
+  # local configs
+  [ "local smudge" = "$(git config filter.lfs.smudge)" ]
+  [ "local smudge" = "$(git config --local filter.lfs.smudge)" ]
+  [ "local clean" = "$(git config filter.lfs.clean)" ]
+  [ "local clean" = "$(git config --local filter.lfs.clean)" ]
+  [ "local filter" = "$(git config filter.lfs.process)" ]
+  [ "local filter" = "$(git config --local filter.lfs.process)" ]
+
+  # worktree configs are empty
+  [ "" = "$(git config --worktree filter.lfs.smudge)" ]
+  [ "" = "$(git config --worktree filter.lfs.clean)" ]
+  [ "" = "$(git config --worktree filter.lfs.process)" ]
+)
+end_test
+
+begin_test "uninstall --worktree without worktreeConfig extension"
+(
+  set -e
+
+  reponame="$(basename "$0" ".sh")-multi-tree-no-config"
+  mkdir "$reponame"
+  cd "$reponame"
+  git init
+
+  touch a.txt
+  git add a.txt
+  git commit -m "initial commit"
+
+  treename="../$reponame-wt"
+  git worktree add "$treename"
+  cd "$treename"
+
+  set +e
+  git lfs uninstall --worktree >out.log
+  res=$?
+  set -e
+
+  cat out.log
+  grep -E "error running.*git.*config" out.log
+  [ "$res" -eq 0 ]
+)
+end_test
+
+begin_test "uninstall --worktree with conflicting scope"
+(
+  set -e
+
+  reponame="$(basename "$0" ".sh")-scope-conflict"
+  mkdir "$reponame"
+  cd "$reponame"
+  git init
+
+  set +e
+  git lfs uninstall --local --worktree 2>err.log
+  res=$?
+  set -e
+
+  [ "Only one of --local and --worktree options can be specified." = "$(cat err.log)" ]
+  [ "0" != "$res" ]
+
+  set +e
+  git lfs uninstall --worktree --system 2>err.log
+  res=$?
+  set -e
+
+  [ "Only one of --worktree and --system options can be specified." = "$(cat err.log)" ]
+  [ "0" != "$res" ]
+)
+end_test


### PR DESCRIPTION
We add support for the `--worktree` option in the Git LFS installation and uninstallation commands, when it is supported by [`git-config(1)`](https://git-scm.com/docs/git-config) (i.e., with Git version 2.20.0 and higher).

Note that when used in a single working tree environment, `--worktree` has the same effect as `--local`; this is due to the way `git-config(1)` handles the option.

We add tests for a variety of conditions such as repositories with single and multiple working trees, and with and without the [`extensions.worktreeConfig`](https://git-scm.com/docs/git-worktree#_configuration_file) Git configuration setting.  We also expand and align some of our existing installation and uninstallation tests to make them more complete and consistent with each other.

Of note, we also change the behaviour of the `git lfs uninstall` command so that it reports errors from its invocations of `git config --remove-section` instead of silencing them.  This brings it more into line with the changes to the `git lfs install` command in #2673.  However, we don't exit early or with an error code in such conditions, per #3624, because we don't want to cause problems any existing users or scripts who depend on being able to repeatedly call `git lfs uninstall` even if it performs no actions.

We make this change to the `git lfs uninstall` behaviour primarily so that `git-config(1)` cautions about missing `worktreeConfig` extension settings are not silenced, but also with the general principle of not hiding errors in mind.

Also of note, we revise the `"install --local outside repository"` test in `t/t-install.sh` because its use of `set +e` masked the fact that it was capturing the wrong output (stderr instead of stdout) and therefore didn't actually validate what it seemed to test.  So in addition to now capturing stdout rather than stderr, we also restrict the effect of the `set +e` setting to just the expected failure of the `git lfs install` command.  We can then use this test template in other existing and new tests where we expect `git lfs install` or `git lfs uninstall` to fail, including with our new `--worktree` option.

Finally, we also make some other minor textual changes to clean up and reorganize configuration-related tests, code blocks, and command-line option descriptions (even though the latter are unused).

This PR should be easiest to review commit-by-commit, but should also not be too hard to read as a single set of changes.

Fixes #4152.
/cc @nagisa as reporter.