### PR TITLE
Fix locking with multiple paths and absolute paths

### DIFF
--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -85,7 +85,15 @@ func lockPath(file string) (string, error) {
 			"could not follow symlinks for %s", wd)
 	}
 
-	abs := filepath.Join(wd, file)
+	var abs string
+	if filepath.IsAbs(file) {
+		abs, err = tools.CanonicalizeSystemPath(file)
+		if err != nil {
+			return "", fmt.Errorf("lfs: unable to canonicalize path %q: %v", file, err)
+		}
+	} else {
+		abs = filepath.Join(wd, file)
+	}
 	path, err := filepath.Rel(repo, abs)
 	if err != nil {
 		return "", err

--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -19,9 +19,8 @@ var (
 )
 
 func lockCommand(cmd *cobra.Command, args []string) {
-	if len(args) == 0 {
-		Print("Usage: git lfs lock <path>")
-		return
+	if len(args) != 1 {
+		Exit("Usage: git lfs lock <path>")
 	}
 
 	path, err := lockPath(args[0])

--- a/commands/command_unlock.go
+++ b/commands/command_unlock.go
@@ -29,9 +29,10 @@ var unlockUsage = "Usage: git lfs unlock (--id my-lock-id | <path>)"
 func unlockCommand(cmd *cobra.Command, args []string) {
 	hasPath := len(args) > 0
 	hasId := len(unlockCmdFlags.Id) > 0
-	if hasPath == hasId {
+	if hasPath == hasId || len(args) > 1 {
 		// If there is both an `--id` AND a `<path>`, or there is
-		// neither, print the usage and quit.
+		// neither, or there are multiple paths, print the usage and
+		// quit.
 		Exit(unlockUsage)
 	}
 

--- a/t/t-lock.sh
+++ b/t/t-lock.sh
@@ -95,6 +95,27 @@ begin_test "lock multiple files"
 )
 end_test
 
+begin_test "lock absolute path"
+(
+  set -e
+
+  reponame="lock-absolute-path"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.dat"
+  echo "a" > a.dat
+  echo "b" > b.dat
+  git add .gitattributes a.dat b.dat
+  git commit -m "add dat files"
+  git push origin main:other
+
+  git lfs lock --json "$(pwd)/a.dat" | tee lock.json
+  id=$(assert_lock lock.json a.dat)
+  assert_server_lock "$reponame" "$id"
+)
+end_test
+
 begin_test "create lock with server using client cert"
 (
   set -e

--- a/t/t-lock.sh
+++ b/t/t-lock.sh
@@ -74,6 +74,27 @@ begin_test "lock with bad ref"
 )
 end_test
 
+begin_test "lock multiple files"
+(
+  set -e
+
+  reponame="lock-multiple-files"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.dat"
+  echo "a" > a.dat
+  echo "b" > b.dat
+  git add .gitattributes a.dat b.dat
+  git commit -m "add dat files"
+  git push origin main:other
+
+  git lfs lock *.dat >log 2>&1 && exit 1
+
+  grep "Usage:" log
+)
+end_test
+
 begin_test "create lock with server using client cert"
 (
   set -e

--- a/t/t-unlock.sh
+++ b/t/t-unlock.sh
@@ -119,6 +119,29 @@ begin_test "unlocking a lock by id with bad ref"
 )
 end_test
 
+begin_test "unlock multiple files"
+(
+  set -e
+
+  reponame="unlock-multiple-files"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.dat"
+  echo "a" > a.dat
+  echo "b" > b.dat
+  git add .gitattributes a.dat b.dat
+  git commit -m "add dat files"
+  git push origin main:other
+
+  git lfs lock a.dat
+  git lfs lock b.dat
+  git lfs unlock *.dat >log 2>&1 && exit 1
+
+  grep "Usage:" log
+)
+end_test
+
 begin_test "unlocking a file makes it readonly"
 (
   set -e


### PR DESCRIPTION
Currently, we accept multiple paths for `git lfs lock` and `git lfs unlock` and then promptly ignore all of them other than the first.  Let's reject these paths instead of silently ignoring them.

Also, we currently accept absolute paths and then produce a bizarre and incorrect relative path from it when using these commands.  Let's fix this as well.

Both commits have sane commit messages explaining the changes in full.

Fixes #4529