### PR TITLE
Drop unused ClearTempStorage() transfer adapter method and tune stale comments

### DIFF
--- a/lfs/gitscanner_refs.go
+++ b/lfs/gitscanner_refs.go
@@ -33,8 +33,8 @@ func (s *lockableNameSet) Check(blobSha string) (string, bool) {
 func noopFoundLockable(name string) {}
 
 // scanRefsToChan scans through all commits reachable by refs contained in
-// "include" and not reachable by any refs included in "excluded" and returns
-// a channel of WrappedPointer objects for all Git LFS pointers it finds.
+// "include" and not reachable by any refs included in "exclude" and invokes
+// the provided callback for each pointer file, valid or invalid, that it finds.
 // Reports unique oids once only, not multiple times if >1 file uses the same content
 func scanRefsToChan(scanner *GitScanner, pointerCb GitScannerFoundPointer, include, exclude []string, gitEnv, osEnv config.Environment, opt *ScanRefsOptions) error {
 	if opt == nil {

--- a/t/t-batch-transfer.sh
+++ b/t/t-batch-transfer.sh
@@ -111,7 +111,6 @@ begin_test "batch transfers with ssh endpoint (git-lfs-authenticate)"
 
   sshurl="${GITSERVER/http:\/\//ssh://git@}/$reponame"
   git config lfs.url "$sshurl"
-  git lfs env
 
   contents="test"
   git lfs track "*.dat"
@@ -137,7 +136,6 @@ begin_test "batch transfers with ssh endpoint (git-lfs-transfer)"
   git config lfs.url "$sshurl"
 
   contents="test"
-  oid="$(calc_oid "$contents")"
   git lfs track "*.dat"
   printf "%s" "$contents" > test.dat
   git add .gitattributes test.dat
@@ -145,7 +143,7 @@ begin_test "batch transfers with ssh endpoint (git-lfs-transfer)"
 
   git push origin main 2>&1
   cd ..
-  GIT_TRACE=1 git clone $sshurl "$reponame-2" 2>&1 | tee trace.log
+  GIT_TRACE=1 git clone "$sshurl" "$reponame-2" 2>&1 | tee trace.log
   grep "lfs-ssh-echo.*git-lfs-transfer .*$reponame.git download" trace.log
   cd "$reponame-2"
   git lfs fsck

--- a/tq/basic_download.go
+++ b/tq/basic_download.go
@@ -20,10 +20,6 @@ type basicDownloadAdapter struct {
 	*adapterBase
 }
 
-func (a *basicDownloadAdapter) ClearTempStorage() error {
-	return os.RemoveAll(a.tempDir())
-}
-
 func (a *basicDownloadAdapter) tempDir() string {
 	// Shared with the SSH adapter.
 	d := filepath.Join(a.fs.LFSStorageDir, "incomplete")

--- a/tq/basic_upload.go
+++ b/tq/basic_upload.go
@@ -25,13 +25,8 @@ type basicUploadAdapter struct {
 	*adapterBase
 }
 
-func (a *basicUploadAdapter) ClearTempStorage() error {
-	// Should be empty already but also remove dir
-	return os.RemoveAll(a.tempDir())
-}
-
 func (a *basicUploadAdapter) tempDir() string {
-	// Must be dedicated to this adapter as deleted by ClearTempStorage
+	// Dedicated to this adapter rather than shared with basic download.
 	d := filepath.Join(os.TempDir(), "git-lfs-basic-temp")
 	if err := tools.MkdirAll(d, a.fs); err != nil {
 		return os.TempDir()

--- a/tq/custom.go
+++ b/tq/custom.go
@@ -119,11 +119,6 @@ func (a *customAdapter) Begin(cfg AdapterConfig, cb ProgressCallback) error {
 	return a.adapterBase.Begin(&customAdapterConfig{AdapterConfig: cfg}, cb)
 }
 
-func (a *customAdapter) ClearTempStorage() error {
-	// no action required
-	return nil
-}
-
 func (a *customAdapter) WorkerStarting(workerNum int) (interface{}, error) {
 	// Start a process per worker
 	// If concurrent = false we have already dialled back workers to 1

--- a/tq/ssh.go
+++ b/tq/ssh.go
@@ -380,12 +380,6 @@ func (a *SSHAdapter) Begin(cfg AdapterConfig, cb ProgressCallback) error {
 	return nil
 }
 
-// ClearTempStorage clears any temporary files, such as unfinished downloads that
-// would otherwise be resumed
-func (a *SSHAdapter) ClearTempStorage() error {
-	return os.RemoveAll(a.tempDir())
-}
-
 func (a *SSHAdapter) Trace(format string, args ...interface{}) {
 	if !a.adapterBase.debugging {
 		return

--- a/tq/ssh.go
+++ b/tq/ssh.go
@@ -173,7 +173,6 @@ func (a *SSHAdapter) DoTransfer(ctx interface{}, t *Transfer, cb ProgressCallbac
 }
 
 func (a *SSHAdapter) download(t *Transfer, conn *ssh.PktlineConnection, cb ProgressCallback) error {
-	// Reserve a temporary filename. We need to make sure nobody operates on the file simultaneously with us.
 	rel, err := t.Rel("download")
 	if err != nil {
 		return err

--- a/tq/transfer.go
+++ b/tq/transfer.go
@@ -245,9 +245,6 @@ type Adapter interface {
 	// once the queued items have completed.
 	// This call blocks until all items have been processed
 	End()
-	// ClearTempStorage clears any temporary files, such as unfinished downloads that
-	// would otherwise be resumed
-	ClearTempStorage() error
 }
 
 // Result of a transfer returned through CompletionChannel()

--- a/tq/transfer.go
+++ b/tq/transfer.go
@@ -235,10 +235,8 @@ type Adapter interface {
 	// Adapter instances can only be one or the other, although the same
 	// type may be instantiated for each direction
 	Direction() Direction
-	// Begin a new batch of uploads or downloads. Call this first, followed by
-	// one or more Add calls. maxConcurrency controls the number of transfers
-	// that may be done at once. The passed in callback will receive updates on
-	// progress. Either argument may be nil if not required by the client.
+	// Begin a new batch of uploads or downloads. Call this first, followed by one
+	// or more Add calls. The passed in callback will receive updates on progress.
 	Begin(cfg AdapterConfig, cb ProgressCallback) error
 	// Add queues a download/upload, which will complete asynchronously and
 	// notify the callbacks given to Begin()

--- a/tq/transfer_test.go
+++ b/tq/transfer_test.go
@@ -33,10 +33,6 @@ func (a *testAdapter) Add(ts ...*Transfer) (retries <-chan TransferResult) {
 func (a *testAdapter) End() {
 }
 
-func (a *testAdapter) ClearTempStorage() error {
-	return nil
-}
-
 func newTestAdapter(name string, dir Direction) Adapter {
 	return &testAdapter{name, dir}
 }

--- a/tq/tus_upload.go
+++ b/tq/tus_upload.go
@@ -23,11 +23,6 @@ type tusUploadAdapter struct {
 	*adapterBase
 }
 
-func (a *tusUploadAdapter) ClearTempStorage() error {
-	// nothing to do, all temp state is on the server end
-	return nil
-}
-
 func (a *tusUploadAdapter) WorkerStarting(workerNum int) (interface{}, error) {
 	return nil, nil
 }


### PR DESCRIPTION
This PR follows up on some notes from a [conversation](https://github.com/git-lfs/git-lfs/pull/4446#discussion_r665860126) in PR #4446, specifically the fact that the `ClearTempStorage()` method of the transfer `Adapter` interface is never utilized, and the current implementations in the basic and SSH transfer adapters would be dangerous if they ever were called.  We therefore remove the method from the interface and drop its implementations from the various transfer adapaters.

(The reason the current implementations are potentially dangerous is that they perform `os.RemoveAll(a.tempDir())` where `tempDir()` is an internal method of each adapter that tries to create a temporary directory within the local Git repository, but if it fails, just returns `os.TempDir()`, and also does not cache the path that it initially returns.  So if `tempDir()` managed to create the local temporary directory, but then it was removed by some external process and file permissions changed such that a final call to `tempDir()` by `ClearTempStorage()` failed to re-create the directory, `ClearTempStorage()` would just try to remove whatever had been returned by `os.TempDir()`, which [according](https://pkg.go.dev/os#TempDir) to the docs may be the system temporary directory, e.g., `/tmp` on Unix.  Fortunately `ClearTempStorage()` has never actually been called, however, since it's introduction in PR #1265.)

We also tidy a few items discovered during the recent reviews of PRs #4446 and #4525, namely:

- We update the comment describing the `scanRefsToChan()` internal function in `lfs/gitscanner_refs.go`, which as noted in this [conversation](https://github.com/git-lfs/git-lfs/pull/4525#discussion_r669249563) has been out of date since PR #1743.
- We update the comment describing the `Begin()` method of the transfer adapter interface in `tq/transfer.go`, which as noted in this [conversation](https://github.com/git-lfs/git-lfs/pull/4446#discussion_r665871222) has been out of date since PR #1774.
- We drop an extra comment about temporary directory creation in `tq/ssh.go` added in PR #4446.
- In `t/t-batch-transfer.sh` we double-quote one instance of the `$sshurl` shell variable (added in PR #4446) and drop several unused lines, as discussed in this [pair of](https://github.com/git-lfs/git-lfs/pull/4446#discussion_r664861460) [conversations](https://github.com/git-lfs/git-lfs/pull/4446#discussion_r664861034).