### PR TITLE
invoke git-config with --includes to ensure it always evaluates include.* directives

### DIFF
--- a/git/config.go
+++ b/git/config.go
@@ -199,7 +199,7 @@ func (c *Configuration) Source() (*ConfigurationSource, error) {
 }
 
 func (c *Configuration) gitConfig(args ...string) (string, error) {
-	args = append([]string{"config"}, args...)
+	args = append([]string{"config", "--includes"}, args...)
 	cmd := subprocess.ExecCommand("git", args...)
 	if len(c.GitDir) > 0 {
 		cmd.Dir = c.GitDir

--- a/t/t-config.sh
+++ b/t/t-config.sh
@@ -256,3 +256,23 @@ begin_test "config: ignoring unsafe lfsconfig keys"
   grep "  core.askpass" status.log
 )
 end_test
+
+begin_test "config respects include.* directives when GIT_CONFIG is set"
+(
+  set -e
+
+  mkdir include-directives
+  cd include-directives
+
+  git init
+
+  git config lfs.url "http://some-url/rest"
+  GIT_CONFIG="$(pwd)/.git/config" git lfs env | tee env.log
+  grep "Endpoint=http://some-url/rest (auth=none)" env.log
+
+  git config --file ./.git/b.config url."http://other-url/".insteadOf "http://some-url/"
+  git config include.path "$(pwd)/.git/b.config"
+  GIT_CONFIG="$(pwd)/.git/config" git lfs env | tee env.log
+  grep "Endpoint=http://other-url/rest (auth=none)" env.log
+)
+end_test


### PR DESCRIPTION
Per `git-config`'s man page, `include.*` directives are not respected by default when asked to evaluate a specific file (whether via `--global`, `--file /path/to/.gitconfig`, or `GIT_CONFIG=/path/to/.gitconfig`).

This patch ensures that, if `GIT_CONFIG` is set in the environment when e.g. `git-lfs-push` is invoked, config directives from included files are evaluated.

This is important if, for example, an included file contains a `url.<foo>.insteadOf` directive or `lfs.<foo>.locksverify` directive that's shared between many repositories.

Before this change, with the following setup:

```
% git config --file /tmp/a.config -l
...
remote.origin.url=https://my-server-alias/foo/bar.git
include.path=/tmp/b.config

% git config --file /tmp/b.config -l
...
url.https://my-actual-server.com/.insteadOf=https://my-server-alias/
```

I'd get something like:

```
% GIT_CONFIG=/tmp/a.config git push
...
batch response: Post "https://my-server-alias/foo/bar.git/info/lfs/objects/batch": dial tcp: lookup my-server-alias: no such host
batch response: Post "https://my-server-alias/foo/bar.git/info/lfs/objects/batch": dial tcp: lookup my-server-alias: no such host
Uploading LFS objects:   0% (0/2), 0 B | 0 B/s, done.
error: failed to push some refs to 'https://my-actual-server.com/foo/bar.git'
```

But now it works as expected. :)

I'm open to adding tests if someone can point me at the best place to add them.