### PR TITLE
Allow reporting of LFS pointers separately in migrate info command

### DIFF
--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -368,6 +368,7 @@ func init() {
 	info.Flags().IntVar(&migrateInfoTopN, "top", 5, "--top=<n>")
 	info.Flags().StringVar(&migrateInfoAboveFmt, "above", "", "--above=<n>")
 	info.Flags().StringVar(&migrateInfoUnitFmt, "unit", "", "--unit=<unit>")
+	info.Flags().StringVar(&migrateInfoPointers, "pointers", "", "Ignore, dereference, or include LFS pointer files")
 
 	importCmd := NewCommand("import", migrateImportCommand)
 	importCmd.Flags().StringVar(&migrateImportAboveFmt, "above", "", "--above=<n>")

--- a/commands/command_migrate_info.go
+++ b/commands/command_migrate_info.go
@@ -21,8 +21,8 @@ import (
 type migrateInfoPointersType int
 
 const (
-	migrateInfoPointersNoFollow = migrateInfoPointersType(iota)
 	migrateInfoPointersFollow   = migrateInfoPointersType(iota)
+	migrateInfoPointersNoFollow = migrateInfoPointersType(iota)
 	migrateInfoPointersIgnore   = migrateInfoPointersType(iota)
 )
 
@@ -86,10 +86,10 @@ func migrateInfoCommand(cmd *cobra.Command, args []string) {
 
 	if pointers := cmd.Flag("pointers"); pointers.Changed {
 		switch pointers.Value.String() {
-		case "no-follow":
-			migrateInfoPointersMode = migrateInfoPointersNoFollow
 		case "follow":
 			migrateInfoPointersMode = migrateInfoPointersFollow
+		case "no-follow":
+			migrateInfoPointersMode = migrateInfoPointersNoFollow
 		case "ignore":
 			migrateInfoPointersMode = migrateInfoPointersIgnore
 		default:

--- a/commands/command_migrate_info.go
+++ b/commands/command_migrate_info.go
@@ -160,7 +160,13 @@ func (e EntriesBySize) Len() int { return len(e) }
 
 // Less returns the whether or not the MigrateInfoEntry given at `i` takes up
 // less total size than the MigrateInfoEntry given at `j`.
-func (e EntriesBySize) Less(i, j int) bool { return e[i].BytesAbove < e[j].BytesAbove }
+func (e EntriesBySize) Less(i, j int) bool {
+	if e[i].BytesAbove == e[j].BytesAbove {
+		return e[i].Qualifier > e[j].Qualifier
+	} else {
+		return e[i].BytesAbove < e[j].BytesAbove
+	}
+}
 
 // Swap swaps the entries given at i, j.
 func (e EntriesBySize) Swap(i, j int) { e[i], e[j] = e[j], e[i] }

--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -81,8 +81,12 @@ like the other two modes, by default the `info` mode operates only on
 the currently checked-out branch and only on commits which do not exist on
 any remote, so to get a summary of the entire repository across all branches,
 use the `--everything` option.  If objects have already been converted to
-Git LFS pointers, the size of the pointers is totaled, not the size of
-the Git LFS objects to which they refer.
+Git LFS pointers, then by default the size of the pointers is totaled, not
+the size of the Git LFS objects to which they refer.  This is done to retain
+compatability with previous versions of Git LFS.  However, if you have already
+have Git LFS objects in your repository, it may be preferable to either
+ignore them by using `--pointers=ignore` or report them separately using
+`--pointers=follow`.
 
 When using the `--everything` option, take note that it means all refs
 (local and remote) will be considered, but not necessarily all file types.
@@ -169,7 +173,10 @@ It supports all the core `migrate` options and these additional ones:
 
 * `--top=<n>`
     Only display the top `n` entries, ordered by how many total files match the
-    given pathspec. Default: top 5 entries.
+    given pathspec.  The default is to show only the top 5 entries.  When
+    `--pointers=follow` is specified and existing Git LFS objects are found,
+    an extra, separate "LFS Objects" line is output in addition to the top
+    `n` entries.
 
 * `--unit=<unit>`
     Format the number of bytes in each entry as a quantity of the storage unit
@@ -179,6 +186,18 @@ It supports all the core `migrate` options and these additional ones:
 
     If a `--unit` is not specified, the largest unit that can fit the number of
     counted bytes as a whole number quantity is chosen.
+
+* `--pointers=[no-follow|follow|ignore]`
+    Treat existing Git LFS pointers in the history according to one of three
+    alternatives.  In the `no-follow` mode, Git LFS pointers are treated as if
+    they were regular files, so the contents of the pointers themselves are
+    reported in the output totals, rather than the contents of the Git LFS
+    objects to which they refer.  This is the default when `--pointers` is not
+    specified, to maintain backwards consistency; however, the other modes may
+    be more intuitive.  The `ignore` mode excludes all Git LFS pointers from
+    the output totals, while the `follow` mode outputs an additional separate
+    "LFS Objects" line item which summarizes the total number and size of the
+    Git LFS objects referenced by pointers.
 
 The format of the output shows the filename pattern, the total size of the
 file objects (excluding those below the `--above` threshold, if one was
@@ -374,6 +393,10 @@ $ git lfs migrate info --include-ref=main
 
 # Check for large files in every branch
 $ git lfs migrate info --everything
+
+# Check for large files in every branch, counting existing Git LFS objects
+# separately, and listing the top 100 or fewer results
+$ git lfs migrate info --everything --pointers=follow --top=100
 ```
 
 The same flags will work in `import` mode:

--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -81,12 +81,11 @@ like the other two modes, by default the `info` mode operates only on
 the currently checked-out branch and only on commits which do not exist on
 any remote, so to get a summary of the entire repository across all branches,
 use the `--everything` option.  If objects have already been converted to
-Git LFS pointers, then by default the size of the pointers is totaled, not
-the size of the Git LFS objects to which they refer.  This is done to retain
-compatability with previous versions of Git LFS.  However, if you have already
-have Git LFS objects in your repository, it may be preferable to either
-ignore them by using `--pointers=ignore` or report them separately using
-`--pointers=follow`.
+Git LFS pointers, then by default the size of the referenced objects is
+totaled and reported separately.  You may also choose to ignore them by
+using `--pointers=ignore` or to treat the pointers as files by using
+`--pointers=no-follow`.  (The latter option is akin to how existing Git LFS
+pointers were handled by the `info` mode in prior versions of Git LFS).
 
 When using the `--everything` option, take note that it means all refs
 (local and remote) will be considered, but not necessarily all file types.
@@ -174,9 +173,9 @@ It supports all the core `migrate` options and these additional ones:
 * `--top=<n>`
     Only display the top `n` entries, ordered by how many total files match the
     given pathspec.  The default is to show only the top 5 entries.  When
-    `--pointers=follow` is specified and existing Git LFS objects are found,
-    an extra, separate "LFS Objects" line is output in addition to the top
-    `n` entries.
+    existing Git LFS objects are found, an extra, separate "LFS Objects" line
+    is output in addition to the top `n` entries, unless the `--pointers`
+    option is used to change this behavior.
 
 * `--unit=<unit>`
     Format the number of bytes in each entry as a quantity of the storage unit
@@ -187,17 +186,16 @@ It supports all the core `migrate` options and these additional ones:
     If a `--unit` is not specified, the largest unit that can fit the number of
     counted bytes as a whole number quantity is chosen.
 
-* `--pointers=[no-follow|follow|ignore]`
+* `--pointers=[follow|no-follow|ignore]`
     Treat existing Git LFS pointers in the history according to one of three
-    alternatives.  In the `no-follow` mode, Git LFS pointers are treated as if
-    they were regular files, so the contents of the pointers themselves are
-    reported in the output totals, rather than the contents of the Git LFS
-    objects to which they refer.  This is the default when `--pointers` is not
-    specified, to maintain backwards consistency; however, the other modes may
-    be more intuitive.  The `ignore` mode excludes all Git LFS pointers from
-    the output totals, while the `follow` mode outputs an additional separate
-    "LFS Objects" line item which summarizes the total number and size of the
-    Git LFS objects referenced by pointers.
+    alternatives.  In the default `follow` case, if any pointers are found,
+    an additional separate "LFS Objects" line item is output which summarizes
+    the total number and size of the Git LFS objects referenced by pointers.
+    In the `ignore` case, any pointers are simply ignored, while the `no-follow`
+    case replicates the behavior of the `info` mode in older Git LFS versions
+    and treats any pointers it finds as if they were regular files, so the
+    output totals only include the contents of the pointers, not the contents
+    of the objects to which they refer.
 
 The format of the output shows the filename pattern, the total size of the
 file objects (excluding those below the `--above` threshold, if one was
@@ -388,15 +386,15 @@ migrate: Updating refs: ..., done
 You can also migrate the entire history of your repository:
 
 ```
-# Check for large files in your local main branch
+# Check for large files and existing Git LFS objects in your local main branch
 $ git lfs migrate info --include-ref=main
 
-# Check for large files in every branch
+# Check for large files and existing Git LFS objects in every branch
 $ git lfs migrate info --everything
 
-# Check for large files in every branch, counting existing Git LFS objects
-# separately, and listing the top 100 or fewer results
-$ git lfs migrate info --everything --pointers=follow --top=100
+# Check for large files in every branch, ignoring any existing Git LFS objects,
+# and listing the top 100 or fewer results
+$ git lfs migrate info --everything --pointers=ignore --top=100
 ```
 
 The same flags will work in `import` mode:

--- a/lfs/pointer.go
+++ b/lfs/pointer.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/git-lfs/git-lfs/errors"
+	"github.com/git-lfs/gitobj/v2"
 )
 
 var (
@@ -79,6 +80,14 @@ func (p *Pointer) Encoded() string {
 
 func EncodePointer(writer io.Writer, pointer *Pointer) (int, error) {
 	return writer.Write([]byte(pointer.Encoded()))
+}
+
+func DecodePointerFromBlob(b *gitobj.Blob) (*Pointer, error) {
+	// Check size before reading
+	if b.Size >= blobSizeCutoff {
+		return nil, errors.NewNotAPointerError(errors.New("blob size exceeds lfs pointer size cutoff"))
+	}
+	return DecodePointer(b.Contents)
 }
 
 func DecodePointerFromFile(file string) (*Pointer, error) {

--- a/t/fixtures/migrate.sh
+++ b/t/fixtures/migrate.sh
@@ -125,7 +125,8 @@ setup_single_local_branch_tracked() {
 
   remove_and_create_local_repo "$reponame"
 
-  git lfs track "*.txt" "*.md"
+  echo "*.txt filter=lfs diff=lfs merge=lfs -text" > .gitattributes
+  echo "*.md filter=lfs diff=lfs merge=lfs -text" >> .gitattributes
 
   git add .gitattributes
   git commit -m "initial commit"
@@ -183,7 +184,7 @@ setup_single_local_branch_tracked_corrupt() {
 
   remove_and_create_local_repo "$reponame"
 
-  git lfs track "*.txt"
+  echo "*.txt filter=lfs diff=lfs merge=lfs -text" > .gitattributes
   git lfs uninstall
 
   base64 < /dev/urandom | head -c 120 > a.txt
@@ -303,7 +304,8 @@ setup_multiple_local_branches_tracked() {
 
   remove_and_create_local_repo "$reponame"
 
-  git lfs track "*.txt" "*.md"
+  echo "*.txt filter=lfs diff=lfs merge=lfs -text" > .gitattributes
+  echo "*.md filter=lfs diff=lfs merge=lfs -text" >> .gitattributes
   git add .gitattributes
   git commit -m "initial commit"
 

--- a/t/t-migrate-info.sh
+++ b/t/t-migrate-info.sh
@@ -382,7 +382,7 @@ begin_test "migrate info (empty set)"
     --exclude-ref=refs/heads/main 2>/dev/null
   )"
 
-  [ "0" -eq "$(echo -n "$migrate" | wc -l | awk '{ print $1 }')" ]
+  [ "0" -eq "$(echo -n "$migrate" | wc -c | awk '{ print $1 }')" ]
 )
 end_test
 
@@ -470,8 +470,6 @@ begin_test "migrate info (--everything with --include-ref)"
     "fatal: cannot use --everything with --include-ref or --exclude-ref" ]
 )
 end_test
-
-exit 0
 
 begin_test "migrate info (--everything with --exclude-ref)"
 (

--- a/t/t-migrate-info.sh
+++ b/t/t-migrate-info.sh
@@ -19,6 +19,16 @@ begin_test "migrate info (default branch)"
   migrated_head="$(git rev-parse HEAD)"
 
   assert_ref_unmoved "HEAD" "$original_head" "$migrated_head"
+
+  # Ensure "follow" command reports no objects if no files are tracked by LFS.
+  diff -u <(git lfs migrate info --pointers=follow 2>&1 | tail -n 2) <(cat <<-EOF
+	*.md 	140 B	1/1 files(s)	100%
+	*.txt	120 B	1/1 files(s)	100%
+	EOF)
+
+  migrated_head="$(git rev-parse HEAD)"
+
+  assert_ref_unmoved "HEAD" "$original_head" "$migrated_head"
 )
 end_test
 
@@ -434,6 +444,159 @@ begin_test "migrate info (--everything)"
 )
 end_test
 
+begin_test "migrate info (all files tracked)"
+(
+  set -e
+
+  setup_single_local_branch_tracked
+
+  original_head="$(git rev-parse HEAD)"
+
+  # Ensure "ignore" command reports no objects if all files are tracked by LFS.
+  diff -u <(git lfs migrate info --pointers=ignore 2>&1 | tail -n 1) <(cat <<-EOF
+	*.gitattributes	83 B	1/1 files(s)	100%
+	EOF)
+
+  migrated_head="$(git rev-parse HEAD)"
+
+  assert_ref_unmoved "HEAD" "$original_head" "$migrated_head"
+
+  # Ensure "follow" command reports objects if all files are tracked by LFS.
+  diff -u <(git lfs migrate info --pointers=follow 2>&1 | tail -n 3) <(cat <<-EOF
+	*.gitattributes	83 B 	1/1 files(s)	100%
+
+	LFS Objects    	260 B	2/2 files(s)	100%
+	EOF)
+
+  migrated_head="$(git rev-parse HEAD)"
+
+  assert_ref_unmoved "HEAD" "$original_head" "$migrated_head"
+
+  # Ensure "no-follow" command reports pointers if all files are tracked by LFS.
+  diff -u <(git lfs migrate info --pointers=no-follow 2>&1 | tail -n 3) <(cat <<-EOF
+	*.md           	128 B	1/1 files(s)	100%
+	*.txt          	128 B	1/1 files(s)	100%
+	*.gitattributes	83 B 	1/1 files(s)	100%
+	EOF)
+
+  migrated_head="$(git rev-parse HEAD)"
+
+  assert_ref_unmoved "HEAD" "$original_head" "$migrated_head"
+
+  # Ensure default command reports pointers if all files are tracked by LFS.
+  diff -u <(git lfs migrate info 2>&1 | tail -n 3) <(cat <<-EOF
+	*.md           	128 B	1/1 files(s)	100%
+	*.txt          	128 B	1/1 files(s)	100%
+	*.gitattributes	83 B 	1/1 files(s)	100%
+	EOF)
+
+  migrated_head="$(git rev-parse HEAD)"
+
+  assert_ref_unmoved "HEAD" "$original_head" "$migrated_head"
+)
+end_test
+
+begin_test "migrate info (--everything, all files tracked)"
+(
+  set -e
+
+  setup_multiple_local_branches_tracked
+
+  original_main="$(git rev-parse refs/heads/main)"
+  original_feature="$(git rev-parse refs/heads/my-feature)"
+
+  # Ensure "ignore" command reports no objects if all files are tracked by LFS.
+  diff -u <(git lfs migrate info --everything --pointers=ignore 2>&1 | tail -n 1) <(cat <<-EOF
+	*.gitattributes	83 B	1/1 files(s)	100%
+	EOF)
+
+  migrated_main="$(git rev-parse refs/heads/main)"
+  migrated_feature="$(git rev-parse refs/heads/my-feature)"
+
+  assert_ref_unmoved "refs/heads/main" "$original_main" "$migrated_main"
+  assert_ref_unmoved "refs/heads/my-feature" "$original_feature" "$migrated_feature"
+
+  # Ensure "follow" command reports objects if all files are tracked by LFS.
+  diff -u <(git lfs migrate info --everything --pointers=follow 2>&1 | tail -n 3) <(cat <<-EOF
+	*.gitattributes	83 B 	1/1 files(s)	100%
+
+	LFS Objects    	290 B	3/3 files(s)	100%
+	EOF)
+
+  migrated_main="$(git rev-parse refs/heads/main)"
+  migrated_feature="$(git rev-parse refs/heads/my-feature)"
+
+  assert_ref_unmoved "refs/heads/main" "$original_main" "$migrated_main"
+  assert_ref_unmoved "refs/heads/my-feature" "$original_feature" "$migrated_feature"
+
+  # Ensure default command reports pointers if all files are tracked by LFS.
+  diff -u <(git lfs migrate info 2>&1 | tail -n 3) <(cat <<-EOF
+	*.md           	128 B	1/1 files(s)	100%
+	*.txt          	128 B	1/1 files(s)	100%
+	*.gitattributes	83 B 	1/1 files(s)	100%
+	EOF)
+
+  migrated_main="$(git rev-parse refs/heads/main)"
+  migrated_feature="$(git rev-parse refs/heads/my-feature)"
+
+  assert_ref_unmoved "refs/heads/main" "$original_main" "$migrated_main"
+  assert_ref_unmoved "refs/heads/my-feature" "$original_feature" "$migrated_feature"
+)
+end_test
+
+begin_test "migrate info (potential fixup)"
+(
+  set -e
+
+  setup_single_local_branch_tracked_corrupt
+
+  original_head="$(git rev-parse HEAD)"
+
+  # Ensure "follow" command reports no objects for files which should be
+  # tracked but have not been stored properly as LFS pointers.
+  diff -u <(git lfs migrate info --pointers=follow 2>&1 | tail -n 2) <(cat <<-EOF
+	*.txt          	120 B	1/1 files(s)	100%
+	*.gitattributes	42 B 	1/1 files(s)	100%
+	EOF)
+
+  migrated_head="$(git rev-parse HEAD)"
+
+  assert_ref_unmoved "HEAD" "$original_head" "$migrated_head"
+
+  # Ensure default command reports files which should be tracked but have not
+  # been stored properly as LFS pointers.
+  diff -u <(git lfs migrate info 2>&1 | tail -n 2) <(cat <<-EOF
+	*.txt          	120 B	1/1 files(s)	100%
+	*.gitattributes	42 B 	1/1 files(s)	100%
+	EOF)
+
+  migrated_head="$(git rev-parse HEAD)"
+
+  assert_ref_unmoved "HEAD" "$original_head" "$migrated_head"
+)
+end_test
+
+begin_test "migrate info (potential fixup, complex nested)"
+(
+  set -e
+
+  setup_single_local_branch_complex_tracked
+
+  original_head="$(git rev-parse HEAD)"
+
+  # Ensure command reports the file which should be tracked but has not been
+  # stored properly (a.txt) and the file which is not tracked (dir/b.txt).
+  diff -u <(git lfs migrate info 2>&1 | tail -n 2) <(cat <<-EOF
+	*.gitattributes	69 B	2/2 files(s)	100%
+	*.txt          	2 B 	2/2 files(s)	100%
+	EOF)
+
+  migrated_head="$(git rev-parse HEAD)"
+
+  assert_ref_unmoved "HEAD" "$original_head" "$migrated_head"
+)
+end_test
+
 begin_test "migrate info (ambiguous reference)"
 (
   set -e
@@ -479,5 +642,16 @@ begin_test "migrate info (--everything with --exclude-ref)"
 
   [ "$(git lfs migrate info --everything --exclude-ref=refs/heads/main 2>&1)" = \
     "fatal: cannot use --everything with --include-ref or --exclude-ref" ]
+)
+end_test
+
+begin_test "migrate info (--pointers invalid)"
+(
+  set -e
+
+  setup_multiple_local_branches
+
+  [ "$(git lfs migrate info --pointers=foo main 2>&1)" = \
+    "Unsupported --pointers option value" ]
 )
 end_test


### PR DESCRIPTION
The output of the `git lfs migrate info` command, when the repository history contains existing Git LFS pointers, treats those pointers as regular files and counts only the size of the pointer, not the referenced object.  This can result in misleading output for repositories where there is a potential use case for the `git lfs migrate import --fixup` command and option, among others.

This PR adds a `--pointers` option to the `git lfs migrate info` command, which accepts one of three values, `ignore`, `follow`, or `no-follow` (the default).  The latter is the default only because it ensures we maintain backwards compatibility with the output of the command in previous Git LFS versions.

The `--pointers=ignore` option simply skips any existing Git LFS pointers when calculating the totals for the summary, while the `follow` alternative reports (on a separate line) the total sizes and numbers of Git LFS objects in the traversed Git history.  For example, on a small test repo:
```
$ git lfs migrate info --pointers=follow --everything
...                              
*.gitattributes	69 B	2/2 files(s)	100%
*.txt          	1 B 	1/1 files(s)	100%

LFS Objects    	1 B 	1/1 files(s)	100%
```

We also adjust the sorting logic for the summary output to make it fully deterministic; previously, if two entries for different file extensions had the same totals, they might appear in any order, but now we sort them using Go's default string comparison ordering.

In the `t/t-migrate-info.sh` test suite, we remove a spurious early `exit 0` which has been in place for some time, meaning the last test was always skipped.  We then add additional tests of the new `--pointers` option and its various settings, with and without Git LFS objects in the test repositories.

We also add, for good measure, a pair of tests which check the behaviour of the `git lfs migrate info` command when there are files in the history which should be Git LFS objects according to the corresponding `.gitattributes` files but are not.  This is another type of situation where `git lfs migrate import --fixup` might be used, so we want to ensure the `info` subcommand produces correct output for it as well.