### PR TITLE
Update git-lfs-migrate man page and add description section

### DIFF
--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -5,6 +5,100 @@ git-lfs-migrate(1) - Migrate history to or from Git LFS
 
 `git lfs migrate` <mode> [options] [--] [branch ...]
 
+## DESCRIPTION
+
+Convert files in a Git repository to or from Git LFS pointers, or
+summarize Git file sizes by file type.  The `import` mode converts Git
+files (i.e., blobs) to Git LFS, while the `export` mode does the reverse,
+and the `info` mode provides an informational summary which may be useful
+in deciding which files to import or export.
+
+In all modes, by default `git lfs migrate` operates only on the currently
+checked-out branch, and only on files (of any size and type) added in
+commits which do not exist on any remote.  Multiple options are available
+to override these defaults.
+
+When converting files to or from Git LFS, the `git lfs migrate` command will
+only make changes to your local repository and working copy, never any
+remotes.  This is intentional as the `import` and `export` modes are
+generally "destructive" in the sense that they rewrite your Git history,
+changing commits and generating new commit SHAs.  (The exception is the
+"no-rewrite" `import` sub-mode; see [IMPORT (NO REWRITE)] for details.)
+
+You should therefore always first commit or stash any uncommitted work
+before using the `import` or `export` modes, and then validate the result of
+the migration before pushing the changes to your remotes, for instance by
+running the `info` mode and by examining your rewritten commit history.
+
+Once you are satisfied with the changes, you will need to force-push the
+new Git history of any rewritten branches to all your remotes.  This is
+a step which should be taken with care, since you will be altering the
+Git history on your remotes.
+
+To examine or modify files in branches other than the currently checked-out
+one, branch refs may be specified directly, or provided in one or more
+`--include-ref` options.  They may also be excluded by prefixing them
+with `^` or providing them in `--exclude-ref` options.  Use the `--everything`
+option to specify that all refs should be examined, including all remote refs.
+See [INCLUDE AND EXCLUDE (REFS)] for details.
+
+For the `info` and `import` modes, all file types are considered by default;
+while useful in the `info` mode, this is often not desirable when importing,
+so either filename patterns (pathspecs) or the `--fixup` option should
+normally be specified in that case.  (At least one include pathspec is
+required for the `export` mode.)  Pathspecs may be defined using the
+`--include` and `--exclude` options (`-I` and `-X` for short), as described
+in [INCLUDE AND EXCLUDE].
+
+As typical Git LFS usage depends on tracking specific file types using
+filename patterns defined in `.gitattributes` files, the `git lfs migrate`
+command will examine, create, and modify `.gitattributes` files as
+necessary.
+
+The `import` mode (see [IMPORT]) will convert Git objects of the file types
+specified (e.g., with `--include`) to Git LFS pointers, and will add entries
+for those file types to `.gitattributes` files, creating those files if they
+do not exist.  The result should be as if `git lfs track` commands had been
+run at the points in your Git history corresponding to where each type of
+converted file first appears.  The exception is if the `--fixup` option is
+given, in which case the `import` mode will only examine any existing
+`.gitattributes` files and then convert Git objects which should be tracked
+by Git LFS but are not yet.
+
+The `export` mode (see [EXPORT]) works as the reverse operation to the
+`import` mode, converting any Git LFS pointers that match the file types
+specified with `--include`, which must be given at least once.  Note that
+`.gitattributes` entries will not be removed, nor will the files; instead,
+the `export` mode inserts "do not track" entries similar to those created
+by the `git lfs untrack` command.  The `--remote` option is available in
+the `export`  mode to specify the remote from which Git LFS objects should
+be fetched if they do not exist in the local Git LFS object cache; if not
+provided, `origin` is used by default.
+
+The `info` mode (see [INFO]) summarizes by file type (i.e., by filename
+extension) the total number and size of files in a repository.  Note that
+like the other two modes, by default the `info` mode operates only on
+the currently checked-out branch and only on commits which do not exist on
+any remote, so to get a summary of the entire repository across all branches,
+use the `--everything` option.  If objects have already been converted to
+Git LFS pointers, the size of the pointers is totaled, not the size of
+the Git LFS objects to which they refer.
+
+When using the `--everything` option, take note that it means all refs
+(local and remote) will be considered, but not necessarily all file types.
+The `import` and `info` modes consider all file types by default, although
+the `--include` and `--exclude` options constrain this behavior.  Also
+note that after importing across all branches with the `--everything` option
+(and then checking to ensure the results are satisfactory!) it may be
+convenient to update multiple branches on your remotes by using the `--all`
+option to `git push`.
+
+Unless the `--skip-fetch` option is given, `git lfs migrate` always begins by
+fetching updated lists of refs from all the remotes returned by `git remote`,
+but as noted above, after making changes to your local Git history while
+converting objects, it will never automatically push those changes to your
+remotes.
+
 ## MODES
 
 * `info`

