### PR TITLE
Use blobSizeCutoff in clean pointer buffer length check

### DIFF
--- a/lfs/gitfilter_clean.go
+++ b/lfs/gitfilter_clean.go
@@ -80,7 +80,7 @@ func (f *GitFilter) copyToTemp(reader io.Reader, fileSize int64, cb tools.CopyCa
 	n, rerr := buf.Read(by)
 	by = by[:n]
 
-	if rerr != nil || (err == nil && len(by) < 512) {
+	if rerr != nil || (err == nil && len(by) < blobSizeCutoff) {
 		err = errors.NewCleanPointerError(ptr, by)
 		return
 	}


### PR DESCRIPTION
When the `"clean"` filter processes a pre-existing LFS pointer blob, the `copyToTemp()` function returns a `CleanPointerError`; it does this when `DecodeFrom()` successfully reads and parses the pointer blob and when the entirety of the blob's contents have been read (i.e., there is no additional blob data to be read).

This latter check was originally introduced in commit e09e5e1000bdc890ff8b27f6f330bbdb980f232b in PR #271, when the relevant code was in the `Clean()` method in the `pointer/clean.go` file; it used the same 512 byte maximum to [determine](https://github.com/git-lfs/git-lfs/blob/e09e5e1000bdc890ff8b27f6f330bbdb980f232b/pointer/clean.go#L39-L42) if all the blob content had been read.  This was aligned with the size of the byte array [used](https://github.com/git-lfs/git-lfs/blob/e09e5e1000bdc890ff8b27f6f330bbdb980f232b/pointer/pointer.go#L66) in `DecodeFrom()` in the `pointer/pointer.go` file.  The 512-byte buffer created in `DecodeFrom()` was [adjusted](https://github.com/git-lfs/git-lfs/blob/e09e5e1000bdc890ff8b27f6f330bbdb980f232b/pointer/pointer.go#L72) and [returned](https://github.com/git-lfs/git-lfs/blob/e09e5e1000bdc890ff8b27f6f330bbdb980f232b/pointer/pointer.go#L74) to `Clean()`, which then checked its length to see if it had been populated to the 512-byte maximum, meaning there might still be additional data to be read.

In commit f58db7f7935fe612f455e2939bbf4617dda9e615 in PR #684 the [size](https://github.com/git-lfs/git-lfs/blob/f58db7f7935fe612f455e2939bbf4617dda9e615/lfs/pointer.go#L105) of the read buffer in `DecodeFrom()` was changed from 512 bytes to the value of `blobSizeCutoff`, which [was](https://github.com/git-lfs/git-lfs/blob/f58db7f7935fe612f455e2939bbf4617dda9e615/lfs/scanner.go#L20-L22) 1024 (and [remains](https://github.com/git-lfs/git-lfs/blob/b2b890aac9e558e09feece6dd0d6108da0f20644/lfs/scanner.go#L9-L11) so since).  However, the check in `Clean()`'s `copyToTemp()` function was not changed at the same time.  (Note that `Clean()` had been refactored and the [check](https://github.com/git-lfs/git-lfs/blob/f58db7f7935fe612f455e2939bbf4617dda9e615/lfs/pointer_clean.go#L75) was in `copyToTemp()`, where it [remains](https://github.com/git-lfs/git-lfs/blob/b2b890aac9e558e09feece6dd0d6108da0f20644/lfs/gitfilter_clean.go#L83).)

In commit 6f54232890174a119f7dbfd562d5c1ab57174d0b in PR #1796 the `DecodeFrom()` method was changed to [return](https://github.com/git-lfs/git-lfs/blob/6f54232890174a119f7dbfd562d5c1ab57174d0b/lfs/pointer.go#L122-L132) an `io.Reader` instead of a byte array, and `copyToTemp()` would then read from that into a byte array [using](https://github.com/git-lfs/git-lfs/blob/6f54232890174a119f7dbfd562d5c1ab57174d0b/lfs/pointer_clean.go#L81) `ioutil.ReadAll()`.  That introduced a bug when handling large malformed pointers, fixed in commit dcc05817c350fc7f629271c7bed5fa4f4e36bde9 in PR #1852 by [reading](https://github.com/git-lfs/git-lfs/blob/dcc05817c350fc7f629271c7bed5fa4f4e36bde9/lfs/pointer_clean.go#L81-L83) into a byte array in `copyToTemp()` with `blobSizeCutoff` length.  However, the check for a resultant data length of less than 512 bytes still [remained](https://github.com/git-lfs/git-lfs/blob/dcc05817c350fc7f629271c7bed5fa4f4e36bde9/lfs/pointer_clean.go#L85) in place.

In order to keep this blob size check in sync with the allocated byte array in `copyToTemp()`, we therefore change
`copyToTemp()` so it checks if a pointer was successfully read and the blob size is below `blobSizeCutoff`.  This
implies there is no more data to be read and we can return a `CleanPointerError` (to signal a clean pointer was
found) containing the byte array, which will then be written out, leaving the blob's contents unchanged.

/cc @ttaylorr for a sanity check.