### PR TITLE
Use host architecture and OS when running `go generate`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ mangen : commands/mancontent_gen.go
 # 'commands' of Git LFS. It depends upon the contents of the 'docs' directory
 # and converts those manpages into code.
 commands/mancontent_gen.go : $(wildcard docs/man/*.ronn)
-	GOARCH= $(GO) generate github.com/git-lfs/git-lfs/commands
+	GOOS= GOARCH= $(GO) generate github.com/git-lfs/git-lfs/commands
 
 # Targets 'all' and 'build' build binaries of Git LFS for the above release
 # matrix.

--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ mangen : commands/mancontent_gen.go
 # 'commands' of Git LFS. It depends upon the contents of the 'docs' directory
 # and converts those manpages into code.
 commands/mancontent_gen.go : $(wildcard docs/man/*.ronn)
-	$(GO) generate github.com/git-lfs/git-lfs/commands
+	GOARCH= $(GO) generate github.com/git-lfs/git-lfs/commands
 
 # Targets 'all' and 'build' build binaries of Git LFS for the above release
 # matrix.


### PR DESCRIPTION
I was trying to [cross-compile git-lfs to macOS for arm64](https://github.com/desktop/dugite-native/pull/354) from an x86_64 machine and I noticed that just [passing a `GOARCH=arm64` variable to `make`](https://github.com/desktop/dugite-native/pull/354/files#diff-b079a6aebd2c75ac12727b1cfcf5ffb9ddf9055a823e3015d7c729fac1628f93R81) would cause a failure like this:
```
go generate github.com/git-lfs/git-lfs/commands
fork/exec /var/folders/4d/hy7gsq2n22jccp96wdbpt3100000gn/T/go-build614314336/b001/exe/mangen: bad CPU type in executable
commands/commands.go:28: running "go": exit status 1
make: *** [commands/mancontent_gen.go] Error 1
```

I don't understand _why_ exactly, but [overriding `GOARCH` with _nothing_](https://github.com/desktop/dugite-native/pull/354/files#diff-b079a6aebd2c75ac12727b1cfcf5ffb9ddf9055a823e3015d7c729fac1628f93R80) (to effectively use the host CPU arch) for the specific `go generate` command fixed the issue. However, I don't know if this could cause issues somewhere else or if there is a better way to fix this problem.

Please, let me know what you think 😄 