### PR TITLE
lfs: don't invoke diff drivers when pruning repositories

### DIFF
--- a/lfs/gitscanner_log.go
+++ b/lfs/gitscanner_log.go
@@ -29,6 +29,8 @@ var (
 	// Arguments to append to a git log call which will limit the output to
 	// lfs changes and format the output suitable for parseLogOutput.. method(s)
 	logLfsSearchArgs = []string{
+		"--no-ext-diff",
+		"--no-textconv",
 		"-G", "oid sha256:", // only diffs which include an lfs file SHA change
 		"-p",                             // include diff so we can read the SHA
 		"-U12",                           // Make sure diff context is always big enough to support 10 extension lines to get whole pointer

--- a/t/t-prune.sh
+++ b/t/t-prune.sh
@@ -858,3 +858,22 @@ begin_test "prune --force"
   refute_local_object "$oid_inrepo" "${#content_inrepo}"
 )
 end_test
+
+begin_test "prune does not invoke external diff programs"
+(
+  set -e
+
+  reponame="prune-external-diff"
+  setup_remote_repo "remote-$reponame"
+
+  clone_repo "remote-$reponame" "clone-$reponame"
+
+  git config diff.word.textconv 'false'
+  echo "*.dot diff=word" >.git/info/attributes
+
+  for n in $(seq 1000); do (echo "$n" > "$n.dot") done
+  git add .
+  git commit -am "initial"
+  git lfs prune
+)
+end_test


### PR DESCRIPTION
Certain file paths are associated with diff textconv patterns with Git for Windows, and these are invoked by default when using git log. However, when we're using git log to scan data to find LFS objects, we don't want to invoke those programs.

Let's fix this by passing appropriate options to disabled these invocations.  In the test, we set the driver to false, since Git will fail if the process it calls also fails.

Fixes #4401