### PR TITLE
lfshttp: only add extra headers if they don't exist already

### DIFF
--- a/lfshttp/client.go
+++ b/lfshttp/client.go
@@ -242,8 +242,10 @@ func (c *Client) ExtraHeadersFor(req *http.Request) http.Header {
 	}
 
 	for k, vs := range extraHeaders {
-		for _, v := range vs {
-			copy[k] = append(copy[k], v)
+		if len(req.Header.Get(k)) == 0 {
+			for _, v := range vs {
+				copy[k] = append(copy[k], v)
+			}
 		}
 	}
 	return copy


### PR DESCRIPTION
In https://github.com/actions/checkout/issues/415 @Roda83 noted that Git LFS files are not downloaded within the GitHub Actions environment on GitHub Enterprise Server in certain cases. 

The `checkout@v2` action uses Git's [`extraheader`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-httpextraHeader) config to make the authentication easily available to all Git calls in the Action environment. At some point the Action runs `git lfs fetch` to [download the LFS files and this works great](https://github.com/actions/checkout/blob/c952173edf28a2bd22e1a4926590c1ac39630461/src/git-command-manager.ts#L245).

This call will download the "metadata" of the LFS files in batch with a `href` and an `authentication` header for each LFS file. Git LFS uses this info to make additional requests to download these files. Usually, these LFS files are downloaded from a different domain than the domain that the repository is cloned from (e.g. `media.ghes-server.com` vs `ghes-server.com`). That's why the `extraheader` is not applied to these requests.

However, if GitHub Enterprise Server is not run in ["subdomain isolation" mode](https://docs.github.com/en/enterprise-server@2.22/admin/configuration/enabling-subdomain-isolation), then the clone domain is equal to the LFS files domain. Consequently, the `extraheader` is applied. That means the requests will have two `authentication` headers and because of that the request will fail.

This PR fixes this issue by checking if a certain header already exists before we add an `extraheader`.

---

I tried to add a test case for this but it turns out that the LFS batch response in our tests does not contain an `authentication` header. Therefore, we have no duplicate header and no problem.

/cc @dassencio @jonico

