### PR TITLE
Add FAQ to README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,10 +82,12 @@ Here are some tips for getting your question answered as quickly as possible:
 * It's helpful if your issue includes the output of `git lfs env`, plus any
   relevant information about platform or configuration (e.g., container or CI
   usage, Cygwin, WSL, or non-Basic authentication).
-* Take a look at the [troubleshooting](https://github.com/git-lfs/git-lfs/wiki/Troubleshooting)
-  page on the wiki. We update it from time to time with information on how to
-  track down problems. If it seems relevant, include any information you've
-  learned by following those steps.
+* Take a look at the
+  [troubleshooting](https://github.com/git-lfs/git-lfs/wiki/Troubleshooting) and
+  [FAQ](https://github.com/git-lfs/git-lfs/wiki/FAQ) pages on the wiki. We
+  update them from time to time with information on how to track down problems.
+  If it seems relevant, include any information you've learned by following
+  those steps.
 * If you're having problems with GitHub's server-side LFS support, it's best to
   reach out to [GitHub's support team](https://github.com/contact) to get help.
   We aren't able to address GitHub-specific issues in this project, but the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 ## Contributing to Git Large File Storage
 
 Hi there! We're thrilled that you'd like to contribute to this project. Your
-help is essential for keeping it great.
+help is essential for making it the best it can be.
 
 Contributions to this project are [released](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) to the public under the [project's open source license](LICENSE.md).
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ $ git lfs help <subcommand>
 ```
 
 The [official documentation](docs) has command references and specifications for
-the tool.
+the tool.  There's also a [FAQ](https://github.com/git-lfs/git-lfs/wiki/FAQ) on
+the wiki which answers some common questions.
 
 You can always [open an issue](https://github.com/git-lfs/git-lfs/issues), and
 one of the Core Team members will respond to you. Please be sure to include:


### PR DESCRIPTION
We have some frequently asked questions that we get, so I've written up a FAQ on the wiki.  Let's add a link to the FAQ in the README and CONTRIBUTING documentation to help users find it more easily.

In addition, rephrase a part of the contributing documentation which uses language similar to a well-known political campaign.  We don't want people to associate our project with any political campaign, since such associations are irrelevant and distracting.