### PR TITLE
Fix downloadFile in gitfilter_smudge.go to actually propagate all errors

### DIFF
--- a/lfs/gitfilter_smudge.go
+++ b/lfs/gitfilter_smudge.go
@@ -112,8 +112,9 @@ func (f *GitFilter) downloadFile(writer io.Writer, ptr *Pointer, workingfile, me
 			} else {
 				multiErr = e
 			}
-			return 0, errors.Wrapf(multiErr, "Error downloading %s (%s)", workingfile, ptr.Oid)
 		}
+
+		return 0, errors.Wrapf(multiErr, "Error downloading %s (%s)", workingfile, ptr.Oid)
 	}
 
 	return f.readLocalFile(writer, ptr, mediafile, workingfile, nil)


### PR DESCRIPTION
Before this commit, loop over errors didn't actually loop
and instead returned only the first error

----

I have to idea how to test this change. I found it because GoLand was complaining that condition `multiErr != nil` inside loop over errors was always false.