### PR TITLE
Add support for Debian 11

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -14,7 +14,7 @@ else ifeq ($(DEB_HOST_ARCH), arm64)
 endif
 
 BUILD_DIR := obj-$(DEB_HOST_GNU_TYPE)
-export DH_GOPKG := github.com/git-lfs/git-lfs
+export DH_GOPKG := github.com/git-lfs/git-lfs/v2
 # DH_GOLANG_EXCLUDES typically incorporates vendor exclusions
 export DH_GOLANG_EXCLUDES := test github.com/olekukonko/ts/* github.com/xeipuuv/* github.com/spf13/cobra/* github.com/kr/* github.com/pkg/errors github.com/alexbrainman/sspi/*
 export DH_GOLANG_GO_GENERATE := 1
@@ -56,8 +56,8 @@ override_dh_auto_install:
 	cp $(BUILD_DIR)/bin/git-lfs debian/git-lfs/usr/bin/
 
 override_dh_auto_test:
-	ln -s ../../../../../../commands/repos $(BUILD_DIR)/src/github.com/git-lfs/git-lfs/commands/repos
-	ln -s ../../../../bin $(BUILD_DIR)/src/github.com/git-lfs/git-lfs/bin
+	ln -s ../../../../../../../commands/repos $(BUILD_DIR)/src/github.com/git-lfs/git-lfs/v2/commands/repos
+	ln -s ../../../../../bin $(BUILD_DIR)/src/github.com/git-lfs/git-lfs/v2/bin
 	#dh_golang uses the wrong dir to test on. This tricks everything into being happy
 	DEB_BUILD_GNU_TYPE=$(DEB_HOST_GNU_TYPE) dh_auto_test
-	rm $(BUILD_DIR)/src/github.com/git-lfs/git-lfs/commands/repos $(BUILD_DIR)/src/github.com/git-lfs/git-lfs/bin
+	rm $(BUILD_DIR)/src/github.com/git-lfs/git-lfs/v2/commands/repos $(BUILD_DIR)/src/github.com/git-lfs/git-lfs/v2/bin

--- a/docker/run_dockers.bsh
+++ b/docker/run_dockers.bsh
@@ -58,7 +58,7 @@ done
 
 if [[ ${#IMAGES[@]} == 0 ]]; then
   # If you change this list, change script/upload as well.
-  IMAGES=(centos_7 centos_8 debian_9 debian_10)
+  IMAGES=(centos_7 centos_8 debian_9 debian_10 debian_11)
 fi
 
 mkdir -p "${PACKAGE_DIR}"

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -62,13 +62,15 @@ $distro_name_map = {
     "ubuntu/bionic",    # ESM April 2028
   ],
   "debian/10" => [
-    "debian/buster",    # Current
+    "debian/buster",
     "linuxmint/ulyana", # EOL April 2025
     "linuxmint/ulyssa", # EOL April 2025
     "ubuntu/focal",     # EOL April 2025
     "ubuntu/groovy",    # EOL July 2021
     "ubuntu/hirsute",   # EOL January 2022
     "ubuntu/impish",    # Current
+  ],
+  "debian/11" => [
   ]
 }
 
@@ -115,6 +117,7 @@ package_files.each do |full_path|
   when /debian\/8/  then ["Debian 8",  "debian/jessie"]
   when /debian\/9/  then ["Debian 9",  "debian/stretch"]
   when /debian\/10/ then ["Debian 10", "debian/buster"]
+  when /debian\/11/ then ["Debian 11", "debian/bullseye"]
   when /centos\/5/  then ["RPM RHEL 5/CentOS 5", "el/5"]
   when /centos\/6/  then ["RPM RHEL 6/CentOS 6", "el/6"]
   when /centos\/7/  then ["RPM RHEL 7/CentOS 7", "el/7"]

--- a/script/upload
+++ b/script/upload
@@ -193,6 +193,7 @@ Up to date packages are available on [PackageCloud](https://packagecloud.io/gith
 [RPM RHEL 8/CentOS 8](https://packagecloud.io/github/git-lfs/packages/el/8/git-lfs-VERSION-1.el8.x86_64.rpm/download)
 [Debian 9](https://packagecloud.io/github/git-lfs/packages/debian/stretch/git-lfs_VERSION_amd64.deb/download)
 [Debian 10](https://packagecloud.io/github/git-lfs/packages/debian/buster/git-lfs_VERSION_amd64.deb/download)
+[Debian 11](https://packagecloud.io/github/git-lfs/packages/debian/bullseye/git-lfs_VERSION_amd64.deb/download)
 
 ## SHA-256 hashes:
 EOM


### PR DESCRIPTION
Debian 11, bullseye, has been released on August 14, 2021.  Add support for it when building Linux packages.

Fixes #4589