--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -1,4 +1,4 @@
-git-lfs-migrate(1) - Migrate history to or from git-lfs
+git-lfs-migrate(1) - Migrate history to or from Git LFS
 =======================================================
 
 ## SYNOPSIS
@@ -8,13 +8,13 @@ git-lfs-migrate(1) - Migrate history to or from git-lfs
 ## MODES
 
 * `info`
-    Show information about repository size.
+    Show information about repository size.  See [INFO].
 
 * `import`
-    Convert large Git objects to LFS pointers.
+    Convert Git objects to Git LFS pointers.  See [IMPORT] and [IMPORT (NO REWRITE)].
 
 * `export`
-    Convert LFS pointers to large Git objects.
+    Convert Git LFS pointers to Git objects.  See [EXPORT].
 
 ## OPTIONS
 
@@ -53,18 +53,19 @@ git-lfs-migrate(1) - Migrate history to or from git-lfs
     Migrate only the set of branches listed. If not given, `git-lfs-migrate(1)`
     will migrate the currently checked out branch.
 
-    References beginning with '^' will be excluded, whereas branches that do not
-    begin with '^' will be included.
+    References beginning with `^` will be excluded, whereas branches that do not
+    begin with `^` will be included.
 
     If any of `--include-ref` or `--exclude-ref` are given, the checked out
     branch will not be appended, but branches given explicitly will be appended.
 
 ### INFO
 
-The 'info' mode has these additional options:
+The `info` mode summarizes the sizes of file objects present in the Git history.
+It supports all the core `migrate` options and these additional ones:
 
 * `--above=<size>`
-    Only count files whose individual filesize is above the given size. 'size'
+    Only count files whose individual filesize is above the given size. `size`
     may be specified as a number of bytes, or a number followed by a storage
     unit, e.g., "1b", "20 MB", "3 TiB", etc.
 
@@ -73,7 +74,7 @@ The 'info' mode has these additional options:
     will be shown.
 
 * `--top=<n>`
-    Only include the top 'n' entries, ordered by how many total files match the
+    Only display the top `n` entries, ordered by how many total files match the
     given pathspec. Default: top 5 entries.
 
 * `--unit=<unit>`
@@ -82,29 +83,42 @@ The 'info' mode has these additional options:
       * b, kib, mib, gib, tib, pib - for IEC storage units
       * b, kb, mb, gb, tb, pb - for SI storage units
 
-    If a --unit is not specified, the largest unit that can fit the number of
+    If a `--unit` is not specified, the largest unit that can fit the number of
     counted bytes as a whole number quantity is chosen.
+
+The format of the output shows the filename pattern, the total size of the
+file objects (excluding those below the `--above` threshold, if one was
+defined), and the ratio of the number of files above the threshold to the
+total number of files; this ratio is also shown as a percentage.  For example:
+
+```
+*.gif             	93 MB 	9480/10504 files(s)	 90%
+*.png              	14 MB 	 1732/1877 files(s)	 92%
+```
+
+By default only the top five entries are shown, but `--top` allows for
+more or fewer to be output as desired.
 
 ### IMPORT
 
-The 'import' mode migrates large objects present in the Git history to pointer
-files tracked and stored with Git LFS. It supports all the core 'migrate'
+The `import` mode migrates objects present in the Git history to pointer
+files tracked and stored with Git LFS. It supports all the core `migrate`
 options and these additional ones:
 
 * `--verbose`
     Print the commit oid and filename of migrated files to STDOUT.
 
 * `--above=<size>`
-    Only migrate files whose individual filesize is above the given size. 'size'
+    Only migrate files whose individual filesize is above the given size. `size`
     may be specified as a number of bytes, or a number followed by a storage
     unit, e.g., "1b", "20 MB", "3 TiB", etc.
 
 * `--object-map=<path>`
