### PR TITLE
Make all checks of blobSizeCutoff consistent

### DIFF
--- a/lfs/gitscanner_catfilebatch.go
+++ b/lfs/gitscanner_catfilebatch.go
@@ -133,7 +133,7 @@ func (s *PointerScanner) next(blob string) (string, string, *WrappedPointer, err
 
 	var buf *bytes.Buffer
 	var to io.Writer = sha
-	if size <= blobSizeCutoff {
+	if size < blobSizeCutoff {
 		buf = bytes.NewBuffer(make([]byte, 0, size))
 		to = io.MultiWriter(to, buf)
 	}
@@ -150,7 +150,7 @@ func (s *PointerScanner) next(blob string) (string, string, *WrappedPointer, err
 	var pointer *WrappedPointer
 	var contentsSha string
 
-	if size <= blobSizeCutoff {
+	if size < blobSizeCutoff {
 		if p, err := DecodePointer(bytes.NewReader(buf.Bytes())); err != nil {
 			contentsSha = fmt.Sprintf("%x", sha.Sum(nil))
 		} else {

--- a/lfs/pointer.go
+++ b/lfs/pointer.go
@@ -87,7 +87,7 @@ func DecodePointerFromFile(file string) (*Pointer, error) {
 	if err != nil {
 		return nil, err
 	}
-	if stat.Size() > blobSizeCutoff {
+	if stat.Size() >= blobSizeCutoff {
 		return nil, errors.NewNotAPointerError(errors.New("file size exceeds lfs pointer size cutoff"))
 	}
 	f, err := os.OpenFile(file, os.O_RDONLY, 0644)


### PR DESCRIPTION
The `blobSizeCutoff` limit is [defined](https://github.com/git-lfs/git-lfs/blob/e2531f0e342bfc55320f50b9068fe83262f4cd16/lfs/scanner.go#L9-L11) such that "any file with a size _below_ this cutoff will be scanned" [emphasis added] when looking for LFS pointer blobs.  In general this is true, but there are few instances where the check is applied such that blobs matching the cutoff limit are also scanned.

We therefore adjust these to match the same comparison logic used elsewhere with this limit.

Two of [these](https://github.com/git-lfs/git-lfs/blob/e2531f0e342bfc55320f50b9068fe83262f4cd16/lfs/gitscanner_catfilebatch.go#L136-L139) [checks](https://github.com/git-lfs/git-lfs/blob/e2531f0e342bfc55320f50b9068fe83262f4cd16/lfs/gitscanner_catfilebatch.go#L153-L162) are in the `PointerScanner.next()` method used by the `runCatFileBatch()` function; they were introduced in commit 844c0b0db2bf3d39f52773e5f63ee10683a28342 in PR #2070 and scan Git objects for eligible LFS pointers when reading the output of `"git cat-file --batch"`.  Note that the corresponding `runCatFileBatchCheck()` function's `catFileBatchCheckScanner.next()` method [excludes](https://github.com/git-lfs/git-lfs/blob/e2531f0e342bfc55320f50b9068fe83262f4cd16/lfs/gitscanner_catfilebatchcheck.go#L112-L114) as LFS [pointers](https://github.com/git-lfs/git-lfs/blob/e2531f0e342bfc55320f50b9068fe83262f4cd16/lfs/gitscanner_catfilebatchcheck.go#L81) any blobs whose size is above or equal to the limit (with a [default](https://github.com/git-lfs/git-lfs/blob/e2531f0e342bfc55320f50b9068fe83262f4cd16/lfs/gitscanner_catfilebatchcheck.go#L25) limit of `blobSizeCutoff`); this aligns with other [usage](https://github.com/git-lfs/git-lfs/blob/e2531f0e342bfc55320f50b9068fe83262f4cd16/lfs/gitfilter_clean.go#L83) and [checks](https://github.com/git-lfs/git-lfs/blob/e2531f0e342bfc55320f50b9068fe83262f4cd16/lfs/pointer.go#L90-L92) of the `blobSizeCutoff` maximum as well.

The other [check](https://github.com/git-lfs/git-lfs/blob/e2531f0e342bfc55320f50b9068fe83262f4cd16/lfs/pointer.go#L90-L92) is in the `DecodePointerFromFile()` function where it is used to exclude from consideration as Git LFS pointers any files larger than `blobSizeCutoff`.  This function is ultimately called by the `"git lfs checkout"` command; the original implementation was added in commit 001ddcd7cfae528a6594be9bab4562c6659a00e7 in PR #527.

/cc #4433