### PR TITLE
Drop obsolete OS support

### DIFF
--- a/docker/run_dockers.bsh
+++ b/docker/run_dockers.bsh
@@ -58,7 +58,7 @@ done
 
 if [[ ${#IMAGES[@]} == 0 ]]; then
   # If you change this list, change script/upload as well.
-  IMAGES=(centos_7 centos_8 debian_8 debian_9 debian_10)
+  IMAGES=(centos_7 centos_8 debian_9 debian_10)
 fi
 
 mkdir -p "${PACKAGE_DIR}"

--- a/docker/run_dockers.bsh
+++ b/docker/run_dockers.bsh
@@ -58,7 +58,7 @@ done
 
 if [[ ${#IMAGES[@]} == 0 ]]; then
   # If you change this list, change script/upload as well.
-  IMAGES=(centos_6 centos_7 centos_8 debian_8 debian_9 debian_10)
+  IMAGES=(centos_7 centos_8 debian_8 debian_9 debian_10)
 fi
 
 mkdir -p "${PACKAGE_DIR}"

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -42,11 +42,15 @@ $distro_name_map = {
     "sles/12.1", # LTSS ends 31 May 2020
     "sles/12.2", # LTSS ends 31 Mar 2021
     "sles/12.3", # LTSS ends 30 Jun 2022
-    "sles/15.0"  # Current
+    "sles/12.4",
+    "sles/12.5",
+    "sles/15.0",
+    "sles/15.1",  # Current
   ],
   "centos/8" => [
     "el/8",
     "fedora/31", # EOL ~2021
+    "fedora/32",
   ],
   # Debian EOL https://wiki.debian.org/LTS/
   # Ubuntu EOL https://wiki.ubuntu.com/Releases

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -126,6 +126,7 @@ package_files.each do |full_path|
   when /centos\/5/  then ["RPM RHEL 5/CentOS 5", "el/5"]
   when /centos\/6/  then ["RPM RHEL 6/CentOS 6", "el/6"]
   when /centos\/7/  then ["RPM RHEL 7/CentOS 7", "el/7"]
+  when /centos\/8/  then ["RPM RHEL 8/CentOS 8", "el/8"]
   end
 
   next unless os

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -27,10 +27,6 @@ $client = Packagecloud::Client.new(credentials)
 # https://packagecloud.io/docs#os_distro_version
 $distro_name_map = {
   # RHEL EOL https://access.redhat.com/support/policy/updates/errata
-  "centos/6" => [
-    "el/6", # End of Extended Support June 30, 2024
-    "scientific/6",
-  ],
   "centos/7" => [
     "el/7",
     "scientific/7",

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -51,10 +51,6 @@ $distro_name_map = {
   # Debian EOL https://wiki.debian.org/LTS/
   # Ubuntu EOL https://wiki.ubuntu.com/Releases
   # Mint EOL https://linuxmint.com/download_all.php
-  "debian/8" => [
-    "debian/jessie",     # EOL June 30, 2020
-    "ubuntu/trusty",     # ESM April 2022
-  ],
   "debian/9" => [
     "debian/stretch",   # EOL June 2022
     "linuxmint/sarah",  # EOL April 2021

--- a/script/upload
+++ b/script/upload
@@ -187,7 +187,6 @@ Up to date packages are available on [PackageCloud](https://packagecloud.io/gith
 
 [RPM RHEL 7/CentOS 7](https://packagecloud.io/github/git-lfs/packages/el/7/git-lfs-VERSION-1.el7.x86_64.rpm/download)
 [RPM RHEL 8/CentOS 8](https://packagecloud.io/github/git-lfs/packages/el/8/git-lfs-VERSION-1.el8.x86_64.rpm/download)
-[Debian 8](https://packagecloud.io/github/git-lfs/packages/debian/jessie/git-lfs_VERSION_amd64.deb/download)
 [Debian 9](https://packagecloud.io/github/git-lfs/packages/debian/stretch/git-lfs_VERSION_amd64.deb/download)
 [Debian 10](https://packagecloud.io/github/git-lfs/packages/debian/buster/git-lfs_VERSION_amd64.deb/download)
 

--- a/script/upload
+++ b/script/upload
@@ -185,7 +185,6 @@ finalize_body_message () {
 
 Up to date packages are available on [PackageCloud](https://packagecloud.io/github/git-lfs) and [Homebrew](http://brew.sh/).
 
-[RPM RHEL 6/CentOS 6](https://packagecloud.io/github/git-lfs/packages/el/6/git-lfs-VERSION-1.el6.x86_64.rpm/download)
 [RPM RHEL 7/CentOS 7](https://packagecloud.io/github/git-lfs/packages/el/7/git-lfs-VERSION-1.el7.x86_64.rpm/download)
 [RPM RHEL 8/CentOS 8](https://packagecloud.io/github/git-lfs/packages/el/8/git-lfs-VERSION-1.el8.x86_64.rpm/download)
 [Debian 8](https://packagecloud.io/github/git-lfs/packages/debian/jessie/git-lfs_VERSION_amd64.deb/download)


### PR DESCRIPTION
This PR drops support for CentOS 6 and Debian 8, which are no longer publicly supported upstream.  While various versions do have extended security support available, we can't access it, and it doesn't seem like a good idea (or responsible to the rest of the Internet) for us to continue to build packages on versions that are known to be insecure.

This also makes our CI runs significantly faster, since we currently build many packages for CentOS 6 that we can now avoid building.  We've shaved 15 minutes off of our build time for Linux packages.

We also add some additional distros that are not in the file.  Note that we don't support Fedora 33 because packagecloud.io does not list it as a supported version at this time.