### PR TITLE
t: use repo v1 with extensions

### DIFF
--- a/t/t-install-worktree.sh
+++ b/t/t-install-worktree.sh
@@ -83,6 +83,7 @@ begin_test "install --worktree with multiple working trees"
   git add a.txt
   git commit -m "initial commit"
 
+  git config core.repositoryformatversion 1
   git config extensions.worktreeConfig true
 
   treename="../$reponame-wt"

--- a/t/t-uninstall-worktree.sh
+++ b/t/t-uninstall-worktree.sh
@@ -106,6 +106,7 @@ begin_test "uninstall --worktree with multiple working trees"
   git add a.txt
   git commit -m "initial commit"
 
+  git config core.repositoryformatversion 1
   git config extensions.worktreeConfig true
 
   treename="../$reponame-wt"


### PR DESCRIPTION
In some of our worktree code, we use configuration options under the extensions hierarchy.  In upstream Git, unknown extensions are rejected if the repository format version is 1; this format version is otherwise identical to version 0.

Until recently, Git would accept extensions with a repository format version of 0, but fail to reject unknown extensions.  However, this could cause serious problems with the repository, so it was recently fixed to ignore all extensions in repository format 0.

These tests set extensions.worktreeConfig without setting the repository format version, and consequently they fail with the latest versions of Git.  Let's set the version appropriately so that our tests continue to work.

I just happened to see the relevant patch series hit the main branch upstream in the past few days, which is why we didn't see this earlier.  Apologies for not catching this in review.
