### PR TITLE
release: v2.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Git LFS Changelog
 
+## 2.12.0 (1 Sep 2020)
+
+This release introduces several new features, such as support for the SHA-256
+repositories coming in a future version of Git, restored support for Go 1.11,
+the ability to read the contents of .lfsconfig from the repository, signed and
+notarized binaries on macOS, and pre-built 32-bit ARM binaries on Linux.  In
+addition, several bugs have been fixed and miscellaneous fixes included.
+
+Note that macOS releases are now shipped as zip files, not tarballs, since it is
+not possible to notarize tarballs.  macOS releases are now also built on macOS,
+so `git lfs dedup` should now function.
+
+We would like to extend a special thanks to the following open-source
+contributors:
+
+* @saracen for adding support for ARM binaries
+* @mversluys for improving locking support
+* @cccfeng for updating our documentation to make it more readable
+* @bluekeyes for improving performance and tracing
+* @gertcuykens for adding missing parts of our documentation
+
+### Features
+
+* config: optionally read .lfsconfig from the repository #4200 (@bk2204)
+* Support SHA-256 repositories #4186 (@bk2204)
+* allow Go 1.11 builds by using WaitStatus.ExitStatus() #4183 (@chrisd8088)
+* add --worktree option to install and uninstall commands #4159 (@chrisd8088)
+* Sign and notarize binaries on macOS #4143 (@bk2204)
+* Makefile: add linux arm build and release targets #4126 (@saracen)
+* Allow locking and unlocking non-existent files #3992 (@mversluys)
+
+### Bugs
+
+* docs/api/locking: add an explicit <br> #4208 (@cccfeng)
+* Fix hang when the user lacks permissions #4207 (@bk2204)
+* Don't mark unlocked files that aren't lockable as read-only #4171 (@bk2204)
+* locking: make patterns with slashes work on Windows #4139 (@bk2204)
+* git: consider full refspec when determining seen refs #4133 (@bk2204)
+
+### Misc
+
+* Fix Windows CI #4199 (@bk2204)
+* Fix testsuite when working with non-master default branch #4174 (@bk2204)
+* git: improve performance of remote ref listing #4176 (@bluekeyes)
+* subprocess: trace all command execution #4175 (@bluekeyes)
+* Update git-lfs-migrate.1.ronn #3869 (@gertcuykens)
+* t: use repo v1 with extensions #4177 (@bk2204)
+* Makefile: ensure temp Go modules can be deleted #4157 (@chrisd8088)
+* Improve test suite robustness via environment #4132 (@bk2204)
+
 ## 2.11.0 (8 May 2020)
 
 This release introduces several new features, such as better support for unnamed

--- a/config/version.go
+++ b/config/version.go
@@ -13,7 +13,7 @@ var (
 )
 
 const (
-	Version = "2.11.0"
+	Version = "2.12.0"
 )
 
 func init() {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+git-lfs (2.12.0) stable; urgency=low
+
+  * New upstream version
+
+ -- brian m. carlson <bk2204@github.com>  Tue, 1 Sep 2020 14:29:00 -0000
+
 git-lfs (2.11.0) stable; urgency=low
 
   * New upstream version

--- a/rpm/SPECS/git-lfs.spec
+++ b/rpm/SPECS/git-lfs.spec
@@ -1,5 +1,5 @@
 Name:           git-lfs
-Version:        2.11.0
+Version:        2.12.0
 Release:        1%{?dist}
 Summary:        Git extension for versioning large files
 

--- a/versioninfo.json
+++ b/versioninfo.json
@@ -3,7 +3,7 @@
 	{
 		"FileVersion": {
 			"Major": 2,
-			"Minor": 11,
+			"Minor": 12,
 			"Patch": 0,
 			"Build": 0
 		}
@@ -13,7 +13,7 @@
 		"FileDescription": "Git LFS",
 		"LegalCopyright": "GitHub, Inc. and Git LFS contributors",
 		"ProductName": "Git Large File Storage (LFS)",
-		"ProductVersion": "2.11.0"
+		"ProductVersion": "2.12.0"
 	},
 	"IconPath": "script/windows-installer/git-lfs-logo.ico"
 }


### PR DESCRIPTION
This is an in-progress look at the next release of Git LFS, v2.12.0, which is scheduled for Monday, August 31, 2020.

We're publishing these changes early so that folks on @git-lfs/implementers can check that things work with their various platforms.

I've attached some builds below for people to use for testing:

[git-lfs-darwin-amd64-v2.12.0-pre.zip](https://github.com/git-lfs/git-lfs/files/5131258/git-lfs-darwin-amd64-v2.12.0-pre.zip)
[git-lfs-freebsd-386-v2.12.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/5131261/git-lfs-freebsd-386-v2.12.0-pre.tar.gz)
[git-lfs-freebsd-amd64-v2.12.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/5131262/git-lfs-freebsd-amd64-v2.12.0-pre.tar.gz)
[git-lfs-linux-386-v2.12.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/5131265/git-lfs-linux-386-v2.12.0-pre.tar.gz)
[git-lfs-linux-amd64-v2.12.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/5131267/git-lfs-linux-amd64-v2.12.0-pre.tar.gz)
[git-lfs-linux-arm64-v2.12.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/5131268/git-lfs-linux-arm64-v2.12.0-pre.tar.gz)
[git-lfs-linux-arm-v2.12.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/5131269/git-lfs-linux-arm-v2.12.0-pre.tar.gz)
[git-lfs-linux-ppc64le-v2.12.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/5131271/git-lfs-linux-ppc64le-v2.12.0-pre.tar.gz)
[git-lfs-linux-s390x-v2.12.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/5131272/git-lfs-linux-s390x-v2.12.0-pre.tar.gz)
[git-lfs-v2.12.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/5131273/git-lfs-v2.12.0-pre.tar.gz)
[git-lfs-windows-386-v2.12.0-pre.zip](https://github.com/git-lfs/git-lfs/files/5131274/git-lfs-windows-386-v2.12.0-pre.zip)
[git-lfs-windows-amd64-v2.12.0-pre.zip](https://github.com/git-lfs/git-lfs/files/5131275/git-lfs-windows-amd64-v2.12.0-pre.zip)

In addition, the CI system will produce artifacts for Windows, Linux, and macOS if you prefer to use those; they should be equivalent.

/cc @git-lfs/core
/cc @git-lfs/implementers
/cc @git-lfs/releases