### PR TITLE
tools: unset XDG_CONFIG_HOME for filetools test

### DIFF
--- a/tools/filetools_test.go
+++ b/tools/filetools_test.go
@@ -152,6 +152,7 @@ func (c *ExpandConfigPathTestCase) Assert(t *testing.T) {
 }
 
 func TestExpandConfigPath(t *testing.T) {
+	os.Unsetenv("XDG_CONFIG_HOME")
 	for desc, c := range map[string]*ExpandConfigPathTestCase{
 		"unexpanded full path": {
 			Path: "/path/to/attributes",


### PR DESCRIPTION
The `TestExpandConfigPath()` method checks a number of conditions under which the `ExpandConfigPath()` method might operate, including when the `$XDG_CONFIG_HOME` environment variable is set.

However, if the variable happens to already be set in the test execution environment, that trips up the `"expanded
default path"` test condition as `ExpandConfigPath()` finds the `$XDG_CONFIG_HOME` variable and (correctly) uses it in constructing the output path.

So we want to run the test method with a clean environment, since it will simulate the `$XDG_CONFIG_HOME` variable being set itself for the relevant test condition.  Therefore we just unset the variable at the start of the test method in case `$XDG_CONFIG_HOME` is already set.

Fixes #4430.
/cc @geofflangenderfer as reporter.