### PR TITLE
script/upload: avoid using Ruby's URI.escape

### DIFF
--- a/script/upload
+++ b/script/upload
@@ -21,6 +21,10 @@ abort () {
   exit 2
 }
 
+uri_encode () {
+  ruby -e 'print ARGV[0].gsub(/[^A-Za-z0-9_.-]/) { |x| "%%%02x" % x.ord }' "$1"
+}
+
 curl () {
   if [ -n "$GITHUB_TOKEN" ]
   then
@@ -232,8 +236,8 @@ upload_assets () {
     base=$(basename "$file")
     desc=$(categorize_asset "$base")
     ct=$(content_type "$base")
-    encbase=$(ruby -ruri -e 'print URI.escape(ARGV[0])' "$base")
-    encdesc=$(ruby -ruri -e 'print URI.escape(ARGV[0])' "$desc")
+    encbase=$(uri_encode "$base")
+    encdesc=$(uri_encode "$desc")
 
     say "\tUploading %s as \"%s\" (Content-Type %s)..." "$base" "$desc" "$ct"
     curl --data-binary "@$file" -H'Accept: application/vnd.github.v3+json' \


### PR DESCRIPTION
Ruby's `URI.escape` is now deprecated because different components of a path require different escaping rules.  However, we still want to perform a similar escaping style, so let's do it ourselves with a `String#gsub` call.  We could use `CGI.escape`, but that encodes spaces as plus signs and it's unclear whether that's a desirable change to make here.  Note that there are no negative consequences for encoding more data than we need to, since the server will decode it for us.

Fixes #4226