### PR TITLE
Fix pattern matching for .gitattributes

### DIFF
--- a/git/attribs.go
+++ b/git/attribs.go
@@ -159,7 +159,7 @@ func GetAttributeFilter(workingDir, gitDir string) *filepathfilter.Filter {
 	for _, path := range paths {
 		// Convert all separators to `/` before creating a pattern to
 		// avoid characters being escaped in situations like `subtree\*.md`
-		patterns = append(patterns, filepathfilter.NewPattern(filepath.ToSlash(path.Path)))
+		patterns = append(patterns, filepathfilter.NewPattern(filepath.ToSlash(path.Path), filepathfilter.Strict(true)))
 	}
 
 	return filepathfilter.NewFromPatterns(patterns, nil)


### PR DESCRIPTION
Currently we use a slightly different algorithm for matching certain wildmatch patterns for backwards compatibility with earlier versions of Git LFS.  However, that algorithm causes some problems with not matching various patterns that Git does match.  To improve our correctness here, let's introduce a strict mode and use it when we're reading patterns from .gitattributes.

This series contains [logical, bisectable commits](https://git-scm.com/docs/SubmittingPatches#separate-commits) with [descriptive commit messages](https://git-scm.com/docs/SubmittingPatches#describe-changes).  Note that you may want to review with whitespace changes disabled, since there are some indentation-only changes.

Fixes #4203.