### PR TITLE
Add --above parameter to 'migrate import'.

### DIFF
--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -31,6 +31,11 @@ var (
 	// of updated references.
 	migrateSkipFetch bool
 
+	// migrateImportAboveFmt indicates the presence of the --above=<size>
+	// flag and instructs 'git lfs migrate import' to import all files
+	// above the provided size.
+	migrateImportAboveFmt string
+
 	// migrateEverything indicates the presence of the --everything flag,
 	// and instructs 'git lfs migrate' to migrate all local references.
 	migrateEverything bool
@@ -365,6 +370,7 @@ func init() {
 	info.Flags().StringVar(&migrateInfoUnitFmt, "unit", "", "--unit=<unit>")
 
 	importCmd := NewCommand("import", migrateImportCommand)
+	importCmd.Flags().StringVar(&migrateImportAboveFmt, "above", "", "--above=<n>")
 	importCmd.Flags().BoolVar(&migrateVerbose, "verbose", false, "Verbose logging")
 	importCmd.Flags().StringVar(&objectMapFilePath, "object-map", "", "Object map file")
 	importCmd.Flags().BoolVar(&migrateNoRewrite, "no-rewrite", false, "Add new history without rewriting previous")

--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -89,6 +89,11 @@ options and these additional ones:
 * `--verbose`
     Print the commit oid and filename of migrated files to STDOUT.
 
+* `--above=<size>`
+    Only migrate files whose individual filesize is above the given size. 'size'
+    may be specified as a number of bytes, or a number followed by a storage
+    unit, e.g., "1b", "20 MB", "3 TiB", etc.
+
 * `--object-map=<path>`
     Write to 'path' a file with the mapping of each rewritten commits. The file
     format is CSV with this pattern: `OLD-SHA`,`NEW-SHA`
@@ -262,6 +267,9 @@ $ git lfs migrate import --include-ref=master --include="*.zip"
 
 # Convert all zip files in every local branch
 $ git lfs migrate import --everything --include="*.zip"
+
+# Convert all files over 100K in every local branch
+$ git lfs migrate import --everything --above=100Kb
 ```
 
 Note: This will require a force push to any existing Git remotes.

--- a/t/fixtures/migrate.sh
+++ b/t/fixtures/migrate.sh
@@ -84,6 +84,30 @@ setup_local_branch_with_nested_gitattrs() {
   git commit -m "add nested .gitattributes"
 }
 
+# setup_single_local_branch_untracked creates a repository as follows:
+#
+#   A---B
+#        \
+#         refs/heads/main
+#
+# - Commit 'A' has 120, in a.txt and 140 in a.md, with neither files tracked as
+#   pointers in Git LFS
+setup_single_local_branch_untracked() {
+  set -e
+
+  reponame="single-local-branch-untracked"
+
+  remove_and_create_local_repo "$reponame"
+
+  git commit --allow-empty -m "initial commit"
+
+  base64 < /dev/urandom | head -c 120 > a.txt
+  base64 < /dev/urandom | head -c 140 > a.md
+
+  git add a.txt a.md
+  git commit -m "add a.{txt,md}"
+}
+
 # setup_single_local_branch_tracked creates a repository as follows:
 #
 #   A---B


### PR DESCRIPTION
The purpose is to allow users to tell git-lfs to migrate
all files over a particular threshold without having to determine
the various paths and patterns that would. This is very useful
for large code bases with inconsistent history of adding large
files in different places. This option makes it possible to
supply `git-lfs migrate import --everything --above=1Mb` and
have git-lfs do the convenient thing and rewrite history. 

Issue #4275 