### PR TITLE
add documentation of security bug report process

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,9 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for info on working on Git LFS and
 sending patches. Related projects are listed on the [Implementations wiki
 page](https://github.com/git-lfs/git-lfs/wiki/Implementations).
 
+See also [SECURITY.md](SECURITY.md) for info on how to submit reports
+of security vulnerabilities.
+
 ## Core Team
 
 These are the humans that form the Git LFS core team, which runs the project.
@@ -174,8 +177,9 @@ These are the humans that form the Git LFS core team, which runs the project.
 In alphabetical order:
 
 | [@bk2204][bk2204-user] | [@chrisd8088][chrisd8088-user] | [@larsxschneider][larsxschneider-user] |
-|---|---|---|
+| :---: | :---: | :---: |
 | [![][bk2204-img]][bk2204-user] | [![][chrisd8088-img]][chrisd8088-user] | [![][larsxschneider-img]][larsxschneider-user] |
+| [PGP 0223B187][bk2204-pgp] | [PGP 088335A9][chrisd8088-pgp] | [PGP A5795889][larsxschneider-pgp] |
 
 [bk2204-img]: https://avatars1.githubusercontent.com/u/497054?s=100&v=4
 [chrisd8088-img]: https://avatars1.githubusercontent.com/u/28857117?s=100&v=4
@@ -183,6 +187,9 @@ In alphabetical order:
 [bk2204-user]: https://github.com/bk2204
 [chrisd8088-user]: https://github.com/chrisd8088
 [larsxschneider-user]: https://github.com/larsxschneider
+[bk2204-pgp]: https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x88ace9b29196305ba9947552f1ba225c0223b187
+[chrisd8088-pgp]: https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x09b4bf756670b76d63515717506c7945088335a9
+[larsxschneider-pgp]: https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xaa3b3450295830d2de6db90caba67be5a5795889
 
 ### Alumni
 
@@ -193,7 +200,7 @@ not be possible without them.
 In alphabetical order:
 
 | [@andyneff][andyneff-user] | [@PastelMobileSuit][PastelMobileSuit-user] | [@rubyist][rubyist-user] | [@sinbad][sinbad-user] | [@technoweenie][technoweenie-user] | [@ttaylorr][ttaylorr-user] |
-|---|---|---|---|---|---|
+| :---: | :---: | :---: | :---: | :---: | :---: |
 | [![][andyneff-img]][andyneff-user] | [![][PastelMobileSuit-img]][PastelMobileSuit-user] | [![][rubyist-img]][rubyist-user] | [![][sinbad-img]][sinbad-user] | [![][technoweenie-img]][technoweenie-user] | [![][ttaylorr-img]][ttaylorr-user] |
 
 [andyneff-img]: https://avatars1.githubusercontent.com/u/7596961?v=3&s=100

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,61 @@
+## Security
+
+Git LFS is a public, open-source project supported by GitHub and a
+broad community of other organizations and individual contributors.
+The Git LFS community takes the security of our project seriously,
+including the all of source code repositories managed through
+our GitHub [organization](https://github.com/git-lfs).
+
+If you believe you have found a security vulnerability in any Git LFS
+client software repository, please report it to us as described below.
+
+If you believe you have found a security vulnerability in a Git LFS API
+service, please report it to the relevant hosting company (e.g., Atlassian,
+GitLab, GitHub, etc.) by following their preferred security report process.
+
+## Reporting Security Issues
+
+*Please do not report security vulnerabilities through public GitHub issues.*
+
+If you believe you have found a security vulnerability in the Git LFS
+client software, including any of our Go modules such as
+[gitobj](https://github.com/git-lfs/gitobj) or
+[pktline](https://github.com/git-lfs/pktline), please report it
+by email to one of the Git LFS [core team members](https://github.com/git-lfs/git-lfs#core-team).
+
+Email addresses for core team members may be found either on their
+personal GitHub pages or simply by searching through the Git history
+for this project; all commits from core team members should have their
+email address in the `Author` Git log field.
+
+If possible, encrypt your message with the core team member's PGP key.
+These may be located by searching a public keyserver or from the
+team member [list](https://github.com/git-lfs/git-lfs#core-team)
+on our home page.
+
+If you do not receive a timely response (generally within 24 hours of the
+first working day after your submission), please follow up by email
+with them and another core team member as well.
+
+Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
+
+  * Type of issue (e.g. buffer overflow, cross-site scripting, etc.)
+  * Full paths of source file(s) related to the manifestation of the issue
+  * The location of the affected source code (tag/branch/commit or direct URL)
+  * Any special configuration required to reproduce the issue
+  * Step-by-step instructions to reproduce the issue
+  * Proof-of-concept or exploit code (if possible)
+  * Impact of the issue, including how an attacker might exploit the issue
+
+This information will help us triage your report more quickly.
+
+We also recommend reviewing our [guidelines](CONTRIBUTING.md) for
+contributors and our [Open Code of Conduct](CODE-OF-CONDUCT.md).
+
+Note that because the Git LFS client is a public open-source project,
+it is not enrolled in any bug bounty programs; however, implementations
+of the Git LFS API service may be, depending on the hosting provider.
+
+## Preferred Languages
+
+We prefer all communications to be in English.


### PR DESCRIPTION
Following the GitHub [template](https://docs.github.com/en/github/managing-security-vulnerabilities/adding-a-security-policy-to-your-repository#about-security-policies) for adding security policies for open-source projects, we add a `SECURITY.md` file which describes the relevant policy for the Git LFS client, as well as providing links to related resources and general information.

In order to facilitate reports of security vulnerabilities via secure email, we also add to the core team roster on our home page links to the PGP keys of each active team member.

Note that once we adopt this PR into this main `git-lfs/git-lfs` repository, we may also want to consider adding a slightly modified version of `SECURITY.md` to our other repositories for Go module dependencies of the main project such as `git-lfs/gitobj`, `git-lfs/pktline`, and `git-lfs/wildmatch`.

Fixes #3749.
/cc @joeyh as reporter.