-    Write to 'path' a file with the mapping of each rewritten commits. The file
+    Write to `path` a file with the mapping of each rewritten commits. The file
     format is CSV with this pattern: `OLD-SHA`,`NEW-SHA`
 
 * `--no-rewrite`
-    Migrate large objects to Git LFS in a new commit without rewriting git
+    Migrate objects to Git LFS in a new commit without rewriting Git
     history. Please note that when this option is used, the `migrate import`
     command will expect a different argument list, specialized options will
     become available, and the core `migrate` options will be ignored. See
@@ -112,14 +126,14 @@ options and these additional ones:
 
 * `--fixup`
     Infer `--include` and `--exclude` filters on a per-commit basis based on the
-    .gitattributes files in a repository. In practice, this option imports any
+    `.gitattributes` files in a repository. In practice, this option imports any
     filepaths which should be tracked by Git LFS according to the repository's
-    .gitattributes file(s), but aren't already pointers. This option is
+    `.gitattributes` file(s), but aren't already pointers. This option is
     incompatible with explicitly given `--include`, `--exclude` filters.
 
 If `--no-rewrite` is not provided and `--include` or `--exclude` (`-I`, `-X`,
-respectively) are given, the .gitattributes will be modified to include any new
-filepath patterns as given by those flags.
+respectively) are given, the `.gitattributes` will be modified to include any
+new filepath patterns as given by those flags.
 
 If `--no-rewrite` is not provided and neither of those flags are given, the
 gitattributes will be incrementally modified to include new filepath extensions
@@ -128,7 +142,7 @@ as they are rewritten in history.
 ### IMPORT (NO REWRITE)
 
 The `import` mode has a special sub-mode enabled by the `--no-rewrite` flag.
-This sub-mode will migrate large objects to pointers as in the base `import`
+This sub-mode will migrate objects to pointers as in the base `import`
 mode, but will do so in a new commit without rewriting Git history. When using
 this sub-mode, the base `migrate` options, such as `--include-ref`, will be
 ignored, as will those for the base `import` mode. The `migrate` command will
@@ -151,41 +165,46 @@ file arguments.
 
 ### EXPORT
 
-The 'export' mode migrates Git LFS pointer files present in the Git history out
+The `export` mode migrates Git LFS pointer files present in the Git history out
 of Git LFS, converting them into their corresponding object files. It supports
-all the core 'migrate' options and these additional ones:
+all the core `migrate` options and these additional ones:
 
 * `--verbose`
     Print the commit oid and filename of migrated files to STDOUT.
 
 * `--object-map=<path>`
-    Write to 'path' a file with the mapping of each rewritten commit. The file
+    Write to `path` a file with the mapping of each rewritten commit. The file
     format is CSV with this pattern: `OLD-SHA`,`NEW-SHA`
 
 * `--remote=<git-remote>`
-    Download LFS objects from the provided 'git-remote' during the export. If
-    not provided, defaults to 'origin'.
+    Download LFS objects from the provided `git-remote` during the export. If
+    not provided, defaults to `origin`.
 
-The 'export' mode requires at minimum a pattern provided with the `--include`
+The `export` mode requires at minimum a pattern provided with the `--include`
 argument to specify which files to export. Files matching the `--include`
 patterns will be removed from Git LFS, while files matching the `--exclude`
 patterns will retain their Git LFS status. The export command will modify the
-.gitattributes to set/unset any filepath patterns as given by those flags.
+`.gitattributes` to set/unset any filepath patterns as given by those flags.
 
 ## INCLUDE AND EXCLUDE
 
-You can configure Git LFS to only migrate tree entries whose pathspec matches
-the include glob and does not match the exclude glob, to reduce total migration
-time or to only migrate part of your repo. Specify multiple patterns using the
-comma as the delimiter.
+You can specify that `git lfs migrate` should only convert files whose
+pathspec matches the `--include` glob patterns and does not match the
+`--exclude` glob patterns, either to reduce total migration time or to only
+migrate part of your repo.  Multiple patterns may be given using commas
+as delimiters.
 
