### PR TITLE
Fix Windows arm64 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,11 +34,11 @@ jobs:
       shell: bash
       env:
         CERT_CONTENTS: ${{secrets.WINDOWS_CERT_BASE64}}
-    - run: PATH="$HOME/go/bin:$PATH" make bin/releases/git-lfs-windows-amd64-$(git describe).zip
+    - run: PATH="$HOME/go/bin:$PATH" GOARCH=amd64 go generate && make bin/releases/git-lfs-windows-amd64-$(git describe).zip
       shell: bash
-    - run: PATH="$HOME/go/bin:$PATH" make bin/releases/git-lfs-windows-386-$(git describe).zip
+    - run: PATH="$HOME/go/bin:$PATH" GOARCH=386 go generate && make bin/releases/git-lfs-windows-386-$(git describe).zip
       shell: bash
-    - run: PATH="$HOME/go/bin:$PATH" make bin/releases/git-lfs-windows-arm64-$(git describe).zip
+    - run: PATH="$HOME/go/bin:$PATH" GOARCH=arm64 go generate && make bin/releases/git-lfs-windows-arm64-$(git describe).zip
       shell: bash
     - run: PATH="$HOME/go/bin:/c/Program Files (x86)/Windows Kits/10/bin/x86:$PATH" CERT_FILE="$HOME/cert.pfx" make release-windows
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ jobs:
     - run: cinst strawberryperl -y
     - run: cinst zip -y
     - run: cinst jq -y
-    - run: cinst windows-sdk-10.0 -y
     - run: gem install ronn
     - run: refreshenv
     - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" go get github.com/josephspurrier/goversioninfo/cmd/goversioninfo

--- a/git-lfs_windows_arm64.go
+++ b/git-lfs_windows_arm64.go
@@ -1,6 +1,6 @@
 //go:build windows && arm64
 // +build windows,arm64
 
-//go:generate goversioninfo -arm=true
+//go:generate goversioninfo -arm=true -64=true
 
 package main

--- a/script/windows-installer/inno-setup-git-lfs-installer.iss
+++ b/script/windows-installer/inno-setup-git-lfs-installer.iss
@@ -12,7 +12,7 @@
 
 #define PathToARM64Binary "..\..\git-lfs-arm64.exe"
 #ifnexist PathToARM64Binary
-  #pragma error PathToARM6464Binary + " does not exist, please build it first."
+  #pragma error PathToARM64Binary + " does not exist, please build it first."
 #endif
 
 ; Arbitrarily choose the x86 executable here as both have the version embedded.


### PR DESCRIPTION
Fixes #4642

This PR does the following:
- Fix Windows arm64 build as reported in https://github.com/git-lfs/git-lfs/issues/4642. The problem was that `go generate` didn't have a GOARCH set, so it used the host architecture (amd64) to build `resource.syso`. That in turn caused the `unknown ARM64 relocation type 7` error. Also, once the `resource.syso` file was generated, GNU Make wouldn't update it for other architectures as it can't recognize if GOARCH has changed.
- Build arm64 `resource.syso` instead of arm (32-bit). While 32-bit arm does work on arm64, Git LFS only supports arm64, so we can safely go with that one.
- Fix small typo in InnoSetup configuration from my previous PR (https://github.com/git-lfs/git-lfs/pull/4586)
- Don't install `windows-sdk-10.0` in the CI release process as [it unnecessarily adds 3 mins to the job](https://github.com/dennisameling/git-lfs/runs/3709739120?check_suite_focus=true). GitHub Actions [already includes several Windows 10 SDK versions out of the box](https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md#workloads-components-and-extensions).

Example release pipeline which succeeded on Windows: https://github.com/dennisameling/git-lfs/runs/3709768442?check_suite_focus=true - ~I don't have my macOS code signing cert at hand currently, so that job obviously failed 😊~