### PR TITLE
urlconfig: anchor regexp for key matching

### DIFF
--- a/config/url_config.go
+++ b/config/url_config.go
@@ -71,7 +71,7 @@ func (c *URLConfig) getAll(prefix, rawurl, key string) []string {
 
 	config := c.git.All()
 
-	re := regexp.MustCompile(fmt.Sprintf(`%s.(\S+).%s`, prefix, key))
+	re := regexp.MustCompile(fmt.Sprintf(`\A%s\.(\S+)\.%s\z`, prefix, key))
 
 	bestMatch := urlMatch{
 		key:       "",

--- a/config/url_config_test.go
+++ b/config/url_config_test.go
@@ -21,6 +21,7 @@ func TestURLConfig(t *testing.T) {
 		"http.https://host.com:443/repo3.git.key": []string{"port"},
 		"http.ssh://host.com:22/repo3.git.key":    []string{"ssh-port"},
 		"http.https://host.*/a.key":               []string{"wild"},
+		"httpXhttps://host.*/aXkey":               []string{"invalid"},
 	})))
 
 	getOne := map[string]string{
@@ -51,6 +52,11 @@ func TestURLConfig(t *testing.T) {
 		value, _ := u.Get("http", rawurl, "key")
 		assert.Equal(t, expected, value, "get one: "+rawurl)
 	}
+
+	value, _ := u.Get("http", "https://host.wild/a/b/c", "k")
+	assert.Equal(t, value, "")
+	value, _ = u.Get("ttp", "https://host.wild/a/b/c", "key")
+	assert.Equal(t, value, "")
 
 	getAll := map[string][]string{
 		"https://root.com/a/b/c":           []string{"root", "root-2"},


### PR DESCRIPTION
Currently, we don't anchor the regexp for matching keys.  That means that if we have a value of http.URL.sslCert and http.URL.sslCertPasswordProtected, the latter can be read when when looking up the former.  To avoid that, let's anchor the regexp properly against the key at the beginning and end.

Fixes #4597