### PR TITLE
corrected debian 11 & 12  derived variants

### DIFF
--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -71,6 +71,7 @@ $distro_name_map = {
   ],
   "debian/11" => [
     "debian/bullseye",  # Current stable
+    "debian/bookworm", # Current testing
   ]
 }
 

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -70,10 +70,7 @@ $distro_name_map = {
     "ubuntu/hirsute",   # EOL January 2022
   ],
   "debian/11" => [
-    "debian/bullseye",  # Current
-  ],
-  "debian/12" => [
-   "debian/bookworm",  # Current
+    "debian/bullseye",  # Current stable
   ]
 }
 

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -70,7 +70,10 @@ $distro_name_map = {
     "ubuntu/hirsute",   # EOL January 2022
   ],
   "debian/11" => [
-    "debian/bookworm",  # Current
+    "debian/bullseye",  # Current
+  ],
+  "debian/12" => [
+   "debian/bookworm",  # Current
   ]
 }
 


### PR DESCRIPTION
corrected debian 11 & 12  derived variants - bullseye (debian 11) and bookworm (debian 12) - for the packagecloud deployment

debian versions synced with the list on the [packagecloud](https://packagecloud.io/docs#anchor-debian)