### PR TITLE
docs: note that -I and -X override configuration settings

### DIFF
--- a/docs/man/git-lfs-clone.1.ronn
+++ b/docs/man/git-lfs-clone.1.ronn
@@ -44,6 +44,9 @@ of paths to include/exclude in the fetch (wildcard matching as per gitignore).
 Only paths which are matched by fetchinclude and not matched by fetchexclude
 will have objects fetched for them.
 
+Note that using the command-line options `-I` and `-X` override the respective
+configuration settings.
+
 ## SEE ALSO
 
 git-clone(1), git-lfs-pull(1).

--- a/docs/man/git-lfs-fetch.1.ronn
+++ b/docs/man/git-lfs-fetch.1.ronn
@@ -46,6 +46,10 @@ lists of paths to include/exclude in the fetch. Only paths which are matched by
 `fetchinclude` and not matched by `fetchexclude` will have objects fetched for
 them.
 
+Note that using the command-line options `-I` and `-X` override the respective
+configuration settings.  Setting either option to an empty string clears the
+value.
+
 ### Examples:
 
 * `git config lfs.fetchinclude "textures,images/foo*"`

--- a/docs/man/git-lfs-pull.1.ronn
+++ b/docs/man/git-lfs-pull.1.ronn
@@ -34,6 +34,10 @@ of paths to include/exclude in the fetch (wildcard matching as per gitignore).
 Only paths which are matched by fetchinclude and not matched by fetchexclude
 will have objects fetched for them.
 
+Note that using the command-line options `-I` and `-X` override the respective
+configuration settings.  Setting either option to an empty string clears the
+value.
+
 ## DEFAULT REMOTE
 
 Without arguments, pull downloads from the default remote. The default remote is


### PR DESCRIPTION
Note in the documentation that -I and -X override their respective configuration settings so it's clear what behavior people can expect. Mention that setting either value to an empty string clears the value.

Fixes #4425