-Pattern matching is done as given to be functionally equivalent to pattern
-matching as in .gitattributes.
+Pattern matching is done so as to be functionally equivalent to the pattern
+matching format of `.gitattributes`.  In addition to simple file extension
+matches (e.g., `*.gif`) patterns may also specify directory paths, in which
+case the `path/**` format may be used to match recursively.
 
 ## INCLUDE AND EXCLUDE (REFS)
 
-You can configure Git LFS to only migrate commits reachable by references
-include by `--include-ref` and not reachable by `--exclude-ref`.
+You can specify that `git lfs migrate` should only convert files added
+in commits reachable from certain references, namely those defined using one
+or more `--include-ref` options, and should ignore files in commits reachable
+from references defined in `--exclude-ref` options.
 
 ```
         D---E---F
@@ -205,15 +224,14 @@ refs/heads/my-feature:     F, E, D, B, A
 refs/remote/origin/main:   A
 ```
 
-The following configuration:
+The following `git lfs migrate` options would, therefore, include commits
+F, E, D, C, and B, but exclude commit A:
 
 ```
   --include-ref=refs/heads/my-feature
   --include-ref=refs/heads/main
   --exclude-ref=refs/remotes/origin/main
 ```
-
-Would, therefore, include commits: F, E, D, C, B, but exclude commit A.
 
 The presence of flag `--everything` indicates that all local and remote
 references should be migrated.
@@ -222,12 +240,12 @@ references should be migrated.
 
 ### Migrate unpushed commits
 
-The migrate command's most common use case is to convert large git objects to
+A common use case for the migrate command is to convert large Git objects to
 LFS before pushing your commits. By default, it only scans commits that don't
 exist on any remote, so long as the repository is non-bare.
 
 First, run `git lfs migrate info` to list the file types taking up the most
-space in your repository.
+space in your repository:
 
 ```
 $ git lfs migrate info
@@ -277,7 +295,9 @@ $ git lfs migrate import --everything --include="*.zip"
 $ git lfs migrate import --everything --above=100Kb
 ```
 
-Note: This will require a force push to any existing Git remotes.
+Note: This will require a force-push to any existing Git remotes.  Using
+the `--all` option when force-pushing may be convenient if many refs were
+updated, e.g., after importing to Git LFS with the `--everything` option.
 
 ### Migrate without rewriting local history
 
@@ -300,5 +320,7 @@ $ git lfs migrate import --no-rewrite \
 ```
 
 ## SEE ALSO
+
+git-lfs-track(1), git-lfs-untrack(1), gitattributes(5).
 
 Part of the git-lfs(1) suite.

--- a/docs/man/mangen.go
+++ b/docs/man/mangen.go
@@ -66,9 +66,9 @@ func main() {
 	out.WriteString("\t// THIS FILE IS GENERATED, DO NOT EDIT\n")
 	out.WriteString("\t// Use 'go generate ./commands' to update\n")
 	fileregex := regexp.MustCompile(`git-lfs(?:-([A-Za-z\-]+))?.\d.ronn`)
-	headerregex := regexp.MustCompile(`^###?\s+([A-Za-z0-9 ]+)`)
+	headerregex := regexp.MustCompile(`^###?\s+([A-Za-z0-9\(\) ]+)`)
 	// only pick up caps in links to avoid matching optional args
-	linkregex := regexp.MustCompile(`\[([A-Z\- ]+)\]`)
+	linkregex := regexp.MustCompile(`\[([A-Z\-\(\) ]+)\]`)
 	// man links
 	manlinkregex := regexp.MustCompile(`(git)(?:-(lfs))?-([a-z\-]+)\(\d\)`)
 	count := 0


### PR DESCRIPTION
We add a lengthy description section to the `it-lfs-migrate` man page to order to provide some context and general guidance on how and when the command should be used, as well as trying to explain several potentially non-intuitive concepts and encourage users to check their repositories thoroughly before and after attempting an import or export operation.

We also adjust some formatting details in the page, fix some typos, and make other minor revisions to suggest using the `--all` option when force-pushing after importing with `--everything`, stop implying that only large files are ever imported or exported, and avoid stating that a single use case is definitely more prevalent than all others.

And we allow man page headers to include parentheses so that the specialized headers in the `git-lfs-migrate` man page (e.g., `"IMPORT (NO REWRITE)"`) are supported and properly linked within the rendered page.

Fixes #4408.
/cc @glass-ships as reporter.