### PR TITLE
.github/workflows: remove special ::add-path commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,6 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
-    - run: |
-        echo "::add-path::C:\Program Files\Git\mingw64\bin"
-        echo "::add-path::C:\Program Files\Git\usr\bin"
-        echo "::add-path::C:\Program Files\Git\bin"
     - run: mkdir -p "$HOME/go/bin"
       shell: bash
     - run: set GOPATH=%HOME%\go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,6 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
-    - run: |
-        echo "::add-path::C:\Program Files\Git\mingw64\bin"
-        echo "::add-path::C:\Program Files\Git\usr\bin"
-        echo "::add-path::C:\Program Files\Git\bin"
     - run: mkdir -p "$HOME/go/bin"
       shell: bash
     - run: set GOPATH=%HOME%\go


### PR DESCRIPTION
We had these commands to work around a problem with an earlier GitHub Actions image not finding the expected Git binaries, but they are no longer necessary.  In addition, GitHub Action now fails our commands because honoring these options causes a security problem, so our CI jobs are failing.  Let's remove them since they're no longer needed nor useful.
