### PR TITLE
githistory/rewriter: Add path to rewrite Tree cache key

### DIFF
--- a/t/fixtures/migrate.sh
+++ b/t/fixtures/migrate.sh
@@ -652,6 +652,28 @@ setup_local_branch_with_dirty_copy() {
   printf "2" >> a.txt
 }
 
+# setup_local_branch_with_copied_file creates a repository as follows:
+#
+#   A
+#    \
+#     refs/heads/main
+#
+# - Commit 'A' has the contents "a.txt" in a.txt, and anoter identical file
+# (same name and content) in another directory.
+setup_local_branch_with_copied_file() {
+  set -e
+
+  reponame="migrate-single-local-branch-with-copied-file"
+  remove_and_create_local_repo "$reponame"
+
+  printf "a.txt" > a.txt
+  mkdir dir
+  cp a.txt dir/
+
+  git add a.txt dir/a.txt
+  git commit -m "initial commit"
+}
+
 # make_bare converts the existing full checkout of a repository into a bare one,
 # and then `cd`'s into it.
 make_bare() {

--- a/t/t-migrate-import.sh
+++ b/t/t-migrate-import.sh
@@ -1001,3 +1001,18 @@ begin_test "migrate import (non-standard refs)"
   assert_local_object "$md_feature_oid" "30"
 )
 end_test
+
+begin_test "migrate import (copied file)"
+(
+  set -e
+
+  setup_local_branch_with_copied_file
+
+  git lfs migrate import --above=1b
+
+  # Expect attributes for "/dir/a" and "/a"
+  if ! grep -q "^/dir/a.txt" ./.gitattributes || ! grep -q "^/a.txt" ./.gitattributes; then
+    exit 1
+  fi
+)
+end_test


### PR DESCRIPTION
Duplicated files (same name & content) were pulled from the rewriteTree cache.
In this case, .gitattribute files was not appended but files were
changed to a pointer anyway.

With this, duplicated files are not pulled from cache (as long as their
full path is different) and .gitattribute patterns match files changed
to a pointer.

This PR also adds a test case.

Fixes #4628


