### PR TITLE
lfshttp: add support for socks5h proxies

### DIFF
--- a/lfshttp/proxy.go
+++ b/lfshttp/proxy.go
@@ -27,6 +27,10 @@ func proxyFromClient(c *Client) func(req *http.Request) (*url.URL, error) {
 			return nil, nil
 		}
 
+		if strings.HasPrefix(proxy, "socks5h://") {
+			proxy = strings.Replace(proxy, "socks5h://", "socks5://", 1)
+		}
+
 		cfg := &httpproxy.Config{
 			HTTPProxy:  proxy,
 			HTTPSProxy: proxy,

--- a/lfshttp/proxy_test.go
+++ b/lfshttp/proxy_test.go
@@ -126,3 +126,18 @@ func TestSocksProxyFromEnvironment(t *testing.T) {
 	assert.Equal(t, "proxy-from-env:3128", proxyURL.Host)
 	assert.Nil(t, err)
 }
+
+func TestSocks5hProxyFromEnvironment(t *testing.T) {
+	c, err := NewClient(NewContext(nil, map[string]string{
+		"HTTPS_PROXY": "socks5h://proxy-from-env:3128",
+	}, nil))
+	require.Nil(t, err)
+
+	req, err := http.NewRequest("GET", "https://some-host.com:123/foo/bar", nil)
+	require.Nil(t, err)
+
+	proxyURL, err := proxyFromClient(c)(req)
+	assert.Equal(t, "socks5", proxyURL.Scheme)
+	assert.Equal(t, "proxy-from-env:3128", proxyURL.Host)
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
Go currently doesn't support the socks5h protocol, but it does know how to handle it if given a URL starting with socks5:// instead.  Let's rewrite the URLs internally to make things just magically work.

Fixes #4258.