### PR TITLE
Add manual pages to release assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1
+    - uses: actions/setup-ruby@v1
+    - run: gem install ronn
     - run: script/cibuild
     - run: CGO_ENABLED=0 make release
     - run: mkdir -p bin/assets
@@ -35,6 +37,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v1
+    - uses: actions/setup-ruby@v1
     - run: |
         echo "::add-path::C:\Program Files\Git\mingw64\bin"
         echo "::add-path::C:\Program Files\Git\usr\bin"
@@ -47,6 +50,10 @@ jobs:
     - run: choco uninstall git.install -y --force
     - run: cinst git --version 2.26.2 -y --force
     - run: refreshenv
+    - run: gem install ronn
+      shell: bash
+    - run: make man
+      shell: bash
     - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" go get github.com/josephspurrier/goversioninfo/cmd/goversioninfo
       shell: bash
     - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" script/cibuild

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
     - run: cinst zip -y
     - run: cinst jq -y
     - run: cinst windows-sdk-10.0 -y
+    - run: gem install ronn
     - run: refreshenv
     - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" go get github.com/josephspurrier/goversioninfo/cmd/goversioninfo
       shell: bash
@@ -52,6 +53,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
     - run: brew install mitchellh/gon/gon
+    - run: gem install ronn
     - run: make release
     - run: CERT_FILE="$HOME/cert.p12" make release-write-certificate
       env:
@@ -83,6 +85,7 @@ jobs:
     - uses: actions/download-artifact@v1
       with:
         name: macos-assets
+    - run: gem install ronn
     - run: CGO_ENABLED=0 make release
     - run: rm -f bin/releases/*windows* bin/releases/*darwin*
     - run: 'find windows-assets -name "*windows*" -type f | xargs -L1 -I{} mv {} bin/releases'

--- a/Makefile
+++ b/Makefile
@@ -290,7 +290,7 @@ RELEASE_TARGETS = \
 
 # RELEASE_INCLUDES are the names of additional files that are added to each
 # release artifact.
-RELEASE_INCLUDES = README.md CHANGELOG.md
+RELEASE_INCLUDES = README.md CHANGELOG.md man
 
 # release is a phony target that builds all of the release artifacts, and then
 # shows the SHA 256 signature of each.
@@ -319,8 +319,9 @@ bin/releases/git-lfs-darwin-%-$(VERSION).zip : \
 $(RELEASE_INCLUDES) bin/git-lfs-darwin-% script/install.sh
 	dir=bin/releases/darwin-$* && \
 	mkdir -p $$dir && \
-	cp $^ $$dir && mv $$dir/git-lfs-darwin-$* $$dir/git-lfs && \
+	cp -R $^ $$dir && mv $$dir/git-lfs-darwin-$* $$dir/git-lfs && \
 	zip -j $@ $$dir/* && \
+	zip -u $@ man/* && \
 	$(RM) -r $$dir
 
 # bin/releases/git-lfs-windows-$(VERSION).zip generates a ZIP compression of all
@@ -331,6 +332,7 @@ $(RELEASE_INCLUDES) bin/git-lfs-darwin-% script/install.sh
 bin/releases/git-lfs-windows-%-$(VERSION).zip : $(RELEASE_INCLUDES) bin/git-lfs-windows-%.exe
 	@mkdir -p bin/releases
 	zip -j -l $@ $^
+	zip -u $@ man/*
 
 # bin/releases/git-lfs-$(VERSION).tar.gz generates a tarball of the source code.
 #


### PR DESCRIPTION
In general, it would be nice to include pre-built manual pages in the release archives, both in the normal troff format and as HTML.  They're already baked into the binary as help output, but for some folks, `man` is easier to use.

This PR includes the manual pages in the archives and sets up the CI system to make sure Ruby and `ronn` are installed so we can build the release assets on every platform.  During the Windows CI run, we don't explicitly run `make release`, so call `make man` so we test that they can be built there.

Fixes #4228
/cc @lunaryorn as submitter