### PR TITLE
Allow users to explicitly limit scan depth

### DIFF
--- a/git/rev_list_scanner.go
+++ b/git/rev_list_scanner.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -247,6 +249,10 @@ func revListArgs(include, exclude []string, opt *ScanRefsOptions) (io.Reader, []
 	case ScanAllMode:
 		args = append(args, "--all")
 	case ScanRangeToRemoteMode:
+		depth, _ := strconv.Atoi(os.Getenv("GIT_LFS_MAX_SCAN_DEPTH"))
+		if depth > 0 {
+			args = append(args, fmt.Sprintf("-%d", depth))
+		}
 		args = append(args, "--ignore-missing")
 		if len(opt.SkippedRefs) == 0 {
 			args = append(args, "--not", "--remotes="+opt.Remote)


### PR DESCRIPTION
In some scenarios git-lfs is unable to correctly deduce how to bound
the range of commits to look and when determining what to push. For
example, with Gerrit you push to refs/for/master in lieu of pushing to
refs/heads/master.  When this happens we will attempt to push
substantially more LFS objects than necessary resulting in poor
performance.

In lieu of using this fallback, if the user has a reasonable idea of
the underlying push depth we should allow them to limit the search
range.  Because we're unable to directly pass parameters via the
underlying git hooks we need to specify this in the command
environment.