### PR TITLE
Fix testsuite when working with non-master default branch

### DIFF
--- a/t/cmd/util/testutils.go
+++ b/t/cmd/util/testutils.go
@@ -336,10 +336,10 @@ type CommitInput struct {
 	CommitDate time.Time
 	// List of files to include in this commit
 	Files []*FileInput
-	// List of parent branches (all branches must have been created in a previous NewBranch or be master)
+	// List of parent branches (all branches must have been created in a previous NewBranch or be main)
 	// Can be omitted to just use the parent of the previous commit
 	ParentBranches []string
-	// Name of a new branch we should create at this commit (optional - master not required)
+	// Name of a new branch we should create at this commit (optional - main not required)
 	NewBranch string
 	// Names of any tags we should create at this commit (optional)
 	Tags []string
@@ -396,7 +396,7 @@ func (repo *Repo) AddCommits(inputs []*CommitInput) []*CommitOutput {
 		repo.callback.Fatalf("Can't chdir to repo %v", err)
 	}
 	// Used to check whether we need to checkout another commit before
-	lastBranch := "master"
+	lastBranch := "main"
 	outputs := make([]*CommitOutput, 0, len(inputs))
 
 	for i, input := range inputs {

--- a/t/fixtures/migrate.sh
+++ b/t/fixtures/migrate.sh
@@ -22,7 +22,7 @@ assert_ref_unmoved() {
 #
 #   A---B
 #        \
-#         refs/heads/master
+#         refs/heads/main
 #
 # - Commit 'A' has 120, in a.txt, and a corresponding entry in .gitattributes.
 setup_local_branch_with_gitattrs() {
@@ -48,7 +48,7 @@ setup_local_branch_with_gitattrs() {
 #
 #   A---B
 #        \
-#         refs/heads/master
+#         refs/heads/main
 #
 # - Commit 'A' has 120, in a.txt, and a corresponding entry in .gitattributes. There is also
 #   140 in a.md, with no corresponding entry in .gitattributes.
@@ -88,7 +88,7 @@ setup_local_branch_with_nested_gitattrs() {
 #
 #   A---B
 #        \
-#         refs/heads/master
+#         refs/heads/main
 #
 # - Commit 'A' has 120, in a.txt and 140 in a.md, with both files tracked as
 #   pointers in Git LFS
@@ -115,7 +115,7 @@ setup_single_local_branch_tracked() {
 #
 #   A
 #    \
-#     refs/heads/master
+#     refs/heads/main
 #
 # - Commit 'A' has 1 byte of text in a.txt and dir/b.txt. According to the
 #   .gitattributes files, a.txt should be tracked using Git LFS, but b.txt should
@@ -146,7 +146,7 @@ setup_single_local_branch_complex_tracked() {
 #
 #   A
 #    \
-#     refs/heads/master
+#     refs/heads/main
 #
 # - Commit 'A' has 120 bytes of random data in a.txt, and tracks *.txt under Git
 #   LFS, but a.txt is not stored as an LFS object.
@@ -174,7 +174,7 @@ setup_single_local_branch_tracked_corrupt() {
 #    / \
 #   A   refs/heads/my-feature
 #    \
-#     refs/heads/master
+#     refs/heads/main
 #
 # - Commit 'A' has 120, 140 bytes of data in a.txt, and a.md, respectively.
 #
@@ -200,7 +200,7 @@ setup_multiple_local_branches() {
   git add a.md
   git commit -m "add an additional 30 bytes to a.md"
 
-  git checkout master
+  git checkout main
 }
 
 # setup_multiple_local_branches_with_alternate_names performs the same task
@@ -226,12 +226,12 @@ setup_multiple_local_branches_with_alternate_names() {
   git add no_extension a.txt
   git commit -m "add an additional 30 bytes to a.txt"
 
-  git checkout master
+  git checkout main
 }
 
 # setup_multiple_local_branches_with_gitattrs creates a repository in the same way
 # as setup_multiple_local_branches, but also adds relevant lfs filters to the
-# .gitattributes file in the master branch
+# .gitattributes file in the main branch
 setup_multiple_local_branches_with_gitattrs() {
   set -e
 
@@ -253,7 +253,7 @@ setup_multiple_local_branches_with_gitattrs() {
 #    / \
 #   A   refs/heads/my-feature
 #   |\
-#   | refs/heads/master
+#   | refs/heads/main
 #    \
 #     refs/pull/1/base
 #
@@ -264,7 +264,7 @@ setup_multiple_local_branches_non_standard() {
   setup_multiple_local_branches
 
   git update-ref refs/pull/1/head "$(git rev-parse my-feature)"
-  git update-ref refs/pull/1/base "$(git rev-parse master)"
+  git update-ref refs/pull/1/base "$(git rev-parse main)"
 }
 
 # setup_multiple_local_branches_tracked creates a repo with exactly the same
@@ -294,14 +294,14 @@ setup_multiple_local_branches_tracked() {
   git add a.md
   git commit -m "add an additional 30 bytes to a.md"
 
-  git checkout master
+  git checkout main
 }
 
 # setup_local_branch_with_space creates a repository as follows:
 #
 #   A
 #    \
-#     refs/heads/master
+#     refs/heads/main
 #
 # - Commit 'A' has 50 bytes in a file named "a file.txt".
 setup_local_branch_with_space() {
@@ -322,9 +322,9 @@ setup_local_branch_with_space() {
 #
 #   A---B
 #    \   \
-#     \   refs/heads/master
+#     \   refs/heads/main
 #      \
-#       refs/remotes/origin/master
+#       refs/remotes/origin/main
 #
 # - Commit 'A' has 120, 140 bytes of data in a.txt, and a.md, respectively. It
 #   is the latest commit pushed to the remote 'origin'.
@@ -343,7 +343,7 @@ setup_single_remote_branch() {
   git add a.txt a.md
   git commit -m "initial commit"
 
-  git push origin master
+  git push origin main
 
   base64 < /dev/urandom | head -c 30 > a.txt
   base64 < /dev/urandom | head -c 50 > a.md
@@ -383,7 +383,7 @@ setup_single_remote_branch_tracked() {
   git add a.txt a.md
   git commit -m "add a.{txt,md}"
 
-  git push origin master
+  git push origin main
 
   base64 < /dev/urandom | head -c 30 > a.txt
   base64 < /dev/urandom | head -c 50 > a.md
@@ -398,9 +398,9 @@ setup_single_remote_branch_tracked() {
 #        / \
 #   A---B   refs/heads/my-feature
 #    \   \
-#     \   refs/heads/master
+#     \   refs/heads/main
 #      \
-#       refs/remotes/origin/master
+#       refs/remotes/origin/main
 #
 # - Commit 'A' has 10, 11 bytes of data in a.txt, and a.md, respectively. It is
 #   the latest commit pushed to the remote 'origin'.
@@ -421,7 +421,7 @@ setup_multiple_remote_branches() {
   git add a.txt a.md
   git commit -m "add 10, 11 bytes, a.{txt,md}"
 
-  git push origin master
+  git push origin main
 
   base64 < /dev/urandom | head -c 20 > a.txt
   base64 < /dev/urandom | head -c 21 > a.md
@@ -435,7 +435,7 @@ setup_multiple_remote_branches() {
   git add a.txt a.md
   git commit -m "add 30, 31 bytes, a.{txt,md}"
 
-  git checkout master
+  git checkout main
 }
 
 # Creates a repo identical to that in setup_multiple_remote_branches(), but
@@ -456,7 +456,7 @@ setup_multiple_remote_branches_gitattrs() {
   git add a.txt a.md
   git commit -m "add 10, 11 bytes, a.{txt,md}"
 
-  git push origin master
+  git push origin main
 
   base64 < /dev/urandom | head -c 20 > a.txt
   base64 < /dev/urandom | head -c 21 > a.md
@@ -470,14 +470,14 @@ setup_multiple_remote_branches_gitattrs() {
   git add a.txt a.md
   git commit -m "add 30, 31 bytes, a.{txt,md}"
 
-  git checkout master
+  git checkout main
 }
 
 # setup_single_local_branch_with_tags creates a repository as follows:
 #
 #   A---B
 #       |\
-#       | refs/heads/master
+#       | refs/heads/main
 #       |
 #        \
 #         refs/tags/v1.0.0
@@ -507,7 +507,7 @@ setup_single_local_branch_with_tags() {
 #
 #   A---B
 #       |\
-#       | refs/heads/master
+#       | refs/heads/main
 #       |
 #        \
 #         refs/tags/v1.0.0 (annotated)
@@ -551,19 +551,19 @@ setup_multiple_remotes() {
   base64 < /dev/urandom | head -c 16 > a.txt
   git add a.txt
   git commit -m "initial commit"
-  git push origin master
+  git push origin main
 
   base64 < /dev/urandom | head -c 16 > a.txt
   git add a.txt
   git commit -m "another commit"
-  git push fork master
+  git push fork main
 }
 
 # setup_single_local_branch_deep_trees creates a repository as follows:
 #
 #   A
 #    \
-#     refs/heads/master
+#     refs/heads/main
 #
 # - Commit 'A' has 120 bytes of data in 'foo/bar/baz/a.txt'.
 setup_single_local_branch_deep_trees() {
@@ -583,7 +583,7 @@ setup_single_local_branch_deep_trees() {
 #
 #   A
 #    \
-#     refs/heads/master
+#     refs/heads/main
 #
 # - Commit 'A' has 120, in a.txt, and a symbolic link link.txt to a.txt.
 setup_local_branch_with_symlink() {
@@ -606,7 +606,7 @@ setup_local_branch_with_symlink() {
 #
 #   A
 #    \
-#     refs/heads/master
+#     refs/heads/main
 #
 # - Commit 'A' has the contents "a.txt in a.txt, and marks a.txt as unclean
 #   in the working copy.

--- a/t/fixtures/templates/HEAD
+++ b/t/fixtures/templates/HEAD
@@ -1,0 +1,1 @@
+ref: refs/heads/master

--- a/t/fixtures/templates/HEAD
+++ b/t/fixtures/templates/HEAD
@@ -1,1 +1,1 @@
-ref: refs/heads/master
+ref: refs/heads/main

--- a/t/t-alternates.sh
+++ b/t/t-alternates.sh
@@ -18,7 +18,7 @@ begin_test "alternates (single)"
   alternate="$TRASHDIR/${reponame}_alternate/.git/objects"
   echo "$(native_path "$alternate")" > .git/objects/info/alternates
 
-  GIT_TRACE=1 git lfs fetch origin master 2>&1 | tee fetch.log
+  GIT_TRACE=1 git lfs fetch origin main 2>&1 | tee fetch.log
   [ "0" -eq "$(grep -c "sending batch of size 1" fetch.log)" ]
 )
 end_test
@@ -45,7 +45,7 @@ begin_test "alternates (multiple)"
   echo "$(native_path "$alternate")" > .git/objects/info/alternates
   echo "$(native_path "$alternate_stale")" >> .git/objects/info/alternates
 
-  GIT_TRACE=1 git lfs fetch origin master 2>&1 | tee fetch.log
+  GIT_TRACE=1 git lfs fetch origin main 2>&1 | tee fetch.log
   [ "0" -eq "$(grep -c "sending batch of size 1" fetch.log)" ]
 )
 end_test
@@ -66,7 +66,7 @@ begin_test "alternates (commented)"
   alternate="$TRASHDIR/${reponame}_alternate/.git/objects"
   echo "# $alternate" > .git/objects/info/alternates
 
-  GIT_TRACE=1 git lfs fetch origin master 2>&1 | tee fetch.log
+  GIT_TRACE=1 git lfs fetch origin main 2>&1 | tee fetch.log
   [ "1" -eq "$(grep -c "sending batch of size 1" fetch.log)" ]
 )
 end_test
@@ -91,7 +91,7 @@ begin_test "alternates (quoted)"
   alternate=$(native_path "$TRASHDIR/${reponame}_alternate/.git/objects" | sed -e 's,\\,/,g')
   echo "\"$alternate\"" > .git/objects/info/alternates
 
-  GIT_TRACE=1 git lfs fetch origin master 2>&1 | tee fetch.log
+  GIT_TRACE=1 git lfs fetch origin main 2>&1 | tee fetch.log
   [ "0" -eq "$(grep -c "sending batch of size 1" fetch.log)" ]
 )
 end_test
@@ -115,10 +115,10 @@ begin_test "alternates (OS environment, single)"
 
   GIT_ALTERNATE_OBJECT_DIRECTORIES="$alternate" \
   GIT_TRACE=1 \
-    git lfs fetch origin master 2>&1 | tee fetch.log
+    git lfs fetch origin main 2>&1 | tee fetch.log
   [ "0" -eq "$(grep -c "sending batch of size 1" fetch.log)" ]
   GIT_ALTERNATE_OBJECT_DIRECTORIES="$alternate" \
-    git lfs push "$(git config remote.origin.url)" master
+    git lfs push "$(git config remote.origin.url)" main
 )
 end_test
 
@@ -147,9 +147,9 @@ begin_test "alternates (OS environment, multiple)"
 
   GIT_ALTERNATE_OBJECT_DIRECTORIES="$alternate_stale$sep$alternate" \
   GIT_TRACE=1 \
-    git lfs fetch origin master 2>&1 | tee fetch.log
+    git lfs fetch origin main 2>&1 | tee fetch.log
   [ "0" -eq "$(grep -c "sending batch of size 1" fetch.log)" ]
   GIT_ALTERNATE_OBJECT_DIRECTORIES="$alternate_stale$sep$alternate" \
-    git lfs push "$(git config remote.origin.url)" master
+    git lfs push "$(git config remote.origin.url)" main
 )
 end_test

--- a/t/t-askpass.sh
+++ b/t/t-askpass.sh
@@ -20,13 +20,13 @@ begin_test "askpass: push with GIT_ASKPASS"
   export LFS_ASKPASS_USERNAME="user"
   export LFS_ASKPASS_PASSWORD="pass"
   git config "credential.helper" ""
-  GIT_ASKPASS="lfs-askpass" SSH_ASKPASS="dont-call-me" GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push origin master 2>&1 | tee push.log
+  GIT_ASKPASS="lfs-askpass" SSH_ASKPASS="dont-call-me" GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push origin main 2>&1 | tee push.log
 
   GITSERVER_USER="$(printf $GITSERVER | sed -e 's/http:\/\//http:\/\/user@/')"
 
   grep "filling with GIT_ASKPASS: lfs-askpass Username for \"$GITSERVER/$reponame\"" push.log
   grep "filling with GIT_ASKPASS: lfs-askpass Password for \"$GITSERVER_USER/$reponame\"" push.log
-  grep "master -> master" push.log
+  grep "main -> main" push.log
 )
 end_test
 
@@ -57,13 +57,13 @@ begin_test "askpass: push with core.askPass"
   git config "credential.helper" ""
   git config "core.askPass" "lfs-askpass"
   cat .git/config
-  SSH_ASKPASS="dont-call-me" GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push origin master 2>&1 | tee push.log
+  SSH_ASKPASS="dont-call-me" GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push origin main 2>&1 | tee push.log
 
   GITSERVER_USER="$(printf $GITSERVER | sed -e 's/http:\/\//http:\/\/user@/')"
 
   grep "filling with GIT_ASKPASS: lfs-askpass Username for \"$GITSERVER/$reponame\"" push.log
   grep "filling with GIT_ASKPASS: lfs-askpass Password for \"$GITSERVER_USER/$reponame\"" push.log
-  grep "master -> master" push.log
+  grep "main -> main" push.log
 )
 end_test
 
@@ -93,13 +93,13 @@ begin_test "askpass: push with SSH_ASKPASS"
   export LFS_ASKPASS_USERNAME="user"
   export LFS_ASKPASS_PASSWORD="pass"
   git config "credential.helper" ""
-  SSH_ASKPASS="lfs-askpass" GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push origin master 2>&1 | tee push.log
+  SSH_ASKPASS="lfs-askpass" GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push origin main 2>&1 | tee push.log
 
   GITSERVER_USER="$(printf $GITSERVER | sed -e 's/http:\/\//http:\/\/user@/')"
 
   grep "filling with GIT_ASKPASS: lfs-askpass Username for \"$GITSERVER/$reponame\"" push.log
   grep "filling with GIT_ASKPASS: lfs-askpass Password for \"$GITSERVER_USER/$reponame\"" push.log
-  grep "master -> master" push.log
+  grep "main -> main" push.log
 )
 end_test
 
@@ -126,9 +126,9 @@ begin_test "askpass: defaults to provided credentials"
   newurl=${url/http:\/\//http:\/\/user\:pass@}
   git remote set-url origin "$newurl"
 
-  GIT_ASKPASS="lfs-askpass" GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push origin master 2>&1 | tee push.log
+  GIT_ASKPASS="lfs-askpass" GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push origin main 2>&1 | tee push.log
 
   [ ! $(grep "filling with GIT_ASKPASS" push.log) ]
-  grep "master -> master" push.log
+  grep "main -> main" push.log
 )
 end_test

--- a/t/t-batch-error-handling.sh
+++ b/t/t-batch-error-handling.sh
@@ -33,7 +33,7 @@ begin_test "batch error handling"
   git add a.dat
   git add .gitattributes
   git commit -m "add a.dat" 2>&1 | tee commit.log
-  grep "master (root-commit)" commit.log
+  grep "main (root-commit)" commit.log
   grep "2 files changed" commit.log
   grep "create mode 100644 a.dat" commit.log
   grep "create mode 100644 .gitattributes" commit.log
@@ -41,12 +41,12 @@ begin_test "batch error handling"
   [ "a" = "$(cat a.dat)" ]
 
   # This is a small shell function that runs several git commands together.
-  assert_pointer "master" "a.dat" "$contents_oid" 1
+  assert_pointer "main" "a.dat" "$contents_oid" 1
 
   refute_server_object "$reponame" "$contents_oid"
 
   # This pushes to the remote repository set up at the top of the test.
-  git push origin master 2>&1 | tee push.log
+  git push origin main 2>&1 | tee push.log
   grep "Unable to parse HTTP response" push.log
 )
 end_test

--- a/t/t-batch-retries-ratelimit.sh
+++ b/t/t-batch-retries-ratelimit.sh
@@ -18,9 +18,9 @@ begin_test "batch storage upload causes retries"
   git add .gitattributes a.dat
   git commit -m "initial commit"
 
-  GIT_TRACE=1 git push origin master 2>&1 | tee push.log
+  GIT_TRACE=1 git push origin main 2>&1 | tee push.log
   if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected \`git push origin master\` to succeed ..."
+    echo >&2 "fatal: expected \`git push origin main\` to succeed ..."
     exit 1
   fi
 
@@ -44,7 +44,7 @@ begin_test "batch storage download causes retries"
   git add .gitattributes a.dat
   git commit -m "initial commit"
 
-  git push origin master
+  git push origin main
   assert_server_object "$reponame" "$oid"
 
   pushd ..
@@ -58,9 +58,9 @@ begin_test "batch storage download causes retries"
 
     git config credential.helper lfstest
 
-    GIT_TRACE=1 git lfs pull origin master 2>&1 | tee pull.log
+    GIT_TRACE=1 git lfs pull origin main 2>&1 | tee pull.log
     if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-      echo >&2 "fatal: expected \`git lfs pull origin master\` to succeed ..."
+      echo >&2 "fatal: expected \`git lfs pull origin main\` to succeed ..."
       exit 1
     fi
 
@@ -85,7 +85,7 @@ begin_test "batch clone causes retries"
   git add .gitattributes a.dat
   git commit -m "initial commit"
 
-  git push origin master
+  git push origin main
   assert_server_object "$reponame" "$oid"
 
   pushd ..

--- a/t/t-batch-retries.sh
+++ b/t/t-batch-retries.sh
@@ -20,9 +20,9 @@ begin_test "batch storage upload causes retries"
 
   git config --local lfs.transfer.maxretries 3
 
-  GIT_TRACE=1 git push origin master 2>&1 | tee push.log
+  GIT_TRACE=1 git push origin main 2>&1 | tee push.log
   if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected \`git push origin master\` to succeed ..."
+    echo >&2 "fatal: expected \`git push origin main\` to succeed ..."
     exit 1
   fi
 
@@ -49,7 +49,7 @@ begin_test "batch storage download causes retries"
   git add .gitattributes a.dat
   git commit -m "initial commit"
 
-  git push origin master
+  git push origin main
   assert_server_object "$reponame" "$oid"
 
   pushd ..
@@ -64,9 +64,9 @@ begin_test "batch storage download causes retries"
     git config credential.helper lfstest
     git config --local lfs.transfer.maxretries 3
 
-    GIT_TRACE=1 git lfs pull origin master 2>&1 | tee pull.log
+    GIT_TRACE=1 git lfs pull origin main 2>&1 | tee pull.log
     if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-      echo >&2 "fatal: expected \`git lfs pull origin master\` to succeed ..."
+      echo >&2 "fatal: expected \`git lfs pull origin main\` to succeed ..."
       exit 1
     fi
 

--- a/t/t-batch-transfer.sh
+++ b/t/t-batch-transfer.sh
@@ -57,7 +57,7 @@ begin_test "batch transfer"
   # change to the clone's working directory
   cd ../clone
 
-  git pull
+  git pull origin master
 
   [ "a" = "$(cat a.dat)" ]
 

--- a/t/t-batch-transfer.sh
+++ b/t/t-batch-transfer.sh
@@ -35,7 +35,7 @@ begin_test "batch transfer"
   git add a.dat
   git add .gitattributes
   git commit -m "add a.dat" 2>&1 | tee commit.log
-  grep "master (root-commit)" commit.log
+  grep "main (root-commit)" commit.log
   grep "2 files changed" commit.log
   grep "create mode 100644 a.dat" commit.log
   grep "create mode 100644 .gitattributes" commit.log
@@ -43,25 +43,25 @@ begin_test "batch transfer"
   [ "a" = "$(cat a.dat)" ]
 
   # This is a small shell function that runs several git commands together.
-  assert_pointer "master" "a.dat" "$contents_oid" 1
+  assert_pointer "main" "a.dat" "$contents_oid" 1
 
   refute_server_object "$reponame" "$contents_oid"
 
   # This pushes to the remote repository set up at the top of the test.
-  git push origin master 2>&1 | tee push.log
+  git push origin main 2>&1 | tee push.log
   grep "Uploading LFS objects: 100% (1/1), 1 B" push.log
-  grep "master -> master" push.log
+  grep "main -> main" push.log
 
   assert_server_object "$reponame" "$contents_oid"
 
   # change to the clone's working directory
   cd ../clone
 
-  git pull origin master
+  git pull origin main
 
   [ "a" = "$(cat a.dat)" ]
 
-  assert_pointer "master" "a.dat" "$contents_oid" 1
+  assert_pointer "main" "a.dat" "$contents_oid" 1
 )
 end_test
 
@@ -88,7 +88,7 @@ begin_test "batch transfers occur in reverse order by size"
   git add *.dat
   git commit -m "add small and large objects"
 
-  GIT_CURL_VERBOSE=1 git push origin master 2>&1 | tee push.log
+  GIT_CURL_VERBOSE=1 git push origin main 2>&1 | tee push.log
 
   batch="$(grep "{\"operation\":\"upload\"" push.log | head -1)"
 
@@ -120,7 +120,7 @@ begin_test "batch transfers with ssh endpoint"
   git add .gitattributes test.dat
   git commit -m "initial commit"
 
-  git push origin master 2>&1
+  git push origin main 2>&1
 )
 end_test
 
@@ -142,6 +142,6 @@ begin_test "batch transfers with ntlm server"
   git add .gitattributes test.dat
   git commit -m "initial commit"
 
-  GIT_CURL_VERBOSE=1 git push origin master 2>&1
+  GIT_CURL_VERBOSE=1 git push origin main 2>&1
 )
 end_test

--- a/t/t-batch-unknown-oids.sh
+++ b/t/t-batch-unknown-oids.sh
@@ -21,7 +21,7 @@ begin_test "transfer queue rejects unknown OIDs"
   git commit -m "add objects"
 
   set +e
-  git push origin master 2>&1 | tee push.log
+  git push origin main 2>&1 | tee push.log
   res="${PIPESTATUS[0]}"
   set -e
 

--- a/t/t-checkout.sh
+++ b/t/t-checkout.sh
@@ -35,7 +35,7 @@ begin_test "checkout"
   [ "$contents" = "$(cat folder1/nested.dat)" ]
   [ "$contents" = "$(cat folder2/nested.dat)" ]
 
-  assert_pointer "master" "file1.dat" "$contents_oid" $contentsize
+  assert_pointer "main" "file1.dat" "$contents_oid" $contentsize
 
   # Remove the working directory
   rm -rf file1.dat file2.dat file3.dat folder1/nested.dat folder2/nested.dat
@@ -94,7 +94,7 @@ begin_test "checkout"
   [ "$contents" = "$(cat folder2/nested.dat)" ]
 
   echo "test checkout with missing data doesn't fail"
-  git push origin master
+  git push origin main
   rm -rf .git/lfs/objects
   rm file*.dat
   git lfs checkout
@@ -174,7 +174,7 @@ begin_test "checkout: write-only file"
     chmod -w "$filename"
 
     refute_file_writeable "$filename"
-    assert_pointer "refs/heads/master" "$filename" "$(calc_oid "$filename\n")" 6
+    assert_pointer "refs/heads/main" "$filename" "$(calc_oid "$filename\n")" 6
 
     git lfs fetch
     git lfs checkout "$filename"
@@ -206,7 +206,7 @@ begin_test "checkout: conflicts"
     git lfs checkout --to base.txt --base file1.dat 2>&1 | tee output.txt
     grep 'Could not checkout.*not in the middle of a merge' output.txt
 
-    git checkout -b second master
+    git checkout -b second main
     echo "def456" > file1.dat
     git add -u
     git commit -m "second"

--- a/t/t-cherry-pick-commits.sh
+++ b/t/t-cherry-pick-commits.sh
@@ -26,7 +26,7 @@ begin_test "cherry-pick two commits without lfs cache"
   git commit -m "add a.dat"
   commit2=$(git log -n1 --format="%H")
 
-  git push origin master
+  git push origin main
 
   git checkout secondbranch
   rm -rf .git/lfs/objects

--- a/t/t-chunked-transfer-encoding.sh
+++ b/t/t-chunked-transfer-encoding.sh
@@ -56,7 +56,7 @@ begin_test "chunked transfer encoding"
   # change to the clone's working directory
   cd ../clone
 
-  git pull 2>&1
+  git pull origin master 2>&1
 
   [ "a" = "$(cat a.dat)" ]
 

--- a/t/t-chunked-transfer-encoding.sh
+++ b/t/t-chunked-transfer-encoding.sh
@@ -34,7 +34,7 @@ begin_test "chunked transfer encoding"
   git add a.dat
   git add .gitattributes
   git commit -m "add a.dat" 2>&1 | tee commit.log
-  grep "master (root-commit)" commit.log
+  grep "main (root-commit)" commit.log
   grep "2 files changed" commit.log
   grep "create mode 100644 a.dat" commit.log
   grep "create mode 100644 .gitattributes" commit.log
@@ -42,24 +42,24 @@ begin_test "chunked transfer encoding"
   [ "a" = "$(cat a.dat)" ]
 
   # This is a small shell function that runs several git commands together.
-  assert_pointer "master" "a.dat" "$contents_oid" 1
+  assert_pointer "main" "a.dat" "$contents_oid" 1
 
   refute_server_object "$reponame" "$contents_oid"
 
   # This pushes to the remote repository set up at the top of the test.
-  git push origin master 2>&1 | tee push.log
+  git push origin main 2>&1 | tee push.log
   grep "Uploading LFS objects: 100% (1/1), 1 B" push.log
-  grep "master -> master" push.log
+  grep "main -> main" push.log
 
   assert_server_object "$reponame" "$contents_oid"
 
   # change to the clone's working directory
   cd ../clone
 
-  git pull origin master 2>&1
+  git pull origin main 2>&1
 
   [ "a" = "$(cat a.dat)" ]
 
-  assert_pointer "master" "a.dat" "$contents_oid" 1
+  assert_pointer "main" "a.dat" "$contents_oid" 1
 )
 end_test

--- a/t/t-clone.sh
+++ b/t/t-clone.sh
@@ -38,7 +38,7 @@ begin_test "clone"
   }
   ]" | lfstest-testutils addcommits
 
-  git push origin master
+  git push origin main
 
   # Now clone again, test specific clone dir
   cd "$TRASHDIR"
@@ -116,7 +116,7 @@ begin_test "cloneSSL"
   }
   ]" | lfstest-testutils addcommits
 
-  git push origin master
+  git push origin main
 
   # Now SSL clone again with 'git lfs clone', test specific clone dir
   cd "$TRASHDIR"
@@ -181,7 +181,7 @@ begin_test "clone ClientCert"
   }
   ]" | lfstest-testutils addcommits
 
-  git push origin master
+  git push origin main
 
   # Now clone again with 'git lfs clone', test specific clone dir
   cd "$TRASHDIR"
@@ -247,14 +247,14 @@ begin_test "clone with flags"
   },
   {
     \"CommitDate\":\"$(get_date -3d)\",
-    \"ParentBranches\":[\"master\"],
+    \"ParentBranches\":[\"main\"],
     \"Files\":[
       {\"Filename\":\"file3.dat\",\"Size\":120},
       {\"Filename\":\"file4.dat\",\"Size\":30}]
   }
   ]" | lfstest-testutils addcommits
 
-  git push origin master branch2
+  git push origin main branch2
 
   # Now clone again, test specific clone dir
   cd "$TRASHDIR"
@@ -330,7 +330,7 @@ begin_test "clone (with include/exclude args)"
 
   git add *.dat .gitattributes
   git commit -m "add a.dat, b.dat" 2>&1 | tee commit.log
-  grep "master (root-commit)" commit.log
+  grep "main (root-commit)" commit.log
   grep "5 files changed" commit.log
   grep "create mode 100644 a.dat" commit.log
   grep "create mode 100644 a-dupe.dat" commit.log
@@ -338,8 +338,8 @@ begin_test "clone (with include/exclude args)"
   grep "create mode 100644 b.dat" commit.log
   grep "create mode 100644 .gitattributes" commit.log
 
-  git push origin master 2>&1 | tee push.log
-  grep "master -> master" push.log
+  git push origin main 2>&1 | tee push.log
+  grep "main -> main" push.log
   grep "Uploading LFS objects: 100% (2/2), 2 B" push.log
 
   cd "$TRASHDIR"
@@ -389,7 +389,7 @@ begin_test "clone (with .lfsconfig)"
 
   git add a.dat b.dat .gitattributes
   git commit -m "add a.dat, b.dat" 2>&1 | tee commit.log
-  grep "master (root-commit)" commit.log
+  grep "main (root-commit)" commit.log
   grep "3 files changed" commit.log
   grep "create mode 100644 a.dat" commit.log
   grep "create mode 100644 b.dat" commit.log
@@ -398,12 +398,12 @@ begin_test "clone (with .lfsconfig)"
   git config -f ".lfsconfig" "lfs.fetchinclude" "a*"
   git add ".lfsconfig"
   git commit -m "config lfs.fetchinclude a*" 2>&1 | tee commit.log
-  grep "master" commit.log
+  grep "main" commit.log
   grep "1 file changed" commit.log
   grep "create mode 100644 .lfsconfig" commit.log
 
-  git push origin master 2>&1 | tee push.log
-  grep "master -> master" push.log
+  git push origin main 2>&1 | tee push.log
+  grep "main -> main" push.log
   grep "Uploading LFS objects: 100% (2/2), 2 B" push.log
 
   pushd "$TRASHDIR"
@@ -443,10 +443,10 @@ begin_test "clone (with .lfsconfig)"
   git config -f ".lfsconfig" "lfs.fetchexclude" "a*"
   git add .lfsconfig
   git commit -m "config lfs.fetchinclude a*" 2>&1 | tee commit.log
-  grep "master" commit.log
+  grep "main" commit.log
   grep "1 file changed" commit.log
-  git push origin master 2>&1 | tee push.log
-  grep "master -> master" push.log
+  git push origin main 2>&1 | tee push.log
+  grep "main -> main" push.log
 
   pushd "$TRASHDIR"
 
@@ -490,10 +490,10 @@ begin_test "clone (without clean filter)"
 
   git add *.dat .gitattributes
   git commit -m "add a.dat, b.dat" 2>&1 | tee commit.log
-  grep "master (root-commit)" commit.log
+  grep "main (root-commit)" commit.log
 
-  git push origin master 2>&1 | tee push.log
-  grep "master -> master" push.log
+  git push origin main 2>&1 | tee push.log
+  grep "main -> main" push.log
   grep "Uploading LFS objects: 100% (1/1), 1 B" push.log
 
   cd "$TRASHDIR"
@@ -542,7 +542,7 @@ begin_test "clone with submodules"
   printf "%s" "$contents_sub2" > "sub2.dat"
   git add sub2.dat .gitattributes
   git commit -m "Nested submodule level 2"
-  git push origin master
+  git push origin main
 
   clone_repo "$submodname1" submod1
   git lfs track "*.dat" 2>&1 | tee track.log
@@ -556,7 +556,7 @@ begin_test "clone with submodules"
   git submodule update
   git add sub2 sub1.dat .gitattributes
   git commit -m "Nested submodule level 1"
-  git push origin master
+  git push origin main
 
   clone_repo "$reponame" rootrepo
   git lfs track "*.dat" 2>&1 | tee track.log
@@ -570,7 +570,7 @@ begin_test "clone with submodules"
   git submodule update
   git add sub1 root.dat .gitattributes
   git commit -m "Root repo"
-  git push origin master
+  git push origin main
 
   pushd "$TRASHDIR"
 
@@ -614,12 +614,12 @@ begin_test "clone in current directory"
   git add .gitattributes a.dat
 
   git commit -m "initial commit" 2>&1 | tee commit.log
-  grep "master (root-commit)" commit.log
+  grep "main (root-commit)" commit.log
   grep "2 files changed" commit.log
   grep "create mode 100644 a.dat" commit.log
   grep "create mode 100644 .gitattributes" commit.log
 
-  git push origin master 2>&1 | tee push.log
+  git push origin main 2>&1 | tee push.log
 
   pushd $TRASHDIR
     mkdir "$reponame-clone"
@@ -707,7 +707,7 @@ begin_test "clone (HTTP server/proxy require cookies)"
   }
   ]" | lfstest-testutils addcommits
 
-  git push origin master
+  git push origin main
 
   # Now clone again, test specific clone dir
   cd "$TRASHDIR"

--- a/t/t-commit-delete-push.sh
+++ b/t/t-commit-delete-push.sh
@@ -17,28 +17,28 @@ begin_test "commit, delete, then push"
   git add deleted.dat .gitattributes
   git commit -m "add deleted file"
 
-  git lfs push origin master --dry-run | grep "push ee31ef227442936872744b50d3297385c08b40ffc7baeaf34a39e6d81d6cd9ee => deleted.dat"
+  git lfs push origin main --dry-run | grep "push ee31ef227442936872744b50d3297385c08b40ffc7baeaf34a39e6d81d6cd9ee => deleted.dat"
 
-  assert_pointer "master" "deleted.dat" "$deleted_oid" 8
+  assert_pointer "main" "deleted.dat" "$deleted_oid" 8
 
   added_oid=$(calc_oid "added\n")
   echo "added" > added.dat
   git add added.dat
   git commit -m "add file"
 
-  git lfs push origin master --dry-run | tee dryrun.log
+  git lfs push origin main --dry-run | tee dryrun.log
   grep "push ee31ef227442936872744b50d3297385c08b40ffc7baeaf34a39e6d81d6cd9ee => deleted.dat" dryrun.log
   grep "push 3428719b7688c78a0cc8ba4b9e80b4e464c815fbccfd4b20695a15ffcefc22af => added.dat" dryrun.log
 
   git rm deleted.dat
   git commit -m "did not need deleted.dat after all"
 
-  git lfs push origin master --dry-run 2>&1 | tee dryrun.log
+  git lfs push origin main --dry-run 2>&1 | tee dryrun.log
   grep "push ee31ef227442936872744b50d3297385c08b40ffc7baeaf34a39e6d81d6cd9ee => deleted.dat" dryrun.log
   grep "push 3428719b7688c78a0cc8ba4b9e80b4e464c815fbccfd4b20695a15ffcefc22af => added.dat" dryrun.log
 
   git log
-  git push origin master 2>&1 > push.log || {
+  git push origin main 2>&1 > push.log || {
     cat push.log
     git lfs logs last
     exit 1

--- a/t/t-content-type.sh
+++ b/t/t-content-type.sh
@@ -17,7 +17,7 @@ begin_test "content-type: is enabled by default"
 
   git add .gitattributes a.tar.gz
   git commit -m "initial commit"
-  GIT_CURL_VERBOSE=1 git push origin master 2>&1 | tee push.log
+  GIT_CURL_VERBOSE=1 git push origin main 2>&1 | tee push.log
 
   [ 1 -eq "$(grep -c "Content-Type: application/x-gzip" push.log)" ]
   [ 0 -eq "$(grep -c "Content-Type: application/octet-stream" push.log)" ]
@@ -40,7 +40,7 @@ begin_test "content-type: is disabled by configuration"
   git add .gitattributes a.tar.gz
   git commit -m "initial commit"
   git config "lfs.$GITSERVER.contenttype" 0
-  GIT_CURL_VERBOSE=1 git push origin master 2>&1 | tee push.log
+  GIT_CURL_VERBOSE=1 git push origin main 2>&1 | tee push.log
 
   [ 0 -eq "$(grep -c "Content-Type: application/x-gzip" push.log)" ]
   [ 1 -eq "$(grep -c "Content-Type: application/octet-stream" push.log)" ]
@@ -60,7 +60,7 @@ begin_test "content-type: warning message"
 
   git add .gitattributes a.txt
   git commit -m "initial commit"
-  git push origin master 2>&1 | tee push.log
+  git push origin main 2>&1 | tee push.log
 
   grep "info: Uploading failed due to unsupported Content-Type header(s)." push.log
   grep "info: Consider disabling Content-Type detection with:" push.log

--- a/t/t-credentials-no-prompt.sh
+++ b/t/t-credentials-no-prompt.sh
@@ -23,7 +23,7 @@ begin_test "attempt private access without credential helper"
   git config credential.helper lfsnoop
   git config -l
 
-  GIT_TERMINAL_PROMPT=0 git push origin master 2>&1 | tee push.log
+  GIT_TERMINAL_PROMPT=0 git push origin main 2>&1 | tee push.log
   grep "Authorization error: $GITSERVER/$reponame" push.log ||
     grep "Git credentials for $GITSERVER/$reponame not found" push.log
 )
@@ -44,7 +44,7 @@ begin_test "askpass: push with bad askpass"
   git commit -m "initial commit"
 
   git config "credential.helper" ""
-  GIT_TERMINAL_PROMPT=0 GIT_ASKPASS="lfs-askpass-2" SSH_ASKPASS="dont-call-me" GIT_TRACE=1 git push origin master 2>&1 | tee push.log
+  GIT_TERMINAL_PROMPT=0 GIT_ASKPASS="lfs-askpass-2" SSH_ASKPASS="dont-call-me" GIT_TRACE=1 git push origin main 2>&1 | tee push.log
   grep "filling with GIT_ASKPASS" push.log                     # attempt askpass
   grep 'credential fill error: exec: "lfs-askpass-2"' push.log # askpass fails
   grep "creds: git credential fill" push.log                   # attempt git credential

--- a/t/t-credentials.sh
+++ b/t/t-credentials.sh
@@ -23,7 +23,7 @@ begin_test "credentials with url-specific helper skips askpass"
   git commit -m "initial commit"
 
   # askpass is skipped
-  GIT_ASKPASS="lfs-bad-cmd" GIT_TRACE=1 git push origin master 2>&1 | tee push.log
+  GIT_ASKPASS="lfs-bad-cmd" GIT_TRACE=1 git push origin main 2>&1 | tee push.log
 
   [ "0" -eq "$(grep "filling with GIT_ASKPASS" push.log | wc -l)" ]
 )
@@ -253,7 +253,7 @@ begin_test "credentials from netrc"
   git add .gitattributes a.dat
   git commit -m "add a.dat"
 
-  GIT_TRACE=1 git lfs push netrc master 2>&1 | tee push.log
+  GIT_TRACE=1 git lfs push netrc main 2>&1 | tee push.log
   grep "Uploading LFS objects: 100% (1/1), 7 B" push.log
   echo "any netrc credential calls:"
   [ "4" -eq "$(cat push.log | grep "netrc: git credential" | wc -l)" ]
@@ -292,7 +292,7 @@ begin_test "credentials from netrc with unknown keyword"
   git add .gitattributes a.dat
   git commit -m "add a.dat"
 
-  GIT_TRACE=1 git lfs push netrc master 2>&1 | tee push.log
+  GIT_TRACE=1 git lfs push netrc main 2>&1 | tee push.log
   grep "Uploading LFS objects: 100% (1/1), 7 B" push.log
   echo "any netrc credential calls:"
   [ "4" -eq "$(cat push.log | grep "netrc: git credential" | wc -l)" ]
@@ -331,7 +331,7 @@ begin_test "credentials from netrc with bad password"
   git add .gitattributes a.dat
   git commit -m "add a.dat"
 
-  git push netrc master 2>&1 | tee push.log
+  git push netrc main 2>&1 | tee push.log
   [ "0" = "$(grep -c "Uploading LFS objects: 100% (1/1), 7 B" push.log)" ]
 )
 end_test
@@ -367,7 +367,7 @@ begin_test "credentials with bad netrc creds will retry"
   git add .gitattributes a.dat
   git commit -m "add a.dat"
 
-  GIT_TRACE=1 GIT_ASKPASS="lfs-askpass" git push netrc master 2>&1 | tee push.log
+  GIT_TRACE=1 GIT_ASKPASS="lfs-askpass" git push netrc main 2>&1 | tee push.log
   grep -c "Uploading LFS objects: 100% (1/1), 7 B" push.log
 
   # netrc credentials should be attempted then rejected for the lock request
@@ -406,14 +406,14 @@ begin_test "credentials from lfs.url"
 
   echo "bad push"
   git lfs env
-  git lfs push origin master 2>&1 | tee push.log
+  git lfs push origin main 2>&1 | tee push.log
   grep "Uploading LFS objects:   0% (0/1), 0 B" push.log
 
   echo "good push"
   gitserverhost=$(echo "$GITSERVER" | cut -d'/' -f3)
   git config lfs.url http://requirecreds:pass@$gitserverhost/$reponame.git/info/lfs
   git lfs env
-  GIT_TRACE=1 git lfs push origin master 2>&1 | tee push.log
+  GIT_TRACE=1 git lfs push origin main 2>&1 | tee push.log
   # A 401 indicates URL access mode for the /storage endpoint
   # was used instead of for the lfsapi endpoint
   grep "HTTP: 401" push.log
@@ -471,14 +471,14 @@ begin_test "credentials from remote.origin.url"
 
   echo "bad push"
   git lfs env
-  git lfs push origin master 2>&1 | tee push.log
+  git lfs push origin main 2>&1 | tee push.log
   grep "Uploading LFS objects:   0% (0/1), 0 B" push.log
 
   echo "good push"
   gitserverhost=$(echo "$GITSERVER" | cut -d'/' -f3)
   git config remote.origin.url http://requirecreds:pass@$gitserverhost/$reponame.git
   git lfs env
-  GIT_TRACE=1 git lfs push origin master 2>&1 | tee push.log
+  GIT_TRACE=1 git lfs push origin main 2>&1 | tee push.log
   # A 401 indicates URL access mode for the /storage endpoint
   # was used instead of for the lfsapi endpoint
   grep "HTTP: 401" push.log

--- a/t/t-custom-transfers.sh
+++ b/t/t-custom-transfers.sh
@@ -25,7 +25,7 @@ begin_test "custom-transfer-wrong-path"
   git add a.dat
   git add .gitattributes
   git commit -m "add a.dat" 2>&1 | tee commit.log
-  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git push origin master 2>&1 | tee pushcustom.log
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git push origin main 2>&1 | tee pushcustom.log
   # use PIPESTATUS otherwise we get exit code from tee
   res=${PIPESTATUS[0]}
   grep "xfer: adapter \"testcustom\" Begin()" pushcustom.log
@@ -88,7 +88,7 @@ begin_test "custom-transfer-upload-download"
   }
   ]" | lfstest-testutils addcommits
 
-  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git push origin master 2>&1 | tee pushcustom.log
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git push origin main 2>&1 | tee pushcustom.log
   # use PIPESTATUS otherwise we get exit code from tee
   [ ${PIPESTATUS[0]} = "0" ]
 
@@ -167,7 +167,7 @@ begin_test "custom-transfer-standalone"
   }
   ]" | lfstest-testutils addcommits
 
-  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git push origin master 2>&1 | tee pushcustom.log
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git push origin main 2>&1 | tee pushcustom.log
   # use PIPESTATUS otherwise we get exit code from tee
   [ ${PIPESTATUS[0]} = "0" ]
 
@@ -259,7 +259,7 @@ begin_test "custom-transfer-standalone-urlmatch"
   }
   ]" | lfstest-testutils addcommits
 
-  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git push origin master 2>&1 | tee pushcustom.log
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git push origin main 2>&1 | tee pushcustom.log
   # use PIPESTATUS otherwise we get exit code from tee
   [ ${PIPESTATUS[0]} = "0" ]
 

--- a/t/t-duplicate-oids.sh
+++ b/t/t-duplicate-oids.sh
@@ -42,7 +42,7 @@ begin_test "multiple revs with same OID get pushed once"
 
   # Delay the push until here, so the server doesn't have a copy of the OID that
   # we're trying to push.
-  git push origin master 2>&1 | tee push.log
+  git push origin main 2>&1 | tee push.log
   grep "Uploading LFS objects: 100% (1/1), 8 B" push.log
 
   assert_server_object "$reponame" "$contents_oid"

--- a/t/t-expired.sh
+++ b/t/t-expired.sh
@@ -25,7 +25,7 @@ for typ in "${expiration_types[@]}"; do
     git add a.dat
     git commit -m "add a.dat"
 
-    GIT_TRACE=1 git push origin master 2>&1 | tee push.log
+    GIT_TRACE=1 git push origin main 2>&1 | tee push.log
     if [ "0" -eq "${PIPESTATUS[0]}" ]; then
       echo >&2 "fatal: expected push to fail, didn't"
       exit 1
@@ -60,7 +60,7 @@ for typ in "${expiration_types[@]}"; do
     git add a.dat
     git commit -m "add a.dat"
 
-    GIT_TRACE=1 git push origin master 2>&1 | tee push.log
+    GIT_TRACE=1 git push origin main 2>&1 | tee push.log
     grep "ssh cache expired" push.log
   )
   end_test

--- a/t/t-extra-header.sh
+++ b/t/t-extra-header.sh
@@ -19,7 +19,7 @@ begin_test "http.<url>.extraHeader"
   git add .gitattributes a.dat
   git commit -m "initial commit"
 
-  GIT_CURL_VERBOSE=1 GIT_TRACE=1 git push origin master 2>&1 | tee curl.log
+  GIT_CURL_VERBOSE=1 GIT_TRACE=1 git push origin main 2>&1 | tee curl.log
 
   grep "> X-Foo: bar" curl.log
   grep "> X-Foo: baz" curl.log
@@ -46,9 +46,9 @@ begin_test "http.<url>.extraHeader with authorization"
   git add .gitattributes a.dat
   git commit -m "initial commit"
 
-  git push origin master 2>&1 | tee curl.log
+  git push origin main 2>&1 | tee curl.log
   if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-    echo >&2 "expected \`git push origin master\` to succeed, didn't"
+    echo >&2 "expected \`git push origin main\` to succeed, didn't"
     exit 1
   fi
 
@@ -83,9 +83,9 @@ begin_test "http.<url>.extraHeader with authorization (casing)"
   git add .gitattributes a.dat
   git commit -m "initial commit"
 
-  git push origin master 2>&1 | tee curl.log
+  git push origin main 2>&1 | tee curl.log
   if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-    echo >&2 "expected \`git push origin master\` to succeed, didn't"
+    echo >&2 "expected \`git push origin main\` to succeed, didn't"
     exit 1
   fi
 
@@ -122,7 +122,7 @@ begin_test "http.<url>.extraHeader with mixed-case URLs"
   git add .gitattributes a.dat
   git commit -m "initial commit"
 
-  GIT_CURL_VERBOSE=1 GIT_TRACE=1 git push origin master 2>&1 | tee curl.log
+  GIT_CURL_VERBOSE=1 GIT_TRACE=1 git push origin main 2>&1 | tee curl.log
 
   grep "> X-Foo: bar" curl.log
   grep "> X-Foo: baz" curl.log

--- a/t/t-fetch-include.sh
+++ b/t/t-fetch-include.sh
@@ -35,7 +35,7 @@ begin_test "fetch: setup for include test"
   grep "create mode 100644 big/big2.big" commit.log
   grep "create mode 100644 big/big3.big" commit.log
 
-  git push origin master | tee push.log
+  git push origin main | tee push.log
   grep "Uploading LFS objects: 100% (2/2), 18 B" push.log
 
   assert_server_object "$reponame" "$contents_oid"
@@ -51,7 +51,7 @@ begin_test "fetch: include first matching file"
   git init
   git lfs install --local --skip-smudge
   git remote add origin $GITSERVER/$reponame
-  git pull origin master
+  git pull origin main
 
   refute_local_object "$contents_oid"
 
@@ -72,7 +72,7 @@ begin_test "fetch: include second matching file"
   git init
   git lfs install --local --skip-smudge
   git remote add origin $GITSERVER/$reponame
-  git pull origin master
+  git pull origin main
 
   refute_local_object "$contents_oid"
 

--- a/t/t-fetch-paths.sh
+++ b/t/t-fetch-paths.sh
@@ -22,7 +22,7 @@ begin_test "init fetch unclean paths"
   git add dir/a.dat
   git add .gitattributes
   git commit -m "add dir/a.dat" 2>&1 | tee commit.log
-  grep "master (root-commit)" commit.log
+  grep "main (root-commit)" commit.log
   grep "2 files changed" commit.log
   grep "create mode 100644 dir/a.dat" commit.log
   grep "create mode 100644 .gitattributes" commit.log
@@ -32,9 +32,9 @@ begin_test "init fetch unclean paths"
   assert_local_object "$contents_oid" 1
   refute_server_object "$contents_oid"
 
-  git push origin master 2>&1 | tee push.log
+  git push origin main 2>&1 | tee push.log
   grep "Uploading LFS objects: 100% (1/1), 1 B" push.log
-  grep "master -> master" push.log
+  grep "main -> main" push.log
 
   assert_server_object "$reponame" "$contents_oid"
 

--- a/t/t-fetch-recent.sh
+++ b/t/t-fetch-recent.sh
@@ -48,14 +48,14 @@ begin_test "init fetch-recent"
   },
   {
     \"CommitDate\":\"$(get_date -1d)\",
-    \"ParentBranches\":[\"master\"],
+    \"ParentBranches\":[\"main\"],
     \"Files\":[
       {\"Filename\":\"file1.dat\",\"Size\":${#content2}, \"Data\":\"$content2\"},
       {\"Filename\":\"file2.dat\",\"Size\":${#content3}, \"Data\":\"$content3\"}]
   }
   ]" | lfstest-testutils addcommits
 
-  git push origin master
+  git push origin main
   git push origin other_branch
   assert_server_object "$reponame" "$oid0"
   assert_server_object "$reponame" "$oid1"
@@ -66,7 +66,7 @@ begin_test "init fetch-recent"
   # This clone is used for subsequent tests
   clone_repo "$reponame" clone
   git checkout other_branch
-  git checkout master
+  git checkout main
 )
 end_test
 
@@ -83,7 +83,7 @@ begin_test "fetch-recent normal"
   git config lfs.fetchrecentcommitsdays 7
 
   # fetch normally, should just get the last state for file1/2
-  git lfs fetch origin master
+  git lfs fetch origin main
   assert_local_object "$oid2" "${#content2}"
   assert_local_object "$oid3" "${#content3}"
   assert_local_object "$oid5" "${#content5}"
@@ -106,7 +106,7 @@ begin_test "fetch-recent commits"
   git config lfs.fetchrecentcommitsdays 7
 
   git lfs fetch --recent origin
-  # that should have fetched master plus previous state needed within 7 days
+  # that should have fetched main plus previous state needed within 7 days
   # current state
   assert_local_object "$oid2" "${#content2}"
   assert_local_object "$oid3" "${#content3}"
@@ -131,7 +131,7 @@ begin_test "fetch-recent days"
   git config lfs.fetchrecentcommitsdays 7
 
   git lfs fetch --recent origin
-  # that should have fetched master plus previous state needed within 7 days
+  # that should have fetched main plus previous state needed within 7 days
   # current state PLUS refs within 6 days (& their commits within 7)
   assert_local_object "$oid2" "${#content2}"
   assert_local_object "$oid3" "${#content3}"

--- a/t/t-fetch-refspec.sh
+++ b/t/t-fetch-refspec.sh
@@ -6,7 +6,7 @@ begin_test "fetch with good ref"
 (
   set -e
 
-  reponame="fetch-master-branch-required"
+  reponame="fetch-main-branch-required"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"
 
@@ -15,12 +15,12 @@ begin_test "fetch with good ref"
   git add .gitattributes a.dat
   git commit -m "add a.dat"
 
-  git push origin master
+  git push origin main
 
   # $ echo "a" | shasum -a 256
   oid="87428fc522803d31065e7bce3cf03fe475096631e5e07bbd7a0fde60c4cf25c7"
   assert_local_object "$oid" 2
-  assert_server_object "$reponame" "$oid" "refs/heads/master"
+  assert_server_object "$reponame" "$oid" "refs/heads/main"
 
   rm -rf .git/lfs/objects
   git lfs fetch --all
@@ -41,7 +41,7 @@ begin_test "fetch with tracked ref"
   git add .gitattributes a.dat
   git commit -m "add a.dat"
 
-  git push origin master:tracked
+  git push origin main:tracked
 
   # $ echo "a" | shasum -a 256
   oid="87428fc522803d31065e7bce3cf03fe475096631e5e07bbd7a0fde60c4cf25c7"
@@ -50,7 +50,7 @@ begin_test "fetch with tracked ref"
 
   rm -rf .git/lfs/objects
   git config push.default upstream
-  git config branch.master.merge refs/heads/tracked
+  git config branch.main.merge refs/heads/tracked
   git lfs fetch --all
   assert_local_object "$oid" 2
 )
@@ -69,7 +69,7 @@ begin_test "fetch with bad ref"
   git add .gitattributes a.dat
   git commit -m "add a.dat"
 
-  git push origin master:other
+  git push origin main:other
 
   # $ echo "a" | shasum -a 256
   oid="87428fc522803d31065e7bce3cf03fe475096631e5e07bbd7a0fde60c4cf25c7"
@@ -83,6 +83,6 @@ begin_test "fetch with bad ref"
     exit 1
   fi
 
-  grep 'Expected ref "refs/heads/other", got "refs/heads/master"' fetch.log
+  grep 'Expected ref "refs/heads/other", got "refs/heads/main"' fetch.log
 )
 end_test

--- a/t/t-fetch.sh
+++ b/t/t-fetch.sh
@@ -24,7 +24,7 @@ begin_test "init for fetch tests"
   git add a.dat
   git add .gitattributes
   git commit -m "add a.dat" 2>&1 | tee commit.log
-  grep "master (root-commit)" commit.log
+  grep "main (root-commit)" commit.log
   grep "2 files changed" commit.log
   grep "create mode 100644 a.dat" commit.log
   grep "create mode 100644 .gitattributes" commit.log
@@ -35,9 +35,9 @@ begin_test "init for fetch tests"
 
   refute_server_object "$reponame" "$contents_oid"
 
-  git push origin master 2>&1 | tee push.log
+  git push origin main 2>&1 | tee push.log
   grep "Uploading LFS objects: 100% (1/1), 1 B" push.log
-  grep "master -> master" push.log
+  grep "main -> main" push.log
 
   assert_server_object "$reponame" "$contents_oid"
 
@@ -107,11 +107,11 @@ begin_test "fetch with remote and branches"
   cd clone
 
   git checkout newbranch
-  git checkout master
+  git checkout main
 
   rm -rf .git/lfs/objects
 
-  git lfs fetch origin master newbranch
+  git lfs fetch origin main newbranch
   assert_local_object "$contents_oid" 1
   assert_local_object "$b_oid" 1
 
@@ -120,14 +120,14 @@ begin_test "fetch with remote and branches"
 )
 end_test
 
-begin_test "fetch with master commit sha1"
+begin_test "fetch with main commit sha1"
 (
   set -e
   cd clone
   rm -rf .git/lfs/objects
 
-  master_sha1=$(git rev-parse master)
-  git lfs fetch origin "$master_sha1"
+  main_sha1=$(git rev-parse main)
+  git lfs fetch origin "$main_sha1"
   assert_local_object "$contents_oid" 1
   refute_local_object "$b_oid" 1
 
@@ -159,7 +159,7 @@ begin_test "fetch with include filters in gitconfig"
   rm -rf .git/lfs/objects
 
   git config "lfs.fetchinclude" "a*"
-  git lfs fetch origin master newbranch
+  git lfs fetch origin main newbranch
   assert_local_object "$contents_oid" 1
   refute_local_object "$b_oid"
 
@@ -177,7 +177,7 @@ begin_test "fetch with exclude filters in gitconfig"
   rm -rf .git/lfs/objects
 
   git config "lfs.fetchexclude" "a*"
-  git lfs fetch origin master newbranch
+  git lfs fetch origin main newbranch
   refute_local_object "$contents_oid"
   assert_local_object "$b_oid" 1
 
@@ -195,14 +195,14 @@ begin_test "fetch with include/exclude filters in gitconfig"
 
   git config "lfs.fetchinclude" "a*,b*"
   git config "lfs.fetchexclude" "c*,d*"
-  git lfs fetch origin master newbranch
+  git lfs fetch origin main newbranch
   assert_local_object "$contents_oid" 1
   assert_local_object "$b_oid" 1
 
   rm -rf .git/lfs/objects
   git config "lfs.fetchinclude" "c*,d*"
   git config "lfs.fetchexclude" "a*,b*"
-  git lfs fetch origin master newbranch
+  git lfs fetch origin main newbranch
   refute_local_object "$contents_oid"
   refute_local_object "$b_oid"
 )
@@ -216,7 +216,7 @@ begin_test "fetch with include filter in cli"
   git config --unset "lfs.fetchexclude"
   rm -rf .git/lfs/objects
 
-  git lfs fetch --include="a*" origin master newbranch
+  git lfs fetch --include="a*" origin main newbranch
   assert_local_object "$contents_oid" 1
   refute_local_object "$b_oid"
 )
@@ -227,7 +227,7 @@ begin_test "fetch with exclude filter in cli"
   set -e
   cd clone
   rm -rf .git/lfs/objects
-  git lfs fetch --exclude="a*" origin master newbranch
+  git lfs fetch --exclude="a*" origin main newbranch
   refute_local_object "$contents_oid"
   assert_local_object "$b_oid" 1
 )
@@ -238,12 +238,12 @@ begin_test "fetch with include/exclude filters in cli"
   set -e
   cd clone
   rm -rf .git/lfs/objects
-  git lfs fetch -I "a*,b*" -X "c*,d*" origin master newbranch
+  git lfs fetch -I "a*,b*" -X "c*,d*" origin main newbranch
   assert_local_object "$contents_oid" 1
   assert_local_object "$b_oid" 1
 
   rm -rf .git/lfs/objects
-  git lfs fetch --include="c*,d*" --exclude="a*,b*" origin master newbranch
+  git lfs fetch --include="c*,d*" --exclude="a*,b*" origin main newbranch
   refute_local_object "$contents_oid"
   refute_local_object "$b_oid"
 )
@@ -255,7 +255,7 @@ begin_test "fetch with include filter overriding exclude filter"
   cd clone
   rm -rf .git/lfs/objects
   git config lfs.fetchexclude "b*"
-  git lfs fetch -I "b.dat" -X "" origin master newbranch
+  git lfs fetch -I "b.dat" -X "" origin main newbranch
   assert_local_object "$b_oid" "1"
 )
 end_test
@@ -272,7 +272,7 @@ begin_test "fetch with missing object"
 
   # should return non-zero, but should also download all the other valid files too
   set +e
-  git lfs fetch origin master newbranch
+  git lfs fetch origin main newbranch
   fetch_exit=$?
   set -e
   [ "$fetch_exit" != "0" ]
@@ -315,7 +315,7 @@ begin_test "fetch-all"
       {\"Filename\":\"file3.dat\",\"Size\":${#content[2]}, \"Data\":\"${content[2]}\"}]
   },
   {
-    \"ParentBranches\":[\"master\"],
+    \"ParentBranches\":[\"main\"],
     \"CommitDate\":\"$(get_date -100d)\",
     \"Files\":[
       {\"Filename\":\"file1.dat\",\"Size\":${#content[3]}, \"Data\":\"${content[3]}\"}]
@@ -327,7 +327,7 @@ begin_test "fetch-all"
       {\"Filename\":\"file2.dat\",\"Size\":${#content[4]}, \"Data\":\"${content[4]}\"}]
   },
   {
-    \"ParentBranches\":[\"master\"],
+    \"ParentBranches\":[\"main\"],
     \"CommitDate\":\"$(get_date -75d)\",
     \"Files\":[
       {\"Filename\":\"file4.dat\",\"Size\":${#content[5]}, \"Data\":\"${content[5]}\"}]
@@ -340,7 +340,7 @@ begin_test "fetch-all"
       {\"Filename\":\"file4.dat\",\"Size\":${#content[6]}, \"Data\":\"${content[6]}\"}]
   },
   {
-    \"ParentBranches\":[\"master\"],
+    \"ParentBranches\":[\"main\"],
     \"CommitDate\":\"$(get_date -60d)\",
     \"Files\":[
       {\"Filename\":\"file1.dat\",\"Size\":${#content[7]}, \"Data\":\"${content[7]}\"}]
@@ -353,20 +353,20 @@ begin_test "fetch-all"
   },
   {
     \"CommitDate\":\"$(get_date -40d)\",
-    \"ParentBranches\":[\"master\"],
+    \"ParentBranches\":[\"main\"],
     \"Files\":[
       {\"Filename\":\"file1.dat\",\"Size\":${#content[9]}, \"Data\":\"${content[9]}\"},
       {\"Filename\":\"file2.dat\",\"Size\":${#content[10]}, \"Data\":\"${content[10]}\"}]
   },
   {
-    \"ParentBranches\":[\"master\"],
+    \"ParentBranches\":[\"main\"],
     \"CommitDate\":\"$(get_date -30d)\",
     \"Files\":[
       {\"Filename\":\"file4.dat\",\"Size\":${#content[11]}, \"Data\":\"${content[11]}\"}]
   }
   ]" | lfstest-testutils addcommits
 
-  git push origin master
+  git push origin main
   git push origin branch1
   git push origin branch3
   git push origin remote_branch_only
@@ -394,8 +394,8 @@ begin_test "fetch-all"
 
   rm -rf .git/lfs/objects
 
-  # fetch all objects reachable from the master branch only
-  git lfs fetch --all origin master
+  # fetch all objects reachable from the main branch only
+  git lfs fetch --all origin main
   for a in 0 1 3 5 7 9 10 11
   do
     assert_local_object "${oid[$a]}" "${#content[$a]}"
@@ -432,8 +432,8 @@ begin_test "fetch-all"
 
   rm -rf lfs/objects
 
-  # fetch all objects reachable from the master branch only
-  git lfs fetch --all origin master
+  # fetch all objects reachable from the main branch only
+  git lfs fetch --all origin main
   for a in 0 1 3 5 7 9 10 11
   do
     assert_local_object "${oid[$a]}" "${#content[$a]}"
@@ -495,7 +495,7 @@ begin_test "fetch with no origin remote"
   git add a.dat
   git add .gitattributes
   git commit -m "add a.dat" 2>&1 | tee commit.log
-  grep "master (root-commit)" commit.log
+  grep "main (root-commit)" commit.log
   grep "2 files changed" commit.log
   grep "create mode 100644 a.dat" commit.log
   grep "create mode 100644 .gitattributes" commit.log
@@ -506,16 +506,16 @@ begin_test "fetch with no origin remote"
 
   refute_server_object "$reponame" "$contents_oid"
 
-  git push origin master 2>&1 | tee push.log
+  git push origin main 2>&1 | tee push.log
   grep "Uploading LFS objects: 100% (1/1), 1 B" push.log
-  grep "master -> master" push.log
+  grep "main -> main" push.log
 
 
   # change to the clone's working directory
   cd ../no-remote-clone
 
   # pull commits & lfs
-  git pull origin master 2>&1
+  git pull origin main 2>&1
   assert_local_object "$contents_oid" 1
 
   # now checkout detached HEAD so we're not tracking anything on remote
@@ -572,7 +572,7 @@ begin_test "fetch --prune"
   ]" | lfstest-testutils addcommits
 
   # push all so no unpushed reason to not prune
-  git push origin master
+  git push origin main
 
   # set no recents so max ability to prune
   git config lfs.fetchrecentrefsdays 0
@@ -597,7 +597,7 @@ begin_test "fetch raw remote url"
   git lfs install --local --skip-smudge
 
   git remote add origin "$GITSERVER/$reponame"
-  git pull origin master
+  git pull origin main
 
   # LFS object not downloaded, pointer in working directory
   refute_local_object "$contents_oid"

--- a/t/t-fetch.sh
+++ b/t/t-fetch.sh
@@ -515,7 +515,7 @@ begin_test "fetch with no origin remote"
   cd ../no-remote-clone
 
   # pull commits & lfs
-  git pull 2>&1
+  git pull origin master 2>&1
   assert_local_object "$contents_oid" 1
 
   # now checkout detached HEAD so we're not tracking anything on remote

--- a/t/t-filter-branch.sh
+++ b/t/t-filter-branch.sh
@@ -34,8 +34,8 @@ begin_test "filter-branch (git-lfs/git-lfs#1773)"
     ' --tag-name-filter cat -- --all
 
 
-  assert_pointer "master" "a.dat" "$(calc_oid "$contents_a")" 12
-  assert_pointer "master" "b.dat" "$(calc_oid "$contents_b")" 12
-  assert_pointer "master" "c.dat" "$(calc_oid "$contents_c")" 12
+  assert_pointer "main" "a.dat" "$(calc_oid "$contents_a")" 12
+  assert_pointer "main" "b.dat" "$(calc_oid "$contents_b")" 12
+  assert_pointer "main" "c.dat" "$(calc_oid "$contents_c")" 12
 )
 end_test

--- a/t/t-filter-process.sh
+++ b/t/t-filter-process.sh
@@ -50,10 +50,10 @@ begin_test "filter process: checking out a branch"
 
     cd "$reponame-assert"
 
-    # Assert that we are on the "master" branch, and have a.dat
-    [ "master" = "$(git rev-parse --abbrev-ref HEAD)" ]
+    # Assert that we are on the "main" branch, and have a.dat
+    [ "main" = "$(git rev-parse --abbrev-ref HEAD)" ]
     [ "$contents_a" = "$(cat a.dat)" ]
-    assert_pointer "master" "a.dat" "$contents_a_oid" 10
+    assert_pointer "main" "a.dat" "$contents_a_oid" 10
 
     git checkout b
 

--- a/t/t-happy-path.sh
+++ b/t/t-happy-path.sh
@@ -56,7 +56,7 @@ begin_test "happy path"
   # change to the clone's working directory
   cd ../clone
 
-  git pull
+  git pull origin master
 
   [ "a" = "$(cat a.dat)" ]
 

--- a/t/t-happy-path.sh
+++ b/t/t-happy-path.sh
@@ -34,7 +34,7 @@ begin_test "happy path"
   git add a.dat
   git add .gitattributes
   git commit -m "add a.dat" 2>&1 | tee commit.log
-  grep "master (root-commit)" commit.log
+  grep "main (root-commit)" commit.log
   grep "2 files changed" commit.log
   grep "create mode 100644 a.dat" commit.log
   grep "create mode 100644 .gitattributes" commit.log
@@ -42,25 +42,25 @@ begin_test "happy path"
   [ "a" = "$(cat a.dat)" ]
 
   # This is a small shell function that runs several git commands together.
-  assert_pointer "master" "a.dat" "$contents_oid" 1
+  assert_pointer "main" "a.dat" "$contents_oid" 1
 
   refute_server_object "$reponame" "$contents_oid"
 
   # This pushes to the remote repository set up at the top of the test.
-  git push origin master 2>&1 | tee push.log
+  git push origin main 2>&1 | tee push.log
   grep "Uploading LFS objects: 100% (1/1), 1 B" push.log
-  grep "master -> master" push.log
+  grep "main -> main" push.log
 
   assert_server_object "$reponame" "$contents_oid"
 
   # change to the clone's working directory
   cd ../clone
 
-  git pull origin master
+  git pull origin main
 
   [ "a" = "$(cat a.dat)" ]
 
-  assert_pointer "master" "a.dat" "$contents_oid" 1
+  assert_pointer "main" "a.dat" "$contents_oid" 1
 )
 end_test
 
@@ -75,7 +75,7 @@ begin_test "happy path on non-origin remote"
   git lfs track "*.dat"
   git add .gitattributes
   git commit -m "track"
-  git push origin master
+  git push origin main
 
   clone_repo "$reponame" clone-without-origin
   git remote rename origin happy-path
@@ -84,12 +84,12 @@ begin_test "happy path on non-origin remote"
   echo "a" > a.dat
   git add a.dat
   git commit -m "boom"
-  git push origin master
+  git push origin main
 
   cd ../clone-without-origin
   echo "remotes:"
   git remote
-  git pull happy-path master
+  git pull happy-path main
 )
 end_test
 
@@ -97,7 +97,7 @@ begin_test "happy path on good ref"
 (
   set -e
 
-  reponame="happy-path-master-branch-required"
+  reponame="happy-path-main-branch-required"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"
 
@@ -106,12 +106,12 @@ begin_test "happy path on good ref"
   git add .gitattributes a.dat
   git commit -m "add a.dat"
 
-  git push origin master
+  git push origin main
 
   # $ echo "a" | shasum -a 256
   oid="87428fc522803d31065e7bce3cf03fe475096631e5e07bbd7a0fde60c4cf25c7"
   assert_local_object "$oid" 2
-  assert_server_object "$reponame" "$oid" "refs/heads/master"
+  assert_server_object "$reponame" "$oid" "refs/heads/main"
 
   clone_repo "$reponame" "$reponame-clone"
   assert_local_object "$oid" 2
@@ -131,7 +131,7 @@ begin_test "happy path on tracked ref"
   git add .gitattributes a.dat
   git commit -m "add a.dat"
 
-  git push origin master:tracked
+  git push origin main:tracked
 
   # $ echo "a" | shasum -a 256
   oid="87428fc522803d31065e7bce3cf03fe475096631e5e07bbd7a0fde60c4cf25c7"
@@ -142,7 +142,7 @@ begin_test "happy path on tracked ref"
 
   git config credential.helper lfstest
   git config push.default upstream
-  git config branch.master.merge refs/heads/tracked
+  git config branch.main.merge refs/heads/tracked
 
   git checkout
   assert_local_object "$oid" 2

--- a/t/t-lock.sh
+++ b/t/t-lock.sh
@@ -6,7 +6,7 @@ begin_test "lock with good ref"
 (
   set -e
 
-  reponame="lock-master-branch-required"
+  reponame="lock-main-branch-required"
   setup_remote_repo_with_file "$reponame" "a.dat"
   clone_repo "$reponame" "$reponame"
 
@@ -17,7 +17,7 @@ begin_test "lock with good ref"
   fi
 
   id=$(assert_lock lock.json a.dat)
-  assert_server_lock "$reponame" "$id" "refs/heads/master"
+  assert_server_lock "$reponame" "$id" "refs/heads/main"
 )
 end_test
 
@@ -35,9 +35,9 @@ begin_test "lock with good tracked ref"
   git commit -m "add a.dat"
 
   git config push.default upstream
-  git config branch.master.merge refs/heads/tracked
-  git config branch.master.remote origin
-  git push origin master
+  git config branch.main.merge refs/heads/tracked
+  git config branch.main.remote origin
+  git push origin main
 
   git lfs lock "a.dat" --json 2>&1 | tee lock.json
   if [ "0" -ne "${PIPESTATUS[0]}" ]; then
@@ -62,7 +62,7 @@ begin_test "lock with bad ref"
   echo "a" > a.dat
   git add .gitattributes a.dat
   git commit -m "add a.dat"
-  git push origin master:other
+  git push origin main:other
 
   GIT_CURL_VERBOSE=1 git lfs lock "a.dat" 2>&1 | tee lock.json
   if [ "0" -eq "${PIPESTATUS[0]}" ]; then
@@ -70,7 +70,7 @@ begin_test "lock with bad ref"
     exit 1
   fi
 
-  grep 'Lock failed: Expected ref "refs/heads/other", got "refs/heads/master"' lock.json
+  grep 'Lock failed: Expected ref "refs/heads/other", got "refs/heads/main"' lock.json
 )
 end_test
 
@@ -145,13 +145,13 @@ begin_test "locking a directory"
   git add dir/a.dat .gitattributes
 
   git commit -m "add dir/a.dat" | tee commit.log
-  grep "master (root-commit)" commit.log
+  grep "main (root-commit)" commit.log
   grep "2 files changed" commit.log
   grep "create mode 100644 dir/a.dat" commit.log
   grep "create mode 100644 .gitattributes" commit.log
 
-  git push origin master 2>&1 | tee push.log
-  grep "master -> master" push.log
+  git push origin main 2>&1 | tee push.log
+  grep "main -> main" push.log
 
   git lfs lock ./dir/ 2>&1 | tee lock.log
   grep "cannot lock directory" lock.log
@@ -179,7 +179,7 @@ begin_test "locking a nested file"
   git add foo/bar/baz/a.dat
   git commit -m "add a.dat"
 
-  git push origin master
+  git push origin main
 
   assert_server_object "$reponame" "$contents_oid"
 
@@ -231,7 +231,7 @@ begin_test "creating a lock (symlinked working directory)"
 
   git add --all .
   git commit -m "initial commit"
-  git push origin master
+  git push origin main
 
   pushd "$TRASHDIR" > /dev/null
     ln -s "$reponame" "$reponame-symlink"
@@ -240,7 +240,7 @@ begin_test "creating a lock (symlinked working directory)"
     git lfs lock --json folder1/folder2/a.dat 2>&1 | tee lock.json
 
     id="$(assert_lock lock.json folder1/folder2/a.dat)"
-    assert_server_lock "$reponame" "$id" master
+    assert_server_lock "$reponame" "$id" main
   popd > /dev/null
 )
 end_test

--- a/t/t-lock.sh
+++ b/t/t-lock.sh
@@ -36,6 +36,7 @@ begin_test "lock with good tracked ref"
 
   git config push.default upstream
   git config branch.master.merge refs/heads/tracked
+  git config branch.master.remote origin
   git push origin master
 
   git lfs lock "a.dat" --json 2>&1 | tee lock.json

--- a/t/t-locks.sh
+++ b/t/t-locks.sh
@@ -14,19 +14,19 @@ begin_test "list a single lock with bad ref"
   echo "f" > f.dat
   git add .gitattributes f.dat
   git commit -m "add f.dat"
-  git push origin master:other
+  git push origin main:other
 
   git checkout -b other
   git lfs lock --json "f.dat" | tee lock.log
 
-  git checkout master
+  git checkout main
   git lfs locks --path "f.dat" 2>&1 | tee locks.log
   if [ "0" -eq "${PIPESTATUS[0]}" ]; then
     echo >&2 "fatal: expected 'git lfs lock \'a.dat\'' to fail"
     exit 1
   fi
 
-  grep 'Expected ref "refs/heads/other", got "refs/heads/master"' locks.log
+  grep 'Expected ref "refs/heads/other", got "refs/heads/main"' locks.log
 )
 end_test
 
@@ -34,14 +34,14 @@ begin_test "list a single lock"
 (
   set -e
 
-  reponame="locks-list-master-branch-required"
+  reponame="locks-list-main-branch-required"
   setup_remote_repo_with_file "$reponame" "f.dat"
   clone_repo "$reponame" "$reponame"
 
   git lfs lock --json "f.dat" | tee lock.log
 
   id=$(assert_lock lock.log f.dat)
-  assert_server_lock "$reponame" "$id" "refs/heads/master"
+  assert_server_lock "$reponame" "$id" "refs/heads/main"
 
   git lfs locks --path "f.dat" | tee locks.log
   [ $(wc -l < locks.log) -eq 1 ]
@@ -65,7 +65,7 @@ begin_test "list a single lock (SSH)"
   git lfs lock --json "f.dat" | tee lock.log
 
   id=$(assert_lock lock.log f.dat)
-  assert_server_lock "$reponame" "$id" "refs/heads/master"
+  assert_server_lock "$reponame" "$id" "refs/heads/main"
 
   GIT_TRACE=1 git lfs locks --path "f.dat" 2>trace.log | tee locks.log
   cat trace.log
@@ -115,8 +115,8 @@ begin_test "list locks with a limit"
   grep "create mode 100644 .gitattributes" commit.log
 
 
-  git push origin master 2>&1 | tee push.log
-  grep "master -> master" push.log
+  git push origin main 2>&1 | tee push.log
+  grep "main -> main" push.log
 
   git lfs lock --json "g_1.dat" | tee lock.log
   assert_server_lock "$reponame" "$(assert_log "lock.log" g_1.dat)"
@@ -151,8 +151,8 @@ begin_test "list locks with pagination"
   done
   grep "create mode 100644 .gitattributes" commit.log
 
-  git push origin master 2>&1 | tee push.log
-  grep "master -> master" push.log
+  git push origin main 2>&1 | tee push.log
+  grep "main -> main" push.log
 
   for i in $(seq 1 5); do
     git lfs lock --json "h_$i.dat" | tee lock.log
@@ -184,8 +184,8 @@ begin_test "cached locks"
   grep "create mode 100644 cached2.dat" commit.log
   grep "create mode 100644 .gitattributes" commit.log
 
-  git push origin master 2>&1 | tee push.log
-  grep "master -> master" push.log
+  git push origin main 2>&1 | tee push.log
+  grep "main -> main" push.log
 
   git lfs lock --json "cached1.dat" | tee lock.log
   assert_server_lock "$(assert_lock "lock.log" cached1.dat)"

--- a/t/t-ls-files.sh
+++ b/t/t-ls-files.sh
@@ -327,10 +327,10 @@ begin_test "ls-files: --all with argument(s)"
   git init "$reponame"
   cd "$reponame"
 
-  git lfs ls-files --all master 2>&1 | tee ls-files.log
+  git lfs ls-files --all main 2>&1 | tee ls-files.log
 
   if [ "0" -eq "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: \`git lfs ls-files --all master\` to fail"
+    echo >&2 "fatal: \`git lfs ls-files --all main\` to fail"
     exit 1
   fi
 

--- a/t/t-malformed-pointers.sh
+++ b/t/t-malformed-pointers.sh
@@ -26,7 +26,7 @@ begin_test "malformed pointers"
     add *.dat
   git commit -m "add malformed pointer"
 
-  git push origin master
+  git push origin main
 
   pushd .. >/dev/null
     clone_repo "$reponame" "$reponame-assert"
@@ -78,7 +78,7 @@ begin_test "empty pointers"
   [ "0" -eq "$(git cat-file -p :empty.dat | wc -c)" ]
   [ "0" -eq "$(wc -c < empty.dat)" ]
 
-  git push origin master
+  git push origin main
 
   pushd .. >/dev/null
     clone_repo "$reponame" "$reponame-assert"

--- a/t/t-mergetool.sh
+++ b/t/t-mergetool.sh
@@ -20,7 +20,7 @@ begin_test "mergetool works with large files"
   git add conflict.dat
   git commit -m "conflict.dat: b"
 
-  git checkout master
+  git checkout main
 
   printf "a" > conflict.dat
   git add conflict.dat

--- a/t/t-migrate-fixup.sh
+++ b/t/t-migrate-fixup.sh
@@ -13,12 +13,12 @@ begin_test "migrate import (--fixup)"
 
   git lfs migrate import --everything --fixup --yes
 
-  assert_pointer "refs/heads/master" "a.txt" "$txt_oid" "120"
+  assert_pointer "refs/heads/main" "a.txt" "$txt_oid" "120"
   assert_local_object "$txt_oid" "120"
 
-  master="$(git rev-parse refs/heads/master)"
-  master_attrs="$(git cat-file -p "$master:.gitattributes")"
-  echo "$master_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"
+  main="$(git rev-parse refs/heads/main)"
+  main_attrs="$(git cat-file -p "$main:.gitattributes")"
+  echo "$main_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"
 )
 end_test
 
@@ -33,17 +33,17 @@ begin_test "migrate import (--fixup, complex nested)"
 
   git lfs migrate import --everything --fixup --yes
 
-  assert_pointer "refs/heads/master" "a.txt" "$a_oid" "1"
-  refute_pointer "refs/heads/master" "b.txt"
+  assert_pointer "refs/heads/main" "a.txt" "$a_oid" "1"
+  refute_pointer "refs/heads/main" "b.txt"
 
   assert_local_object "$a_oid" "1"
   refute_local_object "$b_oid" "1"
 
-  master="$(git rev-parse refs/heads/master)"
-  master_attrs="$(git cat-file -p "$master:.gitattributes")"
-  master_dir_attrs="$(git cat-file -p "$master:dir/.gitattributes")"
-  echo "$master_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"
-  echo "$master_dir_attrs" | grep -q "*.txt !filter !diff !merge"
+  main="$(git rev-parse refs/heads/main)"
+  main_attrs="$(git cat-file -p "$main:.gitattributes")"
+  main_dir_attrs="$(git cat-file -p "$main:dir/.gitattributes")"
+  echo "$main_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"
+  echo "$main_dir_attrs" | grep -q "*.txt !filter !diff !merge"
 )
 end_test
 
@@ -126,6 +126,6 @@ begin_test "migrate import (--fixup with remote tags)"
 
   # We're checking here that this succeeds even though it does nothing in this
   # case.
-  git lfs migrate import --fixup --yes master
+  git lfs migrate import --fixup --yes main
 )
 end_test

--- a/t/t-migrate-import-no-rewrite.sh
+++ b/t/t-migrate-import-no-rewrite.sh
@@ -15,7 +15,7 @@ begin_test "migrate import --no-rewrite (default branch)"
   git lfs migrate import --no-rewrite --yes *.txt
 
   # Ensure our desired files were imported into git-lfs
-  assert_pointer "refs/heads/master" "a.txt" "$txt_oid" "120"
+  assert_pointer "refs/heads/main" "a.txt" "$txt_oid" "120"
   assert_local_object "$txt_oid" "120"
 
   # Ensure the git history remained the same
@@ -52,8 +52,8 @@ begin_test "migrate import --no-rewrite (bare repository)"
   git lfs migrate import --no-rewrite --yes a.txt a.md
 
   # Ensure our desired files were imported
-  assert_pointer "refs/heads/master" "a.txt" "$txt_oid" "30"
-  assert_pointer "refs/heads/master" "a.md" "$md_oid" "50"
+  assert_pointer "refs/heads/main" "a.txt" "$txt_oid" "30"
+  assert_pointer "refs/heads/main" "a.md" "$md_oid" "50"
 
   # Ensure the git history remained the same
   new_commit_oid="$(git rev-parse HEAD~1)"
@@ -84,8 +84,8 @@ begin_test "migrate import --no-rewrite (multiple branches)"
   git lfs migrate import --no-rewrite --yes *.txt *.md
 
   # Ensure our desired files were imported
-  assert_pointer "refs/heads/master" "a.md" "$md_oid" "140"
-  assert_pointer "refs/heads/master" "a.txt" "$txt_oid" "120"
+  assert_pointer "refs/heads/main" "a.md" "$md_oid" "140"
+  assert_pointer "refs/heads/main" "a.txt" "$txt_oid" "120"
 
   assert_local_object "$md_oid" "140"
   assert_local_object "$txt_oid" "120"
@@ -131,11 +131,11 @@ begin_test "migrate import --no-rewrite (nested .gitattributes)"
   setup_local_branch_with_nested_gitattrs
 
   # Ensure a .md filter does not exist in the top-level .gitattributes
-  master_attrs="$(git cat-file -p "$master:.gitattributes")"
-  [ !"$(echo "$master_attrs" | grep -q ".md")" ]
+  main_attrs="$(git cat-file -p "$main:.gitattributes")"
+  [ !"$(echo "$main_attrs" | grep -q ".md")" ]
 
   # Ensure a .md filter exists in the nested .gitattributes
-  nested_attrs="$(git cat-file -p "$master:b/.gitattributes")"
+  nested_attrs="$(git cat-file -p "$main:b/.gitattributes")"
   echo "$nested_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
 
   md_oid="$(calc_oid "$(git cat-file -p :a.md)")"
@@ -146,8 +146,8 @@ begin_test "migrate import --no-rewrite (nested .gitattributes)"
 
   # Ensure a.txt and subtree/a.md were imported, even though *.md only exists in the
   # nested subtree/.gitattributes file
-  assert_pointer "refs/heads/master" "b/a.md" "$nested_md_oid" "140"
-  assert_pointer "refs/heads/master" "a.txt" "$txt_oid" "120"
+  assert_pointer "refs/heads/main" "b/a.md" "$nested_md_oid" "140"
+  assert_pointer "refs/heads/main" "a.txt" "$txt_oid" "120"
 
   assert_local_object "$nested_md_oid" 140
   assert_local_object "$txt_oid" 120

--- a/t/t-migrate-import.sh
+++ b/t/t-migrate-import.sh
@@ -15,21 +15,21 @@ begin_test "migrate import (default branch)"
 
   git lfs migrate import
 
-  assert_pointer "refs/heads/master" "a.md" "$md_oid" "140"
-  assert_pointer "refs/heads/master" "a.txt" "$txt_oid" "120"
+  assert_pointer "refs/heads/main" "a.md" "$md_oid" "140"
+  assert_pointer "refs/heads/main" "a.txt" "$txt_oid" "120"
 
   assert_local_object "$md_oid" "140"
   assert_local_object "$txt_oid" "120"
   refute_local_object "$md_feature_oid" "30"
 
-  master="$(git rev-parse refs/heads/master)"
+  main="$(git rev-parse refs/heads/main)"
   feature="$(git rev-parse refs/heads/my-feature)"
 
-  master_attrs="$(git cat-file -p "$master:.gitattributes")"
+  main_attrs="$(git cat-file -p "$main:.gitattributes")"
   [ ! $(git cat-file -p "$feature:.gitattributes") ]
 
-  echo "$master_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
-  echo "$master_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"
+  echo "$main_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
+  echo "$main_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"
 
   # Ensure that hooks are installed. If we find 'git-lfs' somewhere in
   # .git/hooks/pre-push we assume that the rest went correctly, too.
@@ -61,21 +61,21 @@ begin_test "migrate import (given branch)"
 
   assert_pointer "refs/heads/my-feature" "a.md" "$md_feature_oid" "30"
   assert_pointer "refs/heads/my-feature" "a.txt" "$txt_oid" "120"
-  assert_pointer "refs/heads/master" "a.md" "$md_oid" "140"
-  assert_pointer "refs/heads/master" "a.txt" "$txt_oid" "120"
+  assert_pointer "refs/heads/main" "a.md" "$md_oid" "140"
+  assert_pointer "refs/heads/main" "a.txt" "$txt_oid" "120"
 
   assert_local_object "$md_oid" "140"
   assert_local_object "$md_feature_oid" "30"
   assert_local_object "$txt_oid" "120"
 
-  master="$(git rev-parse refs/heads/master)"
+  main="$(git rev-parse refs/heads/main)"
   feature="$(git rev-parse refs/heads/my-feature)"
 
-  master_attrs="$(git cat-file -p "$master:.gitattributes")"
+  main_attrs="$(git cat-file -p "$main:.gitattributes")"
   feature_attrs="$(git cat-file -p "$feature:.gitattributes")"
 
-  echo "$master_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
-  echo "$master_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"
+  echo "$main_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
+  echo "$main_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"
   echo "$feature_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
   echo "$feature_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"
 )
@@ -93,20 +93,20 @@ begin_test "migrate import (default branch with filter)"
 
   git lfs migrate import --include "*.md"
 
-  assert_pointer "refs/heads/master" "a.md" "$md_oid" "140"
+  assert_pointer "refs/heads/main" "a.md" "$md_oid" "140"
 
   assert_local_object "$md_oid" "140"
   refute_local_object "$txt_oid" "120"
   refute_local_object "$md_feature_oid" "30"
 
-  master="$(git rev-parse refs/heads/master)"
+  main="$(git rev-parse refs/heads/main)"
   feature="$(git rev-parse refs/heads/my-feature)"
 
-  master_attrs="$(git cat-file -p "$master:.gitattributes")"
+  main_attrs="$(git cat-file -p "$main:.gitattributes")"
   [ ! $(git cat-file -p "$feature:.gitattributes") ]
 
-  echo "$master_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
-  echo "$master_attrs" | grep -vq "*.txt filter=lfs diff=lfs merge=lfs"
+  echo "$main_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
+  echo "$main_attrs" | grep -vq "*.txt filter=lfs diff=lfs merge=lfs"
 )
 end_test
 
@@ -129,14 +129,14 @@ begin_test "migrate import (given branch with filter)"
   assert_local_object "$md_feature_oid" "30"
   refute_local_object "$txt_oid" "120"
 
-  master="$(git rev-parse refs/heads/master)"
+  main="$(git rev-parse refs/heads/main)"
   feature="$(git rev-parse refs/heads/my-feature)"
 
-  master_attrs="$(git cat-file -p "$master:.gitattributes")"
+  main_attrs="$(git cat-file -p "$main:.gitattributes")"
   feature_attrs="$(git cat-file -p "$feature:.gitattributes")"
 
-  echo "$master_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
-  echo "$master_attrs" | grep -vq "*.txt filter=lfs diff=lfs merge=lfs"
+  echo "$main_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
+  echo "$main_attrs" | grep -vq "*.txt filter=lfs diff=lfs merge=lfs"
   echo "$feature_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
   echo "$feature_attrs" | grep -vq "*.txt filter=lfs diff=lfs merge=lfs"
 )
@@ -148,29 +148,29 @@ begin_test "migrate import (default branch, exclude remote refs)"
 
   setup_single_remote_branch
 
-  md_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/master:a.md")")"
-  txt_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/master:a.txt")")"
-  md_oid="$(calc_oid "$(git cat-file -p "refs/heads/master:a.md")")"
-  txt_oid="$(calc_oid "$(git cat-file -p "refs/heads/master:a.txt")")"
+  md_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/main:a.md")")"
+  txt_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/main:a.txt")")"
+  md_oid="$(calc_oid "$(git cat-file -p "refs/heads/main:a.md")")"
+  txt_oid="$(calc_oid "$(git cat-file -p "refs/heads/main:a.txt")")"
 
   git lfs migrate import
 
-  assert_pointer "refs/heads/master" "a.md" "$md_oid" "50"
-  assert_pointer "refs/heads/master" "a.txt" "$txt_oid" "30"
+  assert_pointer "refs/heads/main" "a.md" "$md_oid" "50"
+  assert_pointer "refs/heads/main" "a.txt" "$txt_oid" "30"
 
   assert_local_object "$md_oid" "50"
   assert_local_object "$txt_oid" "30"
   refute_local_object "$md_remote_oid" "140"
   refute_local_object "$txt_remote_oid" "120"
 
-  master="$(git rev-parse refs/heads/master)"
-  remote="$(git rev-parse refs/remotes/origin/master)"
+  main="$(git rev-parse refs/heads/main)"
+  remote="$(git rev-parse refs/remotes/origin/main)"
 
-  master_attrs="$(git cat-file -p "$master:.gitattributes")"
+  main_attrs="$(git cat-file -p "$main:.gitattributes")"
   [ ! $(git cat-file -p "$remote:.gitattributes") ]
 
-  echo "$master_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
-  echo "$master_attrs" | grep -vq "*.txt filter=lfs diff=lfs merge=lfs"
+  echo "$main_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
+  echo "$main_attrs" | grep -vq "*.txt filter=lfs diff=lfs merge=lfs"
 )
 end_test
 
@@ -180,37 +180,37 @@ begin_test "migrate import (given branch, exclude remote refs)"
 
   setup_multiple_remote_branches
 
-  md_master_oid="$(calc_oid "$(git cat-file -p "refs/heads/master:a.md")")"
-  md_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/master:a.md")")"
+  md_main_oid="$(calc_oid "$(git cat-file -p "refs/heads/main:a.md")")"
+  md_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/main:a.md")")"
   md_feature_oid="$(calc_oid "$(git cat-file -p "refs/heads/my-feature:a.md")")"
-  txt_master_oid="$(calc_oid "$(git cat-file -p "refs/heads/master:a.txt")")"
-  txt_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/master:a.txt")")"
+  txt_main_oid="$(calc_oid "$(git cat-file -p "refs/heads/main:a.txt")")"
+  txt_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/main:a.txt")")"
   txt_feature_oid="$(calc_oid "$(git cat-file -p "refs/heads/my-feature:a.txt")")"
 
   git lfs migrate import my-feature
 
-  assert_pointer "refs/heads/master" "a.md" "$md_master_oid" "21"
+  assert_pointer "refs/heads/main" "a.md" "$md_main_oid" "21"
   assert_pointer "refs/heads/my-feature" "a.md" "$md_feature_oid" "31"
-  assert_pointer "refs/heads/master" "a.txt" "$txt_master_oid" "20"
+  assert_pointer "refs/heads/main" "a.txt" "$txt_main_oid" "20"
   assert_pointer "refs/heads/my-feature" "a.txt" "$txt_feature_oid" "30"
 
   assert_local_object "$md_feature_oid" "31"
-  assert_local_object "$md_master_oid" "21"
+  assert_local_object "$md_main_oid" "21"
   assert_local_object "$txt_feature_oid" "30"
-  assert_local_object "$txt_master_oid" "20"
+  assert_local_object "$txt_main_oid" "20"
   refute_local_object "$md_remote_oid" "11"
   refute_local_object "$txt_remote_oid" "10"
 
-  master="$(git rev-parse refs/heads/master)"
+  main="$(git rev-parse refs/heads/main)"
   feature="$(git rev-parse refs/heads/my-feature)"
-  remote="$(git rev-parse refs/remotes/origin/master)"
+  remote="$(git rev-parse refs/remotes/origin/main)"
 
-  master_attrs="$(git cat-file -p "$master:.gitattributes")"
+  main_attrs="$(git cat-file -p "$main:.gitattributes")"
   [ ! $(git cat-file -p "$remote:.gitattributes") ]
   feature_attrs="$(git cat-file -p "$feature:.gitattributes")"
 
-  echo "$master_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
-  echo "$master_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"
+  echo "$main_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
+  echo "$main_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"
   echo "$feature_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
   echo "$feature_attrs" | grep -vq "*.txt filter=lfs diff=lfs merge=lfs"
 )
@@ -222,36 +222,36 @@ begin_test "migrate import (given ref, --skip-fetch)"
 
   setup_single_remote_branch
 
-  md_master_oid="$(calc_oid "$(git cat-file -p "refs/heads/master:a.md")")"
-  md_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/master:a.md")")"
-  txt_master_oid="$(calc_oid "$(git cat-file -p "refs/heads/master:a.txt")")"
-  txt_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/master:a.txt")")"
+  md_main_oid="$(calc_oid "$(git cat-file -p "refs/heads/main:a.md")")"
+  md_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/main:a.md")")"
+  txt_main_oid="$(calc_oid "$(git cat-file -p "refs/heads/main:a.txt")")"
+  txt_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/main:a.txt")")"
 
-  git tag pseudo-remote "$(git rev-parse refs/remotes/origin/master)"
-  # Remove the refs/remotes/origin/master ref, and instruct 'git lfs migrate' to
+  git tag pseudo-remote "$(git rev-parse refs/remotes/origin/main)"
+  # Remove the refs/remotes/origin/main ref, and instruct 'git lfs migrate' to
   # not fetch it.
-  git update-ref -d refs/remotes/origin/master
+  git update-ref -d refs/remotes/origin/main
 
   git lfs migrate import --skip-fetch
 
-  assert_pointer "refs/heads/master" "a.md" "$md_master_oid" "50"
+  assert_pointer "refs/heads/main" "a.md" "$md_main_oid" "50"
   assert_pointer "pseudo-remote" "a.md" "$md_remote_oid" "140"
-  assert_pointer "refs/heads/master" "a.txt" "$txt_master_oid" "30"
+  assert_pointer "refs/heads/main" "a.txt" "$txt_main_oid" "30"
   assert_pointer "pseudo-remote" "a.txt" "$txt_remote_oid" "120"
 
-  assert_local_object "$md_master_oid" "50"
-  assert_local_object "$txt_master_oid" "30"
+  assert_local_object "$md_main_oid" "50"
+  assert_local_object "$txt_main_oid" "30"
   assert_local_object "$md_remote_oid" "140"
   assert_local_object "$txt_remote_oid" "120"
 
-  master="$(git rev-parse refs/heads/master)"
+  main="$(git rev-parse refs/heads/main)"
   remote="$(git rev-parse pseudo-remote)"
 
-  master_attrs="$(git cat-file -p "$master:.gitattributes")"
+  main_attrs="$(git cat-file -p "$main:.gitattributes")"
   remote_attrs="$(git cat-file -p "$remote:.gitattributes")"
 
-  echo "$master_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
-  echo "$master_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"
+  echo "$main_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
+  echo "$main_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"
   echo "$remote_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
   echo "$remote_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"
 )
@@ -263,12 +263,12 @@ begin_test "migrate import (un-annotated tags)"
 
   setup_single_local_branch_with_tags
 
-  txt_master_oid="$(calc_oid "$(git cat-file -p "refs/heads/master:a.txt")")"
+  txt_main_oid="$(calc_oid "$(git cat-file -p "refs/heads/main:a.txt")")"
 
   git lfs migrate import --everything
 
-  assert_pointer "refs/heads/master" "a.txt" "$txt_master_oid" "2"
-  assert_local_object "$txt_master_oid" "2"
+  assert_pointer "refs/heads/main" "a.txt" "$txt_main_oid" "2"
+  assert_local_object "$txt_main_oid" "2"
 
   git tag --points-at "$(git rev-parse HEAD)" | grep -q "v1.0.0"
 )
@@ -280,12 +280,12 @@ begin_test "migrate import (annotated tags)"
 
   setup_single_local_branch_with_annotated_tags
 
-  txt_master_oid="$(calc_oid "$(git cat-file -p "refs/heads/master:a.txt")")"
+  txt_main_oid="$(calc_oid "$(git cat-file -p "refs/heads/main:a.txt")")"
 
   git lfs migrate import --everything
 
-  assert_pointer "refs/heads/master" "a.txt" "$txt_master_oid" "2"
-  assert_local_object "$txt_master_oid" "2"
+  assert_pointer "refs/heads/main" "a.txt" "$txt_main_oid" "2"
+  assert_local_object "$txt_main_oid" "2"
 
   git tag --points-at "$(git rev-parse HEAD)" | grep -q "v1.0.0"
 )
@@ -297,32 +297,32 @@ begin_test "migrate import (include/exclude ref)"
 
   setup_multiple_remote_branches
 
-  md_master_oid="$(calc_oid "$(git cat-file -p "refs/heads/master:a.md")")"
-  md_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/master:a.md")")"
+  md_main_oid="$(calc_oid "$(git cat-file -p "refs/heads/main:a.md")")"
+  md_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/main:a.md")")"
   md_feature_oid="$(calc_oid "$(git cat-file -p "refs/heads/my-feature:a.md")")"
-  txt_master_oid="$(calc_oid "$(git cat-file -p "refs/heads/master:a.txt")")"
-  txt_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/master:a.txt")")"
+  txt_main_oid="$(calc_oid "$(git cat-file -p "refs/heads/main:a.txt")")"
+  txt_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/main:a.txt")")"
   txt_feature_oid="$(calc_oid "$(git cat-file -p "refs/heads/my-feature:a.txt")")"
 
   git lfs migrate import \
     --include-ref=refs/heads/my-feature \
-    --exclude-ref=refs/heads/master
+    --exclude-ref=refs/heads/main
 
   assert_pointer "refs/heads/my-feature" "a.md" "$md_feature_oid" "31"
   assert_pointer "refs/heads/my-feature" "a.txt" "$txt_feature_oid" "30"
 
   assert_local_object "$md_feature_oid" "31"
-  refute_local_object "$md_master_oid" "21"
+  refute_local_object "$md_main_oid" "21"
   assert_local_object "$txt_feature_oid" "30"
-  refute_local_object "$txt_master_oid" "20"
+  refute_local_object "$txt_main_oid" "20"
   refute_local_object "$md_remote_oid" "11"
   refute_local_object "$txt_remote_oid" "10"
 
-  master="$(git rev-parse refs/heads/master)"
+  main="$(git rev-parse refs/heads/main)"
   feature="$(git rev-parse refs/heads/my-feature)"
-  remote="$(git rev-parse refs/remotes/origin/master)"
+  remote="$(git rev-parse refs/remotes/origin/main)"
 
-  [ ! $(git cat-file -p "$master:.gitattributes") ]
+  [ ! $(git cat-file -p "$main:.gitattributes") ]
   [ ! $(git cat-file -p "$remote:.gitattributes") ]
   feature_attrs="$(git cat-file -p "$feature:.gitattributes")"
 
@@ -337,30 +337,30 @@ begin_test "migrate import (include/exclude ref args)"
 
   setup_multiple_remote_branches
 
-  md_master_oid="$(calc_oid "$(git cat-file -p "refs/heads/master:a.md")")"
-  md_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/master:a.md")")"
+  md_main_oid="$(calc_oid "$(git cat-file -p "refs/heads/main:a.md")")"
+  md_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/main:a.md")")"
   md_feature_oid="$(calc_oid "$(git cat-file -p "refs/heads/my-feature:a.md")")"
-  txt_master_oid="$(calc_oid "$(git cat-file -p "refs/heads/master:a.txt")")"
-  txt_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/master:a.txt")")"
+  txt_main_oid="$(calc_oid "$(git cat-file -p "refs/heads/main:a.txt")")"
+  txt_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/main:a.txt")")"
   txt_feature_oid="$(calc_oid "$(git cat-file -p "refs/heads/my-feature:a.txt")")"
 
-  git lfs migrate import my-feature ^master
+  git lfs migrate import my-feature ^main
 
   assert_pointer "refs/heads/my-feature" "a.md" "$md_feature_oid" "31"
   assert_pointer "refs/heads/my-feature" "a.txt" "$txt_feature_oid" "30"
 
   assert_local_object "$md_feature_oid" "31"
-  refute_local_object "$md_master_oid" "21"
+  refute_local_object "$md_main_oid" "21"
   assert_local_object "$txt_feature_oid" "30"
-  refute_local_object "$txt_master_oid" "20"
+  refute_local_object "$txt_main_oid" "20"
   refute_local_object "$md_remote_oid" "11"
   refute_local_object "$txt_remote_oid" "10"
 
-  master="$(git rev-parse refs/heads/master)"
+  main="$(git rev-parse refs/heads/main)"
   feature="$(git rev-parse refs/heads/my-feature)"
-  remote="$(git rev-parse refs/remotes/origin/master)"
+  remote="$(git rev-parse refs/remotes/origin/main)"
 
-  [ ! $(git cat-file -p "$master:.gitattributes") ]
+  [ ! $(git cat-file -p "$main:.gitattributes") ]
   [ ! $(git cat-file -p "$remote:.gitattributes") ]
   feature_attrs="$(git cat-file -p "$feature:.gitattributes")"
 
@@ -375,32 +375,32 @@ begin_test "migrate import (include/exclude ref with filter)"
 
   setup_multiple_remote_branches
 
-  md_master_oid="$(calc_oid "$(git cat-file -p "refs/heads/master:a.md")")"
-  md_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/master:a.md")")"
+  md_main_oid="$(calc_oid "$(git cat-file -p "refs/heads/main:a.md")")"
+  md_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/main:a.md")")"
   md_feature_oid="$(calc_oid "$(git cat-file -p "refs/heads/my-feature:a.md")")"
-  txt_master_oid="$(calc_oid "$(git cat-file -p "refs/heads/master:a.txt")")"
-  txt_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/master:a.txt")")"
+  txt_main_oid="$(calc_oid "$(git cat-file -p "refs/heads/main:a.txt")")"
+  txt_remote_oid="$(calc_oid "$(git cat-file -p "refs/remotes/origin/main:a.txt")")"
   txt_feature_oid="$(calc_oid "$(git cat-file -p "refs/heads/my-feature:a.txt")")"
 
   git lfs migrate import \
     --include="*.txt" \
     --include-ref=refs/heads/my-feature \
-    --exclude-ref=refs/heads/master
+    --exclude-ref=refs/heads/main
 
   assert_pointer "refs/heads/my-feature" "a.txt" "$txt_feature_oid" "30"
 
   refute_local_object "$md_feature_oid" "31"
-  refute_local_object "$md_master_oid" "21"
+  refute_local_object "$md_main_oid" "21"
   assert_local_object "$txt_feature_oid" "30"
-  refute_local_object "$txt_master_oid" "20"
+  refute_local_object "$txt_main_oid" "20"
   refute_local_object "$md_remote_oid" "11"
   refute_local_object "$txt_remote_oid" "10"
 
-  master="$(git rev-parse refs/heads/master)"
+  main="$(git rev-parse refs/heads/main)"
   feature="$(git rev-parse refs/heads/my-feature)"
-  remote="$(git rev-parse refs/remotes/origin/master)"
+  remote="$(git rev-parse refs/remotes/origin/main)"
 
-  [ ! $(git cat-file -p "$master:.gitattributes") ]
+  [ ! $(git cat-file -p "$main:.gitattributes") ]
   [ ! $(git cat-file -p "$remote:.gitattributes") ]
   feature_attrs="$(git cat-file -p "$feature:.gitattributes")"
 
@@ -417,18 +417,18 @@ begin_test "migrate import (existing .gitattributes)"
 
   pwd
 
-  master="$(git rev-parse refs/heads/master)"
+  main="$(git rev-parse refs/heads/main)"
 
-  txt_master_oid="$(calc_oid "$(git cat-file -p "$master:a.txt")")"
+  txt_main_oid="$(calc_oid "$(git cat-file -p "$main:a.txt")")"
 
-  git lfs migrate import --yes --include-ref=refs/heads/master --include="*.txt"
+  git lfs migrate import --yes --include-ref=refs/heads/main --include="*.txt"
 
-  assert_local_object "$txt_master_oid" "120"
+  assert_local_object "$txt_main_oid" "120"
 
-  master="$(git rev-parse refs/heads/master)"
-  prev="$(git rev-parse refs/heads/master^1)"
+  main="$(git rev-parse refs/heads/main)"
+  prev="$(git rev-parse refs/heads/main^1)"
 
-  diff -u <(git cat-file -p $master:.gitattributes) <(cat <<-EOF
+  diff -u <(git cat-file -p $main:.gitattributes) <(cat <<-EOF
 *.txt filter=lfs diff=lfs merge=lfs -text
 *.other filter=lfs diff=lfs merge=lfs -text
 EOF)
@@ -447,18 +447,18 @@ begin_test "migrate import (--exclude with existing .gitattributes)"
 
   pwd
 
-  master="$(git rev-parse refs/heads/master)"
+  main="$(git rev-parse refs/heads/main)"
 
-  txt_master_oid="$(calc_oid "$(git cat-file -p "$master:a.txt")")"
+  txt_main_oid="$(calc_oid "$(git cat-file -p "$main:a.txt")")"
 
-  git lfs migrate import --yes --include-ref=refs/heads/master --include="*.txt" --exclude="*.bin"
+  git lfs migrate import --yes --include-ref=refs/heads/main --include="*.txt" --exclude="*.bin"
 
-  assert_local_object "$txt_master_oid" "120"
+  assert_local_object "$txt_main_oid" "120"
 
-  master="$(git rev-parse refs/heads/master)"
-  prev="$(git rev-parse refs/heads/master^1)"
+  main="$(git rev-parse refs/heads/main)"
+  prev="$(git rev-parse refs/heads/main^1)"
 
-  diff -u <(git cat-file -p $master:.gitattributes) <(cat <<-EOF
+  diff -u <(git cat-file -p $main:.gitattributes) <(cat <<-EOF
 *.txt filter=lfs diff=lfs merge=lfs -text
 *.other filter=lfs diff=lfs merge=lfs -text
 *.bin !text -filter -merge -diff
@@ -479,7 +479,7 @@ begin_test "migrate import (identical contents, different permissions)"
   [ "$IS_WINDOWS" -eq 1 ] && exit 0
 
   setup_multiple_local_branches
-  git checkout master
+  git checkout main
 
   echo "foo" >foo.dat
   git add .
@@ -504,7 +504,7 @@ begin_test "migrate import (tags with same name as branches)"
   set -e
 
   setup_multiple_local_branches
-  git checkout master
+  git checkout main
 
   contents="hello"
   oid=$(calc_oid "$contents")
@@ -533,7 +533,7 @@ begin_test "migrate import (bare repository)"
   make_bare
 
   git lfs migrate import \
-    --include-ref=master
+    --include-ref=main
 )
 end_test
 
@@ -576,19 +576,19 @@ begin_test "migrate import (--everything)"
   set -e
 
   setup_multiple_local_branches
-  git checkout master
+  git checkout main
 
-  master_txt_oid="$(calc_oid "$(git cat-file -p :a.txt)")"
-  master_md_oid="$(calc_oid "$(git cat-file -p :a.md)")"
+  main_txt_oid="$(calc_oid "$(git cat-file -p :a.txt)")"
+  main_md_oid="$(calc_oid "$(git cat-file -p :a.md)")"
   feature_md_oid="$(calc_oid "$(git cat-file -p my-feature:a.md)")"
-  master_txt_size="$(git cat-file -p :a.txt | wc -c | awk '{ print $1 }')"
-  master_md_size="$(git cat-file -p :a.md | wc -c | awk '{ print $1 }')"
+  main_txt_size="$(git cat-file -p :a.txt | wc -c | awk '{ print $1 }')"
+  main_md_size="$(git cat-file -p :a.md | wc -c | awk '{ print $1 }')"
   feature_md_size="$(git cat-file -p my-feature:a.md | wc -c | awk '{ print $1 }')"
 
   git lfs migrate import --everything
 
-  assert_pointer "master" "a.txt" "$master_txt_oid" "$master_txt_size"
-  assert_pointer "master" "a.md" "$master_md_oid" "$master_md_size"
+  assert_pointer "main" "a.txt" "$main_txt_oid" "$main_txt_size"
+  assert_pointer "main" "a.md" "$main_md_oid" "$main_md_size"
   assert_pointer "my-feature" "a.md" "$feature_md_oid" "$feature_md_size"
 )
 end_test
@@ -614,7 +614,7 @@ begin_test "migrate import (--everything with args)"
 
   setup_multiple_local_branches
 
-  [ "$(git lfs migrate import --everything master 2>&1)" = \
+  [ "$(git lfs migrate import --everything main 2>&1)" = \
     "fatal: cannot use --everything with explicit reference arguments" ]
 )
 end_test
@@ -625,7 +625,7 @@ begin_test "migrate import (--everything with --include-ref)"
 
   setup_multiple_local_branches
 
-  [ "$(git lfs migrate import --everything --include-ref=refs/heads/master 2>&1)" = \
+  [ "$(git lfs migrate import --everything --include-ref=refs/heads/main 2>&1)" = \
     "fatal: cannot use --everything with --include-ref or --exclude-ref" ]
 )
 end_test
@@ -636,7 +636,7 @@ begin_test "migrate import (--everything with --exclude-ref)"
 
   setup_multiple_local_branches
 
-  [ "$(git lfs migrate import --everything --exclude-ref=refs/heads/master 2>&1)" = \
+  [ "$(git lfs migrate import --everything --exclude-ref=refs/heads/main 2>&1)" = \
     "fatal: cannot use --everything with --include-ref or --exclude-ref" ]
 )
 end_test
@@ -647,19 +647,19 @@ begin_test "migrate import (--everything and --include with glob pattern)"
 
   setup_multiple_local_branches
 
-  md_master_oid="$(calc_oid "$(git cat-file -p "refs/heads/master:a.md")")"
-  txt_master_oid="$(calc_oid "$(git cat-file -p "refs/heads/master:a.txt")")"
+  md_main_oid="$(calc_oid "$(git cat-file -p "refs/heads/main:a.md")")"
+  txt_main_oid="$(calc_oid "$(git cat-file -p "refs/heads/main:a.txt")")"
   md_feature_oid="$(calc_oid "$(git cat-file -p "refs/heads/my-feature:a.md")")"
   txt_feature_oid="$(calc_oid "$(git cat-file -p "refs/heads/my-feature:a.txt")")"
 
   git lfs migrate import --verbose --everything --include='*.[mM][dD]'
 
-  assert_pointer "refs/heads/master" "a.md" "$md_master_oid" "140"
+  assert_pointer "refs/heads/main" "a.md" "$md_main_oid" "140"
   assert_pointer "refs/heads/my-feature" "a.md" "$md_feature_oid" "30"
 
-  assert_local_object "$md_master_oid" "140"
+  assert_local_object "$md_main_oid" "140"
   assert_local_object "$md_feature_oid" "30"
-  refute_local_object "$txt_master_oid"
+  refute_local_object "$txt_main_oid"
   refute_local_object "$txt_feature_oid"
 )
 end_test
@@ -670,27 +670,27 @@ begin_test "migrate import (--everything with tag pointing to tag)"
 
   setup_multiple_local_branches
 
-  md_master_oid="$(calc_oid "$(git cat-file -p "refs/heads/master:a.md")")"
-  txt_master_oid="$(calc_oid "$(git cat-file -p "refs/heads/master:a.txt")")"
+  md_main_oid="$(calc_oid "$(git cat-file -p "refs/heads/main:a.md")")"
+  txt_main_oid="$(calc_oid "$(git cat-file -p "refs/heads/main:a.txt")")"
   md_feature_oid="$(calc_oid "$(git cat-file -p "refs/heads/my-feature:a.md")")"
   txt_feature_oid="$(calc_oid "$(git cat-file -p "refs/heads/my-feature:a.txt")")"
 
-  git tag -a -m abc abc refs/heads/master
+  git tag -a -m abc abc refs/heads/main
   git tag -a -m def def refs/tags/abc
 
   git lfs migrate import --verbose --everything --include='*.[mM][dD]'
 
-  assert_pointer "refs/heads/master" "a.md" "$md_master_oid" "140"
-  assert_pointer "refs/tags/abc" "a.md" "$md_master_oid" "140"
-  assert_pointer "refs/tags/def" "a.md" "$md_master_oid" "140"
+  assert_pointer "refs/heads/main" "a.md" "$md_main_oid" "140"
+  assert_pointer "refs/tags/abc" "a.md" "$md_main_oid" "140"
+  assert_pointer "refs/tags/def" "a.md" "$md_main_oid" "140"
   assert_pointer "refs/heads/my-feature" "a.md" "$md_feature_oid" "30"
 
   git tag --points-at refs/tags/abc | grep -q def
   ! git tag --points-at refs/tags/def | grep -q abc
 
-  assert_local_object "$md_master_oid" "140"
+  assert_local_object "$md_main_oid" "140"
   assert_local_object "$md_feature_oid" "30"
-  refute_local_object "$txt_master_oid"
+  refute_local_object "$txt_main_oid"
   refute_local_object "$txt_feature_oid"
 )
 end_test
@@ -706,7 +706,7 @@ begin_test "migrate import (nested sub-trees and --include with wildcard)"
 
   git lfs migrate import --include="**/*ar/**"
 
-  assert_pointer "refs/heads/master" "foo/bar/baz/a.txt" "$oid" "$size"
+  assert_pointer "refs/heads/main" "foo/bar/baz/a.txt" "$oid" "$size"
   assert_local_object "$oid" "$size"
 )
 end_test
@@ -729,7 +729,7 @@ begin_test "migrate import (handle copies of files)"
   # only import objects under "foo"
   git lfs migrate import --include="foo/**"
 
-  assert_pointer "refs/heads/master" "foo/bar/baz/a.txt" "$oid_tree" "$size"
+  assert_pointer "refs/heads/main" "foo/bar/baz/a.txt" "$oid_tree" "$size"
   assert_local_object "$oid_tree" "$size"
 
   # "a.txt" is not under "foo" and therefore should not be in LFS
@@ -765,7 +765,7 @@ begin_test "migrate import (--include with space)"
 
   git lfs migrate import --include "a file.txt"
 
-  assert_pointer "refs/heads/master" "a file.txt" "$oid" 50
+  assert_pointer "refs/heads/main" "a file.txt" "$oid" 50
   cat .gitattributes
   if [ 1 -ne "$(grep -c "a\[\[:space:\]\]file.txt" .gitattributes)" ]; then
     echo >&2 "fatal: expected \"a[[:space:]]file.txt\" to appear in .gitattributes"
@@ -787,7 +787,7 @@ begin_test "migrate import (handle symbolic link)"
 
   git lfs migrate import --include="*.txt"
 
-  assert_pointer "refs/heads/master" "a.txt" "$txt_oid" "120"
+  assert_pointer "refs/heads/main" "a.txt" "$txt_oid" "120"
 
   assert_local_object "$txt_oid" "120"
   # "link.txt" is a symbolic link so it should be not in LFS
@@ -819,13 +819,13 @@ begin_test "migrate import (multiple remotes)"
 
   setup_multiple_remotes
 
-  original_master="$(git rev-parse master)"
+  original_main="$(git rev-parse main)"
 
   git lfs migrate import
 
-  migrated_master="$(git rev-parse master)"
+  migrated_main="$(git rev-parse main)"
 
-  assert_ref_unmoved "master" "$original_master" "$migrated_master"
+  assert_ref_unmoved "main" "$original_main" "$migrated_main"
 )
 end_test
 
@@ -835,14 +835,14 @@ begin_test "migrate import (dirty copy, negative answer)"
 
   setup_local_branch_with_dirty_copy
 
-  original_master="$(git rev-parse master)"
+  original_main="$(git rev-parse main)"
 
   echo "n" | git lfs migrate import --everything 2>&1 | tee migrate.log
   grep "migrate: working copy must not be dirty" migrate.log
 
-  migrated_master="$(git rev-parse master)"
+  migrated_main="$(git rev-parse main)"
 
-  assert_ref_unmoved "master" "$original_master" "$migrated_master"
+  assert_ref_unmoved "main" "$original_main" "$migrated_main"
 )
 end_test
 
@@ -852,7 +852,7 @@ begin_test "migrate import (dirty copy, unknown then negative answer)"
 
   setup_local_branch_with_dirty_copy
 
-  original_master="$(git rev-parse master)"
+  original_main="$(git rev-parse main)"
 
   echo "x\nn" | git lfs migrate import --everything 2>&1 | tee migrate.log
 
@@ -862,9 +862,9 @@ begin_test "migrate import (dirty copy, unknown then negative answer)"
     | wc -l | awk '{ print $1 }')" ]
   grep "migrate: working copy must not be dirty" migrate.log
 
-  migrated_master="$(git rev-parse master)"
+  migrated_main="$(git rev-parse main)"
 
-  assert_ref_unmoved "master" "$original_master" "$migrated_master"
+  assert_ref_unmoved "main" "$original_main" "$migrated_main"
 )
 end_test
 
@@ -880,7 +880,7 @@ begin_test "migrate import (dirty copy, positive answer)"
   grep "migrate: changes in your working copy will be overridden ..." \
     migrate.log
 
-  assert_pointer "refs/heads/master" "a.txt" "$oid" "5"
+  assert_pointer "refs/heads/main" "a.txt" "$oid" "5"
   assert_local_object "$oid" "5"
 )
 end_test
@@ -897,8 +897,8 @@ begin_test "migrate import (non-standard refs)"
 
   git lfs migrate import --everything
 
-  assert_pointer "refs/heads/master" "a.md" "$md_oid" "140"
-  assert_pointer "refs/heads/master" "a.txt" "$txt_oid" "120"
+  assert_pointer "refs/heads/main" "a.md" "$md_oid" "140"
+  assert_pointer "refs/heads/main" "a.txt" "$txt_oid" "120"
   assert_pointer "refs/pull/1/base" "a.md" "$md_oid" "140"
   assert_pointer "refs/pull/1/base" "a.txt" "$txt_oid" "120"
 

--- a/t/t-migrate-info.sh
+++ b/t/t-migrate-info.sh
@@ -38,7 +38,7 @@ begin_test "migrate info (given branch)"
 
   setup_multiple_local_branches
 
-  original_master="$(git rev-parse refs/heads/master)"
+  original_main="$(git rev-parse refs/heads/main)"
   original_feature="$(git rev-parse refs/heads/my-feature)"
 
   diff -u <(git lfs migrate info my-feature 2>&1 | tail -n 2) <(cat <<-EOF
@@ -46,10 +46,10 @@ begin_test "migrate info (given branch)"
 	*.txt	120 B	1/1 files(s)	100%
 	EOF)
 
-  migrated_master="$(git rev-parse refs/heads/master)"
+  migrated_main="$(git rev-parse refs/heads/main)"
   migrated_feature="$(git rev-parse refs/heads/my-feature)"
 
-  assert_ref_unmoved "refs/heads/master" "$original_master" "$migrated_master"
+  assert_ref_unmoved "refs/heads/main" "$original_main" "$migrated_main"
   assert_ref_unmoved "refs/heads/my-feature" "$original_feature" "$migrated_feature"
 )
 end_test
@@ -68,7 +68,7 @@ begin_test "migrate info (default branch with filter)"
 
   migrated_head="$(git rev-parse HEAD)"
 
-  assert_ref_unmoved "refs/heads/master" "$original_head" "$migrated_head"
+  assert_ref_unmoved "refs/heads/main" "$original_head" "$migrated_head"
 )
 end_test
 
@@ -78,17 +78,17 @@ begin_test "migrate info (given branch with filter)"
 
   setup_multiple_local_branches
 
-  original_master="$(git rev-parse refs/heads/master)"
+  original_main="$(git rev-parse refs/heads/main)"
   original_feature="$(git rev-parse refs/heads/my-feature)"
 
   diff -u <(git lfs migrate info --include "*.md" my-feature 2>&1 | tail -n 1) <(cat <<-EOF
 	*.md	170 B	2/2 files(s)	100%
 	EOF)
 
-  migrated_master="$(git rev-parse refs/heads/master)"
+  migrated_main="$(git rev-parse refs/heads/main)"
   migrated_feature="$(git rev-parse refs/heads/my-feature)"
 
-  assert_ref_unmoved "refs/heads/master" "$original_master" "$migrated_master"
+  assert_ref_unmoved "refs/heads/main" "$original_main" "$migrated_main"
   assert_ref_unmoved "refs/heads/my-feature" "$original_feature" "$migrated_feature"
 )
 end_test
@@ -101,19 +101,19 @@ begin_test "migrate info (default branch, exclude remote refs)"
 
   git show-ref
 
-  original_remote="$(git rev-parse refs/remotes/origin/master)"
-  original_master="$(git rev-parse refs/heads/master)"
+  original_remote="$(git rev-parse refs/remotes/origin/main)"
+  original_main="$(git rev-parse refs/heads/main)"
 
   diff -u <(git lfs migrate info 2>&1 | tail -n 2) <(cat <<-EOF
 	*.md 	50 B	1/1 files(s)	100%
 	*.txt	30 B	1/1 files(s)	100%
 	EOF)
 
-  migrated_remote="$(git rev-parse refs/remotes/origin/master)"
-  migrated_master="$(git rev-parse refs/heads/master)"
+  migrated_remote="$(git rev-parse refs/remotes/origin/main)"
+  migrated_main="$(git rev-parse refs/heads/main)"
 
-  assert_ref_unmoved "refs/heads/master" "$original_master" "$migrated_master"
-  assert_ref_unmoved "refs/remotes/origin/master" "$original_remote" "$migrated_remote"
+  assert_ref_unmoved "refs/heads/main" "$original_main" "$migrated_main"
+  assert_ref_unmoved "refs/remotes/origin/main" "$original_remote" "$migrated_remote"
 )
 end_test
 
@@ -123,8 +123,8 @@ begin_test "migrate info (given branch, exclude remote refs)"
 
   setup_multiple_remote_branches
 
-  original_remote="$(git rev-parse refs/remotes/origin/master)"
-  original_master="$(git rev-parse refs/heads/master)"
+  original_remote="$(git rev-parse refs/remotes/origin/main)"
+  original_main="$(git rev-parse refs/heads/main)"
   original_feature="$(git rev-parse refs/heads/my-feature)"
 
   diff -u <(git lfs migrate info my-feature 2>&1 | tail -n 2) <(cat <<-EOF
@@ -132,12 +132,12 @@ begin_test "migrate info (given branch, exclude remote refs)"
 	*.txt	50 B	2/2 files(s)	100%
 	EOF)
 
-  migrated_remote="$(git rev-parse refs/remotes/origin/master)"
-  migrated_master="$(git rev-parse refs/heads/master)"
+  migrated_remote="$(git rev-parse refs/remotes/origin/main)"
+  migrated_main="$(git rev-parse refs/heads/main)"
   migrated_feature="$(git rev-parse refs/heads/my-feature)"
 
-  assert_ref_unmoved "refs/remotes/origin/master" "$original_remote" "$migrated_remote"
-  assert_ref_unmoved "refs/heads/master" "$original_master" "$migrated_master"
+  assert_ref_unmoved "refs/remotes/origin/main" "$original_remote" "$migrated_remote"
+  assert_ref_unmoved "refs/heads/main" "$original_main" "$migrated_main"
   assert_ref_unmoved "refs/heads/my-feature" "$original_feature" "$migrated_feature"
 )
 end_test
@@ -148,13 +148,13 @@ begin_test "migrate info (given ref, --skip-fetch)"
 
   setup_single_remote_branch
 
-  original_remote="$(git rev-parse refs/remotes/origin/master)"
-  original_master="$(git rev-parse refs/heads/master)"
+  original_remote="$(git rev-parse refs/remotes/origin/main)"
+  original_main="$(git rev-parse refs/heads/main)"
 
   git tag pseudo-remote "$original_remote"
-  # Remove the refs/remotes/origin/master ref, and instruct 'git lfs migrate' to
+  # Remove the refs/remotes/origin/main ref, and instruct 'git lfs migrate' to
   # not fetch it.
-  git update-ref -d refs/remotes/origin/master
+  git update-ref -d refs/remotes/origin/main
 
   diff -u <(git lfs migrate info --skip-fetch 2>&1 | tail -n 2) <(cat <<-EOF
 	*.md 	190 B	2/2 files(s)	100%
@@ -162,10 +162,10 @@ begin_test "migrate info (given ref, --skip-fetch)"
 	EOF)
 
   migrated_remote="$(git rev-parse pseudo-remote)"
-  migrated_master="$(git rev-parse refs/heads/master)"
+  migrated_main="$(git rev-parse refs/heads/main)"
 
-  assert_ref_unmoved "refs/remotes/origin/master" "$original_remote" "$migrated_remote"
-  assert_ref_unmoved "refs/heads/master" "$original_master" "$migrated_master"
+  assert_ref_unmoved "refs/remotes/origin/main" "$original_remote" "$migrated_remote"
+  assert_ref_unmoved "refs/heads/main" "$original_main" "$migrated_main"
 )
 end_test
 
@@ -175,20 +175,20 @@ begin_test "migrate info (include/exclude ref)"
 
   setup_multiple_remote_branches
 
-  original_master="$(git rev-parse refs/heads/master)"
+  original_main="$(git rev-parse refs/heads/main)"
   original_feature="$(git rev-parse refs/heads/my-feature)"
 
   diff -u <(git lfs migrate info \
     --include-ref=refs/heads/my-feature \
-    --exclude-ref=refs/heads/master 2>&1 | tail -n 2) <(cat <<-EOF
+    --exclude-ref=refs/heads/main 2>&1 | tail -n 2) <(cat <<-EOF
 	*.md 	31 B	1/1 files(s)	100%
 	*.txt	30 B	1/1 files(s)	100%
 	EOF)
 
-  migrated_master="$(git rev-parse refs/heads/master)"
+  migrated_main="$(git rev-parse refs/heads/main)"
   migrated_feature="$(git rev-parse refs/heads/my-feature)"
 
-  assert_ref_unmoved "refs/heads/master" "$original_master" "$migrated_master"
+  assert_ref_unmoved "refs/heads/main" "$original_main" "$migrated_main"
   assert_ref_unmoved "refs/heads/my-feature" "$original_feature" "$migrated_feature"
 )
 end_test
@@ -199,19 +199,19 @@ begin_test "migrate info (include/exclude ref args)"
 
   setup_multiple_remote_branches
 
-  original_master="$(git rev-parse refs/heads/master)"
+  original_main="$(git rev-parse refs/heads/main)"
   original_feature="$(git rev-parse refs/heads/my-feature)"
 
   diff -u <(git lfs migrate info \
-    my-feature ^master 2>&1 | tail -n 2) <(cat <<-EOF
+    my-feature ^main 2>&1 | tail -n 2) <(cat <<-EOF
 	*.md 	31 B	1/1 files(s)	100%
 	*.txt	30 B	1/1 files(s)	100%
 	EOF)
 
-  migrated_master="$(git rev-parse refs/heads/master)"
+  migrated_main="$(git rev-parse refs/heads/main)"
   migrated_feature="$(git rev-parse refs/heads/my-feature)"
 
-  assert_ref_unmoved "refs/heads/master" "$original_master" "$migrated_master"
+  assert_ref_unmoved "refs/heads/main" "$original_main" "$migrated_main"
   assert_ref_unmoved "refs/heads/my-feature" "$original_feature" "$migrated_feature"
 )
 end_test
@@ -222,20 +222,20 @@ begin_test "migrate info (include/exclude ref with filter)"
 
   setup_multiple_remote_branches
 
-  original_master="$(git rev-parse refs/heads/master)"
+  original_main="$(git rev-parse refs/heads/main)"
   original_feature="$(git rev-parse refs/heads/my-feature)"
 
   diff -u <(git lfs migrate info \
     --include="*.txt" \
     --include-ref=refs/heads/my-feature \
-    --exclude-ref=refs/heads/master 2>&1 | tail -n 1) <(cat <<-EOF
+    --exclude-ref=refs/heads/main 2>&1 | tail -n 1) <(cat <<-EOF
 	*.txt	30 B	1/1 files(s)	100%
 	EOF)
 
-  migrated_master="$(git rev-parse refs/heads/master)"
+  migrated_main="$(git rev-parse refs/heads/main)"
   migrated_feature="$(git rev-parse refs/heads/my-feature)"
 
-  assert_ref_unmoved "refs/heads/master" "$original_master" "$migrated_master"
+  assert_ref_unmoved "refs/heads/main" "$original_main" "$migrated_main"
   assert_ref_unmoved "refs/heads/my-feature" "$original_feature" "$migrated_feature"
 )
 end_test
@@ -246,15 +246,15 @@ begin_test "migrate info (nested sub-trees, no filter)"
 
   setup_single_local_branch_deep_trees
 
-  original_master="$(git rev-parse refs/heads/master)"
+  original_main="$(git rev-parse refs/heads/main)"
 
   diff -u <(git lfs migrate info 2>/dev/null) <(cat <<-EOF
 	*.txt	120 B	1/1 files(s)	100%
 	EOF)
 
-  migrated_master="$(git rev-parse refs/heads/master)"
+  migrated_main="$(git rev-parse refs/heads/main)"
 
-  assert_ref_unmoved "refs/heads/master" "$original_master" "$migrated_master"
+  assert_ref_unmoved "refs/heads/main" "$original_main" "$migrated_main"
 )
 end_test
 
@@ -336,8 +336,8 @@ begin_test "migrate info (empty set)"
   setup_multiple_local_branches
 
   migrate="$(git lfs migrate info \
-    --include-ref=refs/heads/master \
-    --exclude-ref=refs/heads/master 2>/dev/null
+    --include-ref=refs/heads/main \
+    --exclude-ref=refs/heads/main 2>/dev/null
   )"
 
   [ "0" -eq "$(echo -n "$migrate" | wc -l | awk '{ print $1 }')" ]
@@ -349,9 +349,9 @@ begin_test "migrate info (no-extension files)"
   set -e
 
   setup_multiple_local_branches_with_alternate_names
-  git checkout master
+  git checkout main
 
-  original_master="$(git rev-parse refs/heads/master)"
+  original_main="$(git rev-parse refs/heads/main)"
   original_feature="$(git rev-parse refs/heads/my-feature)"
 
   git lfs migrate info --everything
@@ -361,10 +361,10 @@ begin_test "migrate info (no-extension files)"
 	*.txt       	170 B	2/2 files(s)	100%
 	EOF)
 
-  migrated_master="$(git rev-parse refs/heads/master)"
+  migrated_main="$(git rev-parse refs/heads/main)"
   migrated_feature="$(git rev-parse refs/heads/my-feature)"
 
-  assert_ref_unmoved "refs/heads/master" "$original_master" "$migrated_master"
+  assert_ref_unmoved "refs/heads/main" "$original_main" "$migrated_main"
   assert_ref_unmoved "refs/heads/my-feature" "$original_feature" "$migrated_feature"
 )
 end_test
@@ -374,9 +374,9 @@ begin_test "migrate info (--everything)"
   set -e
 
   setup_multiple_local_branches
-  git checkout master
+  git checkout main
 
-  original_master="$(git rev-parse refs/heads/master)"
+  original_main="$(git rev-parse refs/heads/main)"
   original_feature="$(git rev-parse refs/heads/my-feature)"
 
   diff -u <(git lfs migrate info --everything 2>&1 | tail -n 2) <(cat <<-EOF
@@ -384,10 +384,10 @@ begin_test "migrate info (--everything)"
 	*.txt	120 B	1/1 files(s)	100%
 	EOF)
 
-  migrated_master="$(git rev-parse refs/heads/master)"
+  migrated_main="$(git rev-parse refs/heads/main)"
   migrated_feature="$(git rev-parse refs/heads/my-feature)"
 
-  assert_ref_unmoved "refs/heads/master" "$original_master" "$migrated_master"
+  assert_ref_unmoved "refs/heads/main" "$original_main" "$migrated_main"
   assert_ref_unmoved "refs/heads/my-feature" "$original_feature" "$migrated_feature"
 )
 end_test
@@ -413,7 +413,7 @@ begin_test "migrate info (--everything with args)"
 
   setup_multiple_local_branches
 
-  [ "$(git lfs migrate info --everything master 2>&1)" = \
+  [ "$(git lfs migrate info --everything main 2>&1)" = \
     "fatal: cannot use --everything with explicit reference arguments" ]
 )
 end_test
@@ -424,7 +424,7 @@ begin_test "migrate info (--everything with --include-ref)"
 
   setup_multiple_local_branches
 
-  [ "$(git lfs migrate info --everything --include-ref=refs/heads/master 2>&1)" = \
+  [ "$(git lfs migrate info --everything --include-ref=refs/heads/main 2>&1)" = \
     "fatal: cannot use --everything with --include-ref or --exclude-ref" ]
 )
 end_test
@@ -437,7 +437,7 @@ begin_test "migrate info (--everything with --exclude-ref)"
 
   setup_multiple_local_branches
 
-  [ "$(git lfs migrate info --everything --exclude-ref=refs/heads/master 2>&1)" = \
+  [ "$(git lfs migrate info --everything --exclude-ref=refs/heads/main 2>&1)" = \
     "fatal: cannot use --everything with --include-ref or --exclude-ref" ]
 )
 end_test

--- a/t/t-object-authenticated.sh
+++ b/t/t-object-authenticated.sh
@@ -18,6 +18,6 @@ begin_test "download authenticated object"
   git add .gitattributes
   git commit -m "initial commit"
 
-  GIT_CURL_VERBOSE=1 GIT_TERMINAL_PROMPT=0 git lfs push origin master
+  GIT_CURL_VERBOSE=1 GIT_TERMINAL_PROMPT=0 git lfs push origin main
 )
 end_test

--- a/t/t-post-checkout.sh
+++ b/t/t-post-checkout.sh
@@ -53,14 +53,14 @@ begin_test "post-checkout"
 
   # skipped setting read-only above to make bulk load simpler (no read-only issues)
 
-  git push -u origin master branch2
+  git push -u origin main branch2
 
   # re-clone the repo so we start fresh
   cd ..
   rm -rf "$reponame"
   clone_repo "$reponame" "$reponame"
 
-  # this will be master
+  # this will be main
 
   [ "$(cat file1.dat)" == "file 1 updated commit 2" ]
   [ "$(cat file2.dat)" == "file 2 updated commit 3" ]
@@ -168,14 +168,14 @@ begin_test "post-checkout with subdirectories"
 
   # skipped setting read-only above to make bulk load simpler (no read-only issues)
 
-  git push -u origin master branch2
+  git push -u origin main branch2
 
   # re-clone the repo so we start fresh
   cd ..
   rm -rf "$reponame"
   clone_repo "$reponame" "$reponame"
 
-  # this will be master
+  # this will be main
 
   [ "$(cat bin/file1.dat)" == "file 1 updated commit 2" ]
   [ "$(cat bin/file2.dat)" == "file 2 updated commit 3" ]

--- a/t/t-post-commit.sh
+++ b/t/t-post-commit.sh
@@ -30,7 +30,7 @@ begin_test "post-commit"
   assert_file_writeable pcfile3.big
   assert_file_writeable pcfile4.big
 
-  git push -u origin master
+  git push -u origin main
 
   # now lock files, then edit
   git lfs lock pcfile1.dat

--- a/t/t-post-merge.sh
+++ b/t/t-post-merge.sh
@@ -54,14 +54,14 @@ begin_test "post-merge"
 
   # skipped setting read-only above to make bulk load simpler (no read-only issues)
 
-  git push -u origin master branch2
+  git push -u origin main branch2
 
   # re-clone the repo so we start fresh
   cd ..
   rm -rf "$reponame"
   clone_repo "$reponame" "$reponame"
 
-  # this will be master
+  # this will be main
 
   [ "$(cat file1.dat)" == "file 1 updated commit 2" ]
   [ "$(cat file2.dat)" == "file 2 updated commit 3" ]

--- a/t/t-pre-push.sh
+++ b/t/t-pre-push.sh
@@ -894,6 +894,7 @@ begin_test "pre-push locks verify 403 with good tracked ref"
 
   git config push.default upstream
   git config branch.master.merge refs/heads/tracked
+  git config branch.master.remote origin
   git config "lfs.$GITSERVER/$reponame.git.locksverify" true
   git push 2>&1 | tee push.log
 

--- a/t/t-pre-push.sh
+++ b/t/t-pre-push.sh
@@ -5,7 +5,7 @@
 begin_test "pre-push with good ref"
 (
   set -e
-  reponame="pre-push-master-branch-required"
+  reponame="pre-push-main-branch-required"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"
 
@@ -15,13 +15,13 @@ begin_test "pre-push with good ref"
   git add .gitattributes a.dat
   git commit -m "add a.dat"
 
-  refute_server_object "$reponame" 98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4 "refs/heads/master"
+  refute_server_object "$reponame" 98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4 "refs/heads/main"
 
   # for some reason, using 'tee' and $PIPESTATUS does not work here
-  echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
+  echo "refs/heads/main main refs/heads/main 0000000000000000000000000000000000000000" |
     git lfs pre-push origin "$GITSERVER/$reponame" 2>&1 > push.log
 
-  assert_server_object "$reponame" 98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4 "refs/heads/master"
+  assert_server_object "$reponame" 98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4 "refs/heads/main"
 )
 end_test
 
@@ -41,8 +41,8 @@ begin_test "pre-push with tracked ref"
   refute_server_object "$reponame" 98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4 "refs/heads/tracked"
 
   # for some reason, using 'tee' and $PIPESTATUS does not work here
-  echo "refs/heads/master master refs/heads/tracked 0000000000000000000000000000000000000000" |
-    git lfs pre-push origin master 2>&1 > push.log
+  echo "refs/heads/main main refs/heads/tracked 0000000000000000000000000000000000000000" |
+    git lfs pre-push origin main 2>&1 > push.log
 
   assert_server_object "$reponame" 98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4 "refs/heads/tracked"
 )
@@ -65,7 +65,7 @@ begin_test "pre-push with bad ref"
 
   # for some reason, using 'tee' and $PIPESTATUS does not work here
   set +e
-  echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
+  echo "refs/heads/main main refs/heads/main 0000000000000000000000000000000000000000" |
     git lfs pre-push origin "$GITSERVER/$reponame" 2> push.log
   pushcode=$?
   set -e
@@ -75,7 +75,7 @@ begin_test "pre-push with bad ref"
     exit 1
   fi
 
-  grep 'Expected ref "refs/heads/other", got "refs/heads/master"' push.log
+  grep 'Expected ref "refs/heads/other", got "refs/heads/main"' push.log
 
   refute_server_object "$reponame" 98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4 "refs/heads/other"
 )
@@ -95,7 +95,7 @@ begin_test "pre-push"
 
   git config "lfs.$(repo_endpoint $GITSERVER $reponame).locksverify" true
 
-  echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
+  echo "refs/heads/main main refs/heads/main 0000000000000000000000000000000000000000" |
     git lfs pre-push origin "$GITSERVER/$reponame" |
     tee push.log
   # no output if nothing to do
@@ -110,7 +110,7 @@ begin_test "pre-push"
   refute_server_object "$reponame" 98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4
 
   # push file to the git lfs server
-  echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
+  echo "refs/heads/main main refs/heads/main 0000000000000000000000000000000000000000" |
     git lfs pre-push origin "$GITSERVER/$reponame" 2>&1 |
     tee push.log
   grep "Uploading LFS objects: 100% (1/1), 3 B" push.log
@@ -133,7 +133,7 @@ begin_test "pre-push dry-run"
 
   git config "lfs.$(repo_endpoint $GITSERVER $reponame).locksverify" true
 
-  echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
+  echo "refs/heads/main main refs/heads/main 0000000000000000000000000000000000000000" |
     git lfs pre-push --dry-run origin "$GITSERVER/$reponame" |
     tee push.log
 
@@ -147,7 +147,7 @@ begin_test "pre-push dry-run"
 
   refute_server_object "$reponame" 2840e0eafda1d0760771fe28b91247cf81c76aa888af28a850b5648a338dc15b
 
-  echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
+  echo "refs/heads/main main refs/heads/main 0000000000000000000000000000000000000000" |
     git lfs pre-push --dry-run origin "$GITSERVER/$reponame" |
     tee push.log
   grep "push 2840e0eafda1d0760771fe28b91247cf81c76aa888af28a850b5648a338dc15b => hi.dat" push.log
@@ -180,7 +180,7 @@ begin_test "pre-push 307 redirects"
   git show
 
   # push file to the git lfs server
-  echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
+  echo "refs/heads/main main refs/heads/main 0000000000000000000000000000000000000000" |
     git lfs pre-push origin "$GITSERVER/redirect307/rel/$reponame.git/info/lfs" 2>&1 |
     tee push.log
   grep "Uploading LFS objects: 100% (1/1), 3 B" push.log
@@ -196,7 +196,7 @@ begin_test "pre-push 307 redirects"
   git show
 
   # push file to the git lfs server
-  echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
+  echo "refs/heads/main main refs/heads/main 0000000000000000000000000000000000000000" |
     git lfs pre-push origin "$GITSERVER/redirect307/abs/$reponame.git/info/lfs" 2>&1 |
     tee push.log
   grep "Uploading LFS objects: 100% (1/1), 3 B" push.log
@@ -222,7 +222,7 @@ begin_test "pre-push with existing file"
   git commit -m "add new file through git lfs"
 
   # push file to the git lfs server
-  echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
+  echo "refs/heads/main main refs/heads/main 0000000000000000000000000000000000000000" |
     git lfs pre-push origin "$GITSERVER/$reponame" 2>&1 |
     tee push.log
   grep "Uploading LFS objects: 100% (1/1), 4 B" push.log
@@ -247,7 +247,7 @@ begin_test "pre-push with existing pointer"
   echo "new" > .git/lfs/objects/7a/a7/7aa7a5359173d05b63cfd682e3c38487f3cb4f7f1d60659fe59fab1505977d4c
 
   # push file to the git lfs server
-  echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
+  echo "refs/heads/main main refs/heads/main 0000000000000000000000000000000000000000" |
     git lfs pre-push origin "$GITSERVER/$reponame" 2>&1 |
     tee push.log
   grep "Uploading LFS objects: 100% (1/1), 4 B" push.log
@@ -270,7 +270,7 @@ begin_test "pre-push with missing pointer not on server"
 
   # assert that push fails
   set +e
-  echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
+  echo "refs/heads/main main refs/heads/main 0000000000000000000000000000000000000000" |
     git lfs pre-push origin "$GITSERVER/$reponame" 2>&1 |
     tee push.log
   set -e
@@ -298,7 +298,7 @@ begin_test "pre-push with missing pointer which is on server"
   git commit -m "add first file"
 
   # push file to the git lfs server
-  echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
+  echo "refs/heads/main main refs/heads/main 0000000000000000000000000000000000000000" |
     git lfs pre-push origin "$GITSERVER/$reponame" 2>&1 |
     tee push.log
   grep "Uploading LFS objects: 100% (1/1), 11 B" push.log
@@ -311,7 +311,7 @@ begin_test "pre-push with missing pointer which is on server"
   git add common2.dat
   git commit -m "add second file, same content"
   rm -rf .git/lfs/objects
-  echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
+  echo "refs/heads/main main refs/heads/main 0000000000000000000000000000000000000000" |
     git lfs pre-push origin "$GITSERVER/$reponame" 2>&1 |
     tee push.log
   # make sure there were no errors reported
@@ -354,7 +354,7 @@ begin_test "pre-push with missing and present pointers (lfs.allowincompletepush 
 
   git config lfs.allowincompletepush true
 
-  echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
+  echo "refs/heads/main main refs/heads/main 0000000000000000000000000000000000000000" |
     git lfs pre-push origin "$GITSERVER/$reponame" 2>&1 |
     tee push.log
 
@@ -403,7 +403,7 @@ begin_test "pre-push reject missing pointers (lfs.allowincompletepush default)"
   missing_oid_path=".git/lfs/objects/$missing_oid_part_1/$missing_oid_part_2/$missing_oid"
   rm "$missing_oid_path"
 
-  echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
+  echo "refs/heads/main main refs/heads/main 0000000000000000000000000000000000000000" |
     git lfs pre-push origin "$GITSERVER/$reponame" 2>&1 |
     tee push.log
 
@@ -453,21 +453,21 @@ begin_test "pre-push multiple branches"
       {\"Filename\":\"file2.dat\",\"Size\":${#content[2]}, \"Data\":\"${content[2]}\"}]
   },
   {
-    \"ParentBranches\":[\"master\"],
+    \"ParentBranches\":[\"main\"],
     \"NewBranch\":\"branch2\",
     \"CommitDate\":\"$(get_date -5d)\",
     \"Files\":[
       {\"Filename\":\"file3.dat\",\"Size\":${#content[3]}, \"Data\":\"${content[3]}\"}]
   },
   {
-    \"ParentBranches\":[\"master\"],
+    \"ParentBranches\":[\"main\"],
     \"NewBranch\":\"branch3\",
     \"CommitDate\":\"$(get_date -2d)\",
     \"Files\":[
       {\"Filename\":\"file1.dat\",\"Size\":${#content[4]}, \"Data\":\"${content[4]}\"}]
   },
   {
-    \"ParentBranches\":[\"master\"],
+    \"ParentBranches\":[\"main\"],
     \"NewBranch\":\"branch4\",
     \"CommitDate\":\"$(get_date -1d)\",
     \"Files\":[
@@ -476,7 +476,7 @@ begin_test "pre-push multiple branches"
   ]" | lfstest-testutils addcommits
 
   # make sure when called via git push all branches are updated
-  git push origin master branch1 branch2 branch3 branch4
+  git push origin main branch1 branch2 branch3 branch4
   for ((a=0; a < NUMFILES ; a++))
   do
     assert_server_object "$reponame" "${oid[$a]}"
@@ -491,7 +491,7 @@ begin_test "pre-push with bad remote"
 
   cd repo
 
-  echo "refs/heads/master master refs/heads/master 0000000000000000000000000000000000000000" |
+  echo "refs/heads/main main refs/heads/main 0000000000000000000000000000000000000000" |
     git lfs pre-push not-a-remote "$GITSERVER/$reponame" 2>&1 |
     tee pre-push.log
   grep "Invalid remote name" pre-push.log
@@ -547,7 +547,7 @@ begin_test "pre-push unfetched deleted remote branch & server GC"
   ]" | lfstest-testutils addcommits
 
   # push only the first 2 branches
-  git push origin master branch-to-delete
+  git push origin main branch-to-delete
   for ((a=0; a < 3 ; a++))
   do
     assert_server_object "$reponame" "${oid[$a]}"
@@ -612,7 +612,7 @@ begin_test "pre-push delete branch"
       {\"Filename\":\"file3.dat\",\"Size\":${#content[2]}, \"Data\":\"${content[2]}\"}]
   },
   {
-    \"ParentBranches\":[\"master\"],
+    \"ParentBranches\":[\"main\"],
     \"CommitDate\":\"$(get_date -0d)\",
     \"Files\":[
       {\"Filename\":\"file4.dat\",\"Size\":${#content[3]}, \"Data\":\"${content[3]}\"}]
@@ -620,7 +620,7 @@ begin_test "pre-push delete branch"
   ]" | lfstest-testutils addcommits
 
   # push all branches
-  git push origin master branch-to-delete
+  git push origin main branch-to-delete
   for ((a=0; a < NUMFILES ; a++))
   do
     assert_server_object "$reponame" "${oid[$a]}"
@@ -649,7 +649,7 @@ begin_test "pre-push with our lock"
   git add locked.dat
   git commit -m "add locked.dat"
 
-  git push origin master
+  git push origin main
 
   git lfs lock --json "locked.dat" | tee lock.log
 
@@ -660,7 +660,7 @@ begin_test "pre-push with our lock"
   git add locked.dat
   git commit -m "add unauthorized changes"
 
-  GIT_CURL_VERBOSE=1 git push origin master 2>&1 | tee push.log
+  GIT_CURL_VERBOSE=1 git push origin main 2>&1 | tee push.log
   grep "Consider unlocking your own locked files" push.log
   grep "* locked.dat" push.log
 
@@ -687,7 +687,7 @@ begin_test "pre-push with their lock on lfs file"
   git add locked_theirs.dat
   git commit -m "add locked_theirs.dat"
 
-  git push origin master
+  git push origin main
 
   git lfs lock --json "locked_theirs.dat" | tee lock.log
   id=$(assert_lock lock.log locked_theirs.dat)
@@ -702,7 +702,7 @@ begin_test "pre-push with their lock on lfs file"
     # --no-verify is used to avoid the pre-commit hook which is not under test
     git commit --no-verify -m "add unauthorized changes"
 
-    git push origin master 2>&1 | tee push.log
+    git push origin main 2>&1 | tee push.log
     res="${PIPESTATUS[0]}"
     if [ "0" -eq "$res" ]; then
       echo "push should fail"
@@ -737,7 +737,7 @@ begin_test "pre-push with their lock on non-lfs lockable file"
   git add readme.txt tiny_locked_theirs.dat large_locked_theirs.dat
   git commit -m "add initial files"
 
-  git push origin master
+  git push origin main
 
   git lfs lock --json "tiny_locked_theirs.dat" | tee lock.log
   id=$(assert_lock lock.log tiny_locked_theirs.dat)
@@ -758,7 +758,7 @@ begin_test "pre-push with their lock on non-lfs lockable file"
     # --no-verify is used to avoid the pre-commit hook which is not under test
     git commit --no-verify -am "add unauthorized changes"
 
-    git push origin master 2>&1 | tee push.log
+    git push origin main 2>&1 | tee push.log
     res="${PIPESTATUS[0]}"
     if [ "0" -eq "$res" ]; then
       echo "push should fail"
@@ -795,7 +795,7 @@ begin_test "pre-push locks verify 5xx with verification enabled"
 
   git config "lfs.$endpoint.locksverify" true
 
-  git push origin master 2>&1 | tee push.log
+  git push origin main 2>&1 | tee push.log
   grep "\"origin\" does not support the LFS locking API" push.log
   grep "git config lfs.$endpoint.locksverify false" push.log
 
@@ -822,7 +822,7 @@ begin_test "pre-push disable locks verify on exact url"
 
   git config "lfs.$endpoint.locksverify" false
 
-  git push origin master 2>&1 | tee push.log
+  git push origin main 2>&1 | tee push.log
   [ "0" -eq "$(grep -c "\"origin\" does not support the LFS locking API" push.log)" ]
 
   assert_server_object "$reponame" "$contents_oid"
@@ -848,7 +848,7 @@ begin_test "pre-push disable locks verify on partial url"
 
   git config "lfs.$endpoint.locksverify" false
 
-  git push origin master 2>&1 | tee push.log
+  git push origin main 2>&1 | tee push.log
   [ "0" -eq "$(grep -c "\"origin\" does not support the LFS locking API" push.log)" ]
 
   assert_server_object "$reponame" "$contents_oid"
@@ -859,7 +859,7 @@ begin_test "pre-push locks verify 403 with good ref"
 (
   set -e
 
-  reponame="lock-verify-master-branch-required"
+  reponame="lock-verify-main-branch-required"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"
 
@@ -871,9 +871,9 @@ begin_test "pre-push locks verify 403 with good ref"
   git commit --message "initial commit"
 
   git config "lfs.$GITSERVER/$reponame.git.locksverify" true
-  git push origin master 2>&1 | tee push.log
+  git push origin main 2>&1 | tee push.log
 
-  assert_server_object "$reponame" "$contents_oid" "refs/heads/master"
+  assert_server_object "$reponame" "$contents_oid" "refs/heads/main"
 )
 end_test
 
@@ -893,8 +893,8 @@ begin_test "pre-push locks verify 403 with good tracked ref"
   git commit --message "initial commit"
 
   git config push.default upstream
-  git config branch.master.merge refs/heads/tracked
-  git config branch.master.remote origin
+  git config branch.main.merge refs/heads/tracked
+  git config branch.main.remote origin
   git config "lfs.$GITSERVER/$reponame.git.locksverify" true
   git push 2>&1 | tee push.log
 
@@ -918,7 +918,7 @@ begin_test "pre-push locks verify 403 with explicit ref"
   git commit --message "initial commit"
 
   git config "lfs.$GITSERVER/$reponame.git.locksverify" true
-  git push origin master:explicit 2>&1 | tee push.log
+  git push origin main:explicit 2>&1 | tee push.log
 
   assert_server_object "$reponame" "$contents_oid" "refs/heads/explicit"
 )
@@ -940,7 +940,7 @@ begin_test "pre-push locks verify 403 with bad ref"
   git commit --message "initial commit"
 
   git config "lfs.$GITSERVER/$reponame.git.locksverify" true
-  git push origin master 2>&1 | tee push.log
+  git push origin main 2>&1 | tee push.log
   grep "failed to push some refs" push.log
   refute_server_object "$reponame" "$contents_oid" "refs/heads/other"
 )
@@ -965,7 +965,7 @@ begin_test "pre-push locks verify 5xx with verification unset"
 
   [ -z "$(git config "lfs.$endpoint.locksverify")" ]
 
-  git push origin master 2>&1 | tee push.log
+  git push origin main 2>&1 | tee push.log
   grep "\"origin\" does not support the LFS locking API" push.log
 
   assert_server_object "$reponame" "$contents_oid"
@@ -991,7 +991,7 @@ begin_test "pre-push locks verify 501 with verification enabled"
 
   git config "lfs.$endpoint.locksverify" true
 
-  git push origin master 2>&1 | tee push.log
+  git push origin main 2>&1 | tee push.log
 
   assert_server_object "$reponame" "$contents_oid"
   [ "false" = "$(git config "lfs.$endpoint.locksverify")" ]
@@ -1018,7 +1018,7 @@ begin_test "pre-push locks verify 501 with verification disabled"
 
   git config "lfs.$endpoint.locksverify" false
 
-  git push origin master 2>&1 | tee push.log
+  git push origin main 2>&1 | tee push.log
 
   assert_server_object "$reponame" "$contents_oid"
   [ "false" = "$(git config "lfs.$endpoint.locksverify")" ]
@@ -1044,7 +1044,7 @@ begin_test "pre-push locks verify 501 with verification unset"
 
   [ -z "$(git config "lfs.$endpoint.locksverify")" ]
 
-  git push origin master 2>&1 | tee push.log
+  git push origin main 2>&1 | tee push.log
 
   assert_server_object "$reponame" "$contents_oid"
   [ "false" = "$(git config "lfs.$endpoint.locksverify")" ]
@@ -1069,7 +1069,7 @@ begin_test "pre-push locks verify 200"
   git add .gitattributes a.dat
   git commit --message "initial commit"
 
-  git push origin master 2>&1 | tee push.log
+  git push origin main 2>&1 | tee push.log
 
   grep "Locking support detected on remote \"origin\"." push.log
   grep "git config lfs.$endpoint.locksverify true" push.log
@@ -1096,7 +1096,7 @@ begin_test "pre-push locks verify 403 with verification enabled"
 
   git config "lfs.$endpoint.locksverify" true
 
-  git push origin master 2>&1 | tee push.log
+  git push origin main 2>&1 | tee push.log
   grep "ERROR: Authentication error" push.log
 
   refute_server_object "$reponame" "$contents_oid"
@@ -1123,7 +1123,7 @@ begin_test "pre-push locks verify 403 with verification disabled"
 
   git config "lfs.$endpoint.locksverify" false
 
-  git push origin master 2>&1 | tee push.log
+  git push origin main 2>&1 | tee push.log
 
   assert_server_object "$reponame" "$contents_oid"
   [ "false" = "$(git config "lfs.$endpoint.locksverify")" ]
@@ -1149,7 +1149,7 @@ begin_test "pre-push locks verify 403 with verification unset"
 
   [ -z "$(git config "lfs.$endpoint.locksverify")" ]
 
-  git push origin master 2>&1 | tee push.log
+  git push origin main 2>&1 | tee push.log
   grep "WARNING: Authentication error" push.log
 
   assert_server_object "$reponame" "$contents_oid"
@@ -1173,11 +1173,11 @@ begin_test "pre-push with pushDefault and explicit remote"
   git add .gitattributes a.dat
   git commit -m "add a.dat"
 
-  refute_server_object "$reponame" 98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4 "refs/heads/master"
+  refute_server_object "$reponame" 98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4 "refs/heads/main"
 
-  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git push origin master 2>&1 | tee push.log
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git push origin main 2>&1 | tee push.log
 
-  assert_server_object "$reponame" 98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4 "refs/heads/master"
+  assert_server_object "$reponame" 98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4 "refs/heads/main"
   ! grep wrong-url push.log
 )
 end_test
@@ -1197,9 +1197,9 @@ begin_test "pre-push uses optimization if remote URL matches"
   git add .gitattributes a.dat
   git commit -m "add a.dat"
 
-  refute_server_object "$reponame" $contents_oid "refs/heads/master"
+  refute_server_object "$reponame" $contents_oid "refs/heads/main"
 
-  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git push "$endpoint" master 2>&1 | tee push.log
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git push "$endpoint" main 2>&1 | tee push.log
   grep 'rev-list.*--not --remotes=origin' push.log
 )
 end_test
@@ -1219,25 +1219,25 @@ begin_test "pre-push does not traverse Git objects server has"
   git add .gitattributes a.dat
   git commit -m "add a.dat"
 
-  refute_server_object "$reponame" $contents_oid "refs/heads/master"
+  refute_server_object "$reponame" $contents_oid "refs/heads/main"
 
   # We use a different URL instead of a named remote or the remote URL so that
   # we can't make use of the optimization that ignores objects we already have
   # in remote tracking branches.
-  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git push "$endpoint.git" master 2>&1 | tee push.log
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git push "$endpoint.git" main 2>&1 | tee push.log
 
-  assert_server_object "$reponame" $contents_oid "refs/heads/master"
+  assert_server_object "$reponame" $contents_oid "refs/heads/main"
 
   contents2_oid=$(calc_oid 'hello\n')
   echo "hello" > b.dat
   git add .gitattributes b.dat
   git commit -m "add b.dat"
 
-  refute_server_object "$reponame" $contents2_oid "refs/heads/master"
+  refute_server_object "$reponame" $contents2_oid "refs/heads/main"
 
-  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git push "$endpoint.git" master 2>&1 | tee push.log
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git push "$endpoint.git" main 2>&1 | tee push.log
 
-  assert_server_object "$reponame" $contents2_oid "refs/heads/master"
+  assert_server_object "$reponame" $contents2_oid "refs/heads/main"
 
   # Verify that we haven't tried to push or query for the object we already
   # pushed before; i.e., we didn't see it because we ignored its Git object
@@ -1260,11 +1260,11 @@ begin_test "pre-push with force-pushed ref"
   git commit -m "add a.dat"
   git tag -a -m tagname tagname
 
-  refute_server_object "$reponame" 98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4 "refs/heads/master"
+  refute_server_object "$reponame" 98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4 "refs/heads/main"
 
-  git push origin master tagname
+  git push origin main tagname
 
-  assert_server_object "$reponame" 98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4 "refs/heads/master"
+  assert_server_object "$reponame" 98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4 "refs/heads/main"
 
   # We pick a different message so that we get different object IDs even if both
   # commands run in the same second.
@@ -1292,10 +1292,10 @@ begin_test "pre-push with local path"
   git commit -m "add a.dat"
 
   # Push to the other repo.
-  git push "../$reponame-2" master:foo
+  git push "../$reponame-2" main:foo
 
   # Push to . to make sure that works.
-  git push "." master:foo
+  git push "." main:foo
 
   git lfs fsck
   cd "../$reponame-2"

--- a/t/t-progress-meter.sh
+++ b/t/t-progress-meter.sh
@@ -21,7 +21,7 @@ begin_test "progress meter displays positive progress"
   git add *.dat
   git commit -m "add many objects"
 
-  git push origin master 2>&1 | tee push.log
+  git push origin main 2>&1 | tee push.log
   [ "0" -eq "${PIPESTATUS[0]}" ]
 
   grep "Uploading LFS objects: 100% (128/128), 276 B" push.log

--- a/t/t-progress.sh
+++ b/t/t-progress.sh
@@ -18,7 +18,7 @@ begin_test "GIT_LFS_PROGRESS"
   echo "e" > e.dat
   git add .gitattributes *.dat
   git commit -m "add files"
-  git push origin master 2>&1 | tee push.log
+  git push origin main 2>&1 | tee push.log
   grep "Uploading LFS objects: 100% (5/5), 10 B" push.log
 
   cd ..

--- a/t/t-prune-worktree.sh
+++ b/t/t-prune-worktree.sh
@@ -50,7 +50,7 @@ begin_test "prune worktree"
   },
   {
     \"CommitDate\":\"$(get_date -30d)\",
-    \"ParentBranches\":[\"master\"],
+    \"ParentBranches\":[\"main\"],
     \"NewBranch\":\"branch2\",
     \"Files\":[
       {\"Filename\":\"file.dat\",\"Size\":${#content_oldcommit3}, \"Data\":\"$content_oldcommit3\"}]
@@ -62,14 +62,14 @@ begin_test "prune worktree"
   },
   {
     \"CommitDate\":\"$(get_date -30d)\",
-    \"ParentBranches\":[\"master\"],
+    \"ParentBranches\":[\"main\"],
     \"Files\":[
       {\"Filename\":\"file.dat\",\"Size\":${#content_head}, \"Data\":\"$content_head\"}]
   }
   ]" | lfstest-testutils addcommits
 
   # push everything so that's not a retention issue
-  git push origin master:master branch1:branch1 branch2:branch2
+  git push origin main:main branch1:branch1 branch2:branch2
 
   # don't keep any recent, just checkouts
   git config lfs.fetchrecentrefsdays 0

--- a/t/t-prune.sh
+++ b/t/t-prune.sh
@@ -29,13 +29,13 @@ begin_test "prune unreferenced and old"
 
   # Remember for something to be 'too old' it has to appear on the MINUS side
   # of the diff outside the prune window, i.e. it's not when it was introduced
-  # but when it disappeared from relevance. That's why changes to file1.dat on master
+  # but when it disappeared from relevance. That's why changes to file1.dat on main
   # from 7d ago are included even though the commit itself is outside of the window,
   # that content of file1.dat was relevant until it was removed with a commit, inside the window
   # think of it as windows of relevance that overlap until the content is replaced
 
-  # we also make sure we commit today on master so that the recent commits measured
-  # from latest commit on master tracks back from there
+  # we also make sure we commit today on main so that the recent commits measured
+  # from latest commit on main tracks back from there
   echo "[
   {
     \"CommitDate\":\"$(get_date -20d)\",
@@ -55,13 +55,13 @@ begin_test "prune unreferenced and old"
       {\"Filename\":\"unreferenced.dat\",\"Size\":${#content_unreferenced}, \"Data\":\"$content_unreferenced\"}]
   },
   {
-    \"ParentBranches\":[\"master\"],
+    \"ParentBranches\":[\"main\"],
     \"Files\":[
       {\"Filename\":\"old.dat\",\"Size\":${#content_retain2}, \"Data\":\"$content_retain2\"}]
   }
   ]" | lfstest-testutils addcommits
 
-  git push origin master
+  git push origin main
   git branch -D branch_to_delete
 
   git config lfs.fetchrecentrefsdays 5
@@ -134,7 +134,7 @@ begin_test "prune keep unpushed"
   },
   {
     \"CommitDate\":\"$(get_date -31d)\",
-    \"ParentBranches\":[\"master\"],
+    \"ParentBranches\":[\"main\"],
     \"NewBranch\":\"branch_unpushed\",
     \"Files\":[
       {\"Filename\":\"file.dat\",\"Size\":${#content_keepunpushedbranch1}, \"Data\":\"$content_keepunpushedbranch1\"}]
@@ -151,7 +151,7 @@ begin_test "prune keep unpushed"
   },
   {
     \"CommitDate\":\"$(get_date -21d)\",
-    \"ParentBranches\":[\"master\"],
+    \"ParentBranches\":[\"main\"],
     \"Files\":[
       {\"Filename\":\"file.dat\",\"Size\":${#content_keepunpushedhead2}, \"Data\":\"$content_keepunpushedhead2\"}]
   },
@@ -169,8 +169,8 @@ begin_test "prune keep unpushed"
 
   git lfs prune
 
-  # Now push master and show that older versions on master will be removed
-  git push origin master
+  # Now push main and show that older versions on main will be removed
+  git push origin main
 
   git lfs prune --verbose 2>&1 | tee prune.log
   grep "prune: 6 local object(s), 4 retained" prune.log
@@ -180,13 +180,13 @@ begin_test "prune keep unpushed"
   refute_local_object "$oid_keepunpushedhead1"
   refute_local_object "$oid_keepunpushedhead2"
 
-  # MERGE the secondary branch, delete the branch then push master, then make sure
+  # MERGE the secondary branch, delete the branch then push main, then make sure
   # we delete the intermediate commits but also make sure they're on server
   # resolve conflicts by taking other branch
   git merge -Xtheirs branch_unpushed
   git branch -D branch_unpushed
   git lfs prune --dry-run
-  git push origin master
+  git push origin main
 
   git lfs prune --verbose 2>&1 | tee prune.log
   grep "prune: 4 local object(s), 1 retained" prune.log
@@ -270,7 +270,7 @@ begin_test "prune keep recent"
   },
   {
     \"CommitDate\":\"$(get_date -9d)\",
-    \"ParentBranches\":[\"master\"],
+    \"ParentBranches\":[\"main\"],
     \"NewBranch\":\"branch1\",
     \"Files\":[
       {\"Filename\":\"file.dat\",\"Size\":${#content_prunecommitbranch1}, \"Data\":\"$content_prunecommitbranch1\"}]
@@ -287,7 +287,7 @@ begin_test "prune keep recent"
   },
   {
     \"CommitDate\":\"$(get_date -17d)\",
-    \"ParentBranches\":[\"master\"],
+    \"ParentBranches\":[\"main\"],
     \"NewBranch\":\"branch2\",
     \"Files\":[
       {\"Filename\":\"file.dat\",\"Size\":${#content_prunecommitbranch2}, \"Data\":\"$content_prunecommitbranch2\"}]
@@ -304,7 +304,7 @@ begin_test "prune keep recent"
   },
   {
     \"CommitDate\":\"$(get_date -1d)\",
-    \"ParentBranches\":[\"master\"],
+    \"ParentBranches\":[\"main\"],
     \"Files\":[
       {\"Filename\":\"file.dat\",\"Size\":${#content_keephead}, \"Data\":\"$content_keephead\"}]
   }
@@ -317,7 +317,7 @@ begin_test "prune keep recent"
   git config lfs.pruneoffsetdays 1
 
   # push everything so that's not a reason to retain
-  git push origin master:master branch_old:branch_old branch1:branch1 branch2:branch2
+  git push origin main:main branch_old:branch_old branch1:branch1 branch2:branch2
 
 
   git lfs prune --verbose 2>&1 | tee prune.log
@@ -417,7 +417,7 @@ begin_test "prune remote tests"
   setup_remote_repo "remote2_$reponame"
   cd "$TRASHDIR/$reponame"
   git remote add not_origin "$GITSERVER/remote1_$reponame"
-  git push not_origin master
+  git push not_origin main
 
   git lfs prune --verbose 2>&1 | tee prune.log
   grep "prune: 4 local object(s), 4 retained, done." prune.log
@@ -480,7 +480,7 @@ begin_test "prune verify"
   ]" | lfstest-testutils addcommits
 
   # push all so no unpushed reason to not prune
-  git push origin master
+  git push origin main
 
   # set no recents so max ability to prune normally
   git config lfs.fetchrecentrefsdays 0
@@ -574,14 +574,14 @@ begin_test "prune verify large numbers of refs"
   ]" | lfstest-testutils addcommits
 
   # Generate a large number of refs to old commits make sure prune has a lot of data to read
-  git checkout $(git log --pretty=oneline  master | tail -2 | awk '{print $1}' | head -1)
+  git checkout $(git log --pretty=oneline  main | tail -2 | awk '{print $1}' | head -1)
   for i in $(seq 0 1000); do
     git tag v$i
   done
-  git checkout master
+  git checkout main
 
   # push all so no unpushed reason to not prune
-  # git push origin master
+  # git push origin main
 
   # set no recents so max ability to prune normally
   git config lfs.fetchrecentrefsdays 3

--- a/t/t-pull.sh
+++ b/t/t-pull.sh
@@ -29,7 +29,7 @@ begin_test "pull"
   printf "%s" "$contents3" > dir/dir.dat
   git add .
   git commit -m "add files" 2>&1 | tee commit.log
-  grep "master (root-commit)" commit.log
+  grep "main (root-commit)" commit.log
   grep "5 files changed" commit.log
   grep "create mode 100644 a.dat" commit.log
   grep "create mode 100644 .gitattributes" commit.log
@@ -39,18 +39,18 @@ begin_test "pull"
   [ "A" = "$(cat "á.dat")" ]
   [ "dir" = "$(cat "dir/dir.dat")" ]
 
-  assert_pointer "master" "a.dat" "$contents_oid" 1
-  assert_pointer "master" "á.dat" "$contents2_oid" 1
-  assert_pointer "master" "dir/dir.dat" "$contents3_oid" 3
+  assert_pointer "main" "a.dat" "$contents_oid" 1
+  assert_pointer "main" "á.dat" "$contents2_oid" 1
+  assert_pointer "main" "dir/dir.dat" "$contents3_oid" 3
 
   refute_server_object "$reponame" "$contents_oid"
   refute_server_object "$reponame" "$contents2_oid"
   refute_server_object "$reponame" "$contents33oid"
 
   echo "initial push"
-  git push origin master 2>&1 | tee push.log
+  git push origin main 2>&1 | tee push.log
   grep "Uploading LFS objects: 100% (3/3), 5 B" push.log
-  grep "master -> master" push.log
+  grep "main -> main" push.log
 
   assert_server_object "$reponame" "$contents_oid"
   assert_server_object "$reponame" "$contents2_oid"
@@ -60,8 +60,8 @@ begin_test "pull"
   cd ../clone
 
   echo "normal pull"
-  git config branch.master.remote origin
-  git config branch.master.merge refs/heads/master
+  git config branch.main.remote origin
+  git config branch.main.merge refs/heads/main
   git pull 2>&1
 
   [ "a" = "$(cat a.dat)" ]
@@ -203,7 +203,7 @@ begin_test "pull with raw remote url"
   git lfs install --local --skip-smudge
 
   git remote add origin $GITSERVER/t-pull
-  git pull origin master
+  git pull origin main
 
   contents="a"
   contents_oid=$(calc_oid "$contents")
@@ -232,7 +232,7 @@ begin_test "pull with multiple remotes"
 
   git remote add origin "$GITSERVER/t-pull"
   git remote add bad-remote "invalid-url"
-  git pull origin master
+  git pull origin main
 
   contents="a"
   contents_oid=$(calc_oid "$contents")
@@ -261,7 +261,7 @@ begin_test "pull with invalid insteadof"
   git lfs install --local --skip-smudge
 
   git remote add origin "$GITSERVER/t-pull"
-  git pull origin master
+  git pull origin main
 
   # set insteadOf to rewrite the href of downloading LFS object.
   git config url."$GITSERVER/storage/invalid".insteadOf "$GITSERVER/storage/"
@@ -298,8 +298,8 @@ begin_test "pull: with missing object"
   refute_server_object "$reponame" "$contents_oid"
 
   # should return non-zero, but should also download all the other valid files too
-  git config branch.master.remote origin
-  git config branch.master.merge refs/heads/master
+  git config branch.main.remote origin
+  git config branch.main.merge refs/heads/main
   git lfs pull 2>&1 | tee pull.log
   pull_exit="${PIPESTATUS[0]}"
   [ "$pull_exit" != "0" ]

--- a/t/t-pull.sh
+++ b/t/t-pull.sh
@@ -60,6 +60,8 @@ begin_test "pull"
   cd ../clone
 
   echo "normal pull"
+  git config branch.master.remote origin
+  git config branch.master.merge refs/heads/master
   git pull 2>&1
 
   [ "a" = "$(cat a.dat)" ]
@@ -296,6 +298,8 @@ begin_test "pull: with missing object"
   refute_server_object "$reponame" "$contents_oid"
 
   # should return non-zero, but should also download all the other valid files too
+  git config branch.master.remote origin
+  git config branch.master.merge refs/heads/master
   git lfs pull 2>&1 | tee pull.log
   pull_exit="${PIPESTATUS[0]}"
   [ "$pull_exit" != "0" ]

--- a/t/t-push-bad-dns.sh
+++ b/t/t-push-bad-dns.sh
@@ -21,7 +21,7 @@ begin_test "push: upload to bad dns"
   git config lfs.url "http://git-lfs-bad-dns:$port"
 
   set +e
-  GIT_TERMINAL_PROMPT=0 git push origin master 2>&1 | tee push.log
+  GIT_TERMINAL_PROMPT=0 git push origin main 2>&1 | tee push.log
   res="${PIPESTATUS[0]}"
   set -e
 

--- a/t/t-push-failures-local.sh
+++ b/t/t-push-failures-local.sh
@@ -36,9 +36,9 @@ begin_test "push with missing objects (lfs.allowincompletepush true)"
 
   git config lfs.allowincompletepush true
 
-  git push origin master 2>&1 | tee push.log
+  git push origin main 2>&1 | tee push.log
   if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected \`git push origin master\` to succeed ..."
+    echo >&2 "fatal: expected \`git push origin main\` to succeed ..."
     exit 1
   fi
 
@@ -84,9 +84,9 @@ begin_test "push reject missing objects (lfs.allowincompletepush false)"
 
   git config lfs.allowincompletepush false
 
-  git push origin master 2>&1 | tee push.log
+  git push origin main 2>&1 | tee push.log
   if [ "1" -ne "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected \`git push origin master\` to succeed ..."
+    echo >&2 "fatal: expected \`git push origin main\` to succeed ..."
     exit 1
   fi
 
@@ -131,10 +131,10 @@ begin_test "push reject missing objects (lfs.allowincompletepush default)"
   refute_local_object "$missing_oid"
   assert_local_object "$present_oid" "$present_len"
 
-  git push origin master 2>&1 | tee push.log
+  git push origin main 2>&1 | tee push.log
 
   if [ "0" -eq "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected 'git push origin master' to exit with non-zero code"
+    echo >&2 "fatal: expected 'git push origin main' to exit with non-zero code"
     exit 1
   fi
 
@@ -180,10 +180,10 @@ begin_test "push reject corrupt objects (lfs.allowincompletepush default)"
   refute_local_object "$corrupt_oid" "$corrupt_len"
   assert_local_object "$present_oid" "$present_len"
 
-  git push origin master 2>&1 | tee push.log
+  git push origin main 2>&1 | tee push.log
 
   if [ "0" -eq "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected 'git push origin master' to exit with non-zero code"
+    echo >&2 "fatal: expected 'git push origin main' to exit with non-zero code"
     exit 1
   fi
 

--- a/t/t-push-failures-remote.sh
+++ b/t/t-push-failures-remote.sh
@@ -26,7 +26,7 @@ push_fail_test() {
   git commit -m "welp"
 
   set +e
-  git push origin master 2>&1 | tee push.log
+  git push origin main 2>&1 | tee push.log
   res="${PIPESTATUS[0]}"
   set -e
 

--- a/t/t-push-file-with-branch-name.sh
+++ b/t/t-push-file-with-branch-name.sh
@@ -10,12 +10,12 @@ begin_test "push a file with the same name as a branch"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" repo
 
-  git lfs track "master"
-  echo "master" > master
-  git add .gitattributes master
-  git commit -m "add master"
+  git lfs track "main"
+  echo "main" > main
+  git add .gitattributes main
+  git commit -m "add main"
 
-  git lfs push --all origin master 2>&1 | tee push.log
+  git lfs push --all origin main 2>&1 | tee push.log
   grep "Uploading LFS objects: 100% (1/1), [0-9] B" push.log
 )
 end_test

--- a/t/t-push-file-with-branch-name.sh
+++ b/t/t-push-file-with-branch-name.sh
@@ -16,6 +16,6 @@ begin_test "push a file with the same name as a branch"
   git commit -m "add master"
 
   git lfs push --all origin master 2>&1 | tee push.log
-  grep "Uploading LFS objects: 100% (1/1), 7 B" push.log
+  grep "Uploading LFS objects: 100% (1/1), [0-9] B" push.log
 )
 end_test

--- a/t/t-push.sh
+++ b/t/t-push.sh
@@ -20,9 +20,9 @@ push_repo_setup() {
 begin_test "push with good ref"
 (
   set -e
-  push_repo_setup "push-master-branch-required"
+  push_repo_setup "push-main-branch-required"
 
-  git lfs push origin master
+  git lfs push origin main
 )
 end_test
 
@@ -33,8 +33,8 @@ begin_test "push with tracked ref"
   push_repo_setup "push-tracked-branch-required"
 
   git config push.default upstream
-  git config branch.master.merge refs/heads/tracked
-  git lfs push origin master
+  git config branch.main.merge refs/heads/tracked
+  git lfs push origin main
 )
 end_test
 
@@ -43,13 +43,13 @@ begin_test "push with bad ref"
   set -e
   push_repo_setup "push-other-branch-required"
 
-  git lfs push origin master 2>&1 | tee push.log
+  git lfs push origin main 2>&1 | tee push.log
   if [ "0" -eq "${PIPESTATUS[0]}" ]; then
     echo "expected command to fail"
     exit 1
   fi
 
-  grep 'batch response: Expected ref "refs/heads/other", got "refs/heads/master"' push.log
+  grep 'batch response: Expected ref "refs/heads/other", got "refs/heads/main"' push.log
 )
 end_test
 
@@ -60,7 +60,7 @@ begin_test "push with given remote, configured pushRemote"
 
   git remote add bad-remote "invalid-url"
 
-  git config branch.master.pushRemote bad-remote
+  git config branch.main.pushRemote bad-remote
 
   git lfs push --all origin
 )
@@ -81,11 +81,11 @@ begin_test "push"
   git add .gitattributes a.dat
   git commit -m "add a.dat"
 
-  git lfs push --dry-run origin master 2>&1 | tee push.log
+  git lfs push --dry-run origin main 2>&1 | tee push.log
   grep "push 4c48d2a6991c9895bcddcf027e1e4907280bcf21975492b1afbade396d6a3340 => a.dat" push.log
   [ $(grep -c "^push " push.log) -eq 1 ]
 
-  git lfs push origin master 2>&1 | tee push.log
+  git lfs push origin main 2>&1 | tee push.log
   grep "Uploading LFS objects: 100% (1/1), 7 B" push.log
 
   git checkout -b push-b
@@ -120,7 +120,7 @@ push_all_setup() {
   content2="update"
   content3="branch"
   content4="tagged"
-  content5="master"
+  content5="main"
   extracontent="extra"
   oid1=$(calc_oid "$content1")
   oid2=$(calc_oid "$content2")
@@ -158,7 +158,7 @@ push_all_setup() {
   },
   {
     \"CommitDate\":\"$(get_date -4m)\",
-    \"ParentBranches\":[\"master\"],
+    \"ParentBranches\":[\"main\"],
     \"Tags\":[\"tag\"],
     \"Files\":[
       {\"Filename\":\"file1.dat\",\"Size\":${#content4},\"Data\":\"$content4\"}
@@ -258,7 +258,7 @@ begin_test "push --all (1 ref arg)"
   assert_server_object "$reponame-$suffix" "$oid1"
   assert_server_object "$reponame-$suffix" "$oid2"
   assert_server_object "$reponame-$suffix" "$oid3"
-  refute_server_object "$reponame-$suffix" "$oid4"     # in master and the tag
+  refute_server_object "$reponame-$suffix" "$oid4"     # in main and the tag
   refute_server_object "$reponame-$suffix" "$oid5"
   refute_server_object "$reponame-$suffix" "$extraoid"
 
@@ -310,7 +310,7 @@ begin_test "push --all (multiple ref args)"
   assert_server_object "$reponame-$suffix" "$oid2"
   assert_server_object "$reponame-$suffix" "$oid3"
   assert_server_object "$reponame-$suffix" "$oid4"
-  refute_server_object "$reponame-$suffix" "$oid5"     # only in master
+  refute_server_object "$reponame-$suffix" "$oid5"     # only in main
   refute_server_object "$reponame-$suffix" "$extraoid"
 
   echo "push while missing old objects locally"
@@ -349,7 +349,7 @@ begin_test "push --all (ref with deleted files)"
 
   push_all_setup "ref-with-deleted"
 
-  git lfs push --dry-run --all origin master 2>&1 | tee push.log
+  git lfs push --dry-run --all origin main 2>&1 | tee push.log
   grep "push $oid1 => file1.dat" push.log
   grep "push $oid2 => file1.dat" push.log
   grep "push $oid4 => file1.dat" push.log
@@ -357,7 +357,7 @@ begin_test "push --all (ref with deleted files)"
   grep "push $extraoid => file2.dat" push.log
   [ $(grep -c "^push " push.log) -eq 5 ]
 
-  git lfs push --all origin master 2>&1 | tee push.log
+  git lfs push --all origin main 2>&1 | tee push.log
   grep "5 files" push.log
   assert_server_object "$reponame-$suffix" "$oid1"
   assert_server_object "$reponame-$suffix" "$oid2"
@@ -379,7 +379,7 @@ begin_test "push --all (ref with deleted files)"
   rm ".git/lfs/objects/${oid1:0:2}/${oid1:2:2}/$oid1"
 
   # dry run doesn't change
-  git lfs push --dry-run --all origin master 2>&1 | tee push.log
+  git lfs push --dry-run --all origin main 2>&1 | tee push.log
   grep "push $oid1 => file1.dat" push.log
   grep "push $oid2 => file1.dat" push.log
   grep "push $oid4 => file1.dat" push.log
@@ -387,7 +387,7 @@ begin_test "push --all (ref with deleted files)"
   grep "push $extraoid => file2.dat" push.log
   [ $(grep -c "^push " push.log) -eq 5 ]
 
-  git push --all origin master 2>&1 | tee push.log
+  git push --all origin main 2>&1 | tee push.log
   grep "5 files, 1 skipped" push.log # should be 5?
   assert_server_object "$reponame-$suffix-2" "$oid2"
   refute_server_object "$reponame-$suffix-2" "$oid3"
@@ -469,14 +469,14 @@ begin_test "push modified files"
   },
   {
     \"CommitDate\":\"$(get_date -1m)\",
-    \"ParentBranches\":[\"master\"],
+    \"ParentBranches\":[\"main\"],
     \"Files\":[
       {\"Filename\":\"file1.dat\",\"Size\":${#content3}, \"Data\":\"$content3\"},
       {\"Filename\":\"file2.dat\",\"Size\":${#content4}, \"Data\":\"$content4\"}]
   }
   ]" | lfstest-testutils addcommits
 
-  git lfs push origin master
+  git lfs push origin main
   git lfs push origin other_branch
   assert_server_object "$reponame" "$oid1"
   assert_server_object "$reponame" "$oid2"
@@ -534,7 +534,7 @@ begin_test "push ambiguous branch name"
       {\"Filename\":\"file4.dat\",\"Size\":${#content[3]}, \"Data\":\"${content[3]}\"}]
   },
   {
-    \"ParentBranches\":[\"master\"],
+    \"ParentBranches\":[\"main\"],
     \"CommitDate\":\"$(get_date -1d)\",
     \"Files\":[
       {\"Filename\":\"file1.dat\",\"Size\":${#content[4]}, \"Data\":\"${content[4]}\"}]
@@ -544,8 +544,8 @@ begin_test "push ambiguous branch name"
   # create tag with same name as branch
   git tag ambiguous
 
-  # lfs push master, should work
-  git lfs push origin master
+  # lfs push main, should work
+  git lfs push origin main
 
   # push ambiguous, does not fail since lfs scans git with sha, not ref name
   git lfs push origin ambiguous
@@ -568,12 +568,12 @@ begin_test "push (retry with expired actions)"
   git add .gitattributes a.dat
 
   git commit -m "add a.dat, .gitattributes" 2>&1 | tee commit.log
-  grep "master (root-commit)" commit.log
+  grep "main (root-commit)" commit.log
   grep "2 files changed" commit.log
   grep "create mode 100644 a.dat" commit.log
   grep "create mode 100644 .gitattributes" commit.log
 
-  GIT_TRACE=1 git push origin master 2>&1 | tee push.log
+  GIT_TRACE=1 git push origin main 2>&1 | tee push.log
 
   expected="enqueue retry #1 after 0.25s for \"$contents_oid\" (size: $contents_size): LFS: tq: action \"upload\" expires at"
 
@@ -599,14 +599,14 @@ begin_test "push to raw remote url"
   printf "%s" "$contents" > raw.dat
   git add raw.dat .gitattributes
   git commit -m "add" 2>&1 | tee commit.log
-  grep "master (root-commit)" commit.log
+  grep "main (root-commit)" commit.log
   grep "2 files changed" commit.log
   grep "create mode 100644 raw.dat" commit.log
   grep "create mode 100644 .gitattributes" commit.log
 
   refute_server_object push-raw "$contents_oid"
 
-  git lfs push $GITSERVER/push-raw master
+  git lfs push $GITSERVER/push-raw main
 
   assert_server_object push-raw "$contents_oid"
 )
@@ -626,13 +626,13 @@ begin_test "push (with invalid object size)"
 
   git add a.dat .gitattributes
   git commit -m "add a.dat, .gitattributes" 2>&1 | tee commit.log
-  grep "master (root-commit)" commit.log
+  grep "main (root-commit)" commit.log
   grep "2 files changed" commit.log
   grep "create mode 100644 a.dat" commit.log
   grep "create mode 100644 .gitattributes" commit.log
 
   set +e
-  git push origin master 2>&1 2> push.log
+  git push origin main 2>&1 2> push.log
   res="$?"
   set -e
 
@@ -662,7 +662,7 @@ begin_test "push with deprecated _links"
   git add a.dat
   git commit -m "add a.dat"
 
-  git push origin master
+  git push origin main
 
   assert_server_object "$reponame" "$contents_oid"
 )
@@ -680,7 +680,7 @@ begin_test "push with invalid pushInsteadof"
   git config lfs.transfer.enablehrefrewrite true
 
   set +e
-  git lfs push origin master > push.log 2>&1
+  git lfs push origin main > push.log 2>&1
   res=$?
 
   set -e
@@ -691,7 +691,7 @@ begin_test "push with invalid pushInsteadof"
 
   # lfs-push succeed after unsetting enableHrefRewrite config
   git config --unset lfs.transfer.enablehrefrewrite
-  git lfs push origin master
+  git lfs push origin main
 )
 end_test
 
@@ -713,7 +713,7 @@ begin_test 'push with data the server already has'
   git add a.dat
   git commit -m "add a.dat"
 
-  git push origin master
+  git push origin main
 
   assert_server_object "$reponame" "$contents_oid"
 
@@ -759,7 +759,7 @@ begin_test 'push with multiple refs and data the server already has'
   git add a.dat
   git commit -m "add a.dat"
 
-  git push origin master
+  git push origin main
 
   assert_server_object "$reponame" "$contents_oid"
 
@@ -780,10 +780,10 @@ begin_test 'push with multiple refs and data the server already has'
   # We use the URL so that we cannot take advantage of the existing "origin/*"
   # refs that we know the server must have.
   GIT_TRACE=1 GIT_TRANSFER_TRACE=1 GIT_CURL_VERBOSE=1 \
-    git push "$(git config remote.origin.url)" master v1.0.0 2>&1 | tee push.log
+    git push "$(git config remote.origin.url)" main v1.0.0 2>&1 | tee push.log
 
   # We should not find a batch request for the object which is in the earlier
-  # version of master, since we know the remote side has it.
+  # version of main, since we know the remote side has it.
   [ "$(grep -c "$contents_oid" push.log)" = 0 ]
 
   # Yet we should have pushed the new object successfully.
@@ -814,9 +814,9 @@ begin_test "push custom reference"
 
   # Create and try pushing a reference in a nonstandard namespace, that is,
   # outside of refs/heads, refs/tags, and refs/remotes.
-  git update-ref refs/custom/remote/heads/master refs/heads/master
+  git update-ref refs/custom/remote/heads/main refs/heads/main
 
-  git lfs push origin refs/custom/remote/heads/master
+  git lfs push origin refs/custom/remote/heads/main
   assert_server_object "$reponame" "$oid"
 )
 end_test

--- a/t/t-push.sh
+++ b/t/t-push.sh
@@ -200,7 +200,7 @@ begin_test "push --all (no ref args)"
   [ $(grep -c "^push " < push.log) -eq 6 ]
 
   git push --all origin 2>&1 | tee push.log
-  [ $(grep -c "Uploading LFS objects: 100% (6/6), 36 B" push.log) -eq 1 ]
+  [ $(grep -c "Uploading LFS objects: 100% (6/6)" push.log) -eq 1 ]
   assert_server_object "$reponame-$suffix" "$oid1"
   assert_server_object "$reponame-$suffix" "$oid2"
   assert_server_object "$reponame-$suffix" "$oid3"
@@ -232,7 +232,7 @@ begin_test "push --all (no ref args)"
   [ $(grep -c "^push " push.log) -eq 6 ]
 
   git push --all origin 2>&1 | tee push.log
-  grep "Uploading LFS objects: 100% (6/6), 36 B" push.log
+  grep "Uploading LFS objects: 100% (6/6)" push.log
   assert_server_object "$reponame-$suffix-2" "$oid2"
   assert_server_object "$reponame-$suffix-2" "$oid3"
   assert_server_object "$reponame-$suffix-2" "$oid4"

--- a/t/t-reference-clone.sh
+++ b/t/t-reference-clone.sh
@@ -38,7 +38,7 @@ begin_test "clone with reference"
   git add a.dat
   git add .gitattributes
   git commit -m "add a.dat" 2>&1
-  git push origin master
+  git push origin main
 
   delete_server_object "$reponame" "$oid"
 
@@ -49,7 +49,7 @@ begin_test "clone with reference"
 
   cd "$TRASHDIR/$repo"
 
-  assert_pointer "master" "a.dat" "$oid" 1
+  assert_pointer "main" "a.dat" "$oid" 1
   assert_same_inode "$repo_dir" "$ref_repo_dir" "$oid"
 )
 end_test
@@ -79,15 +79,15 @@ begin_test "fetch from clone reference"
   git add a.dat
   git add .gitattributes
   git commit -m "add a.dat" 2>&1
-  git push origin master
+  git push origin main
 
   delete_server_object "$reponame" "$oid"
 
   cd "$repo_dir"
-  GIT_LFS_SKIP_SMUDGE=1 git pull origin master
+  GIT_LFS_SKIP_SMUDGE=1 git pull origin main
   git lfs pull
 
-  assert_pointer "master" "a.dat" "$oid" 1
+  assert_pointer "main" "a.dat" "$oid" 1
   assert_same_inode "$TRASHDIR/$repo" "$TRASHDIR/$ref_repo" "$oid"
 )
 end_test

--- a/t/t-reference-clone.sh
+++ b/t/t-reference-clone.sh
@@ -84,7 +84,7 @@ begin_test "fetch from clone reference"
   delete_server_object "$reponame" "$oid"
 
   cd "$repo_dir"
-  GIT_LFS_SKIP_SMUDGE=1 git pull
+  GIT_LFS_SKIP_SMUDGE=1 git pull origin master
   git lfs pull
 
   assert_pointer "master" "a.dat" "$oid" 1

--- a/t/t-resume-http-range.sh
+++ b/t/t-resume-http-range.sh
@@ -23,7 +23,7 @@ begin_test "resume-http-range"
   git add a.dat
   git add .gitattributes
   git commit -m "add a.dat" 2>&1 | tee commit.log
-  git push origin master
+  git push origin main
 
   assert_server_object "$reponame" "$contents_oid"
 
@@ -64,7 +64,7 @@ begin_test "resume-http-range-fallback"
   git add a.dat
   git add .gitattributes
   git commit -m "add a.dat" 2>&1 | tee commit.log
-  git push origin master
+  git push origin main
 
   assert_server_object "$reponame" "$contents_oid"
 
@@ -107,7 +107,7 @@ begin_test "resume-http-range-retry"
   git add a.dat
   git add .gitattributes
   git commit -m "add a.dat" 2>&1 | tee commit.log
-  git push origin master
+  git push origin main
 
   assert_server_object "$reponame" "$contents_oid"
 

--- a/t/t-resume-tus.sh
+++ b/t/t-resume-tus.sh
@@ -23,7 +23,7 @@ begin_test "tus-upload-uninterrupted"
   git add a.dat
   git add .gitattributes
   git commit -m "add a.dat" 2>&1 | tee commit.log
-  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git push origin master 2>&1 | tee pushtus.log
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git push origin main 2>&1 | tee pushtus.log
   grep "xfer: tus.io uploading" pushtus.log
 
   assert_server_object "$reponame" "$contents_oid"
@@ -59,7 +59,7 @@ begin_test "tus-upload-interrupted-resume"
   git add a.dat verify.dat
   git add .gitattributes
   git commit -m "add a.dat, verify.dat" 2>&1 | tee commit.log
-  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git push origin master 2>&1 | tee pushtus_resume.log
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git push origin main 2>&1 | tee pushtus_resume.log
   # first attempt will start from the beginning
   grep "xfer: tus.io uploading" pushtus_resume.log
   grep "HTTP: 500" pushtus_resume.log

--- a/t/t-smudge.sh
+++ b/t/t-smudge.sh
@@ -19,7 +19,7 @@ begin_test "smudge"
   output="$(pointer fcf5015df7a9089a7aa7fe74139d4b8f7d62e52d5a34f9a87aeffc8e8c668254 9 | git lfs smudge)"
   [ "smudge a" = "$output" ]
 
-  git push origin master
+  git push origin main
 
   # download it from the git lfs server
   rm -rf .git/lfs/objects
@@ -75,7 +75,7 @@ begin_test "smudge include/exclude"
   # smudge works even though it hasn't been pushed, by reading from .git/lfs/objects
   [ "smudge a" = "$(echo "$pointer" | git lfs smudge)" ]
 
-  git push origin master
+  git push origin main
 
   # this WOULD download except we're going to prevent it with include/exclude
   rm -rf .git/lfs/objects
@@ -101,7 +101,7 @@ begin_test "smudge with skip"
   pointer="$(pointer fcf5015df7a9089a7aa7fe74139d4b8f7d62e52d5a34f9a87aeffc8e8c668254 9)"
   [ "smudge a" = "$(echo "$pointer" | git lfs smudge)" ]
 
-  git push origin master
+  git push origin main
 
   # Must clear the cache because smudge will use
   # cached objects even with --skip/GIT_LFS_SKIP_SMUDGE
@@ -152,7 +152,7 @@ begin_test "smudge clone with include/exclude"
   git add a.dat
   git add .gitattributes
   git commit -m "add a.dat" 2>&1 | tee commit.log
-  grep "master (root-commit)" commit.log
+  grep "main (root-commit)" commit.log
   grep "2 files changed" commit.log
   grep "create mode 100644 a.dat" commit.log
   grep "create mode 100644 .gitattributes" commit.log
@@ -161,9 +161,9 @@ begin_test "smudge clone with include/exclude"
 
   assert_local_object "$contents_oid" 1
 
-  git push origin master 2>&1 | tee push.log
+  git push origin main 2>&1 | tee push.log
   grep "Uploading LFS objects: 100% (1/1), 1 B" push.log
-  grep "master -> master" push.log
+  grep "main -> main" push.log
 
   assert_server_object "$reponame" "$contents_oid"
 
@@ -195,7 +195,7 @@ begin_test "smudge skip download failure"
   # smudge works even though it hasn't been pushed, by reading from .git/lfs/objects
   [ "smudge a" = "$(echo "$pointer" | git lfs smudge)" ]
 
-  git push origin master
+  git push origin main
 
   # make it try to download but we're going to make it fail
   rm -rf .git/lfs/objects
@@ -233,8 +233,8 @@ begin_test "smudge no ref, non-origin"
   git add .gitattributes a.dat
   git commit -m "add a.dat"
 
-  git push origin master
-  master=$(git rev-parse master)
+  git push origin main
+  main=$(git rev-parse main)
 
   cd ..
   git init "$reponame"
@@ -246,7 +246,7 @@ begin_test "smudge no ref, non-origin"
   git config remote.random.url "$GITSERVER/$reponame"
   git fetch "$GITSERVER/$reponame"
 
-  git checkout "$master"
+  git checkout "$main"
   [ "smudge a" = "$(cat a.dat)" ]
 )
 end_test

--- a/t/t-ssh.sh
+++ b/t/t-ssh.sh
@@ -21,7 +21,7 @@ begin_test "ssh with proxy command in lfs.url"
   git add .gitattributes test.dat
   git commit -m "initial commit"
 
-  git push origin master 2>&1 | tee push.log
+  git push origin main 2>&1 | tee push.log
   if [ "0" -eq "${PIPESTATUS[0]}" ]; then
     echo >&2 "fatal: push succeeded"
     exit 1

--- a/t/t-status.sh
+++ b/t/t-status.sh
@@ -40,7 +40,7 @@ begin_test "status"
   file_3_new_oid_short="$(echo "$file_3_new_oid" | head -c 7)"
   printf "%s" "$file_3_new" > file3.dat
 
-  expected="On branch master
+  expected="On branch main
 
 Objects to be committed:
 
@@ -135,7 +135,7 @@ begin_test "status in a sub-directory"
 
   printf "ASDF" > file.dat
 
-  expected="On branch master
+  expected="On branch main
 
 Objects to be committed:
 
@@ -243,7 +243,7 @@ begin_test "status shows multiple copies of partially staged files"
   contents_2_oid_short="$(echo "$contents_2_oid" | head -c 7)"
   printf "%s" "$contents_2" > a.dat
 
-  expected="On branch master
+  expected="On branch main
 
 Objects to be committed:
 
@@ -285,7 +285,7 @@ begin_test "status: LFS to LFS change"
   printf "%s" "$contents_new" > a.dat
   git add a.dat
 
-  expected="On branch master
+  expected="On branch main
 
 Objects to be committed:
 
@@ -325,7 +325,7 @@ begin_test "status: Git to LFS change"
   printf "%s" "$contents_new" > a.dat
   git add a.dat
 
-  expected="On branch master
+  expected="On branch main
 
 Objects to be committed:
 
@@ -358,7 +358,7 @@ begin_test "status: Git to LFS conversion"
   git add .gitattributes
   git commit -m "track *.dat"
 
-  git push origin master
+  git push origin main
 
   pushd "$TRASHDIR" > /dev/null
     clone_repo "$reponame" "$reponame-2"
@@ -371,8 +371,8 @@ begin_test "status: Git to LFS conversion"
       exit 1
     fi
 
-    expected="On branch master
-Objects to be pushed to origin/master:
+    expected="On branch main
+Objects to be pushed to origin/main:
 
 
 Objects to be committed:
@@ -426,7 +426,7 @@ begin_test "status (unpushed objects)"
   git add .gitattributes
   git commit -m "initial commit"
 
-  git push -u origin master
+  git push -u origin main
 
   contents="a"
   oid="$(calc_oid "$contents")"
@@ -435,8 +435,8 @@ begin_test "status (unpushed objects)"
   git add a.dat
   git commit -m "add a large file"
 
-  expected="On branch master
-Objects to be pushed to origin/master:
+  expected="On branch main
+Objects to be pushed to origin/main:
 
 	a.dat ($oid)
 
@@ -477,7 +477,7 @@ begin_test "status (deleted files)"
   git add .gitattributes
   git commit -m "initial commit"
 
-  git push -u origin master
+  git push -u origin main
 
   contents="a"
   oid="$(calc_oid "$contents")"
@@ -489,8 +489,8 @@ begin_test "status (deleted files)"
 
   git rm a.dat
 
-  expected="On branch master
-Objects to be pushed to origin/master:
+  expected="On branch main
+Objects to be pushed to origin/main:
 
 	a.dat ($oid)
 
@@ -536,7 +536,7 @@ begin_test "status (file to dir)"
   git reset HEAD~
   git add test
 
-  expected="On branch master
+  expected="On branch main
 
 Objects to be committed:
 
@@ -582,7 +582,7 @@ begin_test "status: permission change"
     exit 1
   fi
 
-  expected="On branch master
+  expected="On branch main
 
 Objects to be committed:
 

--- a/t/t-status.sh
+++ b/t/t-status.sh
@@ -426,7 +426,7 @@ begin_test "status (unpushed objects)"
   git add .gitattributes
   git commit -m "initial commit"
 
-  git push origin master
+  git push -u origin master
 
   contents="a"
   oid="$(calc_oid "$contents")"
@@ -477,7 +477,7 @@ begin_test "status (deleted files)"
   git add .gitattributes
   git commit -m "initial commit"
 
-  git push origin master
+  git push -u origin master
 
   contents="a"
   oid="$(calc_oid "$contents")"

--- a/t/t-submodule-lfsconfig.sh
+++ b/t/t-submodule-lfsconfig.sh
@@ -25,7 +25,7 @@ begin_test "submodule env with .lfsconfig"
   printf "%s" "$submodcontent" > dir/test.dat
   git add .lfsconfig .gitattributes dir
   git commit -m "create submodule"
-  git push origin master
+  git push origin main
 
   assert_server_object "$lfsname" "$submodoid"
 
@@ -33,7 +33,7 @@ begin_test "submodule env with .lfsconfig"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" repo
   git config -f .lfsconfig lfs.url "$GITSERVER/$lfsname.git/info/lfs"
-  git submodule add -b master "$GITSERVER/$submodname" sub
+  git submodule add -b main "$GITSERVER/$submodname" sub
   git submodule update
   git lfs track "*.dat"
   mkdir dir
@@ -42,7 +42,7 @@ begin_test "submodule env with .lfsconfig"
   printf "%s" "$repocontent" > dir/test.dat
   git add .gitattributes .lfsconfig .gitmodules dir sub
   git commit -m "create repo"
-  git push origin master
+  git push origin main
 
   assert_server_object "$lfsname" "$repooid"
 

--- a/t/t-submodule-lfsconfig.sh
+++ b/t/t-submodule-lfsconfig.sh
@@ -33,7 +33,7 @@ begin_test "submodule env with .lfsconfig"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" repo
   git config -f .lfsconfig lfs.url "$GITSERVER/$lfsname.git/info/lfs"
-  git submodule add "$GITSERVER/$submodname" sub
+  git submodule add -b master "$GITSERVER/$submodname" sub
   git submodule update
   git lfs track "*.dat"
   mkdir dir

--- a/t/t-submodule-recurse.sh
+++ b/t/t-submodule-recurse.sh
@@ -19,13 +19,13 @@ begin_test "submodule with submodule.recurse = true"
   echo "foo" > file.dat
   git add .gitattributes file.dat
   git commit -a -m "add file"
-  git push origin master
+  git push origin main
   subcommit1=$(git rev-parse HEAD)
 
   echo "bar" > file.dat
   git add file.dat
   git commit -a -m "update file"
-  git push origin master
+  git push origin main
   subcommit2=$(git rev-parse HEAD)
 
   clone_repo "$reponame" repo
@@ -34,7 +34,7 @@ begin_test "submodule with submodule.recurse = true"
   git -C submodule reset --hard "$subcommit1"
   git add .gitmodules submodule
   git commit -m "add submodule"
-  git push origin master
+  git push origin main
 
   git checkout -b feature
   git -C submodule reset --hard "$subcommit2"

--- a/t/t-submodule.sh
+++ b/t/t-submodule.sh
@@ -16,14 +16,14 @@ begin_test "submodule local git dir"
   echo "sub module" > dir/README
   git add dir/README
   git commit -a -m "submodule readme"
-  git push origin master
+  git push origin main
 
   clone_repo "$reponame" repo
   git submodule add "$GITSERVER/$submodname" sub
   git submodule update
   git add .gitmodules sub
   git commit -m "add submodule"
-  git push origin master
+  git push origin main
 
   grep "sub module" sub/dir/README || {
     echo "submodule not setup correctly?"

--- a/t/t-track.sh
+++ b/t/t-track.sh
@@ -133,8 +133,8 @@ begin_test "track directory"
   git add foo\ bar
   git commit -am "add foo bar"
 
-  assert_pointer "master" "foo bar/a" "87428fc522803d31065e7bce3cf03fe475096631e5e07bbd7a0fde60c4cf25c7" 2
-  assert_pointer "master" "foo bar/b" "0263829989b6fd954f72baaf2fc64bc2e2f01d692d4de72986ea808f6e99813f" 2
+  assert_pointer "main" "foo bar/a" "87428fc522803d31065e7bce3cf03fe475096631e5e07bbd7a0fde60c4cf25c7" 2
+  assert_pointer "main" "foo bar/b" "0263829989b6fd954f72baaf2fc64bc2e2f01d692d4de72986ea808f6e99813f" 2
 )
 end_test
 
@@ -679,7 +679,7 @@ begin_test "track: escaped glob pattern in .gitattributes"
   git commit -m 'Add unusually named file'
 
   # If Git understood our escaping, we'll have a pointer. Otherwise, we won't.
-  assert_pointer "master" "$filename" "$contents_oid" 15
+  assert_pointer "main" "$filename" "$contents_oid" 15
 )
 end_test
 
@@ -707,6 +707,6 @@ begin_test "track: escaped glob pattern with spaces in .gitattributes"
   git commit -m 'Add unusually named file'
 
   # If Git understood our escaping, we'll have a pointer. Otherwise, we won't.
-  assert_pointer "master" "$filename" "$contents_oid" 15
+  assert_pointer "main" "$filename" "$contents_oid" 15
 )
 end_test

--- a/t/t-unlock.sh
+++ b/t/t-unlock.sh
@@ -42,6 +42,7 @@ begin_test "unlocking a lock by path with tracked ref"
 
   git config push.default upstream
   git config branch.master.merge refs/heads/tracked
+  git config branch.master.remote origin
   git push origin master
 
   git lfs lock --json "c.dat" | tee lock.log

--- a/t/t-unlock.sh
+++ b/t/t-unlock.sh
@@ -14,16 +14,16 @@ begin_test "unlocking a lock by path with good ref"
 (
   set -e
 
-  reponame="unlock-by-path-master-branch-required"
+  reponame="unlock-by-path-main-branch-required"
   setup_repo "$reponame" "c.dat"
 
   git lfs lock --json "c.dat" | tee lock.log
 
   id=$(assert_lock lock.log c.dat)
-  assert_server_lock "$reponame" "$id" "refs/heads/master"
+  assert_server_lock "$reponame" "$id" "refs/heads/main"
 
   git lfs unlock --id="$id"
-  refute_server_lock "$reponame" "$id" "refs/heads/master"
+  refute_server_lock "$reponame" "$id" "refs/heads/main"
 )
 end_test
 
@@ -41,9 +41,9 @@ begin_test "unlocking a lock by path with tracked ref"
   git commit -m "add c.dat"
 
   git config push.default upstream
-  git config branch.master.merge refs/heads/tracked
-  git config branch.master.remote origin
-  git push origin master
+  git config branch.main.merge refs/heads/tracked
+  git config branch.main.remote origin
+  git push origin main
 
   git lfs lock --json "c.dat" | tee lock.log
 
@@ -67,7 +67,7 @@ begin_test "unlocking a lock by path with bad ref"
   echo "c" > c.dat
   git add .gitattributes c.dat
   git commit -m "add c.dat"
-  git push origin master:other
+  git push origin main:other
 
   git checkout -b other
   git lfs lock --json "c.dat" | tee lock.log
@@ -75,7 +75,7 @@ begin_test "unlocking a lock by path with bad ref"
   id=$(assert_lock lock.log c.dat)
   assert_server_lock "$reponame" "$id" "refs/heads/other"
 
-  git checkout master
+  git checkout main
   git lfs unlock --id="$id" 2>&1 | tee unlock.log
   if [ "0" -eq "${PIPESTATUS[0]}" ]; then
     echo >&2 "fatal: expected 'git lfs lock \'a.dat\'' to fail"
@@ -83,7 +83,7 @@ begin_test "unlocking a lock by path with bad ref"
   fi
 
   assert_server_lock "$reponame" "$id" "refs/heads/other"
-  grep 'Expected ref "refs/heads/other", got "refs/heads/master"' unlock.log
+  grep 'Expected ref "refs/heads/other", got "refs/heads/main"' unlock.log
 )
 end_test
 
@@ -99,7 +99,7 @@ begin_test "unlocking a lock by id with bad ref"
   echo "c" > c.dat
   git add .gitattributes c.dat
   git commit -m "add c.dat"
-  git push origin master:other
+  git push origin main:other
 
   git checkout -b other
   git lfs lock --json "c.dat" | tee lock.log
@@ -107,7 +107,7 @@ begin_test "unlocking a lock by id with bad ref"
   id=$(assert_lock lock.log c.dat)
   assert_server_lock "$reponame" "$id" "refs/heads/other"
 
-  git checkout master
+  git checkout main
   git lfs unlock --id="$id" 2>&1 | tee unlock.log
   if [ "0" -eq "${PIPESTATUS[0]}" ]; then
     echo >&2 "fatal: expected 'git lfs lock \'a.dat\'' to fail"
@@ -115,7 +115,7 @@ begin_test "unlocking a lock by id with bad ref"
   fi
 
   assert_server_lock "$reponame" "$id" "refs/heads/other"
-  grep 'Expected ref "refs/heads/other", got "refs/heads/master"' unlock.log
+  grep 'Expected ref "refs/heads/other", got "refs/heads/main"' unlock.log
 )
 end_test
 

--- a/t/t-unusual-filenames.sh
+++ b/t/t-unusual-filenames.sh
@@ -23,7 +23,7 @@ begin_test "push unusually named files"
   git add -- .gitattributes *.dat
   git commit -m "add files"
 
-  git push origin master | tee push.log
+  git push origin main | tee push.log
   grep "Uploading LFS objects: 100% (1/1), 1 B" push.log
 )
 end_test

--- a/t/t-upload-redirect.sh
+++ b/t/t-upload-redirect.sh
@@ -18,9 +18,9 @@ begin_test "redirect upload"
   git add .gitattributes a.dat
   git commit -m "initial commit"
 
-  GIT_TRACE=1 git push origin master 2>&1 | tee push.log
+  GIT_TRACE=1 git push origin main 2>&1 | tee push.log
   if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected \`git push origin master\` to succeed ..."
+    echo >&2 "fatal: expected \`git push origin main\` to succeed ..."
     exit 1
   fi
 

--- a/t/t-verify.sh
+++ b/t/t-verify.sh
@@ -22,7 +22,7 @@ begin_test "verify with retries"
   git add a.dat
   git commit -m "add a.dat"
 
-  GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push origin master 2>&1 | tee push.log
+  GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push origin main 2>&1 | tee push.log
 
   grep "Authorization: Basic * * * * *" push.log
 
@@ -51,7 +51,7 @@ begin_test "verify with retries (success without retry)"
   git add a.dat
   git commit -m "add a.dat"
 
-  GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push origin master 2>&1 | tee push.log
+  GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push origin main 2>&1 | tee push.log
 
   grep "Authorization: Basic * * * * *" push.log
 
@@ -81,7 +81,7 @@ begin_test "verify with retries (insufficient retries)"
   git commit -m "add a.dat"
 
   set +e
-  GIT_TRACE=1 git push origin master 2>&1 | tee push.log
+  GIT_TRACE=1 git push origin main 2>&1 | tee push.log
   if [ "0" -eq "${PIPESTATUS[0]}" ]; then
     echo >&2 "verify: expected \"git push\" to fail, didn't ..."
     exit 1
@@ -115,7 +115,7 @@ begin_test "verify with retries (bad .gitconfig)"
   git add a.dat
   git commit -m "add a.dat"
 
-  GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push origin master 2>&1 | tee push.log
+  GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push origin main 2>&1 | tee push.log
 
   grep "Authorization: Basic * * * * *" push.log
 

--- a/t/t-zero-len-file.sh
+++ b/t/t-zero-len-file.sh
@@ -22,9 +22,9 @@ begin_test "push zero len file"
   git commit -m "add files" | tee commit.log
 
   # cut from commit output
-  #   $ git cat-file -p master
+  #   $ git cat-file -p main
   #   tree 2d67d025fb1f9df9fa349412b4b130e982314e92
-  tree="$(git cat-file -p master | cut -f 2 -d " " | head -n 1)"
+  tree="$(git cat-file -p main | cut -f 2 -d " " | head -n 1)"
 
   # cut from tree output
   #   $ git cat-file -p "$tree"
@@ -36,9 +36,9 @@ begin_test "push zero len file"
   # look for lfs pointer in git blob
   [ "0" = "$(git cat-file -p "$emptyblob" | grep "lfs" -c)" ]
 
-  assert_pointer "master" "full.dat" "$contents_oid" 4
+  assert_pointer "main" "full.dat" "$contents_oid" 4
 
-  git push origin master | tee push.log
+  git push origin main | tee push.log
   grep "Uploading LFS objects: 100% (1/1), 4 B" push.log
 )
 end_test

--- a/t/testenv.sh
+++ b/t/testenv.sh
@@ -23,6 +23,18 @@ then
   IS_MAC=1
 fi
 
+# Convert potentially MinGW bash paths to native Windows paths
+# Needed to match generic built paths in test scripts to native paths generated from Go
+native_path() {
+  local arg=$1
+  if [ $IS_WINDOWS -eq 1 ]; then
+    # Use params form to avoid interpreting any '\' characters
+    printf '%s' "$(cygpath -w $arg)"
+  else
+    printf '%s' "$arg"
+  fi
+}
+
 resolve_symlink() {
   local arg=$1
   if [ $IS_WINDOWS -eq 1 ]; then
@@ -127,6 +139,7 @@ GIT_LFS_FORCE_PROGRESS=1
 GIT_CONFIG_NOSYSTEM=1
 GIT_TERMINAL_PROMPT=0
 GIT_SSH=lfs-ssh-echo
+GIT_TEMPLATE_DIR="$(native_path "$ROOTDIR/t/fixtures/templates")"
 APPVEYOR_REPO_COMMIT_MESSAGE="test: env test should look for GIT_SSH too"
 LC_ALL=C
 
@@ -134,6 +147,7 @@ export CREDSDIR
 export GIT_LFS_FORCE_PROGRESS
 export GIT_CONFIG_NOSYSTEM
 export GIT_SSH
+export GIT_TEMPLATE_DIR
 export APPVEYOR_REPO_COMMIT_MESSAGE
 export LC_ALL
 

--- a/t/testhelpers.sh
+++ b/t/testhelpers.sh
@@ -3,7 +3,7 @@
 # assert_pointer confirms that the pointer in the repository for $path in the
 # given $ref matches the given $oid and $size.
 #
-#   $ assert_pointer "master" "path/to/file" "some-oid" 123
+#   $ assert_pointer "main" "path/to/file" "some-oid" 123
 assert_pointer() {
   local ref="$1"
   local path="$2"
@@ -27,7 +27,7 @@ assert_pointer() {
 # refute_pointer confirms that the file in the repository for $path in the
 # given $ref is _not_ a pointer.
 #
-#   $ refute_pointer "master" "path/to/file"
+#   $ refute_pointer "main" "path/to/file"
 refute_pointer() {
   local ref="$1"
   local path="$2"
@@ -451,13 +451,13 @@ setup_remote_repo_with_file() {
   git add .gitattributes $filename
   git commit -m "add $filename" | tee commit.log
 
-  grep "master (root-commit)" commit.log
+  grep "main (root-commit)" commit.log
   grep "2 files changed" commit.log
   grep "create mode 100644 $filename" commit.log
   grep "create mode 100644 .gitattributes" commit.log
 
-  git push origin master 2>&1 | tee push.log
-  grep "master -> master" push.log
+  git push origin main 2>&1 | tee push.log
+  grep "main -> main" push.log
 }
 
 # substring_position returns the position of a substring in a 1-indexed search

--- a/t/testhelpers.sh
+++ b/t/testhelpers.sh
@@ -706,18 +706,6 @@ get_date() {
   fi
 }
 
-# Convert potentially MinGW bash paths to native Windows paths
-# Needed to match generic built paths in test scripts to native paths generated from Go
-native_path() {
-  local arg=$1
-  if [ $IS_WINDOWS -eq 1 ]; then
-    # Use params form to avoid interpreting any '\' characters
-    printf '%s' "$(cygpath -w $arg)"
-  else
-    printf '%s' "$arg"
-  fi
-}
-
 # escape any instance of '\' with '\\' on Windows
 escape_path() {
   local unescaped="$1"


### PR DESCRIPTION
Git is likely going to switch the default branch name soon, so it makes sense for us to ensure that our testsuite works with such a version of Git.  In order to do so, let's use the existing template mechanism to use a different default branch name and update the testsuite so it continues to work.

Each patch is logically independent with a useful commit message.  The last patch is large and was written by an automated command which is included in the commit message for easy review.  Therefore, it may be desirable to review this series commit by commit.