### PR TITLE
Fix bound for largefilewarning

### DIFF
--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -178,7 +178,7 @@ func smudgeFilename(args []string) string {
 }
 
 func possiblyMalformedObjectSize(n int64) bool {
-	return n > 4*humanize.Gigabyte
+	return n >= 4*humanize.Gibibyte
 }
 
 func init() {


### PR DESCRIPTION
**Short:** The bound was `> 4GB` when it should be `≥ 4GiB`.

**Long:** It is documented in the git-lfs manpages that the largefilewarning should be triggered for files “4GiB or larger” but the code triggered the warning for files “strictly larger than 4GB”. Thus, the warning triggered more often than it should. This is, of course, assuming that the documentation is correct and the code incorrect and not vice versa. This, however, seems to be the case when reading up on the underlying problem, e.g. [in this e-mail thread](https://public-inbox.org/git/93ccf86d-0090-a311-9825-7e23fd6a4141@web.de/t/).

(Yes, I have enough files between 4GB and 4GiB that I was sufficiently annoyed to create this PR.)