### PR TITLE
ci: don't reinstall openssl with Homebrew

### DIFF
--- a/script/build-git
+++ b/script/build-git
@@ -5,12 +5,7 @@ DIR="$1"
 case $(uname -s) in
   Darwin)
     brew install curl zlib pcre2 openssl
-    brew reinstall curl zlib pcre2 openssl
-    for i in curl zlib pcre2 openssl
-    do
-      brew unlink $i || true;
-      brew link --force $i || true
-    done;;
+    brew link --force curl zlib pcre2 openssl;;
   Linux)
     export DEBIAN_FRONTEND=noninteractive
     sed -e 's/^deb/deb-src/' /etc/apt/sources.list | sudo tee /etc/apt/sources.list.d/src.list


### PR DESCRIPTION
GitHub Actions ships its own version of the openssl Homebrew package that fails to reinstall with an EPERM error.  Since the reason we did these contortions was to relink gettext and we finally gave up and disabled gettext, let's just go back to a brew link --force and stop trying to reinstall.
