### PR TITLE
 Add config variables for default remotes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -220,8 +220,9 @@ func (c *Configuration) IsDefaultRemote() bool {
 
 // Remote returns the default remote based on:
 // 1. The currently tracked remote branch, if present
-// 2. Any other SINGLE remote defined in .git/config
-// 3. Use "origin" as a fallback.
+// 2. The value of remote.lfsdefault.
+// 3. Any other SINGLE remote defined in .git/config
+// 4. Use "origin" as a fallback.
 // Results are cached after the first hit.
 func (c *Configuration) Remote() string {
 	ref := c.CurrentRef()
@@ -232,6 +233,9 @@ func (c *Configuration) Remote() string {
 	if c.currentRemote == nil {
 		if remote, ok := c.Git.Get(fmt.Sprintf("branch.%s.remote", ref.Name)); len(ref.Name) != 0 && ok {
 			// try tracking remote
+			c.currentRemote = &remote
+		} else if remote, ok := c.Git.Get("remote.lfsdefault"); ok {
+			// try default remote
 			c.currentRemote = &remote
 		} else if remotes := c.Remotes(); len(remotes) == 1 {
 			// use only remote if there is only 1
@@ -251,6 +255,8 @@ func (c *Configuration) PushRemote() string {
 
 	if c.pushRemote == nil {
 		if remote, ok := c.Git.Get(fmt.Sprintf("branch.%s.pushRemote", ref.Name)); ok {
+			c.pushRemote = &remote
+		} else if remote, ok := c.Git.Get("remote.lfspushdefault"); ok {
 			c.pushRemote = &remote
 		} else if remote, ok := c.Git.Get("remote.pushDefault"); ok {
 			c.pushRemote = &remote

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -61,6 +61,46 @@ func TestRemoteBranchPushDefault(t *testing.T) {
 	assert.Equal(t, "c", cfg.PushRemote())
 }
 
+func TestLFSDefault(t *testing.T) {
+	cfg := NewFrom(Values{
+		Git: map[string][]string{
+			"remote.lfspushdefault": []string{"a"},
+			"remote.pushdefault":    []string{"b"},
+			"remote.lfsdefault":     []string{"c"},
+		},
+	})
+
+	assert.Equal(t, "c", cfg.Remote())
+	assert.Equal(t, "a", cfg.PushRemote())
+}
+
+func TestLFSDefaultSimple(t *testing.T) {
+	cfg := NewFrom(Values{
+		Git: map[string][]string{
+			"remote.lfsdefault": []string{"a"},
+		},
+	})
+
+	assert.Equal(t, "a", cfg.Remote())
+	assert.Equal(t, "a", cfg.PushRemote())
+}
+
+func TestLFSDefaultBranch(t *testing.T) {
+	cfg := NewFrom(Values{
+		Git: map[string][]string{
+			"branch.main.remote":     []string{"a"},
+			"remote.pushdefault":     []string{"b"},
+			"branch.main.pushremote": []string{"c"},
+			"remote.lfspushdefault":  []string{"d"},
+			"remote.lfsdefault":      []string{"e"},
+		},
+	})
+	cfg.ref = &git.Ref{Name: "main"}
+
+	assert.Equal(t, "a", cfg.Remote())
+	assert.Equal(t, "c", cfg.PushRemote())
+}
+
 func TestBasicTransfersOnlySetValue(t *testing.T) {
 	cfg := NewFrom(Values{
 		Git: map[string][]string{

--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -40,6 +40,20 @@ be scoped inside the configuration for a remote.
   The url used to call the Git LFS remote API when pushing. Default blank (derive
   from either LFS non-push urls or clone url).
 
+* `remote.lfsdefault`
+
+  The remote used to find the Git LFS remote API.  `lfs.url` and
+  `branch.*.remote` for the current branch override this setting.  If this
+  setting is not specified and there is exactly one remote, that remote is
+  picked; otherwise, the default is `origin`.
+
+* `remote.lfspushdefault`
+
+  The remote used to find the Git LFS remote API when pushing.  `lfs.url` and
+  `branch.*.pushremote` for the current branch override this setting.  If this
+  setting is not set, `remote.pushdefault` is used, or if that is not set, the
+  order of selection is used as specified in the `remote.lfsdefault` above.
+
 * `lfs.dialtimeout`
 
   Sets the maximum time, in seconds, that the HTTP client will wait to initiate


### PR DESCRIPTION
Currently, if there's no default remote for the current branch set, we look for the name of any single remote, and if not, we fall back to "origin."

However, some people prefer to use a different name for their remotes, such as "upstream".  We don't really want to mandate that users provide a specific name for their remotes, so let's add two variables, `remote.lfsdefault` and `remote.lfspushdefault`, that control the default remote and the default push remote, respectively.  Let's document them, and the lookup order, as well, so folks can reason about the behavior adequately.

Fixes #4464 
/cc @dflems as reporter