### PR TITLE
subprocess: don't treat empty PATH component as . on Windows

### DIFF
--- a/subprocess/path.go
+++ b/subprocess/path.go
@@ -32,6 +32,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -52,6 +53,11 @@ func LookPath(file string) (string, error) {
 	path := os.Getenv("PATH")
 	for _, dir := range filepath.SplitList(path) {
 		if dir == "" {
+			// Windows often has empty components in the PATH and
+			// treating them as "." is not expected.
+			if runtime.GOOS == "windows" {
+				continue
+			}
 			// Unix shell semantics: path element "" means "."
 			dir = "."
 		}


### PR DESCRIPTION
It's common for Windows machines to have trailing empty PATH components and users there don't expect that to mean "." like it does on Unix.  To avoid unexpected behavior and somewhat improve security, treat the empty PATH component differently on Windows.
