### PR TITLE
Avoid panic on SIGINT by skipping cleanup when config uninitialized

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -433,6 +433,9 @@ func (c *Configuration) Filesystem() *fs.Filesystem {
 }
 
 func (c *Configuration) Cleanup() error {
+	if c == nil {
+		return nil
+	}
 	c.loading.Lock()
 	defer c.loading.Unlock()
 	return c.fs.Cleanup()


### PR DESCRIPTION
If a `SIGINT` is delivered before the `commands.cfg` `Configuration` structure is initialized then when the goroutine which responds to the signal runs the `commands.Cleanup()` method, it panics after dereferencing a null pointer to the `Configuration` structure while trying to acquire the `loading` mutex that protects the struct's `fs` member.

We can resolve this by simply testing for a `nil` `Configuration` structure pointer in the `config.Cleanup()` method and returning immediately in that case.

Fixes #4450.
/cc @KalleOlaviNiemitalo as reporter.