### PR TITLE
README: improve steps for building from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,10 @@ $ ./install.sh
 
 #### From source
 
-- Place the `git-lfs` binary on your system’s executable `$PATH` or equivalent.
+- Ensure you have the latest version of Go, GNU make, and a standard Unix-compatible build environment installed.
+- On Windows, install `goversioninfo` with `go get github.com/josephspurrier/goversioninfo/cmd/goversioninfo`.
+- Run `make`.
+- Place the `git-lfs` binary, which can be found in `bin`, on your system’s executable `$PATH` or equivalent.
 - Git LFS requires global configuration changes once per-machine. This can be done by
 running:
 


### PR DESCRIPTION
The `README` currently makes a lot of assumptions about the requirements to build from source.  Let's explain to the user what those requirements are and to invoke `make`, since we tend to build things differently from most other Go projects.

Fixes #4522
/cc @matthiasbeyer as reporter