### PR TITLE
Add support for Windows ARM64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '1.17.x'
     - run: mkdir -p "$HOME/go/bin"
       shell: bash
     - run: set GOPATH=%HOME%\go
@@ -66,6 +69,11 @@ jobs:
     - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" make GOARCH=amd64 -B
       shell: bash
     - run: mv bin\git-lfs.exe git-lfs-x64.exe
+    - run: rm -f commands/mancontent_gen.go
+      shell: bash
+    - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" make GOARCH=arm64 -B
+      shell: bash
+    - run: mv bin\git-lfs.exe git-lfs-arm64.exe
     - run: iscc script\windows-installer\inno-setup-git-lfs-installer.iss
     - run: mkdir -p bin/assets
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,8 @@ jobs:
       shell: bash
     - run: PATH="$HOME/go/bin:$PATH" make bin/releases/git-lfs-windows-386-$(git describe).zip
       shell: bash
+    - run: PATH="$HOME/go/bin:$PATH" make bin/releases/git-lfs-windows-arm64-$(git describe).zip
+      shell: bash
     - run: PATH="$HOME/go/bin:/c/Program Files (x86)/Windows Kits/10/bin/x86:$PATH" CERT_FILE="$HOME/cert.pfx" make release-windows
       shell: bash
       env:

--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,8 @@ BUILD_TARGETS = \
 	bin/git-lfs-freebsd-amd64 \
 	bin/git-lfs-freebsd-386 \
 	bin/git-lfs-windows-amd64.exe \
-	bin/git-lfs-windows-386.exe
+	bin/git-lfs-windows-386.exe \
+	bin/git-lfs-windows-arm64.exe
 
 # mangen is a shorthand for ensuring that commands/mancontent_gen.go is kept
 # up-to-date with the contents of docs/man/*.ronn.
@@ -236,6 +237,8 @@ bin/git-lfs-windows-amd64.exe : resource.syso $(SOURCES) mangen
 	$(call BUILD,windows,amd64,-windows-amd64.exe)
 bin/git-lfs-windows-386.exe : resource.syso $(SOURCES) mangen
 	$(call BUILD,windows,386,-windows-386.exe)
+bin/git-lfs-windows-arm64.exe : resource.syso $(SOURCES) mangen
+	$(call BUILD,windows,arm64,-windows-arm64.exe)
 
 # .DEFAULT_GOAL sets the operating system-appropriate Git LFS binary as the
 # default output of 'make'.
@@ -291,6 +294,7 @@ RELEASE_TARGETS = \
 	bin/releases/git-lfs-freebsd-386-$(VERSION).tar.gz \
 	bin/releases/git-lfs-windows-amd64-$(VERSION).zip \
 	bin/releases/git-lfs-windows-386-$(VERSION).zip \
+	bin/releases/git-lfs-windows-arm64-$(VERSION).zip \
 	bin/releases/git-lfs-$(VERSION).tar.gz
 
 # RELEASE_INCLUDES are the names of additional files that are added to each
@@ -367,10 +371,13 @@ bin/releases/git-lfs-windows-assets-$(VERSION).tar.gz :
 	@# work properly.
 	$(MAKE) -B GOARCH=amd64 && cp ./bin/git-lfs.exe ./git-lfs-x64.exe
 	$(MAKE) -B GOARCH=386 && cp ./bin/git-lfs.exe ./git-lfs-x86.exe
+	$(MAKE) -B GOARCH=arm64 && cp ./bin/git-lfs.exe ./git-lfs-arm64.exe
 	@echo Signing git-lfs-x64.exe
 	@signtool.exe sign -debug -fd sha256 -tr http://timestamp.digicert.com -td sha256 $(CERT_ARGS) -v git-lfs-x64.exe
 	@echo Signing git-lfs-x86.exe
 	@signtool.exe sign -debug -fd sha256 -tr http://timestamp.digicert.com -td sha256 $(CERT_ARGS) -v git-lfs-x86.exe
+	@echo Signing git-lfs-arm64.exe
+	@signtool.exe sign -debug -fd sha256 -tr http://timestamp.digicert.com -td sha256 $(CERT_ARGS) -v git-lfs-arm64.exe
 	iscc.exe script/windows-installer/inno-setup-git-lfs-installer.iss
 	@# This file will be named according to the version number in the
 	@# versioninfo.json, not according to $(VERSION).
@@ -379,9 +386,10 @@ bin/releases/git-lfs-windows-assets-$(VERSION).tar.gz :
 	@signtool.exe sign -debug -fd sha256 -tr http://timestamp.digicert.com -td sha256 $(CERT_ARGS) -v git-lfs-windows.exe
 	mv git-lfs-x64.exe git-lfs-windows-amd64.exe
 	mv git-lfs-x86.exe git-lfs-windows-386.exe
+	mv git-lfs-arm64.exe git-lfs-windows-arm64.exe
 	@# We use tar because Git Bash doesn't include zip.
-	tar -czf $@ git-lfs-windows-amd64.exe git-lfs-windows-386.exe git-lfs-windows.exe
-	$(RM) git-lfs-windows-amd64.exe git-lfs-windows-386.exe git-lfs-windows.exe
+	tar -czf $@ git-lfs-windows-amd64.exe git-lfs-windows-386.exe git-lfs-windows-arm64.exe git-lfs-windows.exe
+	$(RM) git-lfs-windows-amd64.exe git-lfs-windows-386.exe git-lfs-windows-arm64.exe git-lfs-windows.exe
 
 # release-windows-rebuild takes the archive produced by release-windows and
 # incorporates the signed binaries into the existing zip archives.
