### PR TITLE
Consider scheme of request URL, not proxy URL, when choosing proxy

### DIFF
--- a/lfshttp/proxy.go
+++ b/lfshttp/proxy.go
@@ -75,7 +75,7 @@ func getProxyServers(u *url.URL, urlCfg *config.URLConfig, osEnv config.Environm
 	if urlCfg != nil {
 		gitProxy, ok := urlCfg.Get("http", u.String(), "proxy")
 		if len(gitProxy) > 0 && ok {
-			if strings.HasPrefix(gitProxy, "https://") {
+			if u.Scheme == "https" {
 				httpsProxy = gitProxy
 			}
 			httpProxy = gitProxy

--- a/lfshttp/proxy_test.go
+++ b/lfshttp/proxy_test.go
@@ -69,6 +69,34 @@ func TestProxyFromEnvironment(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestHTTPSProxyFromEnvironment(t *testing.T) {
+	c, err := NewClient(NewContext(nil, map[string]string{
+		"HTTPS_PROXY": "http://proxy-from-env:8080",
+	}, nil))
+	require.Nil(t, err)
+
+	req, err := http.NewRequest("GET", "https://some-host.com:123/foo/bar", nil)
+	require.Nil(t, err)
+
+	proxyURL, err := proxyFromClient(c)(req)
+	assert.Equal(t, "proxy-from-env:8080", proxyURL.Host)
+	assert.Nil(t, err)
+}
+
+func TestHTTPProxyFromEnvironment(t *testing.T) {
+	c, err := NewClient(NewContext(nil, map[string]string{
+		"HTTPS_PROXY": "http://proxy-from-env:8080",
+	}, nil))
+	require.Nil(t, err)
+
+	req, err := http.NewRequest("GET", "http://some-host.com:123/foo/bar", nil)
+	require.Nil(t, err)
+
+	proxyURL, err := proxyFromClient(c)(req)
+	assert.Nil(t, proxyURL)
+	assert.Nil(t, err)
+}
+
 func TestProxyIsNil(t *testing.T) {
 	c, _ := NewClient(nil)
 


### PR DESCRIPTION
If a user has a proxy using HTTP but a URL using HTTPS, we fail to honor the http.proxy configuration setting because we check the scheme of the proxy URL, not the scheme of the request URL.  Let's fix this by deciding which proxy variable to set based on the request URL, as was probably intended, rather than the proxy URL.

Add some tests for this case, as well as the case that we correctly ignore the HTTPS_PROXY environment variable if the scheme of the request URL is HTTP, which we were previously lacking.

/cc @bhilton (as submitter)
Fixes #4392