### PR TITLE
Add filename in verify request header.

### DIFF
--- a/tq/verify.go
+++ b/tq/verify.go
@@ -1,6 +1,7 @@
 package tq
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/git-lfs/git-lfs/lfsapi"
@@ -37,6 +38,8 @@ func verifyUpload(c *lfsapi.Client, remote string, t *Transfer) error {
 
 	req.Header.Set("Content-Type", "application/vnd.git-lfs+json")
 	req.Header.Set("Accept", "application/vnd.git-lfs+json")
+	req.Header.Set("Content-Disposition",fmt.Sprintf("attachment; filename=\"%s\"",t.Name))
+
 	for key, value := range action.Header {
 		req.Header.Set(key, value)
 	}


### PR DESCRIPTION
When using Alibaba OSS(Object Storage Service) as binary assets server, the content-type field will be included in checking pre-signed url due to the security reason. But as the LFS api specifications, the api will not know the content-type information when generating pre-signed url, causing the url unmatched. One possible solution is to using default content-type "application/octet-stream" when signing url and set content-type to "application/octet-stream" in batch reponse's header field.
This causes another problem, since both LFS api and oss does not the file name and see the content-type as octet-stream. The file type information is losing and it is important, because we want to provide a dashboard to our users for managing those files tracked by LFS. It will be a convience if they can filt files by file types.
By checking the source code we find that it is easy to provide the filename in verify requests. We decided to provide the filename in request header instead of in request body, because it will do less effect to the original api.

Signed-off-by: yunhuai.xzy <yunhuai.xzy@alibaba-inc.com>