@@ -391,7 +399,7 @@ release-windows-rebuild: bin/releases/git-lfs-windows-assets-$(VERSION).tar.gz
 	file="$$PWD/$^"; \
 		( \
 			tar -C "$$temp" -xzf "$$file" && \
-			for i in 386 amd64; do \
+			for i in 386 amd64 arm64; do \
 				cp "$$temp/git-lfs-windows-$$i.exe" "$$temp/git-lfs.exe" && \
 				zip -d bin/releases/git-lfs-windows-$$i-$(VERSION).zip "git-lfs-windows-$$i.exe" && \
 				zip -j -l bin/releases/git-lfs-windows-$$i-$(VERSION).zip  "$$temp/git-lfs.exe";  \

--- a/git-lfs_windows.go
+++ b/git-lfs_windows.go
@@ -1,5 +1,5 @@
-//go:build windows
-// +build windows
+//go:build windows && !arm64
+// +build windows,!arm64
 
 //go:generate goversioninfo
 

--- a/git-lfs_windows_arm64.go
+++ b/git-lfs_windows_arm64.go
@@ -1,0 +1,6 @@
+//go:build windows && arm64
+// +build windows,arm64
+
+//go:generate goversioninfo -arm=true
+
+package main

--- a/script/windows-installer/inno-setup-git-lfs-installer.iss
+++ b/script/windows-installer/inno-setup-git-lfs-installer.iss
@@ -10,6 +10,11 @@
   #pragma error PathToX64Binary + " does not exist, please build it first."
 #endif
 
+#define PathToARM64Binary "..\..\git-lfs-arm64.exe"
+#ifnexist PathToARM64Binary
+  #pragma error PathToARM6464Binary + " does not exist, please build it first."
+#endif
+
 ; Arbitrarily choose the x86 executable here as both have the version embedded.
 #define MyVersionInfoVersion GetFileVersion(PathToX86Binary)
 
@@ -32,7 +37,7 @@ AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}
 AppUpdatesURL={#MyAppURL}
 AppVersion={#MyAppVersion}
-ArchitecturesInstallIn64BitMode=x64
+ArchitecturesInstallIn64BitMode=x64 arm64
 ChangesEnvironment=yes
 Compression=lzma
 DefaultDirName={code:GetDefaultDirName}
@@ -59,8 +64,9 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Filename: "{code:GetExistingGitInstallation}\git-lfs-uninstaller.exe"; Parameters: "/S"; Flags: skipifdoesntexist
 
 [Files]
-Source: {#PathToX86Binary}; DestDir: "{app}"; Flags: ignoreversion; DestName: "git-lfs.exe"; AfterInstall: InstallGitLFS; Check: not Is64BitInstallMode
-Source: {#PathToX64Binary}; DestDir: "{app}"; Flags: ignoreversion; DestName: "git-lfs.exe"; AfterInstall: InstallGitLFS; Check: Is64BitInstallMode
+Source: {#PathToX86Binary}; DestDir: "{app}"; Flags: ignoreversion; DestName: "git-lfs.exe"; AfterInstall: InstallGitLFS; Check: IsX86
+Source: {#PathToX64Binary}; DestDir: "{app}"; Flags: ignoreversion; DestName: "git-lfs.exe"; AfterInstall: InstallGitLFS; Check: IsX64
+Source: {#PathToARM64Binary}; DestDir: "{app}"; Flags: ignoreversion; DestName: "git-lfs.exe"; AfterInstall: InstallGitLFS; Check: IsARM64
 
 [Registry]
 Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; ValueType: expandsz; ValueName: "Path"; ValueData: "{olddata};{app}"; Check: IsAdminLoggedOn and NeedsAddPath('{app}')
@@ -99,8 +105,10 @@ begin
       if not (Pos('Git\cmd', ExtractFilePath(ExecStdOut)) = 0) then begin
         // Proxy Git path detected
         Result := ExpandConstant('{pf}');
-      if Is64BitInstallMode then
+      if IsX64 then
         Result := Result + '\Git\mingw64\bin'
+      else if IsARM64 then
+        Result := Result + '\Git\arm64\bin'
       else
         Result := Result + '\Git\mingw32\bin';
       end else begin


### PR DESCRIPTION
Follow-up PR on #4584

Go 1.17 added support for the Windows ARM64 build target. This PR adds that support to Git LFS, including the required CI + installer logic.

The installer correctly recognizes ARM64 and writes to the `Program Files` folder (not `Program Files (x86)`):

![image](https://user-images.githubusercontent.com/17739158/129964671-5a96f7f3-ad15-4fa8-93da-dfdc64a34db4.png)

The installed executable is native ARM64 indeed:

![image](https://user-images.githubusercontent.com/17739158/129964727-fddcb7b6-8ddf-4889-9ebf-c8363c034e94.png)

```
PS C:\Program Files\Git LFS> .\git-lfs
git-lfs/2.13.0 (GitHub; windows arm64; go 1.17)
```