### PR TITLE
Disable ANSI color codes while log parsing and anchor diff regular expressions

### DIFF
--- a/lfs/gitscanner_log.go
+++ b/lfs/gitscanner_log.go
@@ -218,8 +218,8 @@ func newLogScanner(dir LogDiffDirection, r io.Reader) *logScanner {
 		// no need to compile these regexes on every `git-lfs` call, just ones that
 		// use the scanner.
 		commitHeaderRegex:    regexp.MustCompile(fmt.Sprintf(`^lfs-commit-sha: (%s)(?: (%s))*`, git.ObjectIDRegex, git.ObjectIDRegex)),
-		fileHeaderRegex:      regexp.MustCompile(`diff --git a\/(.+?)\s+b\/(.+)`),
-		fileMergeHeaderRegex: regexp.MustCompile(`diff --cc (.+)`),
+		fileHeaderRegex:      regexp.MustCompile(`^diff --git a\/(.+?)\s+b\/(.+)`),
+		fileMergeHeaderRegex: regexp.MustCompile(`^diff --cc (.+)`),
 		pointerDataRegex:     regexp.MustCompile(`^([\+\- ])(version https://git-lfs|oid sha256|size|ext-).*$`),
 	}
 }

--- a/lfs/gitscanner_log.go
+++ b/lfs/gitscanner_log.go
@@ -31,6 +31,7 @@ var (
 	logLfsSearchArgs = []string{
 		"--no-ext-diff",
 		"--no-textconv",
+		"--color=never",
 		"-G", "oid sha256:", // only diffs which include an lfs file SHA change
 		"-p",                             // include diff so we can read the SHA
 		"-U12",                           // Make sure diff context is always big enough to support 10 extension lines to get whole pointer

--- a/t/t-fetch-recent.sh
+++ b/t/t-fetch-recent.sh
@@ -105,6 +105,9 @@ begin_test "fetch-recent commits"
   git config lfs.fetchrecentremoterefs false
   git config lfs.fetchrecentcommitsdays 7
 
+  # force color codes in git diff meta-information
+  git config color.diff always
+
   git lfs fetch --recent origin
   # that should have fetched main plus previous state needed within 7 days
   # current state

--- a/t/t-prune.sh
+++ b/t/t-prune.sh
@@ -167,6 +167,9 @@ begin_test "prune keep unpushed"
   git config lfs.fetchrecentcommitsdays 0 # only keep AT refs, no recents
   git config lfs.pruneoffsetdays 2
 
+  # force color codes in git diff meta-information
+  git config color.diff always
+
   git lfs prune
 
   # Now push main and show that older versions on main will be removed
@@ -315,6 +318,9 @@ begin_test "prune keep recent"
   git config lfs.fetchrecentremoterefs true
   git config lfs.fetchrecentcommitsdays 1
   git config lfs.pruneoffsetdays 1
+
+  # force color codes in git diff meta-information
+  git config color.diff always
 
   # push everything so that's not a reason to retain
   git push origin main:main branch_old:branch_old branch1:branch1 branch2:branch2
@@ -669,6 +675,9 @@ begin_test "prune keep stashed changes"
   assert_local_object "$oid_stashed" "${#content_stashed}"
   assert_local_object "$oid_stashedbranch" "${#content_stashedbranch}"
 
+  # force color codes in git diff meta-information
+  git config color.diff always
+
   # Prune data, should NOT delete stashed files
   git lfs prune
 
@@ -766,6 +775,9 @@ begin_test "prune keep stashed changes in index"
   assert_local_object "$oid_stashed" "${#content_stashed}"
   assert_local_object "$oid_indexstashedbranch" "${#content_indexstashedbranch}"
   assert_local_object "$oid_stashedbranch" "${#content_stashedbranch}"
+
+  # force color codes in git diff meta-information
+  git config color.diff always
 
   # Prune data, should NOT delete stashed file or stashed changes to index
   git lfs prune
@@ -883,6 +895,9 @@ begin_test "prune keep stashed untracked files"
   assert_local_object "$oid_indexstashedbranch" "${#content_indexstashedbranch}"
   assert_local_object "$oid_stashedbranch" "${#content_stashedbranch}"
   assert_local_object "$oid_untrackedstashedbranch" "${#content_untrackedstashedbranch}"
+
+  # force color codes in git diff meta-information
+  git config color.diff always
 
   # Prune data, should NOT delete stashed file or stashed changes to index
   git lfs prune


### PR DESCRIPTION
If a user has set the Git `color.diff` configuration option to `always` then commands such as `git lfs fetch --recent` and `git lfs prune` may fail because the `fileHeaderRegex` [regular expression](https://github.com/git-lfs/git-lfs/blob/314c30dfc0b54da612ea8f21d7a7f113f310bed0/lfs/gitscanner_log.go#L220) incorrectly captures ANSI escape sequences into the file paths it tries to parse from lines beginning with `diff --git`.

We first alter some existing tests of those Git LFS commands to make sure we demonstrate the problem reliably; then we add the `--color=never` option to all invocations of `git log -p`, which resolves the issue, because we never supply the `--line-prefix` option, and those are the only two possible prefixes to `diff --git` [lines](https://github.com/git/git/blob/225bc32a989d7a22fa6addafd4ce7dcd04675dbf/diff.c#L3466) and `diff -cc` [combined diff](https://github.com/git/git/blob/225bc32a989d7a22fa6addafd4ce7dcd04675dbf/combine-diff.c#L917-L919) [lines](https://github.com/git/git/blob/225bc32a989d7a22fa6addafd4ce7dcd04675dbf/combine-diff.c#L947-L948).

In addition, we can then anchor the `fileHeaderRegex` regular expression and the (seemingly presently unused) `fileMergeHeaderRegex` such that they only attempt to match lines beginning with `diff` rather than any line containing `diff --git a/(.*) b/(.*)`, which might be found in the actual (if unusual) file content.  This should improve regular expression matching performance when scanning `git log` output.