### PR TITLE
CanonicalizePath: Ignore EvalSymlinks error on windows if file exists

### DIFF
--- a/tools/filetools.go
+++ b/tools/filetools.go
@@ -498,6 +498,13 @@ func CanonicalizePath(path string, missingOk bool) (string, error) {
 		if err != nil && os.IsNotExist(err) && missingOk {
 			return path, nil
 		}
+		if err != nil && runtime.GOOS == "windows" {
+			// As EvalSymlinks is broken on windows
+			// it may fail even if the path is valid, so if the file exists we should use it
+			if _, err1 := os.Stat(path); !os.IsNotExist(err1) {
+				return path, nil
+			}
+		}
 		return result, err
 	}
 	return "", nil


### PR DESCRIPTION
My take on trying to fix #4333.
This works for the repo steps I provided, but maybe there are some general caveats I have overseen.
As I am not able to put the repo steps into a test, I have no test added for this.

Running `git lfs env` after repo steps in #4333 I get following output:

```
git-lfs/2.12.1 (GitHub; windows amd64; go 1.14.10; git 85b28e06)
git version 2.29.2.windows.2

Error: error converting "C:\\USBStick\\test_repo\\.git" to absolute: EvalSymlinks: too many links
LocalWorkingDir=
LocalGitDir=
LocalGitStorageDir=
LocalMediaDir=lfs\objects
LocalReferenceDirs=
TempDir=lfs\tmp
ConcurrentTransfers=8
TusTransfers=false
BasicTransfersOnly=false
SkipDownloadErrors=false
FetchRecentAlways=false
FetchRecentRefsDays=7
FetchRecentCommitsDays=0
FetchRecentRefsIncludeRemotes=true
PruneOffsetDays=3
PruneVerifyRemoteAlways=false
PruneRemoteName=origin
LfsStorageDir=lfs
AccessDownload=none
AccessUpload=none
DownloadTransfers=basic,lfs-standalone-file
UploadTransfers=basic,lfs-standalone-file
GIT_EXEC_PATH=C:/Program Files/Git/mingw64/libexec/git-core
git config filter.lfs.process = "git-lfs filter-process"
git config filter.lfs.smudge = "git-lfs smudge -- %f"
git config filter.lfs.clean = "git-lfs clean -- %f"
```