### PR TITLE
config: optionally read .lfsconfig from the repository

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -76,7 +76,7 @@ func NewIn(workdir, gitdir string) *Configuration {
 
 	c.Git = &delayedEnvironment{
 		callback: func() Environment {
-			sources, err := gitConf.Sources(filepath.Join(c.LocalWorkingDir(), ".lfsconfig"))
+			sources, err := gitConf.Sources(c.LocalWorkingDir(), ".lfsconfig")
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error reading git config: %s\n", err)
 			}

--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -12,6 +12,11 @@ details. This configuration file is useful for setting options such as the LFS
 URL or access type for all users of a repository, especially when these differ
 from the default. The `.lfsconfig` file uses the same format as `.gitconfig`.
 
+If the `.lfsconfig` file is missing, the index is checked for a version of the
+file, and that is used instead.  If both are missing, `HEAD` is checked for the
+file.  If the repository is bare, only `HEAD` is checked.  This order may change
+for checkouts in the future to better match Git's behavior.
+
 Settings from Git configuration files override the `.lfsconfig` file. This
 allows you to override settings like `lfs.url` in your local environment without
 having to modify the `.lfsconfig` file.

--- a/t/t-config.sh
+++ b/t/t-config.sh
@@ -42,6 +42,80 @@ begin_test "default config"
 )
 end_test
 
+begin_test "config reads from repository"
+(
+  set -e
+  reponame="repository-config"
+  setup_remote_repo "$reponame"
+  mkdir $reponame
+  cd $reponame
+  git init
+  git remote add origin "$GITSERVER/$reponame"
+  git lfs env | tee env.log
+  grep "Endpoint=$GITSERVER/$reponame.git/info/lfs (auth=none)" env.log
+
+  git config --file=.lfsconfig lfs.url http://lfsconfig-file
+  git config --file=.lfsconfig lfs.http://lfsconfig-file.access lfsconfig
+  git add .lfsconfig
+  git commit -m 'Add file'
+  git push origin HEAD
+
+  git checkout -b side
+  git config --file=.lfsconfig lfs.url http://lfsconfig-file-side
+  git config --file=.lfsconfig lfs.http://lfsconfig-file-side.access lfsconfig
+  git add .lfsconfig
+  git commit -m 'Add file for side'
+  git push origin HEAD
+
+  mkdir "../$reponame-2"
+  cd "../$reponame-2"
+  git init
+  git remote add origin "$GITSERVER/$reponame"
+
+  git lfs env | tee env.log
+  grep "Endpoint=$GITSERVER/$reponame.git/info/lfs (auth=none)" env.log
+
+  git fetch origin
+  git symbolic-ref HEAD refs/remotes/origin/side
+  git show "HEAD:.lfsconfig"
+  git lfs env | tee env.log
+  grep "Endpoint=http://lfsconfig-file-side (auth=lfsconfig)" env.log
+
+  git read-tree refs/remotes/origin/main
+  git lfs env | tee env.log
+  grep "Endpoint=http://lfsconfig-file (auth=lfsconfig)" env.log
+)
+end_test
+
+begin_test "can read LFS file with name before .lfsconfig"
+(
+  set -e
+  reponame="early-file-config"
+  setup_remote_repo "$reponame"
+  mkdir $reponame
+  cd $reponame
+  git init
+  git remote add origin "$GITSERVER/$reponame"
+
+  git lfs track "*.bin"
+  git config --file=.lfsconfig lfs.url "$GITSERVER/$reponame.git/info/lfs"
+
+  echo "abc" > .bin
+  echo "def" > a.bin
+
+  git add .
+  git commit -m "Add files"
+  git push origin HEAD
+  rm -fr .git/lfs/objects
+
+  cd ..
+  git clone "$reponame" "$reponame-2"
+  cd "$reponame-2"
+  grep abc .bin
+  grep def a.bin
+)
+end_test
+
 begin_test "extension config"
 (
   set -e


### PR DESCRIPTION
Currently we only read .lfsconfig from the working tree.  This is better than nothing, but it means that if there's an LFS file that starts with a name earlier than .lfsconfig, we won't read the proper config file, and we won't use any LFS remote URLs that are located in that file.

If the file is missing, let's additionally read from the index, if there's a working tree, and then from HEAD.  If the repository is bare, let's just read from HEAD.  This is very similar to what Git does for .gitmodules.

It does, however, differ in one significant way: Git will read from the index first if it's doing a checkout, since that might have newer information.  We don't do that here, since it's not totally clear that we can articulate all the cases where that occurs in Git LFS, but we explicitly allow for the possibility of changing the behavior in the future and document the feature accordingly.

We no longer read the file .lfsconfig from a bare repository, but that we did this in the first place was very questionable and pretty clearly a bug, so it's intentional that we no longer do.

It's intentional that we ignore errors from this code path, since Git doesn't distinguish well between older versions which don't support the `--blob` flag to `git config` (those before 1.8.4), cases where the revision is missing, and actual errors.  We don't want to do a `git rev-parse` on each revision, since that would add potentially two more Git calls to every invocation of Git LFS.

Fixes #4077