### PR TITLE
Advertise hash algorithm supported in batch request

### DIFF
--- a/docs/api/batch.md
+++ b/docs/api/batch.md
@@ -36,6 +36,8 @@ be assumed by the server.
 * `objects` - An Array of objects to download.
   * `oid` - String OID of the LFS object.
   * `size` - Integer byte size of the LFS object. Must be at least zero.
+* `hash_algo` - The hash algorithm used to name Git LFS objects.  Optional;
+  defaults to `sha256` if not specified.
 
 Note: Git LFS currently only supports the `basic` transfer adapter. This
 property was added for future compatibility with some experimental transfer
@@ -56,7 +58,8 @@ transfer adapters.
       "oid": "12345678",
       "size": 123
     }
-  ]
+  ],
+  "hash_algo": "sha256"
 }
 ```
 
@@ -148,6 +151,8 @@ omitted.
     * `expires_at` - String uppercase RFC 3339-formatted timestamp with second
       precision for when the given action expires (usually due to a temporary
       token).
+* `hash_algo` - The hash algorithm used to name Git LFS objects for this
+  repository.  Optional; defaults to `sha256` if not specified.
 
 Download operations MUST specify a `download` action, or an object error if the
 object cannot be downloaded for some reason. See "Response Errors" below.
@@ -179,7 +184,8 @@ completely. The client will then assume the server already has it.
         }
       }
     }
-  ]
+  ],
+  "hash_algo": "sha256"
 }
 ```
 
@@ -200,13 +206,15 @@ return a 200 status code, and provide per-object errors. Here is an example:
         "message": "Object does not exist"
       }
     }
-  ]
+  ],
+  "hash_algo": "sha256"
 }
 ```
 
 LFS object error codes should match HTTP status codes where possible:
 
 * 404 - The object does not exist on the server.
+* 409 - The specified hash algorithm disagrees with the server's acceptable options.
 * 410 - The object was removed by the owner.
 * 422 - Validation error.
 

--- a/docs/proposals/ssh_adapter.md
+++ b/docs/proposals/ssh_adapter.md
@@ -132,7 +132,8 @@ size = 1*DIGIT
 
 The `transfer` argument is equivalent to the corresponding value in the HTTP
 JSON API.  The `refname` argument is equivalent to the `name` argument of the
-`ref` object in the HTTP JSON API.
+`ref` object in the HTTP JSON API.  The `hash-algo` argument is equivalent to
+the `hash_algo` argument in the HTTP JSON API.
 
 Unknown arguments should be ignored, as should unknown key-value pairs in the
 `oid-line` production.
@@ -164,6 +165,9 @@ another string, `token`, which is an opaque identifier relevant only to the
 server to help it manage authentication.  These strings must meet the syntax for
 the `value` production above; if arbitrary bytes are needed, Base64 encoding is
 recommended.
+
+The `hash-algo` argument has the same meaning as the `hash_algo` field in the
+HTTP JSON API.
 
 The `expires-in` and `expires-at` key-value pairs have the same meaning as their
 corresponding items from the HTTP JSON API.

--- a/tq/api.go
+++ b/tq/api.go
@@ -1,6 +1,7 @@
 package tq
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/git-lfs/git-lfs/v3/errors"
@@ -24,11 +25,13 @@ type batchRequest struct {
 	Objects              []*Transfer `json:"objects"`
 	TransferAdapterNames []string    `json:"transfers,omitempty"`
 	Ref                  *batchRef   `json:"ref"`
+	HashAlgorithm        string      `json:"hash_algo"`
 }
 
 type BatchResponse struct {
 	Objects             []*Transfer `json:"objects"`
 	TransferAdapterName string      `json:"transfer"`
+	HashAlgorithm       string      `json:"hash_algo"`
 	endpoint            lfshttp.Endpoint
 }
 
@@ -42,6 +45,7 @@ func Batch(m *Manifest, dir Direction, remote string, remoteRef *git.Ref, object
 		Objects:              objects,
 		TransferAdapterNames: m.GetAdapterNames(dir),
 		Ref:                  &batchRef{Name: remoteRef.Refspec()},
+		HashAlgorithm:        "sha256",
 	})
 }
 
@@ -93,6 +97,10 @@ func (c *tqClient) Batch(remote string, bReq *batchRequest) (*BatchResponse, err
 
 	if err := lfshttp.DecodeJSON(res, bRes); err != nil {
 		return bRes, errors.Wrap(err, "batch response")
+	}
+
+	if bRes.HashAlgorithm != "" && bRes.HashAlgorithm != "sha256" {
+		return bRes, errors.Wrap(fmt.Errorf("unsupported hash algorithm"), "batch response")
 	}
 
 	if res.StatusCode != 200 {

--- a/tq/api_test.go
+++ b/tq/api_test.go
@@ -28,7 +28,7 @@ func TestAPIBatch(t *testing.T) {
 		}
 
 		assert.Equal(t, "POST", r.Method)
-		assert.Equal(t, "91", r.Header.Get("Content-Length"))
+		assert.Equal(t, "106", r.Header.Get("Content-Length"))
 
 		bodyLoader, body := gojsonschema.NewReaderLoader(r.Body)
 		bReq := &batchRequest{}


### PR DESCRIPTION
To future-proof ourselves against the need to change hash algorithms in the future, let's advertise the hash algorithm to the remote side.  If the value is not `sha256` or absent (which is treated as the same thing), we fail.