### PR TITLE
Update README and Contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,17 @@ them as separate pull requests.
 * Explain the rationale for your change in the pull request. You can often use
   part of a good commit message as a starting point.
 
+## Discussions
+
+[Our discussions](https://github.com/git-lfs/git-lfs/discussions) are the
+perfect place to ask a question if you're not sure on something, provide
+feedback that isn't a bug report or feature request, or learn about use cases or
+best practices with Git LFS.  There's even a search box to help you see if
+someone has already answered your question!
+
+You can also check [the FAQ](https://github.com/git-lfs/git-lfs/wiki/FAQ) to see
+if your question is well known and already has an easy answer.
+
 ## Issues
 
 If you think you've found a bug or have an issue, we'd love to hear about it!

--- a/README.md
+++ b/README.md
@@ -170,6 +170,11 @@ The [official documentation](docs) has command references and specifications for
 the tool.  There's also a [FAQ](https://github.com/git-lfs/git-lfs/wiki/FAQ) on
 the wiki which answers some common questions.
 
+If you have a question on how to use Git LFS, aren't sure about something, or
+are looking for input from others on tips about best practices or use cases,
+feel free to
+[start a discussion](https://github.com/git-lfs/git-lfs/discussions).
+
 You can always [open an issue](https://github.com/git-lfs/git-lfs/issues), and
 one of the Core Team members will respond to you. Please be sure to include:
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,22 @@ To https://github.com/git-lfs/git-lfs-test
 
 Note: Git LFS requires at least Git 1.8.2 on Linux or 1.8.5 on macOS.
 
+### Uninstalling
+
+If you've decided that Git LFS isn't right for you, you can convert your
+repository back to a plain Git repository with `git lfs migrate` as well.  For
+example:
+
+```ShellSession
+$ git lfs migrate export --include="*.psd" --everything
+```
+
+Note that this will rewrite history and change all of the Git object IDs in your
+repository, just like the import version of this command.
+
+If there's some reason that things aren't working out for you, please let us
+know in an issue, and we'll definitely try to help or get it fixed.
+
 ## Limitations
 
 Git LFS maintains a list of currently known limitations, which you can find and


### PR DESCRIPTION
This introduces two new pieces to our common Markdown files.

The first one covers uninstalling Git LFS, since that's a question that a lot of users have.  We now have an entry for it in the FAQ as well, so hopefully that documentation should be easier to find.

The second piece encourages users to use the discussions functionality for things that aren't bug reports or feature requests.  As outlined in the commit message, that allows askers to easily mark a correct answer, which both helps future users and also prevents those users from popping up in an issue asking for the canonical answer when one has been given.

Fixes #4426