### PR TITLE
migrate import: make --above affect only individual files

### DIFF
--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -170,7 +170,7 @@ func migrateImportCommand(cmd *cobra.Command, args []string) {
 				return nil, err
 			}
 
-			if ext := filepath.Ext(path); len(ext) > 0 {
+			if ext := filepath.Ext(path); len(ext) > 0 && above == 0 {
 				exts.Add(fmt.Sprintf("*%s filter=lfs diff=lfs merge=lfs -text", ext))
 			} else {
 				exts.Add(fmt.Sprintf("/%s filter=lfs diff=lfs merge=lfs -text", path))


### PR DESCRIPTION
The `--above` option is supposed to only affect individual files, but in its current configuration, the entry added to the `.gitattributes` file is a wildcard pattern for the entire extension.  This is a problem because other files with the same extension won't necessarily be converted, leading to the dreaded message that some files "should have been pointers, but weren't".

Let's fix this by doing what the documentation says: only adding individual files themselves.  That fixes this problem and also the inconsistency in our documentation.

Fixes #4511
