### PR TITLE
LFS repository format version

### DIFF
--- a/commands/command_clean.go
+++ b/commands/command_clean.go
@@ -90,6 +90,7 @@ func clean(gf *lfs.GitFilter, to io.Writer, from io.Reader, fileName string, fil
 
 func cleanCommand(cmd *cobra.Command, args []string) {
 	requireStdin("This command should be run by the Git 'clean' filter")
+	setupRepository()
 	installHooks(false)
 
 	var fileName string

--- a/commands/command_filter_process.go
+++ b/commands/command_filter_process.go
@@ -37,6 +37,7 @@ var filterSmudgeSkip bool
 
 func filterCommand(cmd *cobra.Command, args []string) {
 	requireStdin("This command should be run by the Git filter process")
+	setupRepository()
 	installHooks(false)
 
 	s := git.NewFilterProcessScanner(os.Stdin, os.Stdout)

--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -150,6 +150,7 @@ func smudge(gf *lfs.GitFilter, to io.Writer, from io.Reader, filename string, sk
 
 func smudgeCommand(cmd *cobra.Command, args []string) {
 	requireStdin("This command should be run by the Git 'smudge' filter")
+	setupRepository()
 	installHooks(false)
 
 	if !smudgeSkip && cfg.Os.Bool("GIT_LFS_SKIP_SMUDGE", false) {

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -328,15 +328,28 @@ func setupRepository() {
 		ExitWithError(errors.Wrap(
 			err, "fatal: could not determine bareness"))
 	}
+	verifyRepositoryVersion()
 
 	if !bare {
 		changeToWorkingCopy()
 	}
 }
 
+func verifyRepositoryVersion() {
+	key := "lfs.repositoryformatversion"
+	val := cfg.FindGitLocalKey(key)
+	if val == "" {
+		cfg.SetGitLocalKey(key, "0")
+	} else if val != "0" {
+		Print("Unknown repository format version: %s", val)
+		os.Exit(128)
+	}
+}
+
 func setupWorkingCopy() {
 	requireInRepo()
 	requireWorkingCopy()
+	verifyRepositoryVersion()
 	changeToWorkingCopy()
 }
 

--- a/t/t-repo-format.sh
+++ b/t/t-repo-format.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+. "$(dirname "$0")/testlib.sh"
+
+begin_test "repository format version"
+(
+  set -e
+
+  reponame="lfs-repo-version"
+  git init $reponame
+  cd $reponame
+
+  [ -z "$(git config --local lfs.repositoryFormatVersion)" ]
+
+  git lfs track '*.dat'
+
+  [ "$(git config --local lfs.repositoryFormatVersion)" = "0" ]
+
+  git config --local lfs.repositoryFormatVersion 1
+
+  git lfs track '*.bin' >output 2>&1 && exit 1
+  cat output
+  grep "Unknown repository format version: 1" output
+
+  git config --local --unset lfs.repositoryFormatVersion
+  # Verify that global settings are ignored.
+  git config --global lfs.repositoryFormatVersion 1
+
+  git lfs track '*.bin'
+)
+end_test


### PR DESCRIPTION
We've had several proposals to change how data is stored on disk, such as by compressing files when stored inside the .git directory. Unfortunately, those proposals are incompatible with how data is stored now and we would likely break older clients if we implemented them.

To make it possible for us to implement them in the future, let's do what Git does and add support for a repository format version.  We read the configuration option `lfs.repositoryFormatVersion` from the local configuration, and if it is nonzero, we exit with an error.  We also assume that if the value is not set, then it is implicitly 0 and set it if possible.  We ignore any errors when writing to allow working with read-only repositories in the limited circumstances where that can be valuable.

The plan in the future is to support repository format v1, which, like Git's, will be the same but for a set of `lfs.repositoryextension.*` keys which denote extensions.  Such extensions will be ignored in v0, but will be mandatory to understand in v1; unknown keys will cause Git LFS to abort.  The implementation of this functionality is left to the future, however.

In addition, make sure we set up the repositories where appropriate so that all major subsystems set the proper value.

Fixes #4533