### PR TITLE
Tighten LFS pointer regexp

### DIFF
--- a/lfs/pointer.go
+++ b/lfs/pointer.go
@@ -22,7 +22,7 @@ var (
 	}
 	latest      = "https://git-lfs.github.com/spec/v1"
 	oidType     = "sha256"
-	oidRE       = regexp.MustCompile(`\A[[:alnum:]]{64}`)
+	oidRE       = regexp.MustCompile(`\A[0-9a-f]{64}\z`)
 	matcherRE   = regexp.MustCompile("git-media|hawser|git-lfs")
 	extRE       = regexp.MustCompile(`\Aext-\d{1}-\w+`)
 	pointerKeys = []string{"version", "oid", "size"}

--- a/lfs/pointer_test.go
+++ b/lfs/pointer_test.go
@@ -274,6 +274,11 @@ size 12345`,
 ext-0-foo boom:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 oid sha256:4d7a214614ab2935c943f9e0ff69d22eadbb8f32b1258daaa5e2ca24d17e2393
 size 12345`,
+
+		// bad OID
+		`version https://git-lfs.github.com/spec/v1
+oid sha256:4d7a214614ab2935c943f9e0ff69d22eadbb8f32b1258daaa5e2ca24d17e2393&
+size 177735`,
 	}
 
 	for _, ex := range examples {


### PR DESCRIPTION
This prevents a potential parameter injection that might result from
decoding an LFS pointer file with trailing characters in the OID.