### PR TITLE
Canonicalize Windows paths like Git does

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -20,8 +20,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-Portions of the subprocess directory are copied from Go and are under the
-following license:
+Portions of the subprocess and tools directories are copied from Go and are
+under the following license:
 
 Copyright (c) 2010 The Go Authors. All rights reserved.
 

--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/git-lfs/git-lfs/errors"
 	"github.com/git-lfs/git-lfs/git"
+	"github.com/git-lfs/git-lfs/tools"
 	"github.com/spf13/cobra"
 )
 
@@ -79,7 +80,7 @@ func lockPath(file string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	wd, err = filepath.EvalSymlinks(wd)
+	wd, err = tools.CanonicalizeSystemPath(wd)
 	if err != nil {
 		return "", errors.Wrapf(err,
 			"could not follow symlinks for %s", wd)

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -347,7 +347,7 @@ func changeToWorkingCopy() {
 		ExitWithError(errors.Wrap(
 			err, "fatal: could not determine current working directory"))
 	}
-	cwd, err = filepath.EvalSymlinks(cwd)
+	cwd, err = tools.CanonicalizeSystemPath(cwd)
 	if err != nil {
 		ExitWithError(errors.Wrap(
 			err, "fatal: could not canonicalize current working directory"))

--- a/debian/copyright
+++ b/debian/copyright
@@ -31,6 +31,7 @@ Files: vendor/github.com/alexbrainman/sspi/*
  subprocess/path.go
  subprocess/path_nix.go
  subprocess/path_windows.go
+ tools/filetools_windows.go
 Copyright: 2009, 2010, 2012, 2017 The Go Authors
 License: Go
  Redistribution and use in source and binary forms, with or without

--- a/lfshttp/standalone/standalone.go
+++ b/lfshttp/standalone/standalone.go
@@ -137,7 +137,7 @@ func gitDirAtPath(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return filepath.EvalSymlinks(gitdir)
+	return tools.CanonicalizeSystemPath(gitdir)
 }
 
 func fixUrlPath(path string) string {

--- a/tools/filetools.go
+++ b/tools/filetools.go
@@ -60,7 +60,7 @@ func ResolveSymlinks(path string) string {
 		return path
 	}
 
-	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+	if resolved, err := CanonicalizeSystemPath(path); err == nil {
 		return resolved
 	}
 	return path

--- a/tools/filetools.go
+++ b/tools/filetools.go
@@ -494,7 +494,7 @@ func CanonicalizePath(path string, missingOk bool) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		result, err := filepath.EvalSymlinks(path)
+		result, err := CanonicalizeSystemPath(path)
 		if err != nil && os.IsNotExist(err) && missingOk {
 			return path, nil
 		}

--- a/tools/filetools_nix.go
+++ b/tools/filetools_nix.go
@@ -1,0 +1,13 @@
+// +build !windows
+
+package tools
+
+import "path/filepath"
+
+func CanonicalizeSystemPath(path string) (string, error) {
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	return filepath.EvalSymlinks(path)
+}

--- a/tools/filetools_windows.go
+++ b/tools/filetools_windows.go
@@ -1,0 +1,53 @@
+// +build windows
+
+package tools
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+func openSymlink(path string) (windows.Handle, error) {
+	p, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return 0, err
+	}
+
+	attrs := uint32(windows.FILE_FLAG_BACKUP_SEMANTICS)
+	h, err := windows.CreateFile(p, 0, 0, nil, windows.OPEN_EXISTING, attrs, 0)
+	if err != nil {
+		return 0, err
+	}
+
+	return h, nil
+}
+
+func CanonicalizeSystemPath(path string) (string, error) {
+	h, err := openSymlink(path)
+	if err != nil {
+		return "", err
+	}
+	defer windows.CloseHandle(h)
+
+	buf := make([]uint16, 100)
+	for {
+		n, err := windows.GetFinalPathNameByHandle(h, &buf[0], uint32(len(buf)), 0)
+		if err != nil {
+			return "", err
+		}
+		if n < uint32(len(buf)) {
+			break
+		}
+		buf = make([]uint16, n)
+	}
+
+	s := windows.UTF16ToString(buf)
+	if len(s) > 4 && s[:4] == `\\?\` {
+		s = s[4:]
+		if len(s) > 3 && s[:3] == `UNC` {
+			// return path like \\server\share\...
+			return `\` + s[3:], nil
+		}
+		return s, nil
+	}
+	return s, nil
+}


### PR DESCRIPTION
Git consistently uses canonicalized paths internally.  This is for many reasons, but mostly to verify that a single path is within a repository. In order to interoperate properly with Git, we need to canonicalize paths and do it in the same way as Git.

On Unix systems, to canonicalize a path, it is sufficient to make the path absolute and then resolve any symlinks.  Go provides two functions to do these two steps, filepath.Abs and filepath.EvalSymlinks, and they work as advertised.

Windows, however, has much more complex path handling and these functions do not handle all cases.  The typical way to canonicalize paths on Windows is using GetFinalPathNameByHandle, and this is the technique Git uses.

Go, however, does not provide a general API to canonicalize paths, unlike Rust's std::fs::canonicalize and similar functionality in myriad other languages.  Therefore, in order to get this working on Windows, let's add a function to canonicalize paths in the appropriate system way, one for Unix systems and one for Windows.  The code comes from Go's standard library, so update the copyright and license accordingly.

Update the CanonicalizePath function to use the new function.  We duplicate the Abs call because we an absolute path in CanonicalizePath in some cases even if the path is missing, whereas the new function needs to do it in all cases because we will use it other situations in the future.  This should be a simple string check, so it should not involve an extra system call or other overhead.

Use the new function in some other parts of the code where we were previously using filepath.EvalSymlinks.

There are no tests for this case because the situations which are problematic require either SMB shares or SUBST, and neither is acceptable in a testsuite like ours.

Fixes #4238
Fixes #4012