### PR TITLE
workflows/ci: build latest Git with SHA-256

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
     - uses: actions/checkout@v1
     - run: git clone -b master https://github.com/git/git.git "$HOME/git"
     - run: script/build-git "$HOME/git"
-    - run: script/cibuild
+    - run: GIT_DEFAULT_HASH=sha256 script/cibuild
   build-earliest:
     name: Build with earliest Git
     strategy:


### PR DESCRIPTION
We'd like to make sure that our code works with SHA-256 Git repositories, so when we build with the latest Git, let's test with SHA-256 repositories.
