### PR TITLE
Honor GIT_WORK_TREE

### DIFF
--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -20,7 +20,7 @@ var (
 )
 
 func checkoutCommand(cmd *cobra.Command, args []string) {
-	requireInRepo()
+	setupRepository()
 
 	stage, err := whichCheckout()
 	if err != nil {

--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -70,7 +70,7 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 	// Make sure we pop back to dir we started in at the end
 	defer os.Chdir(cwd)
 
-	requireInRepo()
+	setupRepository()
 
 	// Support --origin option to clone
 	if len(cloneFlags.Origin) > 0 {

--- a/commands/command_dedup.go
+++ b/commands/command_dedup.go
@@ -24,7 +24,7 @@ var (
 )
 
 func dedupTestCommand(*cobra.Command, []string) {
-	requireInRepo()
+	setupRepository()
 
 	if supported, err := tools.CheckCloneFileSupported(cfg.TempDir()); err != nil || !supported {
 		if err == nil {
@@ -46,7 +46,7 @@ func dedupCommand(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	requireInRepo()
+	setupRepository()
 	if gitDir, err := git.GitDir(); err != nil {
 		ExitWithError(err)
 	} else if supported, err := tools.CheckCloneFileSupported(gitDir); err != nil || !supported {

--- a/commands/command_env.go
+++ b/commands/command_env.go
@@ -44,7 +44,7 @@ func envCommand(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	for _, env := range lfs.Environ(cfg, getTransferManifest()) {
+	for _, env := range lfs.Environ(cfg, getTransferManifest(), oldEnv) {
 		Print(env)
 	}
 

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -34,7 +34,7 @@ func getIncludeExcludeArgs(cmd *cobra.Command) (include, exclude *string) {
 }
 
 func fetchCommand(cmd *cobra.Command, args []string) {
-	requireInRepo()
+	setupRepository()
 
 	var refs []*git.Ref
 

--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -26,7 +26,7 @@ var (
 // chain a lfs-fsck, but I don't think it does.
 func fsckCommand(cmd *cobra.Command, args []string) {
 	installHooks(false)
-	requireInRepo()
+	setupRepository()
 
 	ref, err := git.CurrentRef()
 	if err != nil {

--- a/commands/command_install.go
+++ b/commands/command_install.go
@@ -36,7 +36,7 @@ func cmdInstallOptions() *lfs.FilterOptions {
 	requireGitVersion()
 
 	if localInstall || worktreeInstall {
-		requireInRepo()
+		setupRepository()
 	}
 
 	switch {

--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -20,7 +20,7 @@ var (
 )
 
 func lsFilesCommand(cmd *cobra.Command, args []string) {
-	requireInRepo()
+	setupRepository()
 
 	var ref string
 	var otherRef string

--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -61,7 +61,7 @@ var (
 // migrate takes the given command and arguments, *gitobj.ObjectDatabase, as well
 // as a BlobRewriteFn to apply, and performs a migration.
 func migrate(args []string, r *githistory.Rewriter, l *tasklog.Logger, opts *githistory.RewriteOptions) {
-	requireInRepo()
+	setupRepository()
 
 	opts, err := rewriteOptions(args, opts, l)
 	if err != nil {

--- a/commands/command_migrate_export.go
+++ b/commands/command_migrate_export.go
@@ -102,7 +102,7 @@ func migrateExportCommand(cmd *cobra.Command, args []string) {
 		UpdateRefs: true,
 	}
 
-	requireInRepo()
+	setupRepository()
 
 	opts, err = rewriteOptions(args, opts, l)
 	if err != nil {

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -17,7 +17,7 @@ import (
 
 func pullCommand(cmd *cobra.Command, args []string) {
 	requireGitVersion()
-	requireInRepo()
+	setupRepository()
 
 	if len(args) > 0 {
 		// Remote is first arg

--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -21,8 +21,7 @@ var (
 )
 
 func statusCommand(cmd *cobra.Command, args []string) {
-	requireInRepo()
-	requireWorkingCopy()
+	setupWorkingCopy()
 
 	// tolerate errors getting ref so this works before first commit
 	ref, _ := git.CurrentRef()

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -32,16 +32,7 @@ var (
 
 func trackCommand(cmd *cobra.Command, args []string) {
 	requireGitVersion()
-
-	if cfg.LocalGitDir() == "" {
-		Print("Not a git repository.")
-		os.Exit(128)
-	}
-
-	if cfg.LocalWorkingDir() == "" {
-		Print("This operation must be run in a work tree.")
-		os.Exit(128)
-	}
+	setupWorkingCopy()
 
 	if !cfg.Os.Bool("GIT_LFS_TRACK_NO_INSTALL_HOOKS", false) {
 		installHooks(false)

--- a/commands/command_untrack.go
+++ b/commands/command_untrack.go
@@ -12,14 +12,7 @@ import (
 // untrackCommand takes a list of paths as an argument, and removes each path from the
 // default attributes file (.gitattributes), if it exists.
 func untrackCommand(cmd *cobra.Command, args []string) {
-	if cfg.LocalGitDir() == "" {
-		Print("Not a git repository.")
-		os.Exit(128)
-	}
-	if cfg.LocalWorkingDir() == "" {
-		Print("This operation must be run in a work tree.")
-		os.Exit(128)
-	}
+	setupWorkingCopy()
 
 	installHooks(false)
 

--- a/commands/command_update.go
+++ b/commands/command_update.go
@@ -15,7 +15,7 @@ var (
 // .git/lfs.
 func updateCommand(cmd *cobra.Command, args []string) {
 	requireGitVersion()
-	requireInRepo()
+	setupRepository()
 
 	lfsAccessRE := regexp.MustCompile(`\Alfs\.(.*)\.access\z`)
 	for key, _ := range cfg.Git.All() {

--- a/commands/run.go
+++ b/commands/run.go
@@ -92,6 +92,8 @@ Simply type ` + root.Name() + ` help [path to command] for full details.`,
 
 	root.Flags().BoolVarP(&rootVersion, "version", "v", false, "")
 
+	canonicalizeEnvironment()
+
 	cfg = config.New()
 
 	for _, f := range commandFuncs {

--- a/git/git.go
+++ b/git/git.go
@@ -747,20 +747,11 @@ func GitAndRootDirs() (string, string, error) {
 	paths := strings.Split(output, "\n")
 	pathLen := len(paths)
 
-	for i := 0; i < pathLen; i++ {
-		if paths[i] != "" {
-			paths[i], err = tools.TranslateCygwinPath(paths[i])
-			if err != nil {
-				return "", "", fmt.Errorf("error translating cygwin path: %s", err)
-			}
-		}
-	}
-
 	if pathLen == 0 {
 		return "", "", fmt.Errorf("bad git rev-parse output: %q", output)
 	}
 
-	absGitDir, err := canonicalizeDir(paths[0])
+	absGitDir, err := tools.CanonicalizePath(paths[0], false)
 	if err != nil {
 		return "", "", fmt.Errorf("error converting %q to absolute: %s", paths[0], err)
 	}
@@ -769,19 +760,8 @@ func GitAndRootDirs() (string, string, error) {
 		return absGitDir, "", nil
 	}
 
-	absRootDir, err := canonicalizeDir(paths[1])
+	absRootDir, err := tools.CanonicalizePath(paths[1], false)
 	return absGitDir, absRootDir, err
-}
-
-func canonicalizeDir(path string) (string, error) {
-	if len(path) > 0 {
-		path, err := filepath.Abs(path)
-		if err != nil {
-			return "", err
-		}
-		return filepath.EvalSymlinks(path)
-	}
-	return "", nil
 }
 
 func RootDir() (string, error) {
@@ -796,7 +776,7 @@ func RootDir() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return canonicalizeDir(path)
+	return tools.CanonicalizePath(path, false)
 }
 
 func GitDir() (string, error) {
@@ -809,11 +789,7 @@ func GitDir() (string, error) {
 		return "", fmt.Errorf("failed to call git rev-parse --git-dir: %v %v: %v", err, string(out), buf.String())
 	}
 	path := strings.TrimSpace(string(out))
-	path, err = tools.TranslateCygwinPath(path)
-	if err != nil {
-		return "", err
-	}
-	return canonicalizeDir(path)
+	return tools.CanonicalizePath(path, false)
 }
 
 func GitCommonDir() (string, error) {
@@ -836,7 +812,7 @@ func GitCommonDir() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return canonicalizeDir(path)
+	return tools.CanonicalizePath(path, false)
 }
 
 // GetAllWorkTreeHEADs returns the refs that all worktrees are using as HEADs

--- a/subprocess/subprocess_nix.go
+++ b/subprocess/subprocess_nix.go
@@ -9,6 +9,6 @@ import (
 // ExecCommand is a small platform specific wrapper around os/exec.Command
 func ExecCommand(name string, arg ...string) *Cmd {
 	cmd := exec.Command(name, arg...)
-	cmd.Env = env
+	cmd.Env = fetchEnvironment()
 	return newCmd(cmd)
 }

--- a/subprocess/subprocess_windows.go
+++ b/subprocess/subprocess_windows.go
@@ -11,6 +11,6 @@ import (
 func ExecCommand(name string, arg ...string) *Cmd {
 	cmd := exec.Command(name, arg...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
-	cmd.Env = env
+	cmd.Env = fetchEnvironment()
 	return newCmd(cmd)
 }

--- a/t/t-checkout.sh
+++ b/t/t-checkout.sh
@@ -224,3 +224,29 @@ begin_test "checkout: conflicts"
   popd > /dev/null
 )
 end_test
+
+
+begin_test "checkout: GIT_WORK_TREE"
+(
+  set -e
+
+  reponame="checkout-work-tree"
+  remotename="$(basename "$0" ".sh")"
+  export GIT_WORK_TREE="$reponame" GIT_DIR="$reponame-git"
+  mkdir "$GIT_WORK_TREE" "$GIT_DIR"
+  git init
+  git remote add origin "$GITSERVER/$remotename"
+
+  git lfs uninstall --skip-repo
+
+  git fetch origin
+  git checkout -B main origin/main
+
+  git lfs install
+  git lfs fetch
+  git lfs checkout
+
+  contents="something something"
+  [ "$contents" = "$(cat "$reponame/file1.dat")" ]
+)
+end_test

--- a/t/t-untrack.sh
+++ b/t/t-untrack.sh
@@ -158,3 +158,21 @@ begin_test "untrack removes escaped pattern in .gitattributes"
   fi
 )
 end_test
+
+begin_test "untrack works with GIT_WORK_TREE"
+(
+  set -e
+
+  reponame="untrack-work-tree"
+  export GIT_WORK_TREE="$reponame" GIT_DIR="$reponame-git"
+  mkdir "$GIT_WORK_TREE" "$GIT_DIR"
+  git init
+  git lfs track '*.bin'
+
+  grep -F '*.bin filter=lfs diff=lfs merge=lfs -text' "$reponame/.gitattributes"
+
+  git lfs untrack '*.bin'
+
+  [ ! -s "$reponame/.gitattributes" ]
+)
+end_test


### PR DESCRIPTION
Currently, we don't honor GIT_WORK_TREE like Git does.  Git implicitly changes into the working tree of the repository if this variable is set, but we currently don't do that.

Let's fix that by mimicking Git's behavior so this works correctly, which necessitates transforming the various environment variables we pass to Git so that they are valid when we change directories.

These commits are logical, bisectable, and independent and have sane commit messages.

Fixes #4213
/cc @Mr-Tao as reporter