### PR TITLE
Fix up handling of the "migrate info" command's --top option

### DIFF
--- a/commands/command_migrate_info.go
+++ b/commands/command_migrate_info.go
@@ -106,7 +106,7 @@ func migrateInfoCommand(cmd *cobra.Command, args []string) {
 	entries = removeEmptyEntries(entries)
 	sort.Sort(sort.Reverse(entries))
 
-	migrateInfoTopN = tools.ClampInt(migrateInfoTopN, len(entries), 0)
+	migrateInfoTopN = tools.ClampInt(migrateInfoTopN, 0, len(entries))
 
 	entries = entries[:tools.MaxInt(0, migrateInfoTopN)]
 

--- a/commands/command_migrate_info.go
+++ b/commands/command_migrate_info.go
@@ -89,7 +89,6 @@ func migrateInfoCommand(cmd *cobra.Command, args []string) {
 			}
 
 			entry.Total++
-			entry.BytesTotal += b.Size
 
 			if b.Size > int64(migrateInfoAbove) {
 				entry.TotalAbove++
@@ -124,8 +123,6 @@ type MigrateInfoEntry struct {
 	BytesAbove int64
 	// TotalAbove is the count of all files above a given size threshold.
 	TotalAbove int64
-	// BytesTotal is the number of bytes of all files
-	BytesTotal int64
 	// Total is the count of all files.
 	Total int64
 }

--- a/commands/command_migrate_info.go
+++ b/commands/command_migrate_info.go
@@ -108,7 +108,7 @@ func migrateInfoCommand(cmd *cobra.Command, args []string) {
 
 	migrateInfoTopN = tools.ClampInt(migrateInfoTopN, 0, len(entries))
 
-	entries = entries[:tools.MaxInt(0, migrateInfoTopN)]
+	entries = entries[:migrateInfoTopN]
 
 	entries.Print(os.Stdout)
 }

--- a/t/fixtures/migrate.sh
+++ b/t/fixtures/migrate.sh
@@ -179,7 +179,7 @@ setup_single_local_branch_complex_tracked() {
 setup_single_local_branch_tracked_corrupt() {
   set -e
 
-  reponame="migrate-single-locla-branch-with-attrs-corrupt"
+  reponame="migrate-single-local-branch-with-attrs-corrupt"
 
   remove_and_create_local_repo "$reponame"
 

--- a/t/t-migrate-import.sh
+++ b/t/t-migrate-import.sh
@@ -465,8 +465,6 @@ begin_test "migrate import (existing .gitattributes)"
 
   setup_local_branch_with_gitattrs
 
-  pwd
-
   main="$(git rev-parse refs/heads/main)"
 
   txt_main_oid="$(calc_oid "$(git cat-file -p "$main:a.txt")")"
@@ -494,8 +492,6 @@ begin_test "migrate import (--exclude with existing .gitattributes)"
   set -e
 
   setup_local_branch_with_gitattrs
-
-  pwd
 
   main="$(git rev-parse refs/heads/main)"
 

--- a/tools/math.go
+++ b/tools/math.go
@@ -20,7 +20,7 @@ func MaxInt(a, b int) int {
 
 // ClampInt returns the integer "n" bounded between "min" and "max".
 func ClampInt(n, min, max int) int {
-	return MinInt(min, MaxInt(max, n))
+	return MinInt(max, MaxInt(min, n))
 }
 
 // MinInt64 returns the smaller of two `int`s, "a", or "b".

--- a/tools/math_test.go
+++ b/tools/math_test.go
@@ -6,22 +6,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func MinIntPicksTheSmallerInt(t *testing.T) {
+func TestMinIntPicksTheSmallerInt(t *testing.T) {
 	assert.Equal(t, -1, MinInt(-1, 1))
 }
 
-func MaxIntPicksTheBiggertInt(t *testing.T) {
+func TestMaxIntPicksTheBiggertInt(t *testing.T) {
 	assert.Equal(t, 1, MaxInt(-1, 1))
 }
 
-func ClampDiscardsIntsLowerThanMin(t *testing.T) {
+func TestClampDiscardsIntsLowerThanMin(t *testing.T) {
 	assert.Equal(t, 0, ClampInt(-1, 0, 1))
 }
 
-func ClampDiscardsIntsGreaterThanMax(t *testing.T) {
+func TestClampDiscardsIntsGreaterThanMax(t *testing.T) {
 	assert.Equal(t, 1, ClampInt(2, 0, 1))
 }
 
-func ClampAcceptsIntsWithinBounds(t *testing.T) {
+func TestClampAcceptsIntsWithinBounds(t *testing.T) {
 	assert.Equal(t, 1, ClampInt(1, 0, 2))
 }


### PR DESCRIPTION
This PR addresses some internal bugs and oversights in the `git lfs migrate info` command's handling of its `--top` option, and adds some tests to verify the correctness of these changes.

First, the `tools.ClampInt()` function does not always return a value between its `min` and `max` arguments because it reverses their meaning, and the relevant tests in the corresponding `tools/math_test.go` file do not report the problem because they do not execute when the `go test ./tools` command is run.  The latter bug is a result of the test functions lacking the necessary `Test*` prefix to be recognized by the Go `test` command.
    
After we fix the `ClampInt()` function, we rename all the test functions in tools/math_test.go to follow the `Test*()` naming scheme, which ensures they now run properly.
    
Lastly, we change the one caller of the `ClampInt()` function, the `migrateInfoCommand()` function, which previously worked correctly because it also reversed the order of the arguments it passed to the function.  That reversal was introduced in commit bd2e1b27368745f4014a448c371fd72c658ef9d6 in PR #2313, as part of the development of the `migrate info` command, presumably because the author discovered the call was not working as expected.

Next, we can simplify one line in the `migrateInfoCommand()` function where it resets the `entries` list of informational entries to be output to include no more entries than the setting of the `--top` option, because we have already clamped the `migrateInfoTopN` value to be between zero and the total number of entries.  So we can drop the second call to `tools.MaxInt()` here; there is no chance `migrateInfoTopN` could be less than zero at this point.

To confirm our changes and any future ones work as advertised, we then add one test and revise one other.

The new test checks that the `--top` option works in multiple cases, including when its value is zero or below zero, or when it is greater than the number of available entries to be printed by the `git lfs migrate info` command.

The revised test is changed so that it confirms that only the highest available entry is printed when `--top=1` is specified.  Previously, because the `--above` option is also set in this test, there was only one matching entry to be printed, and so the `--top=1` was redundant.  If `--top=2` had been specified, the test would still have passed.

Lastly, we can make a few additional cleanups.  The `TotalBytes` variable is computed but never used in the output of the `git lfs migrate info` command, so we can simply remove it.  And we also remove some leftover `pwd` commands in the `t/t-migrate-import.sh` test file and fix a typo in the `t/fixtures/migrate.sh` file.