### PR TITLE
update go.mod to reflect Go 1.12 minimum

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,4 +29,4 @@ require (
 	gopkg.in/yaml.v2 v2.2.8 // indirect
 )
 
-go 1.11
+go 1.12


### PR DESCRIPTION
Bump the minimum Go version specified in our `go.mod` to match our CI tooling and our dependency on some Go 1.12 features, specifically our use of `os.ProcessState.ExitCode()`.

Note that an alternative is proposed in #4183 and we should adopt either that one or this, but not both.

Fixes #4179.
/cc @andrewarchi as reporter.