### PR TITLE
Fix hang when the user lacks permissions

### DIFF
--- a/fs/cleanup.go
+++ b/fs/cleanup.go
@@ -16,6 +16,11 @@ func (f *Filesystem) cleanupTmp() error {
 		return nil
 	}
 
+	// No temporary directory?  No problem.
+	if _, err := os.Stat(tmpdir); err != nil && os.IsNotExist(err) {
+		return nil
+	}
+
 	var walkErr error
 	tools.FastWalkDir(tmpdir, func(parentDir string, info os.FileInfo, err error) {
 		if err != nil {

--- a/tools/filetools.go
+++ b/tools/filetools.go
@@ -304,6 +304,8 @@ func fastWalkWithExcludeFiles(rootDir string) *fastWalker {
 	}
 
 	go func() {
+		defer w.Wait()
+
 		dirFi, err := os.Stat(w.rootDir)
 		if err != nil {
 			w.ch <- fastWalkInfo{Err: err}
@@ -311,7 +313,6 @@ func fastWalkWithExcludeFiles(rootDir string) *fastWalker {
 		}
 
 		w.Walk(true, "", dirFi, excludePaths)
-		w.Wait()
 	}()
 	return w
 }


### PR DESCRIPTION
If the user tries to run certain commands, such as `git lfs track`, in a repository where they lack sufficient permissions, we can hang when attempting to clean up temporary files if the temporary directory is missing and we lack permissions to create it.  Let's fix that hang by closing the channel we're waiting on when there's an error, and let's clean up the error message that comes up if the temporary directory doesn't exist.

The commit messages for each commit describe the situation in more detail.

There are no tests for this case because it's difficult to do without having multiple users, and of course we don't want to assume that the test suite has root privileges to do that.

Fixes #4205
/cc @rphodges as submitter