### PR TITLE
Make git lfs migrate import handle missing extensions

### DIFF
--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -172,6 +172,8 @@ func migrateImportCommand(cmd *cobra.Command, args []string) {
 
 			if ext := filepath.Ext(path); len(ext) > 0 {
 				exts.Add(fmt.Sprintf("*%s filter=lfs diff=lfs merge=lfs -text", ext))
+			} else {
+				exts.Add(fmt.Sprintf("/%s filter=lfs diff=lfs merge=lfs -text", path))
 			}
 
 			return &gitobj.Blob{

--- a/t/fixtures/migrate.sh
+++ b/t/fixtures/migrate.sh
@@ -95,6 +95,8 @@ setup_local_branch_with_nested_gitattrs() {
 setup_single_local_branch_untracked() {
   set -e
 
+  local name="${1:-a.md}"
+
   reponame="single-local-branch-untracked"
 
   remove_and_create_local_repo "$reponame"
@@ -102,10 +104,10 @@ setup_single_local_branch_untracked() {
   git commit --allow-empty -m "initial commit"
 
   base64 < /dev/urandom | head -c 120 > a.txt
-  base64 < /dev/urandom | head -c 140 > a.md
+  base64 < /dev/urandom | head -c 140 > "$name"
 
-  git add a.txt a.md
-  git commit -m "add a.{txt,md}"
+  git add a.txt "$name"
+  git commit -m "add a.txt and $name"
 }
 
 # setup_single_local_branch_tracked creates a repository as follows:

--- a/t/t-migrate-import.sh
+++ b/t/t-migrate-import.sh
@@ -422,7 +422,7 @@ begin_test "migrate import (above)"
   # was converted into a git-lfs pointer by the migration.
   assert_local_object "$md_main_oid" "140"
   assert_pointer "refs/heads/main" "a.md" "$md_main_oid" "140"
-  refute_pointer "refs/heads/main" "a.txt" "$md_main_oid" "120"
+  refute_pointer "refs/heads/main" "a.txt" "$txt_main_oid" "120"
   refute_local_object "$txt_main_oid" "120"
 
   # The migration should have identified that *.md files are now

--- a/t/t-migrate-import.sh
+++ b/t/t-migrate-import.sh
@@ -434,6 +434,31 @@ begin_test "migrate import (above)"
 )
 end_test
 
+begin_test "migrate import (above without extension)"
+(
+  set -e
+  setup_single_local_branch_untracked "just-b"
+
+  b_main_oid="$(calc_oid "$(git cat-file -p "refs/heads/main:just-b")")"
+  txt_main_oid="$(calc_oid "$(git cat-file -p "refs/heads/main:a.txt")")"
+
+  git lfs migrate import --above 121B
+  # Ensure that 'b', whose size is above our 121 byte threshold
+  # was converted into a git-lfs pointer by the migration.
+  assert_local_object "$b_main_oid" "140"
+  assert_pointer "refs/heads/main" "just-b" "$b_main_oid" "140"
+  refute_pointer "refs/heads/main" "a.txt" "$txt_main_oid" "120"
+  refute_local_object "$txt_main_oid" "120"
+
+  # The migration should have identified that /b is now tracked
+  # because it migrated it.
+  main_attrs="$(git cat-file -p "$main:.gitattributes")"
+
+  echo "$main_attrs" | grep -q "/just-b filter=lfs diff=lfs merge=lfs"
+  echo "$main_attrs" | grep -vq "*.txt filter=lfs diff=lfs merge=lfs"
+)
+end_test
+
 begin_test "migrate import (existing .gitattributes)"
 (
   set -e


### PR DESCRIPTION
Currently, if we have a file and it contains an extension, we'll add that extension to the list of paths that should be placed in .gitattributes.  However, if the file does not contain an extension, it won't be listed at all.  As a result, we may convert a file flagged by the --above option but never cause Git to filter it properly.

Let's fix this by writing an attribute into the repository with the path relative to the root if we don't contain an extension.  This means that people can store typical Unix binaries, which lack extensions, as LFS files more easily.

In addition, there is a commit to clean up a thinko in the existing test.

/cc @ansman as reporter
Fixes #4312