### PR TITLE
Fix Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
     - run: set GOPATH=%HOME%\go
     - run: cinst InnoSetup -y
     - run: cinst strawberryperl -y
+    - run: choco uninstall git.install -y --force
+    - run: cinst git --version 2.26.2 -y --force
     - run: refreshenv
     - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" go get github.com/josephspurrier/goversioninfo/cmd/goversioninfo
       shell: bash

--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -167,7 +167,7 @@ be scoped inside the configuration for a remote.
   each retry until reaching this limit. If a server requests a delay using the
   `Retry-After` header, the header value overrides the exponential delay for
   that attempt and is not limited by this option.
-  
+
   Must be an integer which is not negative. Use zero to disable delays between
   retries unless requested by a server. If the value is not an integer, is
   negative, or is not given, a value of ten will be used instead.

--- a/script/cibuild
+++ b/script/cibuild
@@ -38,8 +38,11 @@ pushd t >/dev/null
 popd >/dev/null
 
 echo "Looking for trailing whitespace..."
-! git grep -lE '[[:space:]]+$' | \
-  grep -vE '(^vendor/|\.git/(objects/|index)|\.bat$)'
+if git grep -lE '[[:space:]]+$' | \
+   grep -vE '(^vendor/|\.git/(objects/|index)|\.bat$)'
+then
+  exit 1
+fi
 
 echo "Formatting files..."
 # Building and installing goimports and goversioninfo will have modified go.mod


### PR DESCRIPTION
This series addresses a couple of problems with our CI system.

* First, our trailing whitespace check was not functional, so there's a commit to remove the trailing whitespace that's crept it and one to fix the check.
* Second, Git for Windows 2.27.0 introduced a bug that, with the configuration used by GitHub Actions, causes all symlinks to be perpetually marked modified, causing our formatting check to fail.

The commits are, as usual, logical and bisectable with sane commit messages.