### PR TITLE
pull: gracefully handle merge conflicts

### DIFF
--- a/commands/pull.go
+++ b/commands/pull.go
@@ -67,7 +67,7 @@ func (c *singleCheckout) Run(p *lfs.WrappedPointer) {
 	// Check the content - either missing or still this pointer (not exist is ok)
 	filepointer, err := lfs.DecodePointerFromFile(cwdfilepath)
 	if err != nil && !os.IsNotExist(err) {
-		if errors.IsNotAPointerError(err) {
+		if errors.IsNotAPointerError(err) || errors.IsBadPointerKeyError(err) {
 			// File has non-pointer content, leave it alone
 			return
 		}

--- a/t/t-pull.sh
+++ b/t/t-pull.sh
@@ -284,6 +284,36 @@ begin_test "pull with invalid insteadof"
 )
 end_test
 
+begin_test "pull with merge conflict"
+(
+  set -e
+  git init pull-merge-conflict
+  cd pull-merge-conflict
+
+  git lfs track "*.bin"
+  git add .
+  git commit -m 'gitattributes'
+  printf abc > abc.bin
+  git add .
+  git commit -m 'abc'
+
+  git checkout -b def
+  printf def > abc.bin
+  git add .
+  git commit -m 'def'
+
+  git checkout main
+  printf ghi > abc.bin
+  git add .
+  git commit -m 'ghi'
+
+  # This will exit nonzero because of the merge conflict.
+  GIT_LFS_SKIP_SMUDGE=1 git merge def || true
+  git lfs pull > pull.log 2>&1
+  [ ! -s pull.log ]
+)
+end_test
+
 begin_test "pull: with missing object"
 (
   set -e


### PR DESCRIPTION
When a merge conflict occurs, it obviously isn't possible to check out the file using git lfs checkout or git lfs pull, since it's unclear which revision the user wants.  git lfs checkout handles this gracefully by just ignoring the conflict, whereas git lfs pull causes a full logged error, which is excessive.

Let's make git lfs pull match the behavior of git lfs checkout here by having it ignore malformed pointer files just like it ignores files that are not pointers.

Fixes #1608