### PR TITLE
subprocess: trace all command execution

### DIFF
--- a/git/config.go
+++ b/git/config.go
@@ -175,7 +175,6 @@ func (c *Configuration) Source() (*ConfigurationSource, error) {
 
 func (c *Configuration) gitConfig(args ...string) (string, error) {
 	args = append([]string{"config"}, args...)
-	subprocess.Trace("git", args...)
 	cmd := subprocess.ExecCommand("git", args...)
 	if len(c.GitDir) > 0 {
 		cmd.Dir = c.GitDir

--- a/subprocess/cmd.go
+++ b/subprocess/cmd.go
@@ -14,6 +14,26 @@ type Cmd struct {
 	pipes []io.Closer
 }
 
+func (c *Cmd) Run() error {
+	c.trace()
+	return c.Cmd.Run()
+}
+
+func (c *Cmd) Start() error {
+	c.trace()
+	return c.Cmd.Start()
+}
+
+func (c *Cmd) Output() ([]byte, error) {
+	c.trace()
+	return c.Cmd.Output()
+}
+
+func (c *Cmd) CombinedOutput() ([]byte, error) {
+	c.trace()
+	return c.Cmd.CombinedOutput()
+}
+
 func (c *Cmd) StdoutPipe() (io.ReadCloser, error) {
 	stdout, err := c.Cmd.StdoutPipe()
 	c.pipes = append(c.pipes, stdout)
@@ -38,6 +58,14 @@ func (c *Cmd) Wait() error {
 	}
 
 	return c.Cmd.Wait()
+}
+
+func (c *Cmd) trace() {
+	if len(c.Args) > 0 {
+		Trace(c.Args[0], c.Args[1:]...)
+	} else {
+		Trace(c.Path)
+	}
 }
 
 func newCmd(cmd *exec.Cmd) *Cmd {

--- a/subprocess/subprocess.go
+++ b/subprocess/subprocess.go
@@ -46,7 +46,6 @@ func BufferedExec(name string, args ...string) (*BufferedCmd, error) {
 
 // SimpleExec is a small wrapper around os/exec.Command.
 func SimpleExec(name string, args ...string) (string, error) {
-	Trace(name, args...)
 	return Output(ExecCommand(name, args...))
 }
 


### PR DESCRIPTION
Trace all command execution at the time when the command starts. Previously, only "simple" execution created trace entries, leading to mysterious gaps in trace logs where time passed but it looked like nothing was happening.

An alternate approach might be to log the trace line when the `subprocess.Cmd` is created. in `newCmd`. If commands are always executed right after creation, that might be enough and it avoids overriding the additional methods from `os/exec.Cmd`.