### PR TITLE
Parse stash log entries parsimonously in prune command

### DIFF
--- a/lfs/gitscanner_log.go
+++ b/lfs/gitscanner_log.go
@@ -83,7 +83,7 @@ func scanStashed(cb GitScannerFoundPointer, s *GitScanner) error {
 	// older Git versions (at least <=2.7) don't report merge parents in
 	// the reflog, we can't extract the parent SHAs from "Merge:" lines
 	// in the log; we can, however, use the "git log -m" option to force
-	// individual diffs of all the merge parents in a second step.
+	// an individual diff with the first merge parent in a second step.
 	logArgs := []string{"-g", "--format=%h", "refs/stash", "--"}
 
 	cmd, err := git.Log(logArgs...)
@@ -95,7 +95,8 @@ func scanStashed(cb GitScannerFoundPointer, s *GitScanner) error {
 
 	var stashMergeShas []string
 	for scanner.Scan() {
-		stashMergeShas = append(stashMergeShas, strings.TrimSpace(scanner.Text()))
+		stashMergeSha := strings.TrimSpace(scanner.Text())
+		stashMergeShas = append(stashMergeShas, fmt.Sprintf("%v^..%v", stashMergeSha, stashMergeSha))
 	}
 	err = cmd.Wait()
 	if err != nil {
@@ -103,21 +104,26 @@ func scanStashed(cb GitScannerFoundPointer, s *GitScanner) error {
 		return nil
 	}
 
-	// We can use the log parser if we provide the -m option to get
-	// merge diffs shown individually
-	logArgs = []string{"-m"}
+	// We can use the log parser if we provide the -m and --first-parent
+	// options to get the first WIP merge diff shown individually, then
+	// no additional options to get the second index merge diff and
+	// possible third untracked files merge diff in a subsequent step.
+	stashMergeLogArgs := [][]string{{"-m", "--first-parent"}, {}}
 
-	// Add standard search args to find lfs references
-	logArgs = append(logArgs, logLfsSearchArgs...)
+	for _, logArgs := range stashMergeLogArgs {
+		// Add standard search args to find lfs references
+		logArgs = append(logArgs, logLfsSearchArgs...)
 
-	logArgs = append(logArgs, stashMergeShas...)
+		logArgs = append(logArgs, stashMergeShas...)
 
-	cmd, err = git.Log(logArgs...)
-	if err != nil {
-		return err
+		cmd, err = git.Log(logArgs...)
+		if err != nil {
+			return err
+		}
+
+		parseScannerLogOutput(cb, LogDiffAdditions, cmd)
 	}
 
-	parseScannerLogOutput(cb, LogDiffAdditions, cmd)
 	return nil
 }
 

--- a/t/t-prune.sh
+++ b/t/t-prune.sh
@@ -608,19 +608,39 @@ begin_test "prune keep stashed changes"
   grep "Tracking \"\*.dat\"" track.log
 
   # generate content we'll use
+  content_oldandpushed="To delete: pushed and too old"
+  oid_oldandpushed=$(calc_oid "$content_oldandpushed")
+  content_retain1="Retained content 1"
+  oid_retain1=$(calc_oid "$content_retain1")
+
   content_inrepo="This is the original committed data"
   oid_inrepo=$(calc_oid "$content_inrepo")
   content_stashed="This data will be stashed and should not be deleted"
   oid_stashed=$(calc_oid "$content_stashed")
 
-  # We just need one commit of base data, makes it easier to test stash
+  # We need to test with older commits to ensure they get pruned as expected
   echo "[
+  {
+    \"CommitDate\":\"$(get_date -20d)\",
+    \"Files\":[
+      {\"Filename\":\"old.dat\",\"Size\":${#content_oldandpushed}, \"Data\":\"$content_oldandpushed\"}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -7d)\",
+    \"Files\":[
+      {\"Filename\":\"old.dat\",\"Size\":${#content_retain1}, \"Data\":\"$content_retain1\"}]
+  },
   {
     \"CommitDate\":\"$(get_date -1d)\",
     \"Files\":[
       {\"Filename\":\"stashedfile.dat\",\"Size\":${#content_inrepo}, \"Data\":\"$content_inrepo\"}]
   }
   ]" | lfstest-testutils addcommits
+
+  git push origin main
+
+  assert_local_object "$oid_oldandpushed" "${#content_oldandpushed}"
+  assert_local_object "$oid_retain1" "${#content_retain1}"
 
   # now modify the file, and stash it
   printf '%s' "$content_stashed" > stashedfile.dat
@@ -633,8 +653,9 @@ begin_test "prune keep stashed changes"
   # Prune data, should NOT delete stashed file
   git lfs prune
 
+  refute_local_object "$oid_oldandpushed" "${#content_oldandpushed}"
+  assert_local_object "$oid_retain1" "${#content_retain1}"
   assert_local_object "$oid_stashed" "${#content_stashed}"
-
 )
 end_test
 
@@ -651,6 +672,11 @@ begin_test "prune keep stashed changes in index"
   grep "Tracking \"\*.dat\"" track.log
 
   # generate content we'll use
+  content_oldandpushed="To delete: pushed and too old"
+  oid_oldandpushed=$(calc_oid "$content_oldandpushed")
+  content_retain1="Retained content 1"
+  oid_retain1=$(calc_oid "$content_retain1")
+
   content_inrepo="This is the original committed data"
   oid_inrepo=$(calc_oid "$content_inrepo")
   content_indexstashed="This data will be stashed from the index and should not be deleted"
@@ -658,14 +684,29 @@ begin_test "prune keep stashed changes in index"
   content_stashed="This data will be stashed and should not be deleted"
   oid_stashed=$(calc_oid "$content_stashed")
 
-  # We just need one commit of base data, makes it easier to test stash
+  # We need to test with older commits to ensure they get pruned as expected
   echo "[
+  {
+    \"CommitDate\":\"$(get_date -20d)\",
+    \"Files\":[
+      {\"Filename\":\"old.dat\",\"Size\":${#content_oldandpushed}, \"Data\":\"$content_oldandpushed\"}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -7d)\",
+    \"Files\":[
+      {\"Filename\":\"old.dat\",\"Size\":${#content_retain1}, \"Data\":\"$content_retain1\"}]
+  },
   {
     \"CommitDate\":\"$(get_date -1d)\",
     \"Files\":[
       {\"Filename\":\"stashedfile.dat\",\"Size\":${#content_inrepo}, \"Data\":\"$content_inrepo\"}]
   }
   ]" | lfstest-testutils addcommits
+
+  git push origin main
+
+  assert_local_object "$oid_oldandpushed" "${#content_oldandpushed}"
+  assert_local_object "$oid_retain1" "${#content_retain1}"
 
   # now modify the file, and add it to the index
   printf '%s' "$content_indexstashed" > stashedfile.dat
@@ -683,6 +724,8 @@ begin_test "prune keep stashed changes in index"
   # Prune data, should NOT delete stashed file or stashed changes to index
   git lfs prune
 
+  refute_local_object "$oid_oldandpushed" "${#content_oldandpushed}"
+  assert_local_object "$oid_retain1" "${#content_retain1}"
   assert_local_object "$oid_stashed" "${#content_stashed}"
   assert_local_object "$oid_indexstashed" "${#content_indexstashed}"
 
@@ -707,6 +750,11 @@ begin_test "prune keep stashed untracked files"
   grep "Tracking \"\*.dat\"" track.log
 
   # generate content we'll use
+  content_oldandpushed="To delete: pushed and too old"
+  oid_oldandpushed=$(calc_oid "$content_oldandpushed")
+  content_retain1="Retained content 1"
+  oid_retain1=$(calc_oid "$content_retain1")
+
   content_inrepo="This is the original committed data"
   oid_inrepo=$(calc_oid "$content_inrepo")
   content_indexstashed="This data will be stashed from the index and should not be deleted"
@@ -716,14 +764,29 @@ begin_test "prune keep stashed untracked files"
   content_untrackedstashed="This UNTRACKED FILE data will be stashed and should not be deleted"
   oid_untrackedstashed=$(calc_oid "$content_untrackedstashed")
 
-  # We just need one commit of base data, makes it easier to test stash
+  # We need to test with older commits to ensure they get pruned as expected
   echo "[
+  {
+    \"CommitDate\":\"$(get_date -20d)\",
+    \"Files\":[
+      {\"Filename\":\"old.dat\",\"Size\":${#content_oldandpushed}, \"Data\":\"$content_oldandpushed\"}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -7d)\",
+    \"Files\":[
+      {\"Filename\":\"old.dat\",\"Size\":${#content_retain1}, \"Data\":\"$content_retain1\"}]
+  },
   {
     \"CommitDate\":\"$(get_date -1d)\",
     \"Files\":[
       {\"Filename\":\"stashedfile.dat\",\"Size\":${#content_inrepo}, \"Data\":\"$content_inrepo\"}]
   }
   ]" | lfstest-testutils addcommits
+
+  git push origin main
+
+  assert_local_object "$oid_oldandpushed" "${#content_oldandpushed}"
+  assert_local_object "$oid_retain1" "${#content_retain1}"
 
   # now modify the file, and add it to the index
   printf '%s' "$content_indexstashed" > stashedfile.dat
@@ -746,10 +809,11 @@ begin_test "prune keep stashed untracked files"
   # Prune data, should NOT delete stashed file or stashed changes to index
   git lfs prune
 
+  refute_local_object "$oid_oldandpushed" "${#content_oldandpushed}"
+  assert_local_object "$oid_retain1" "${#content_retain1}"
   assert_local_object "$oid_stashed" "${#content_stashed}"
   assert_local_object "$oid_indexstashed" "${#content_indexstashed}"
   assert_local_object "$oid_untrackedstashed" "${#content_untrackedstashed}"
-
 )
 end_test
 
@@ -769,6 +833,8 @@ begin_test "prune recent changes with --recent"
   oid_inrepo=$(calc_oid "$content_inrepo")
   content_new="this data will be recent"
   oid_new=$(calc_oid "$content_new")
+  content_stashed="This data will be stashed and should not be deleted"
+  oid_stashed=$(calc_oid "$content_stashed")
 
   echo "[
   {
@@ -778,10 +844,14 @@ begin_test "prune recent changes with --recent"
   }
   ]" | lfstest-testutils addcommits
 
-  # now modify the file, and stash it
+  # now modify the file, and commit it
   printf '%s' "$content_new" > file.dat
   git add .
   git commit -m 'Update file.dat'
+
+  # now modify the file, and stash it
+  printf '%s' "$content_stashed" > file.dat
+  git stash
 
   git config lfs.fetchrecentrefsdays 5
   git config lfs.fetchrecentremoterefs true
@@ -789,12 +859,14 @@ begin_test "prune recent changes with --recent"
 
   assert_local_object "$oid_new" "${#content_new}"
   assert_local_object "$oid_inrepo" "${#content_inrepo}"
+  assert_local_object "$oid_stashed" "${#content_stashed}"
 
   # prune data, should not delete.
   git lfs prune --recent
 
   assert_local_object "$oid_new" "${#content_new}"
   assert_local_object "$oid_inrepo" "${#content_inrepo}"
+  assert_local_object "$oid_stashed" "${#content_stashed}"
 
   git push origin HEAD
 
@@ -803,6 +875,7 @@ begin_test "prune recent changes with --recent"
 
   assert_local_object "$oid_new" "${#content_new}"
   refute_local_object "$oid_inrepo" "${#content_inrepo}"
+  assert_local_object "$oid_stashed" "${#content_stashed}"
 )
 end_test
 
@@ -822,6 +895,8 @@ begin_test "prune --force"
   oid_inrepo=$(calc_oid "$content_inrepo")
   content_new="this data will be recent"
   oid_new=$(calc_oid "$content_new")
+  content_stashed="This data will be stashed and should not be deleted"
+  oid_stashed=$(calc_oid "$content_stashed")
 
   echo "[
   {
@@ -831,10 +906,14 @@ begin_test "prune --force"
   }
   ]" | lfstest-testutils addcommits
 
-  # now modify the file, and stash it
+  # now modify the file, and commit it
   printf '%s' "$content_new" > file.dat
   git add .
   git commit -m 'Update file.dat'
+
+  # now modify the file, and stash it
+  printf '%s' "$content_stashed" > file.dat
+  git stash
 
   git config lfs.fetchrecentrefsdays 5
   git config lfs.fetchrecentremoterefs true
@@ -842,12 +921,14 @@ begin_test "prune --force"
 
   assert_local_object "$oid_new" "${#content_new}"
   assert_local_object "$oid_inrepo" "${#content_inrepo}"
+  assert_local_object "$oid_stashed" "${#content_stashed}"
 
   # prune data, should not delete.
   git lfs prune --force
 
   assert_local_object "$oid_new" "${#content_new}"
   assert_local_object "$oid_inrepo" "${#content_inrepo}"
+  assert_local_object "$oid_stashed" "${#content_stashed}"
 
   git push origin HEAD
 
@@ -856,6 +937,7 @@ begin_test "prune --force"
 
   refute_local_object "$oid_new" "${#content_new}"
   refute_local_object "$oid_inrepo" "${#content_inrepo}"
+  assert_local_object "$oid_stashed" "${#content_stashed}"
 )
 end_test
 

--- a/t/t-prune.sh
+++ b/t/t-prune.sh
@@ -610,6 +610,8 @@ begin_test "prune keep stashed changes"
   # generate content we'll use
   content_oldandpushed="To delete: pushed and too old"
   oid_oldandpushed=$(calc_oid "$content_oldandpushed")
+  content_unreferenced="To delete: unreferenced"
+  oid_unreferenced=$(calc_oid "$content_unreferenced")
   content_retain1="Retained content 1"
   oid_retain1=$(calc_oid "$content_retain1")
 
@@ -631,7 +633,14 @@ begin_test "prune keep stashed changes"
       {\"Filename\":\"old.dat\",\"Size\":${#content_retain1}, \"Data\":\"$content_retain1\"}]
   },
   {
+    \"CommitDate\":\"$(get_date -4d)\",
+    \"NewBranch\":\"branch_to_delete\",
+    \"Files\":[
+      {\"Filename\":\"unreferenced.dat\",\"Size\":${#content_unreferenced}, \"Data\":\"$content_unreferenced\"}]
+  },
+  {
     \"CommitDate\":\"$(get_date -1d)\",
+    \"ParentBranches\":[\"main\"],
     \"Files\":[
       {\"Filename\":\"stashedfile.dat\",\"Size\":${#content_inrepo}, \"Data\":\"$content_inrepo\"}]
   }
@@ -640,12 +649,14 @@ begin_test "prune keep stashed changes"
   git push origin main
 
   assert_local_object "$oid_oldandpushed" "${#content_oldandpushed}"
+  assert_local_object "$oid_unreferenced" "${#content_unreferenced}"
   assert_local_object "$oid_retain1" "${#content_retain1}"
 
   # now modify the file, and stash it
   printf '%s' "$content_stashed" > stashedfile.dat
 
   git stash
+  git branch -D branch_to_delete
 
   # Prove that the stashed data was stored in LFS (should call clean filter)
   assert_local_object "$oid_stashed" "${#content_stashed}"
@@ -654,6 +665,7 @@ begin_test "prune keep stashed changes"
   git lfs prune
 
   refute_local_object "$oid_oldandpushed" "${#content_oldandpushed}"
+  refute_local_object "$oid_unreferenced" "${#content_unreferenced}"
   assert_local_object "$oid_retain1" "${#content_retain1}"
   assert_local_object "$oid_stashed" "${#content_stashed}"
 )
@@ -674,6 +686,8 @@ begin_test "prune keep stashed changes in index"
   # generate content we'll use
   content_oldandpushed="To delete: pushed and too old"
   oid_oldandpushed=$(calc_oid "$content_oldandpushed")
+  content_unreferenced="To delete: unreferenced"
+  oid_unreferenced=$(calc_oid "$content_unreferenced")
   content_retain1="Retained content 1"
   oid_retain1=$(calc_oid "$content_retain1")
 
@@ -697,7 +711,14 @@ begin_test "prune keep stashed changes in index"
       {\"Filename\":\"old.dat\",\"Size\":${#content_retain1}, \"Data\":\"$content_retain1\"}]
   },
   {
+    \"CommitDate\":\"$(get_date -4d)\",
+    \"NewBranch\":\"branch_to_delete\",
+    \"Files\":[
+      {\"Filename\":\"unreferenced.dat\",\"Size\":${#content_unreferenced}, \"Data\":\"$content_unreferenced\"}]
+  },
+  {
     \"CommitDate\":\"$(get_date -1d)\",
+    \"ParentBranches\":[\"main\"],
     \"Files\":[
       {\"Filename\":\"stashedfile.dat\",\"Size\":${#content_inrepo}, \"Data\":\"$content_inrepo\"}]
   }
@@ -706,6 +727,7 @@ begin_test "prune keep stashed changes in index"
   git push origin main
 
   assert_local_object "$oid_oldandpushed" "${#content_oldandpushed}"
+  assert_local_object "$oid_unreferenced" "${#content_unreferenced}"
   assert_local_object "$oid_retain1" "${#content_retain1}"
 
   # now modify the file, and add it to the index
@@ -716,6 +738,7 @@ begin_test "prune keep stashed changes in index"
   printf '%s' "$content_stashed" > stashedfile.dat
 
   git stash
+  git branch -D branch_to_delete
 
   # Prove that the stashed data was stored in LFS (should call clean filter)
   assert_local_object "$oid_indexstashed" "${#content_indexstashed}"
@@ -725,6 +748,7 @@ begin_test "prune keep stashed changes in index"
   git lfs prune
 
   refute_local_object "$oid_oldandpushed" "${#content_oldandpushed}"
+  refute_local_object "$oid_unreferenced" "${#content_unreferenced}"
   assert_local_object "$oid_retain1" "${#content_retain1}"
   assert_local_object "$oid_indexstashed" "${#content_indexstashed}"
   assert_local_object "$oid_stashed" "${#content_stashed}"
@@ -746,6 +770,8 @@ begin_test "prune keep stashed untracked files"
   # generate content we'll use
   content_oldandpushed="To delete: pushed and too old"
   oid_oldandpushed=$(calc_oid "$content_oldandpushed")
+  content_unreferenced="To delete: unreferenced"
+  oid_unreferenced=$(calc_oid "$content_unreferenced")
   content_retain1="Retained content 1"
   oid_retain1=$(calc_oid "$content_retain1")
 
@@ -771,7 +797,14 @@ begin_test "prune keep stashed untracked files"
       {\"Filename\":\"old.dat\",\"Size\":${#content_retain1}, \"Data\":\"$content_retain1\"}]
   },
   {
+    \"CommitDate\":\"$(get_date -4d)\",
+    \"NewBranch\":\"branch_to_delete\",
+    \"Files\":[
+      {\"Filename\":\"unreferenced.dat\",\"Size\":${#content_unreferenced}, \"Data\":\"$content_unreferenced\"}]
+  },
+  {
     \"CommitDate\":\"$(get_date -1d)\",
+    \"ParentBranches\":[\"main\"],
     \"Files\":[
       {\"Filename\":\"stashedfile.dat\",\"Size\":${#content_inrepo}, \"Data\":\"$content_inrepo\"}]
   }
@@ -780,6 +813,7 @@ begin_test "prune keep stashed untracked files"
   git push origin main
 
   assert_local_object "$oid_oldandpushed" "${#content_oldandpushed}"
+  assert_local_object "$oid_unreferenced" "${#content_unreferenced}"
   assert_local_object "$oid_retain1" "${#content_retain1}"
 
   # now modify the file, and add it to the index
@@ -794,6 +828,7 @@ begin_test "prune keep stashed untracked files"
 
   # stash, including untracked
   git stash -u
+  git branch -D branch_to_delete
 
   # Prove that ALL stashed data was stored in LFS (should call clean filter)
   assert_local_object "$oid_indexstashed" "${#content_indexstashed}"
@@ -804,6 +839,7 @@ begin_test "prune keep stashed untracked files"
   git lfs prune
 
   refute_local_object "$oid_oldandpushed" "${#content_oldandpushed}"
+  refute_local_object "$oid_unreferenced" "${#content_unreferenced}"
   assert_local_object "$oid_retain1" "${#content_retain1}"
   assert_local_object "$oid_indexstashed" "${#content_indexstashed}"
   assert_local_object "$oid_stashed" "${#content_stashed}"

--- a/t/t-prune.sh
+++ b/t/t-prune.sh
@@ -718,22 +718,16 @@ begin_test "prune keep stashed changes in index"
   git stash
 
   # Prove that the stashed data was stored in LFS (should call clean filter)
-  assert_local_object "$oid_stashed" "${#content_stashed}"
   assert_local_object "$oid_indexstashed" "${#content_indexstashed}"
+  assert_local_object "$oid_stashed" "${#content_stashed}"
 
   # Prune data, should NOT delete stashed file or stashed changes to index
   git lfs prune
 
   refute_local_object "$oid_oldandpushed" "${#content_oldandpushed}"
   assert_local_object "$oid_retain1" "${#content_retain1}"
-  assert_local_object "$oid_stashed" "${#content_stashed}"
   assert_local_object "$oid_indexstashed" "${#content_indexstashed}"
-
-  # Restore working tree from stash
-  git stash pop --index
-
-  # Reset working tree to index from stash
-  git checkout .
+  assert_local_object "$oid_stashed" "${#content_stashed}"
 )
 end_test
 
@@ -802,8 +796,8 @@ begin_test "prune keep stashed untracked files"
   git stash -u
 
   # Prove that ALL stashed data was stored in LFS (should call clean filter)
-  assert_local_object "$oid_stashed" "${#content_stashed}"
   assert_local_object "$oid_indexstashed" "${#content_indexstashed}"
+  assert_local_object "$oid_stashed" "${#content_stashed}"
   assert_local_object "$oid_untrackedstashed" "${#content_untrackedstashed}"
 
   # Prune data, should NOT delete stashed file or stashed changes to index
@@ -811,8 +805,8 @@ begin_test "prune keep stashed untracked files"
 
   refute_local_object "$oid_oldandpushed" "${#content_oldandpushed}"
   assert_local_object "$oid_retain1" "${#content_retain1}"
-  assert_local_object "$oid_stashed" "${#content_stashed}"
   assert_local_object "$oid_indexstashed" "${#content_indexstashed}"
+  assert_local_object "$oid_stashed" "${#content_stashed}"
   assert_local_object "$oid_untrackedstashed" "${#content_untrackedstashed}"
 )
 end_test


### PR DESCRIPTION
When looking for Git LFS pointers in the Git stash in order to avoid pruning the corresponding local objects during a `git lfs prune` command (functionality which was added in #4209), we want to avoid looking further back in the Git log file than necessary; otherwise, we may potentially find many LFS object references which we should prune but incorrectly consider to be part of the stashes.

We therefore proceed in two steps; first looking solely at each stash entry's WIP merge commit using the command `git log -m --first-parent <stash-sha>^..<stash-sha>`, and then looking at each entry's index merge commit and possible additional untracked files merge commit using the command `git log <stash-sha>^..<stash-sha>`.  By limiting these commands' commit ranges to just the stash merge commits, we skip improperly traversing the full log.

We update the relevant tests to include older commits, one of which should be pruned in each case; note that
with these changes the tests fail with the previous version of the `git lfs prune` logic for stashes.  We also add stashes to two other tests and confirm that in both cases the LFS objects from the stashed commits are retained, but no additional objects are also unexpectedly retained as a result of the stash.

Further, we make sure the three dedicated stash tests work with more than a single stash entry each, stashing work on a branch which is then deleted.  We expect the stashed LFS content to be retained while the unreferenced LFS objects committed on the deleted branch are pruned.  In the case where we test this with `git stash -u`, we need to ensure we first commit the `.gitattributes` file created by `git lfs track`, because otherwise our first `git stash -u` removes it and then we are unable to create LFS objects after checking out the to-be-deleted-later branch.

(It may be very marginally easier to review this PR by ignoring whitespace changes.)

Fixes #4439 and (part of) #4288.
/cc @samaursa as reporter.