### PR TITLE
Make lfshttp package builds more portable

### DIFF
--- a/lfshttp/certs_freebsd.go
+++ b/lfshttp/certs_freebsd.go
@@ -1,8 +1,0 @@
-package lfshttp
-
-import "crypto/x509"
-
-func appendRootCAsForHostFromPlatform(pool *x509.CertPool, host string) *x509.CertPool {
-	// Do nothing, use golang default
-	return pool
-}

--- a/lfshttp/certs_linux.go
+++ b/lfshttp/certs_linux.go
@@ -1,8 +1,0 @@
-package lfshttp
-
-import "crypto/x509"
-
-func appendRootCAsForHostFromPlatform(pool *x509.CertPool, host string) *x509.CertPool {
-	// Do nothing, use golang default
-	return pool
-}

--- a/lfshttp/certs_nix.go
+++ b/lfshttp/certs_nix.go
@@ -1,3 +1,5 @@
+// +build !darwin,!windows
+
 package lfshttp
 
 import "crypto/x509"

--- a/lfshttp/certs_openbsd.go
+++ b/lfshttp/certs_openbsd.go
@@ -1,8 +1,0 @@
-package lfshttp
-
-import "crypto/x509"
-
-func appendRootCAsForHostFromPlatform(pool *x509.CertPool, host string) *x509.CertPool {
-	// Do nothing, use golang default
-	return pool
-}


### PR DESCRIPTION
Currently, we have a large number of identical cert files for various platforms, all of which are non-macOS Unix systems.  These files all simply provide the default system configuration and nothing else.

We recently noticed by looking at the NetBSD pkgsrc repository, which, despite its name, can be used on many systems, that there is a patch to support Solaris.  Unsurprisingly, it duplicates this same file.

Since using the default system behavior is the prudent thing to do if we don't have anything else to do, let's make our project more portable by simply using this same file for all systems other than macOS or Windows. That way, we'll work on Solaris and NetBSD, among other systems, and any other Unix systems which support Go in the future will also magically work.

Fixes #4475