### PR TITLE
.github/workflows: don't try to install older Git

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,6 @@ jobs:
     - run: set GOPATH=%HOME%\go
     - run: cinst InnoSetup -y
     - run: cinst strawberryperl -y
-    - run: choco uninstall git.install -y --force
-    - run: cinst git --version 2.26.2 -y --force
     - run: refreshenv
     - run: gem install ronn
       shell: bash


### PR DESCRIPTION
Git for Windows 2.27.0 had a bug where symlinks would appear perpetually modified when core.fscache was enabled, causing our CI job to fail because it looks for modified files after running the formatter. However, a newer version of Git is now available and our old code is failing, so let's remove it and use the newer version of Git that's shipped by default.
