### PR TITLE
Add test for download gzip transport compression

### DIFF
--- a/lfshttp/client.go
+++ b/lfshttp/client.go
@@ -311,6 +311,10 @@ func (c *Client) DoWithRedirect(cli *http.Client, req *http.Request, remote stri
 		return nil, nil, nil
 	}
 
+	if res.Uncompressed {
+		tracerx.Printf("http: decompressed gzipped response")
+	}
+
 	c.traceResponse(req, tracedReq, res)
 
 	if res.StatusCode != 301 &&

--- a/t/t-push.sh
+++ b/t/t-push.sh
@@ -830,3 +830,45 @@ begin_test "push --object-id (invalid value)"
   [ "$(grep -c 'too short object ID' push.log)" -eq 2 ]
 )
 end_test
+
+begin_test "storage upload with compression"
+(
+  set -e
+
+  reponame="storage-compress"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" storage-compress
+
+  contents="storage-compress"
+  oid="$(calc_oid "$contents")"
+  printf "%s" "$contents" > a.dat
+
+  git lfs track "*.dat"
+  git add .gitattributes a.dat
+  git commit -m "initial commit"
+
+  GIT_CURL_VERBOSE=1 git push origin main | tee push.log
+  assert_server_object "$reponame" "$oid"
+
+  pushd ..
+    git \
+      -c "filter.lfs.process=" \
+      -c "filter.lfs.smudge=cat" \
+      -c "filter.lfs.required=false" \
+      clone "$GITSERVER/$reponame" "$reponame-assert"
+
+    cd "$reponame-assert"
+
+    git config credential.helper lfstest
+
+    GIT_TRACE=1 git lfs pull origin main 2>&1 | tee pull.log
+    if [ "0" -ne "${PIPESTATUS[0]}" ]; then
+      echo >&2 "fatal: expected \`git lfs pull origin main\` to succeed ..."
+      exit 1
+    fi
+
+    grep "decompressed gzipped response" pull.log
+    assert_local_object "$oid" "${#contents}"
+  popd
+)
+end_test


### PR DESCRIPTION
Since we're uploading and downloading a large amount of data, we may prefer to use transport compression.  Currently, Go will do this for us automatically unless we ask it not to.  Let's detect this case and add a trace output so people can find it and we can add a test that it continues to work.

Note that it's not possible to detect this using the headers since Go adds the headers on the request and strips the headers on the response as part of making the request, so it's not readily apparent to users without this trace output.
