### PR TITLE
lfsapi: don't warn about duplicate but identical aliases

### DIFF
--- a/lfsapi/endpoint_finder.go
+++ b/lfsapi/endpoint_finder.go
@@ -335,10 +335,11 @@ func initAliases(e *endpointGitFinder, git config.Environment) {
 
 func storeAlias(aliases map[string]string, key string, values []string, suffix string) {
 	for _, value := range values {
-		if _, ok := aliases[value]; ok {
+		url := key[len(aliasPrefix) : len(key)-len(suffix)]
+		if v, ok := aliases[value]; ok && v != url {
 			fmt.Fprintf(os.Stderr, "WARNING: Multiple 'url.*.%s' keys with the same alias: %q\n", suffix, value)
 		}
-		aliases[value] = key[len(aliasPrefix) : len(key)-len(suffix)]
+		aliases[value] = url
 	}
 }
 


### PR DESCRIPTION
Currently, we warn about aliases (e.g., `url.*.insteadOf`) when there's already an alias for the same URL; that is, when the `insteadOf` entry matches an existing one.  However, in some environments, multiple aliases are defined, but all to the same root URL (the one in the key).

In such a case, don't warn, since these aliases are already identical. Do continue to warn if the root URL is different at all, since these are different aliases for the same URL, and add a test for both of these cases.

/cc @kaelig as reporter
Fixes #4412