### PR TITLE
Let packagecloud.io recognize almalinux

### DIFF
--- a/rpm/build_rpms.bsh
+++ b/rpm/build_rpms.bsh
@@ -14,7 +14,7 @@ else #Basically Centos 5/6
 fi
 
 case "${OS_NAME}" in
-  centos*|red*)
+  centos*|red*|almalinux)
     RPM_DIST=".el${VERSION_ID}"
     ;;
   fedora)

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -43,6 +43,7 @@ $distro_name_map = {
     "sles/15.2",  # Current
   ],
   "centos/8" => [
+    "almalinux/8",
     "el/8",
     "fedora/32",
     "fedora/33",


### PR DESCRIPTION
This seems to be the change necessary to let almalinux-based system to be treated the same way as Red Hat Enterprise Linux or CentOS.

Workaround: set `os=el` in the environment