### PR TITLE
Makefile: allow make release to be run twice in a row

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,6 +332,7 @@ $(RELEASE_INCLUDES) bin/git-lfs-darwin-% script/install.sh
 # CRLF in the non-binary components of the artifact.
 bin/releases/git-lfs-windows-%-$(VERSION).zip : $(RELEASE_INCLUDES) bin/git-lfs-windows-%.exe
 	@mkdir -p bin/releases
+	rm -f $@
 	zip -j -l $@ $^
 	zip -u $@ man/*
 


### PR DESCRIPTION
We recently fixed a problem with the macOS target to make it possible to build a second time after running `make release`, but we forgot a Windows target as well.  Let's make it possible to run that command twice in a row.
