### PR TITLE
config: map missing port to default for HTTP key lookups

### DIFF
--- a/config/url_config.go
+++ b/config/url_config.go
@@ -113,7 +113,7 @@ func (c *URLConfig) getAll(prefix, rawurl, key string) []string {
 		}
 
 		// Rule #3: Port Number must match exactly
-		if searchURL.Port() != configURL.Port() {
+		if portForURL(searchURL) != portForURL(configURL) {
 			continue
 		}
 
@@ -163,6 +163,23 @@ func (c *URLConfig) getAll(prefix, rawurl, key string) []string {
 	}
 
 	return c.git.GetAll(bestMatch.key)
+}
+
+func portForURL(u *url.URL) string {
+	port := u.Port()
+	if port != "" {
+		return port
+	}
+	switch u.Scheme {
+	case "http":
+		return "80"
+	case "https":
+		return "443"
+	case "ssh":
+		return "22"
+	default:
+		return ""
+	}
 }
 
 // compareHosts compares a hostname with a configuration hostname to determine

--- a/config/url_config_test.go
+++ b/config/url_config_test.go
@@ -8,17 +8,19 @@ import (
 
 func TestURLConfig(t *testing.T) {
 	u := NewURLConfig(EnvironmentOf(MapFetcher(map[string][]string{
-		"http.key":                           []string{"root", "root-2"},
-		"http.https://host.com.key":          []string{"host", "host-2"},
-		"http.https://user@host.com/a.key":   []string{"user-a", "user-b"},
-		"http.https://user@host.com.key":     []string{"user", "user-2"},
-		"http.https://host.com/a.key":        []string{"host-a", "host-b"},
-		"http.https://host.com:8080.key":     []string{"port", "port-2"},
-		"http.https://host.com/repo.git.key": []string{".git"},
-		"http.https://host.com/repo.key":     []string{"no .git"},
-		"http.https://host.com/repo2.key":    []string{"no .git"},
-		"http.http://host.com/repo.key":      []string{"http"},
-		"http.https://host.*/a.key":          []string{"wild"},
+		"http.key":                                []string{"root", "root-2"},
+		"http.https://host.com.key":               []string{"host", "host-2"},
+		"http.https://user@host.com/a.key":        []string{"user-a", "user-b"},
+		"http.https://user@host.com.key":          []string{"user", "user-2"},
+		"http.https://host.com/a.key":             []string{"host-a", "host-b"},
+		"http.https://host.com:8080.key":          []string{"port", "port-2"},
+		"http.https://host.com/repo.git.key":      []string{".git"},
+		"http.https://host.com/repo.key":          []string{"no .git"},
+		"http.https://host.com/repo2.key":         []string{"no .git"},
+		"http.http://host.com/repo.key":           []string{"http"},
+		"http.https://host.com:443/repo3.git.key": []string{"port"},
+		"http.ssh://host.com:22/repo3.git.key":    []string{"ssh-port"},
+		"http.https://host.*/a.key":               []string{"wild"},
 	})))
 
 	getOne := map[string]string{
@@ -34,10 +36,14 @@ func TestURLConfig(t *testing.T) {
 		"https://host.com/repo":                       "no .git",
 		"https://host.com/repo2.git/info/lfs/foo/bar": "no .git",
 		"https://host.com/repo2.git/info/lfs":         "no .git",
+		"https://host.com:443/repo2.git/info/lfs":     "no .git",
 		"https://host.com/repo2.git/info":             "host-2", // doesn't match /.git/info/lfs\Z/
 		"https://host.com/repo2.git":                  "host-2", // ditto
+		"https://host.com/repo3.git/info/lfs":         "port",
+		"ssh://host.com/repo3.git/info/lfs":           "ssh-port",
 		"https://host.com/repo2":                      "no .git",
 		"http://host.com/repo":                        "http",
+		"http://host.com:80/repo":                     "http",
 		"https://host.wild/a/b/c":                     "wild",
 	}
 


### PR DESCRIPTION
When Git performs a lookup for a key with urlmatch semantics, it matches the default port if none is specified in the URL.  However, our code currently doesn't do that, instead having a missing port match only another missing port entry.

Let's fix the behavior to match Git's by mapping a missing port to the default port.  We add tests for checking both URLs (the config one and the one we're sending data to) to make sure that our code is robust.

Fixes #4281
/cc @slietzau as reporter
