### PR TITLE
Fix 429 retry-after handling for LFS batch API endpoint

### DIFF
--- a/t/cmd/lfstest-gitserver.go
+++ b/t/cmd/lfstest-gitserver.go
@@ -409,6 +409,17 @@ func lfsBatchHandler(w http.ResponseWriter, r *http.Request, id, repo string) {
 		}
 	}
 
+	if strings.HasSuffix(repo, "batch-retry-later") {
+		if timeLeft, isWaiting := checkRateLimit("batch", "", repo, ""); isWaiting {
+			w.Header().Set("Retry-After", strconv.Itoa(timeLeft))
+			w.WriteHeader(http.StatusTooManyRequests)
+
+			w.Write([]byte("rate limit reached"))
+			fmt.Println("Setting header to: ", strconv.Itoa(timeLeft))
+			return
+		}
+	}
+
 	res := []lfsObject{}
 	testingChunked := testingChunkedTransferEncoding(r)
 	testingTus := testingTusUploadInBatchReq(r)

--- a/t/t-batch-storage-retries-ratelimit.sh
+++ b/t/t-batch-storage-retries-ratelimit.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+. "$(dirname "$0")/testlib.sh"
+
+begin_test "batch storage upload causes retries"
+(
+  set -e
+
+  reponame="batch-storage-upload-retry-later"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" batch-storage-repo-upload
+
+  contents="storage-upload-retry-later"
+  oid="$(calc_oid "$contents")"
+  printf "%s" "$contents" > a.dat
+
+  git lfs track "*.dat"
+  git add .gitattributes a.dat
+  git commit -m "initial commit"
+
+  GIT_TRACE=1 git push origin main 2>&1 | tee push.log
+  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected \`git push origin main\` to succeed ..."
+    exit 1
+  fi
+
+  assert_server_object "$reponame" "$oid"
+)
+end_test
+
+begin_test "batch storage download causes retries"
+(
+  set -e
+
+  reponame="batch-storage-download-retry-later"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" batch-storage-repo-download
+
+  contents="storage-download-retry-later"
+  oid="$(calc_oid "$contents")"
+  printf "%s" "$contents" > a.dat
+
+  git lfs track "*.dat"
+  git add .gitattributes a.dat
+  git commit -m "initial commit"
+
+  git push origin main
+  assert_server_object "$reponame" "$oid"
+
+  pushd ..
+    git \
+      -c "filter.lfs.process=" \
+      -c "filter.lfs.smudge=cat" \
+      -c "filter.lfs.required=false" \
+      clone "$GITSERVER/$reponame" "$reponame-assert"
+
+    cd "$reponame-assert"
+
+    git config credential.helper lfstest
+
+    GIT_TRACE=1 git lfs pull origin main 2>&1 | tee pull.log
+    if [ "0" -ne "${PIPESTATUS[0]}" ]; then
+      echo >&2 "fatal: expected \`git lfs pull origin main\` to succeed ..."
+      exit 1
+    fi
+
+	assert_local_object "$oid" "${#contents}"
+  popd
+)
+end_test
+
+begin_test "batch clone causes retries"
+(
+  set -e
+
+  reponame="batch-storage-clone-retry-later"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" batch-storage-repo-clone
+
+  contents="storage-download-retry-later"
+  oid="$(calc_oid "$contents")"
+  printf "%s" "$contents" > a.dat
+
+  git lfs track "*.dat"
+  git add .gitattributes a.dat
+  git commit -m "initial commit"
+
+  git push origin main
+  assert_server_object "$reponame" "$oid"
+
+  pushd ..
+    git lfs clone "$GITSERVER/$reponame" "$reponame-assert"
+    if [ "0" -ne "$?" ]; then
+	  echo >&2 "fatal: expected \`git lfs clone \"$GITSERVER/$reponame\" \"$reponame-assert\"\` to su``"
+	  exit 1
+	fi
+
+    cd "$reponame-assert"
+
+    assert_local_object "$oid" "${#contents}"
+  popd
+)
+end_test

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -557,22 +557,30 @@ func (q *TransferQueue) enqueueAndCollectRetriesFor(batch batch) (batch, error) 
 		var err error
 		bRes, err = Batch(q.manifest, q.direction, q.remote, q.ref, batch.ToTransfers())
 		if err != nil {
+			var hasNonScheduledErrors = false
 			// If there was an error making the batch API call, mark all of
 			// the objects for retry, and return them along with the error
 			// that was encountered. If any of the objects couldn't be
 			// retried, they will be marked as failed.
 			for _, t := range batch {
 				if q.canRetryObject(t.Oid, err) {
+					hasNonScheduledErrors = true
 					enqueueRetry(t, err, nil)
 				} else if readyTime, canRetry := q.canRetryObjectLater(t.Oid, err); canRetry {
-					err = nil
 					enqueueRetry(t, err, &readyTime)
 				} else {
+					hasNonScheduledErrors = true
 					q.wait.Done()
 				}
 			}
 
-			return next, errors.NewRetriableError(err)
+			// Only return error and mark operation as failure if at least one object
+			// was not enqueued for retrial at a later point.
+			if hasNonScheduledErrors {
+				return next, errors.NewRetriableError(err)
+			} else {
+				return next, nil
+			}
 		}
 	}
 


### PR DESCRIPTION
This MR corrects the handling of `429` retry-after HTTP errors for the *LFS batch API* endpoint and adds the matching integration tests. Said functionality was already working for the *storage API* endpoint and was also covered by integration tests.

Receiving `429` retry-after HTTP errors also for the *LFS batch API* endpoint is a likely scenario when using a Git-server with shared rate-limit bucket like GitLab or reverse HA-Proxy and project with multiple LFS files.

**Scenario before 5b6a929**

``` txt
#     21:45:55.445971 trace git-lfs: tq: running as batched queue, batch size of 100
#     21:45:55.446155 trace git-lfs: run_command: git rev-list --objects --ignore-missing --not --remotes=origin --stdin --
#     21:45:55.447408 trace git-lfs: exec: git '-c' 'filter.lfs.smudge=' '-c' 'filter.lfs.clean=' '-c' 'filter.lfs.process=' '-c' 'filter.lfs.required=false' 'cat-file' '--batch-check'
#     21:45:55.448571 trace git-lfs: exec: git '-c' 'filter.lfs.smudge=' '-c' 'filter.lfs.clean=' '-c' 'filter.lfs.process=' '-c' 'filter.lfs.required=false' 'rev-parse' '--git-common-dir'
21:45:55.453201 trace git-lfs: tq: sending batch of size 1                            
#     21:45:55.453405 trace git-lfs: api: batch 1 files
#     21:45:55.453493 trace git-lfs: creds: git credential cache ("http", "127.0.0.1:50427", "batch-upload-retry-later")
#     21:45:55.453497 trace git-lfs: Filled credentials for http://127.0.0.1:50427/batch-upload-retry-later
#     21:45:55.453506 trace git-lfs: HTTP: POST http://127.0.0.1:50427/batch-upload-retry-later.git/info/lfs/objects/batch
#     21:45:55.453994 trace git-lfs: HTTP: 429
#     21:45:55.454012 trace git-lfs: HTTP: rate limit reached
#     21:45:55.454042 trace git-lfs: api error: LFS: Error
#     21:45:55.454057 trace git-lfs: tq: enqueue retry #1 after 11.00s for "5404ee773986b403c227c48c61913b32109d8b2aa512b6fba044acc14cfe30a5" (size: 17)
#     21:46:06.458175 trace git-lfs: tq: sending batch of size 1
#     21:46:06.458340 trace git-lfs: api: batch 1 files
#     21:46:06.458559 trace git-lfs: creds: git credential cache ("http", "127.0.0.1:50427", "batch-upload-retry-later")
#     21:46:06.458573 trace git-lfs: Filled credentials for http://127.0.0.1:50427/batch-upload-retry-later
#     21:46:06.458593 trace git-lfs: HTTP: POST http://127.0.0.1:50427/batch-upload-retry-later.git/info/lfs/objects/batch
#     21:46:06.459614 trace git-lfs: HTTP: 200
#     21:46:06.459672 trace git-lfs: HTTP: {"objects":[{"oid":"5404ee773986b403c227c48c61913b32109d8b2aa512b6fba044acc14cfe30a5","size":17,"actions":{"upload":{"href":"http://127.0.0.1:50427/storage/5404ee773986b403c227c48c61913b32109d8b2aa512b6fba044acc14cfe30a5?r=batch-upload-retry-later","expires_at":"0001-01-01T00:00:00Z"}}}]}
#     21:46:06.459794 trace git-lfs: tq: starting transfer adapter "basic"
21:46:06.460290 trace git-lfs: HTTP: PUT http://127.0.0.1:50427/storage/5404ee773986b403c227c48c61913b32109d8b2aa512b6fba044acc14cfe30a5
#     21:46:06.460847 trace git-lfs: HTTP: 200
LFS: Errorading LFS objects: 100% (1/1), 17 B | 0 B/s                                 
#     Uploading LFS objects: 100% (1/1), 17 B | 0 B/s, done.
#     error: failed to push some refs to 'http://127.0.0.1:50427/batch-upload-retry-later'
```

**Scenario after 5b6a929**

``` txt
#     21:48:12.247153 trace git-lfs: tq: running as batched queue, batch size of 100
#     21:48:12.247292 trace git-lfs: run_command: git rev-list --objects --ignore-missing --not --remotes=origin --stdin --
#     21:48:12.248517 trace git-lfs: exec: git '-c' 'filter.lfs.smudge=' '-c' 'filter.lfs.clean=' '-c' 'filter.lfs.process=' '-c' 'filter.lfs.required=false' 'cat-file' '--batch-check'
#     21:48:12.249654 trace git-lfs: exec: git '-c' 'filter.lfs.smudge=' '-c' 'filter.lfs.clean=' '-c' 'filter.lfs.process=' '-c' 'filter.lfs.required=false' 'rev-parse' '--git-common-dir'
21:48:12.253900 trace git-lfs: tq: sending batch of size 1                            
#     21:48:12.254047 trace git-lfs: api: batch 1 files
#     21:48:12.254111 trace git-lfs: creds: git credential cache ("http", "127.0.0.1:50476", "batch-upload-retry-later")
#     21:48:12.254114 trace git-lfs: Filled credentials for http://127.0.0.1:50476/batch-upload-retry-later
#     21:48:12.254122 trace git-lfs: HTTP: POST http://127.0.0.1:50476/batch-upload-retry-later.git/info/lfs/objects/batch
#     21:48:12.254607 trace git-lfs: HTTP: 429
#     21:48:12.254656 trace git-lfs: HTTP: rate limit reached
#     21:48:12.254726 trace git-lfs: api error: LFS: Error
#     21:48:12.254739 trace git-lfs: tq: enqueue retry #1 after 11.00s for "5404ee773986b403c227c48c61913b32109d8b2aa512b6fba044acc14cfe30a5" (size: 17)
#     21:48:23.255059 trace git-lfs: tq: sending batch of size 1
#     21:48:23.255175 trace git-lfs: api: batch 1 files
#     21:48:23.255381 trace git-lfs: creds: git credential cache ("http", "127.0.0.1:50476", "batch-upload-retry-later")
#     21:48:23.255395 trace git-lfs: Filled credentials for http://127.0.0.1:50476/batch-upload-retry-later
#     21:48:23.255413 trace git-lfs: HTTP: POST http://127.0.0.1:50476/batch-upload-retry-later.git/info/lfs/objects/batch
#     21:48:23.256850 trace git-lfs: HTTP: 200
#     21:48:23.256921 trace git-lfs: HTTP: {"objects":[{"oid":"5404ee773986b403c227c48c61913b32109d8b2aa512b6fba044acc14cfe30a5","size":17,"actions":{"upload":{"href":"http://127.0.0.1:50476/storage/5404ee773986b403c227c48c61913b32109d8b2aa512b6fba044acc14cfe30a5?r=batch-upload-retry-later","expires_at":"0001-01-01T00:00:00Z"}}}]}
#     21:48:23.257081 trace git-lfs: tq: starting transfer adapter "basic"
21:48:23.257734 trace git-lfs: HTTP: PUT http://127.0.0.1:50476/storage/5404ee773986b403c227c48c61913b32109d8b2aa512b6fba044acc14cfe30a5
#     21:48:23.258297 trace git-lfs: HTTP: 200
Uploading LFS objects: 100% (1/1), 17 B | 0 B/s, done.                                
#     21:48:23.258484 trace git-lfs: filepathfilter: rewrite ".git" as "**/.git/**" (strict: false)
#     21:48:23.258505 trace git-lfs: filepathfilter: rewrite "**/.git" as "**/.git" (strict: false)
#     21:48:23.258593 trace git-lfs: filepathfilter: accepting "tmp"
#     21:48:23.261340 run-command.c:667       trace: run_command: git send-pack --stateless-rpc --helper-status --thin --no-progress http://127.0.0.1:50476/batch-upload-retry-later/ --stdin
#     21:48:23.266824 git.c:455               trace: built-in: git send-pack --stateless-rpc --helper-status --thin --no-progress http://127.0.0.1:50476/batch-upload-retry-later/ --stdin
#     21:48:23.269580 run-command.c:667       trace: run_command: git pack-objects --all-progress-implied --revs --stdout --thin --delta-base-offset -q
#     21:48:23.274333 git.c:455               trace: built-in: git pack-objects --all-progress-implied --revs --stdout --thin --delta-base-offset -q
#     To http://127.0.0.1:50476/batch-upload-retry-later
#      * [new branch]      main -> main
```

See commit messages for more details.
