### PR TITLE
go.mod: bump gitobj to v2.0.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/git-lfs/git-lfs
 require (
 	github.com/avast/retry-go v2.4.2+incompatible
 	github.com/dpotapov/go-spnego v0.0.0-20210315154721-298b63a54430
-	github.com/git-lfs/gitobj/v2 v2.0.1
+	github.com/git-lfs/gitobj/v2 v2.0.2
 	github.com/git-lfs/go-netrc v0.0.0-20180525200031-e0e9ca483a18
 	github.com/git-lfs/pktline v0.0.0-20210330133718-06e9096e2825
 	github.com/git-lfs/wildmatch v1.0.4

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/dpotapov/go-spnego v0.0.0-20210315154721-298b63a54430 h1:oempk9HjNt6r
 github.com/dpotapov/go-spnego v0.0.0-20210315154721-298b63a54430/go.mod h1:AVSs/gZKt1bOd2AhkhbS7Qh56Hv7klde22yXVbwYJhc=
 github.com/git-lfs/gitobj/v2 v2.0.1 h1:mUGOWP+fU36rs7TY7a5Lol9FuockOBjPFUW/lwOM7Mo=
 github.com/git-lfs/gitobj/v2 v2.0.1/go.mod h1:q6aqxl6Uu3gWsip5GEKpw+7459F97er8COmU45ncAxw=
+github.com/git-lfs/gitobj/v2 v2.0.2 h1:p8rWlhEyiSsC+4Qc+EdufySatf8sDtvJIrHAHgf7Ar8=
+github.com/git-lfs/gitobj/v2 v2.0.2/go.mod h1:q6aqxl6Uu3gWsip5GEKpw+7459F97er8COmU45ncAxw=
 github.com/git-lfs/go-netrc v0.0.0-20180525200031-e0e9ca483a18 h1:7Th0eBA4rT8WJNiM1vppjaIv9W5WJinhpbCJvRJxloI=
 github.com/git-lfs/go-netrc v0.0.0-20180525200031-e0e9ca483a18/go.mod h1:70O4NAtvWn1jW8V8V+OKrJJYcxDLTmIozfi2fmSz5SI=
 github.com/git-lfs/pktline v0.0.0-20210330133718-06e9096e2825 h1:riQhgheTL7tMF4d5raz9t3+IzoR1i1wqxE1kZC6dY+U=

--- a/vendor/github.com/git-lfs/gitobj/v2/tree.go
+++ b/vendor/github.com/git-lfs/gitobj/v2/tree.go
@@ -9,9 +9,19 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"syscall"
 
 	"github.com/git-lfs/gitobj/v2/pack"
+)
+
+// We define these here instead of using the system ones because not all
+// operating systems use the traditional values.  For example, zOS uses
+// different values.
+const (
+	sIFMT      = int32(0170000)
+	sIFREG     = int32(0100000)
+	sIFDIR     = int32(0040000)
+	sIFLNK     = int32(0120000)
+	sIFGITLINK = int32(0160000)
 )
 
 // Tree encapsulates a Git tree object.
@@ -209,24 +219,18 @@ func (e *TreeEntry) Equal(other *TreeEntry) bool {
 // Type is the type of entry (either blob: BlobObjectType, or a sub-tree:
 // TreeObjectType).
 func (e *TreeEntry) Type() ObjectType {
-	switch e.Filemode & syscall.S_IFMT {
-	case syscall.S_IFREG:
+	switch e.Filemode & sIFMT {
+	case sIFREG:
 		return BlobObjectType
-	case syscall.S_IFDIR:
+	case sIFDIR:
 		return TreeObjectType
-	case syscall.S_IFLNK:
+	case sIFLNK:
 		return BlobObjectType
+	case sIFGITLINK:
+		return CommitObjectType
 	default:
-		if e.Filemode == 0xe000 {
-			// Mode 0xe000, or a gitlink, has no formal filesystem
-			// (`syscall.S_IF<t>`) equivalent.
-			//
-			// Safeguard that catch here, or otherwise panic.
-			return CommitObjectType
-		} else {
-			panic(fmt.Sprintf("gitobj: unknown object type: %o",
-				e.Filemode))
-		}
+		panic(fmt.Sprintf("gitobj: unknown object type: %o",
+			e.Filemode))
 	}
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -8,7 +8,7 @@ github.com/avast/retry-go
 github.com/davecgh/go-spew/spew
 # github.com/dpotapov/go-spnego v0.0.0-20210315154721-298b63a54430
 github.com/dpotapov/go-spnego
-# github.com/git-lfs/gitobj/v2 v2.0.1
+# github.com/git-lfs/gitobj/v2 v2.0.2
 github.com/git-lfs/gitobj/v2
 github.com/git-lfs/gitobj/v2/errors
 github.com/git-lfs/gitobj/v2/pack


### PR DESCRIPTION
Bump gitobj to v2.0.2 to fix support for zOS, which has different stat constants than most other Unices.
