### PR TITLE
prune: add options to be more aggressive about pruning

### DIFF
--- a/docs/man/git-lfs-prune.1.ronn
+++ b/docs/man/git-lfs-prune.1.ronn
@@ -34,6 +34,14 @@ details about `lfs.storage` option.
 * `--dry-run` `-d`
   Don't actually delete anything, just report on what would have been done
 
+* `--force` `-f`
+  Prune all objects except unpushed objects, including objects required for
+  currently checked out refs.  Implies `--recent`.
+
+* `--recent`
+  Prune even objects that would normally be preserved by the configuration
+  options specified below in [RECENT FILES].
+
 * `--verify-remote` `-c`
   Contact the remote and check that copies of the files we would delete
   definitely exist before deleting. See [VERIFY REMOTE].

--- a/lfs/config.go
+++ b/lfs/config.go
@@ -21,6 +21,10 @@ type FetchPruneConfig struct {
 	PruneVerifyRemoteAlways bool
 	// Name of remote to check for unpushed and verify checks
 	PruneRemoteName string
+	// Whether to ignore all recent options.
+	PruneRecent bool
+	// Whether to delete everything pushed.
+	PruneForce bool
 }
 
 func NewFetchPruneConfig(git config.Environment) FetchPruneConfig {
@@ -37,5 +41,7 @@ func NewFetchPruneConfig(git config.Environment) FetchPruneConfig {
 		PruneOffsetDays:               git.Int("lfs.pruneoffsetdays", 3),
 		PruneVerifyRemoteAlways:       git.Bool("lfs.pruneverifyremotealways", false),
 		PruneRemoteName:               pruneRemote,
+		PruneRecent:                   false,
+		PruneForce:                    false,
 	}
 }


### PR DESCRIPTION
Some users really want to minimize the amount of data they store on the local system, especially for large checkouts.  Let's add two options, --recent and --force, the former which ignores the recency settings and the latter which additionally prunes objects which are currently checked out.  We will never prune objects that are unpushed, even with these options, including stashed objects.

Add tests and documentation for both of these options.

Fixes #4367
/cc @Pierre-Bartet as reporter