### PR TITLE
Stop supporting Go older than 1.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     name: Build with specific Go
     strategy:
       matrix:
-        go: ['1.11.x', '1.12.x', '1.13.x', '1.14.x']
+        go: ['1.13.x', '1.14.x']
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
When using Go 1.12, we need to download some of the HTTP/2 code as part of the build process.  However, that code uses the Go 1.13 errors package and expects errors.Is to work, which it does not.  Since this isn't really practically avoidable and Go upstream is not going to care about getting those older Go versions to work, let's drop support for Go before 1.13.

Note that we only guarantee compatibility with the latest Go version, so this doesn't violate our support policy.

I'm not including newer versions of Go because they are extremely picky about the build process and things are currently broken on at least 1.16, and my goal here is to unbreak the build system as quickly as possible.
