### PR TITLE
Makefile: don't fail the second time macOS builds are built

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -318,6 +318,7 @@ $(RELEASE_INCLUDES) bin/git-lfs-% script/install.sh
 bin/releases/git-lfs-darwin-%-$(VERSION).zip : \
 $(RELEASE_INCLUDES) bin/git-lfs-darwin-% script/install.sh
 	dir=bin/releases/darwin-$* && \
+	rm -f $@ && \
 	mkdir -p $$dir && \
 	cp -R $^ $$dir && mv $$dir/git-lfs-darwin-$* $$dir/git-lfs && \
 	zip -j $@ $$dir/* && \


### PR DESCRIPTION
zip has an interesting feature: if there is nothing to do, it exits 12. Since in our macOS release CI target, we build the same asset multiple times due to using two separate invocations of make, we end up with a case where zip exits 12 unexpectedly.

Ideally make would realize that our assets don't need to be rebuilt, but as long as we're going to rebuild them, let's remove the existing file so zip doesn't get bent out of shape about the fact that our operation isn't doing anything useful.

This caused the v2.13.0 release job to fail, so I'll need to do a v2.13.1 with this change.