### PR TITLE
Fix numbered list in git lfs examples

### DIFF
--- a/docs/man/git-lfs.1.ronn
+++ b/docs/man/git-lfs.1.ronn
@@ -115,7 +115,7 @@ To get started with Git LFS, the following commands can be used.
 
         git add .gitattributes
 
- 3. Commit, push and work with the files normally:
+ 4. Commit, push and work with the files normally:
 
         git add file.iso
         git commit -m "Add disk image"


### PR DESCRIPTION
When the file is rendered in the browser the numbers in the numbered list are automatically corrected, while when the file is shown in the command line the numbers are wrong. 