### PR TITLE
tools: always force a UTF-8 locale for cygpath

### DIFF
--- a/tools/os_tools.go
+++ b/tools/os_tools.go
@@ -29,6 +29,15 @@ func Getwd() (dir string, err error) {
 
 func translateCygwinPath(path string) (string, error) {
 	cmd := subprocess.ExecCommand("cygpath", "-w", path)
+	// cygpath uses ISO-8850-1 as the default encoding if the locale is not
+	// set, resulting in breakage, since we want a UTF-8 path.
+	env := make([]string, 0, len(cmd.Env)+1)
+	for _, val := range cmd.Env {
+		if !strings.HasPrefix(val, "LC_ALL=") {
+			env = append(env, val)
+		}
+	}
+	cmd.Env = append(env, "LC_ALL=C.UTF-8")
 	buf := &bytes.Buffer{}
 	cmd.Stderr = buf
 	out, err := cmd.Output()


### PR DESCRIPTION
When we look up the repository path from Git, we pass it through cygpath -w to canonicalize it into a Windows path, since Cygwin's Git will give us a Unix-style path.  We perform path canonicalization not only on Cygwin, but also on MINGW as well, which include Git Bash, since we want to accept and canonicalize Unix-style paths there as well.

Normally, this works great.  However, if invoked not from Git Bash, but via the Git for Windows bash.exe command, no locale is set in the environment, despite the locale binary indicating UTF-8 locales.  As a result, if non-ASCII character exist in the path name, it tries to encode them in ISO-8850-1.

On a standard Unix, where paths are always bytes, defaulting to ISO-8859-1 might be fine, because regardless of the encoding, paths are always bytes and no encoding needs to be performed.  On macOS, where the file system and all locales use UTF-8, this is also not a problem, because again, no encoding needs to be done.

However, on Windows, where paths are natively stored as UTF-16, this is remarkably unhelpful, since the majority of Unicode code points cannot be represented in ISO-8859-1.  Thus, the vast majority of paths are broken by cygpath when the locale is not set.

Since we know we always want UTF-8 from cygpath, let's just force that in the environment we pass it.  We need to copy the environment since the value we have is shared among all executed subcommands and we don't want to modify other commands' locales, since that would cause error messages to be printed in English instead of the user's locale.

Note that before this change, the test would fail because the local working directory was not read, and therefore it would be empty on Windows.

Fixes #4227
