### PR TITLE
Add GIT_LFS_SKIP_PUSH to allow skipping the pre-push hook

### DIFF
--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -43,6 +43,10 @@ func prePushCommand(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
+	if cfg.Os.Bool("GIT_LFS_SKIP_PUSH", false) {
+		return
+	}
+
 	requireGitVersion()
 
 	// Remote is first arg

--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -360,6 +360,13 @@ be scoped inside the configuration for a remote.
   `git lfs smudge` and `git lfs filter-process`. If unset, or set to 'false',
   '0', 'off', or similar, Git LFS will smudge files as normal.
 
+* `GIT_LFS_SKIP_PUSH`
+
+  Sets whether or not Git LFS will attempt to upload new Git LFS object in a
+  pre-push hook. If 'true', '1', 'on', or similar, Git LFS will skip the
+  pre-push hook, so no new Git LFS objects will be uploaded. If unset, or set to
+  'false', '0', 'off', or similar, Git LFS will proceed as normal.
+
 * `GIT_LFS_SET_LOCKABLE_READONLY`
   `lfs.setlockablereadonly`
 

--- a/docs/man/git-lfs-pre-push.1.ronn
+++ b/docs/man/git-lfs-pre-push.1.ronn
@@ -14,6 +14,14 @@ the following format:
 
 It also takes the remote name and URL as arguments.
 
+If any of those Git objects are associated with Git LFS objects, those
+objects will be pushed to the Git LFS API.
+
+In the case of pushing a new branch, the list of Git objects will be all of
+the Git objects in this branch.
+
+In the case of deleting a branch, no attempts to push Git LFS objects will be
+made.
 ## SEE ALSO
 
 git-lfs-clean(1), git-lfs-push(1).

--- a/docs/man/git-lfs-pre-push.1.ronn
+++ b/docs/man/git-lfs-pre-push.1.ronn
@@ -22,6 +22,12 @@ the Git objects in this branch.
 
 In the case of deleting a branch, no attempts to push Git LFS objects will be
 made.
+
+## OPTIONS
+
+* `GIT_LFS_SKIP_PUSH`:
+    Do nothing on pre-push. For more, see: git-lfs-config(5).
+
 ## SEE ALSO
 
 git-lfs-clean(1), git-lfs-push(1).


### PR DESCRIPTION
As described in #3721, it is sometimes useful to allow temporarily disabling Git LFS functionality when doing `git push`, for example when pushing to a remote that doesn’t support Git LFS.

This pull request also slightly improves the documentation on the `pre-push` Git LFS hook.

Fixes #3721.
