### PR TITLE
Mark skipdownloaderrors as safe

### DIFF
--- a/config/git_fetcher.go
+++ b/config/git_fetcher.go
@@ -190,4 +190,5 @@ var safeKeys = []string{
 	"lfs.locksverify",
 	"lfs.pushurl",
 	"lfs.url",
+	"lfs.skipdownloaderrors",
 }

--- a/config/git_fetcher.go
+++ b/config/git_fetcher.go
@@ -189,6 +189,6 @@ var safeKeys = []string{
 	"lfs.gitprotocol",
 	"lfs.locksverify",
 	"lfs.pushurl",
-	"lfs.url",
 	"lfs.skipdownloaderrors",
+	"lfs.url",
 }

--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -405,6 +405,7 @@ including and limited to:
 - lfs.url
 - remote.{name}.lfsurl
 - lfs.{*}.access
+- lfs.skipdownloaderrors
 
 The set of keys allowed in this file is restricted for security reasons.
 

--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -402,10 +402,10 @@ including and limited to:
 - lfs.gitprotocol
 - lfs.locksverify
 - lfs.pushurl
-- lfs.url
-- remote.{name}.lfsurl
-- lfs.{*}.access
 - lfs.skipdownloaderrors
+- lfs.url
+- lfs.{*}.access
+- remote.{name}.lfsurl
 
 The set of keys allowed in this file is restricted for security reasons.
 


### PR DESCRIPTION
This option can't be used to do anything dangerous.

Fixes #4467