### PR TITLE
gitobj 2.0.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/alexbrainman/sspi v0.0.0-20180125232955-4729b3d4d858
 	github.com/avast/retry-go v2.4.2+incompatible
 	github.com/dpotapov/go-spnego v0.0.0-20190506202455-c2c609116ad0
-	github.com/git-lfs/gitobj/v2 v2.0.0
+	github.com/git-lfs/gitobj/v2 v2.0.1
 	github.com/git-lfs/go-netrc v0.0.0-20180525200031-e0e9ca483a18
 	github.com/git-lfs/go-ntlm v0.0.0-20190401175752-c5056e7fa066
 	github.com/git-lfs/wildmatch v1.0.4

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dpotapov/go-spnego v0.0.0-20190506202455-c2c609116ad0 h1:Hhh7nu7CfFVlnBJqmDDUh+j1H5fqjLMzM4czZzNNJGM=
 github.com/dpotapov/go-spnego v0.0.0-20190506202455-c2c609116ad0/go.mod h1:P4f4MSk7h52F2PK0lCapn5+fu47Uf8aRdxDSqgezxZE=
-github.com/git-lfs/gitobj/v2 v2.0.0 h1:2Nm6MQo6coYxv1yYptgBQfny9HFRLHHdbYetBDIkJyg=
-github.com/git-lfs/gitobj/v2 v2.0.0/go.mod h1:q6aqxl6Uu3gWsip5GEKpw+7459F97er8COmU45ncAxw=
+github.com/git-lfs/gitobj/v2 v2.0.1 h1:mUGOWP+fU36rs7TY7a5Lol9FuockOBjPFUW/lwOM7Mo=
+github.com/git-lfs/gitobj/v2 v2.0.1/go.mod h1:q6aqxl6Uu3gWsip5GEKpw+7459F97er8COmU45ncAxw=
 github.com/git-lfs/go-netrc v0.0.0-20180525200031-e0e9ca483a18 h1:7Th0eBA4rT8WJNiM1vppjaIv9W5WJinhpbCJvRJxloI=
 github.com/git-lfs/go-netrc v0.0.0-20180525200031-e0e9ca483a18/go.mod h1:70O4NAtvWn1jW8V8V+OKrJJYcxDLTmIozfi2fmSz5SI=
 github.com/git-lfs/go-ntlm v0.0.0-20190401175752-c5056e7fa066 h1:f5UyyCnv3o2EHy+zsqOyYa8jB5bZR/N9ZEideqeDYag=

--- a/vendor/github.com/git-lfs/gitobj/v2/SECURITY.md
+++ b/vendor/github.com/git-lfs/gitobj/v2/SECURITY.md
@@ -1,0 +1,4 @@
+Please see
+[SECURITY.md](https://github.com/git-lfs/git-lfs/blob/master/SECURITY.md)
+in the main Git LFS repository for information on how to report security
+vulnerabilities in this package.

--- a/vendor/github.com/git-lfs/gitobj/v2/commit.go
+++ b/vendor/github.com/git-lfs/gitobj/v2/commit.go
@@ -97,7 +97,7 @@ func (c *Commit) Decode(hash hash.Hash, from io.Reader, size int64) (n int, err 
 	var messageParts []string
 
 	s := bufio.NewScanner(from)
-	s.Buffer(nil, 1024*1024)
+	s.Buffer(nil, 10*1024*1024)
 	for s.Scan() {
 		text := s.Text()
 		n = n + len(text+"\n")

--- a/vendor/github.com/git-lfs/gitobj/v2/pack/index.go
+++ b/vendor/github.com/git-lfs/gitobj/v2/pack/index.go
@@ -7,7 +7,7 @@ import (
 	"io"
 )
 
-const maxHashSize = sha256.Size
+const MaxHashSize = sha256.Size
 
 // Index stores information about the location of objects in a corresponding
 // packfile.

--- a/vendor/github.com/git-lfs/gitobj/v2/pack/index_v1.go
+++ b/vendor/github.com/git-lfs/gitobj/v2/pack/index_v1.go
@@ -13,7 +13,7 @@ type V1 struct {
 // Name implements IndexVersion.Name by returning the 20 byte SHA-1 object name
 // for the given entry at offset "at" in the v1 index file "idx".
 func (v *V1) Name(idx *Index, at int64) ([]byte, error) {
-	var sha [maxHashSize]byte
+	var sha [MaxHashSize]byte
 
 	hashlen := v.hash.Size()
 

--- a/vendor/github.com/git-lfs/gitobj/v2/pack/index_v2.go
+++ b/vendor/github.com/git-lfs/gitobj/v2/pack/index_v2.go
@@ -13,7 +13,7 @@ type V2 struct {
 // Name implements IndexVersion.Name by returning the 20 byte SHA-1 object name
 // for the given entry at offset "at" in the v2 index file "idx".
 func (v *V2) Name(idx *Index, at int64) ([]byte, error) {
-	var sha [maxHashSize]byte
+	var sha [MaxHashSize]byte
 
 	hashlen := v.hash.Size()
 

--- a/vendor/github.com/git-lfs/gitobj/v2/pack/packfile.go
+++ b/vendor/github.com/git-lfs/gitobj/v2/pack/packfile.go
@@ -190,7 +190,7 @@ func (p *Packfile) findBase(typ PackedObjectType, offset, objOffset int64) (Chai
 	// We assume that we have to read at least an object ID's worth (the
 	// hash length in the case of a OBJ_REF_DELTA, or greater than the
 	// length of the base offset encoded in an OBJ_OFS_DELTA).
-	var sha [32]byte
+	var sha [MaxHashSize]byte
 	if _, err := p.r.ReadAt(sha[:hashlen], offset); err != nil {
 		return nil, baseOffset, err
 	}

--- a/vendor/github.com/git-lfs/gitobj/v2/tree.go
+++ b/vendor/github.com/git-lfs/gitobj/v2/tree.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+
+	"github.com/git-lfs/gitobj/v2/pack"
 )
 
 // Tree encapsulates a Git tree object.
@@ -53,7 +55,7 @@ func (t *Tree) Decode(hash hash.Hash, from io.Reader, size int64) (n int, err er
 		n += len(fname)
 		fname = strings.TrimSuffix(fname, "\x00")
 
-		var sha [32]byte
+		var sha [pack.MaxHashSize]byte
 		if _, err = io.ReadFull(buf, sha[:hashlen]); err != nil {
 			return n, err
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -8,7 +8,7 @@ github.com/avast/retry-go
 github.com/davecgh/go-spew/spew
 # github.com/dpotapov/go-spnego v0.0.0-20190506202455-c2c609116ad0
 github.com/dpotapov/go-spnego
-# github.com/git-lfs/gitobj/v2 v2.0.0
+# github.com/git-lfs/gitobj/v2 v2.0.1
 github.com/git-lfs/gitobj/v2
 github.com/git-lfs/gitobj/v2/errors
 github.com/git-lfs/gitobj/v2/pack


### PR DESCRIPTION
Bump the revision of gitobj to v2.0.1 to pick up the fixes in git-lfs/gitobj#23.