### PR TITLE
allow Go 1.11 builds by using WaitStatus.ExitStatus()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     name: Build with specific Go
     strategy:
       matrix:
-        go: ['1.12.x', '1.13.x', '1.14.x']
+        go: ['1.11.x', '1.12.x', '1.13.x', '1.14.x']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
By replacing a call to `os.ProcessState.ExitCode()`, which is only available in Go 1.12, with a slightly more complicated use of `os.ProcessState.Sys()` and `syscall.WaitStatus.ExitStatus()`, we can still support Go 1.11.  Therefore we also add 1.11 to the set of Go versions we build in CI (on Linux only, though).

Because `syscall.WaitStatus.ExitStatus()` is available on both Unix and Windows, we should not lose any OS support with this change; see also this answer to a related Stack Overflow [question](https://stackoverflow.com/questions/10385551/get-exit-code-go).

Note that an alternative, which simply sets our minimum Go version in `go.mod` to 1.12, is proposed in #4182.  We should adopt either this PR or that one, but not both.

Fixes #4179.
/cc @andrewarchi as reporter (and who suggested the code change).