### PR TITLE
release: v2.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Git LFS Changelog
 
+## 2.13.1 (11 Dec 2020)
+
+This release fixes a bug in our build tooling that prevents our release process
+from working properly.  This release is otherwise identical to 2.13.0.
+
+### Misc
+
+* Makefile: don't fail the second time macOS builds are built #4341 (@bk2204)
+
 ## 2.13.0 (10 Dec 2020)
 
 This release introduces several new features, such as the `--above` option to

--- a/Makefile
+++ b/Makefile
@@ -318,6 +318,7 @@ $(RELEASE_INCLUDES) bin/git-lfs-% script/install.sh
 bin/releases/git-lfs-darwin-%-$(VERSION).zip : \
 $(RELEASE_INCLUDES) bin/git-lfs-darwin-% script/install.sh
 	dir=bin/releases/darwin-$* && \
+	rm -f $@ && \
 	mkdir -p $$dir && \
 	cp -R $^ $$dir && mv $$dir/git-lfs-darwin-$* $$dir/git-lfs && \
 	zip -j $@ $$dir/* && \

--- a/config/version.go
+++ b/config/version.go
@@ -13,7 +13,7 @@ var (
 )
 
 const (
-	Version = "2.13.0"
+	Version = "2.13.1"
 )
 
 func init() {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+git-lfs (2.13.1) stable; urgency=low
+
+  * New upstream version
+
+ -- brian m. carlson <bk2204@github.com>  Fri, 11 Dec 2020 14:29:00 -0000
+
 git-lfs (2.13.0) stable; urgency=low
 
   * New upstream version

--- a/rpm/SPECS/git-lfs.spec
+++ b/rpm/SPECS/git-lfs.spec
@@ -1,5 +1,5 @@
 Name:           git-lfs
-Version:        2.13.0
+Version:        2.13.1
 Release:        1%{?dist}
 Summary:        Git extension for versioning large files
 

--- a/versioninfo.json
+++ b/versioninfo.json
@@ -4,7 +4,7 @@
 		"FileVersion": {
 			"Major": 2,
 			"Minor": 13,
-			"Patch": 0,
+			"Patch": 1,
 			"Build": 0
 		}
 	},
@@ -13,7 +13,7 @@
 		"FileDescription": "Git LFS",
 		"LegalCopyright": "GitHub, Inc. and Git LFS contributors",
 		"ProductName": "Git Large File Storage (LFS)",
-		"ProductVersion": "2.13.0"
+		"ProductVersion": "2.13.1"
 	},
 	"IconPath": "script/windows-installer/git-lfs-logo.ico"
 }


### PR DESCRIPTION
This is an in-progress look at the next release of Git LFS, v2.12.0, which is scheduled for Friday, December 11, 2020.

I'm not providing binaries here because this is a very simple bug fix for a CI problem that prevented us from releasing v2.13.0.  Therefore, it should not function any differently from v2.13.0 other than containing a different version number.

The CI system will produce artifacts for Windows, Linux, and macOS if you need some test binaries.

/cc @git-lfs/core
/cc @git-lfs/implementers
/cc @git-lfs/releases