### PR TITLE
Switch from which to command -v

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -518,7 +518,7 @@ vendor : go.mod
 # still performs the linting sequence, but gracefully skips over running a
 # non-existent command.
 .PHONY : fmt
-ifeq ($(shell test -x "`which $(GOIMPORTS)`"; echo $$?),0)
+ifeq ($(shell test -x "`command -v $(GOIMPORTS)`"; echo $$?),0)
 fmt : $(SOURCES) | lint
 	@$(GOIMPORTS) $(GOIMPORTS_EXTRA_OPTS) $?;
 else

--- a/docker/gpg-agent_start.bsh
+++ b/docker/gpg-agent_start.bsh
@@ -8,7 +8,7 @@ CUR_DIR=$(dirname ${BASH_SOURCE[0]})
 IMAGE_NAME=andyneff/gpg_agent
 CONTAINER_NAME=git-lfs-gpg
 
-: ${SUDO=`if ( [ ! -w /var/run/docker.sock ] && id -nG | grep -qwv docker && [ "${DOCKER_HOST:+dh}" != "dh" ] ) && which sudo > /dev/null 2>&1; then echo sudo; fi`}
+: ${SUDO=`if ( [ ! -w /var/run/docker.sock ] && id -nG | grep -qwv docker && [ "${DOCKER_HOST:+dh}" != "dh" ] ) && command -v sudo > /dev/null 2>&1; then echo sudo; fi`}
 
 if [ "$(docker inspect -f {{.State.Running}} ${CONTAINER_NAME})" != "true" ]; then
   OTHER_OPTIONS=("-e" "GPG_DEFAULT_CACHE=${GPG_DEFAULT_CACHE:-31536000}")

--- a/docker/run_dockers.bsh
+++ b/docker/run_dockers.bsh
@@ -30,7 +30,7 @@ mkdir -p ${PACKAGE_DIR}/centos || :
 mkdir -p ${PACKAGE_DIR}/debian || :
 
 #If you are not in docker group and you have sudo, default value is sudo
-: ${SUDO=`if ( [ ! -w /var/run/docker.sock ] && id -nG | grep -qwv docker && [ "${DOCKER_HOST:+dh}" != "dh" ] ) && which sudo > /dev/null 2>&1; then echo sudo; fi`}
+: ${SUDO=`if ( [ ! -w /var/run/docker.sock ] && id -nG | grep -qwv docker && [ "${DOCKER_HOST:+dh}" != "dh" ] ) && command -v sudo > /dev/null 2>&1; then echo sudo; fi`}
 
 function split_image_name()
 { #$1 - image dockerfile

--- a/rpm/build_rpms.bsh
+++ b/rpm/build_rpms.bsh
@@ -36,13 +36,13 @@ if [[ ${NODEPS:-0} != 0 ]]; then
   RPMBUILD=("${RPMBUILD[@]}" --nodeps)
 fi
 
-SUDO=${SUDO=`if which sudo > /dev/null 2>&1; then echo sudo; fi`}
+SUDO=${SUDO=`if command -v sudo > /dev/null 2>&1; then echo sudo; fi`}
 export PATH=${PATH}:/usr/local/bin
 
 set -vx
 
 echo "Downloading/checking for some essentials..."
-if which git > /dev/null 2>&1; then
+if command -v git > /dev/null 2>&1; then
   GIT_VERSION=($(git --version))
   IFS_OLD=${IFS}
   IFS=.
@@ -59,7 +59,7 @@ if [[ ${VERSION_ID[0]} == 5 ]]; then
     $SUDO yum install -y epel-release
   fi
 fi
-$SUDO yum install -y make curl which rpm-build tar bison perl-Digest-SHA
+$SUDO yum install -y make curl rpm-build tar bison perl-Digest-SHA
 
 mkdir -p ${CURDIR}/{BUILD,BUILDROOT,SOURCES,RPMS,SRPMS}
 
@@ -72,7 +72,7 @@ if ( [[ ${GIT_VERSION[0]} == 1 ]] && [[ ${GIT_VERSION[1]} < 8 ]] ) || [[ ${GIT_V
   fi
 fi
 
-if ! which go; then
+if ! command -v go; then
   echo "Installing go... one way or another"
   if [[ ${VERSION_ID[0]} == 5 ]]; then
     $SUDO yum install -y curl.x86_64 glibc gcc
@@ -89,7 +89,7 @@ if ! which go; then
   fi
 fi
 
-if which ruby > /dev/null 2>&1; then
+if command -v ruby > /dev/null 2>&1; then
   IFS_OLD=${IFS}
   IFS=.
   RUBY_VERSION=($(ruby -e "print RUBY_VERSION"))
@@ -124,7 +124,7 @@ if [[ ${VERSION_ID[0]} == 8 ]]; then
   $SUDO yum install -y rubygems-devel
 fi
 
-if ! which ronn; then
+if ! command -v ronn; then
   echo "Downloading some ruby gems..."
   pushd ${CURDIR}/SOURCES
     curl -L -O https://rubygems.org/downloads/rdiscount-2.1.8.gem

--- a/t/testhelpers.sh
+++ b/t/testhelpers.sh
@@ -559,7 +559,7 @@ setup() {
     mkdir "$REMOTEDIR"
   fi
 
-  echo "# Git LFS: ${LFS_BIN:-$(which git-lfs)}"
+  echo "# Git LFS: ${LFS_BIN:-$(command -v git-lfs)}"
   git lfs version | sed -e 's/^/# /g'
   git version | sed -e 's/^/# /g'
 


### PR DESCRIPTION
Debian has recently deprecated the which utility and will remove it in a future version, since POSIX specifies `command -v` for finding the location of a path and has for some time.  In addition, which has started complaining loudly to standard error, so it causes test and makefile output to be hard to read.

Let's switch to the preferred invocation, `command -v`, in the Makefile, build tooling, and test suite.
