### PR TITLE
release: v3.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     name: Build with specific Go
     strategy:
       matrix:
-        go: ['1.11.x', '1.12.x', '1.13.x', '1.14.x']
+        go: ['1.13.x', '1.14.x']
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ jobs:
     - run: cinst strawberryperl -y
     - run: cinst zip -y
     - run: cinst jq -y
-    - run: cinst windows-sdk-10.0 -y
     - run: gem install ronn
     - run: refreshenv
     - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" go get github.com/josephspurrier/goversioninfo/cmd/goversioninfo
@@ -34,11 +33,11 @@ jobs:
       shell: bash
       env:
         CERT_CONTENTS: ${{secrets.WINDOWS_CERT_BASE64}}
-    - run: PATH="$HOME/go/bin:$PATH" make bin/releases/git-lfs-windows-amd64-$(git describe).zip
+    - run: PATH="$HOME/go/bin:$PATH" GOARCH=amd64 go generate && make bin/releases/git-lfs-windows-amd64-$(git describe).zip
       shell: bash
-    - run: PATH="$HOME/go/bin:$PATH" make bin/releases/git-lfs-windows-386-$(git describe).zip
+    - run: PATH="$HOME/go/bin:$PATH" GOARCH=386 go generate && make bin/releases/git-lfs-windows-386-$(git describe).zip
       shell: bash
-    - run: PATH="$HOME/go/bin:$PATH" make bin/releases/git-lfs-windows-arm64-$(git describe).zip
+    - run: PATH="$HOME/go/bin:$PATH" GOARCH=arm64 go generate && make bin/releases/git-lfs-windows-arm64-$(git describe).zip
       shell: bash
     - run: PATH="$HOME/go/bin:/c/Program Files (x86)/Windows Kits/10/bin/x86:$PATH" CERT_FILE="$HOME/cert.pfx" make release-windows
       shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Git LFS Changelog
 
+## 3.0.1 (28 Sep 2021)
+
+This release is a bugfix release which fixes the Windows ARM64 build process and
+addresses a regression in support for empty files in pull and fetch.
+
+We would like to extend a special thanks to the following open-source
+contributors:
+
+* @dennisameling for fixing support for Windows on ARM64
+
+### Bugs
+
+* Fix Windows arm64 release #4647 (@dennisameling)
+* fs: specify a file as existing if it's empty #4654 (@bk2204)
+
 ## 3.0.0 (24 Sep 2021)
 
 This release is a major new release and introduces several new features, such as

--- a/commands/command_dedup.go
+++ b/commands/command_dedup.go
@@ -112,6 +112,10 @@ func dedup(p *lfs.WrappedPointer) (success bool, err error) {
 
 	// Do clone
 	srcFile := cfg.Filesystem().ObjectPathname(p.Oid)
+	if srcFile == os.DevNull {
+		return true, nil
+	}
+
 	dstFile := filepath.Join(cfg.LocalWorkingDir(), p.Name)
 
 	// Clone the file. This overwrites the destination if it exists.

--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -107,7 +107,11 @@ func fsckCommand(cmd *cobra.Command, args []string) {
 
 	for _, oid := range corruptOids {
 		badFile := filepath.Join(badDir, oid)
-		if err := os.Rename(cfg.Filesystem().ObjectPathname(oid), badFile); err != nil {
+		srcFile := cfg.Filesystem().ObjectPathname(oid)
+		if srcFile == os.DevNull {
+			continue
+		}
+		if err := os.Rename(srcFile, badFile); err != nil {
 			ExitWithError(err)
 		}
 	}

--- a/commands/command_prune.go
+++ b/commands/command_prune.go
@@ -307,6 +307,9 @@ func pruneDeleteFiles(prunableObjects []string, logger *tasklog.Logger) {
 			problems.WriteString(fmt.Sprintf("Unable to find media path for %v: %v\n", oid, err))
 			continue
 		}
+		if mediaFile == os.DevNull {
+			continue
+		}
 		err = os.Remove(mediaFile)
 		if err != nil {
 			problems.WriteString(fmt.Sprintf("Failed to remove file %v: %v\n", mediaFile, err))

--- a/config/version.go
+++ b/config/version.go
@@ -13,7 +13,7 @@ var (
 )
 
 const (
-	Version = "3.0.0"
+	Version = "3.0.1"
 )
 
 func init() {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+git-lfs (3.0.1) stable; urgency=low
+
+  * New upstream version
+
+ -- brian m. carlson <bk2204@github.com>  Tue, 28 Sep 2021 14:29:00 -0000
+
 git-lfs (3.0.0) stable; urgency=low
 
   * New upstream version

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -3,6 +3,8 @@ package fs
 import (
 	"bufio"
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -16,7 +18,10 @@ import (
 	"github.com/rubyist/tracerx"
 )
 
-var oidRE = regexp.MustCompile(`\A[[:alnum:]]{64}`)
+var (
+	oidRE             = regexp.MustCompile(`\A[[:alnum:]]{64}`)
+	EmptyObjectSHA256 = hex.EncodeToString(sha256.New().Sum(nil))
+)
 
 // Environment is a copy of a subset of the interface
 // github.com/git-lfs/git-lfs/config.Environment.
@@ -61,12 +66,18 @@ func (f *Filesystem) EachObject(fn func(Object) error) error {
 }
 
 func (f *Filesystem) ObjectExists(oid string, size int64) bool {
+	if size == 0 {
+		return true
+	}
 	return tools.FileExistsOfSize(f.ObjectPathname(oid), size)
 }
 
 func (f *Filesystem) ObjectPath(oid string) (string, error) {
 	if len(oid) < 4 {
 		return "", fmt.Errorf("too short object ID: %q", oid)
+	}
+	if oid == EmptyObjectSHA256 {
+		return os.DevNull, nil
 	}
 	dir := f.localObjectDir(oid)
 	if err := tools.MkdirAll(dir, f); err != nil {
@@ -76,6 +87,9 @@ func (f *Filesystem) ObjectPath(oid string) (string, error) {
 }
 
 func (f *Filesystem) ObjectPathname(oid string) string {
+	if oid == EmptyObjectSHA256 {
+		return os.DevNull
+	}
 	return filepath.Join(f.localObjectDir(oid), oid)
 }
 

--- a/git-lfs_windows_arm64.go
+++ b/git-lfs_windows_arm64.go
@@ -1,6 +1,6 @@
 //go:build windows && arm64
 // +build windows,arm64
 
-//go:generate goversioninfo -arm=true
+//go:generate goversioninfo -arm=true -64=true
 
 package main

--- a/lfs/pointer.go
+++ b/lfs/pointer.go
@@ -3,8 +3,6 @@ package lfs
 import (
 	"bufio"
 	"bytes"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
@@ -14,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/git-lfs/git-lfs/v3/errors"
+	"github.com/git-lfs/git-lfs/v3/fs"
 	"github.com/git-lfs/gitobj/v2"
 )
 
@@ -82,8 +81,7 @@ func (p *Pointer) Encoded() string {
 }
 
 func EmptyPointer() *Pointer {
-	oid := hex.EncodeToString(sha256.New().Sum(nil))
-	return NewPointer(oid, 0, nil)
+	return NewPointer(fs.EmptyObjectSHA256, 0, nil)
 }
 
 func EncodePointer(writer io.Writer, pointer *Pointer) (int, error) {

--- a/rpm/SPECS/git-lfs.spec
+++ b/rpm/SPECS/git-lfs.spec
@@ -1,5 +1,5 @@
 Name:           git-lfs
-Version:        3.0.0
+Version:        3.0.1
 Release:        1%{?dist}
 Summary:        Git extension for versioning large files
 

--- a/script/windows-installer/inno-setup-git-lfs-installer.iss
+++ b/script/windows-installer/inno-setup-git-lfs-installer.iss
@@ -12,7 +12,7 @@
 
 #define PathToARM64Binary "..\..\git-lfs-arm64.exe"
 #ifnexist PathToARM64Binary
-  #pragma error PathToARM6464Binary + " does not exist, please build it first."
+  #pragma error PathToARM64Binary + " does not exist, please build it first."
 #endif
 
 ; Arbitrarily choose the x86 executable here as both have the version embedded.

--- a/t/t-fetch.sh
+++ b/t/t-fetch.sh
@@ -71,6 +71,23 @@ begin_test "fetch"
 )
 end_test
 
+begin_test "fetch (empty file)"
+(
+  set -e
+  cd clone
+  rm -rf .git/lfs/objects
+
+  touch empty.dat
+  git add empty.dat
+  git commit -m 'empty'
+
+  git lfs fetch
+
+  git lfs fsck 2>&1 | tee fsck.log
+  grep "Git LFS fsck OK" fsck.log
+)
+end_test
+
 begin_test "fetch (shared repository)"
 (
   set -e

--- a/t/t-prune.sh
+++ b/t/t-prune.sh
@@ -1038,6 +1038,27 @@ begin_test "prune --force"
 )
 end_test
 
+begin_test "prune does not fail on empty files"
+(
+  set -e
+
+  reponame="prune-empty-file"
+  setup_remote_repo "remote-$reponame"
+
+  clone_repo "remote-$reponame" "clone-$reponame"
+
+  git lfs track "*.dat" 2>&1 | tee track.log
+  grep "Tracking \"\*.dat\"" track.log
+
+  touch empty.dat
+  git add .gitattributes empty.dat
+  git commit -m 'Add empty'
+  git push origin main
+
+  git lfs prune --force
+)
+end_test
+
 begin_test "prune does not invoke external diff programs"
 (
   set -e

--- a/t/t-pull.sh
+++ b/t/t-pull.sh
@@ -138,6 +138,14 @@ begin_test "pull"
   git lfs pull -I "*.dat"
   assert_clean_status
 
+  echo "lfs pull with empty file"
+  touch empty.dat
+  git add empty.dat
+  git commit -m 'empty'
+  git lfs pull
+  [ -z "$(cat empty.dat)" ]
+  assert_clean_status
+
   echo "lfs pull in subdir"
   cd dir
   git lfs pull

--- a/versioninfo.json
+++ b/versioninfo.json
@@ -4,7 +4,7 @@
 		"FileVersion": {
 			"Major": 3,
 			"Minor": 0,
-			"Patch": 0,
+			"Patch": 1,
 			"Build": 0
 		}
 	},
@@ -13,7 +13,7 @@
 		"FileDescription": "Git LFS",
 		"LegalCopyright": "GitHub, Inc. and Git LFS contributors",
 		"ProductName": "Git Large File Storage (LFS)",
-		"ProductVersion": "3.0.0"
+		"ProductVersion": "3.0.1"
 	},
 	"IconPath": "script/windows-installer/git-lfs-logo.ico"
 }


### PR DESCRIPTION
This is an in-progress look at the next release of Git LFS, v2.13.3, which is scheduled for today, Tuesday, September 28, 2021.

I've attached some builds below for people to use for testing:

[git-lfs-darwin-amd64-v3.0.1-pre.zip](https://github.com/git-lfs/git-lfs/files/7244625/git-lfs-darwin-amd64-v3.0.1-pre.zip)
[git-lfs-darwin-arm64-v3.0.1-pre.zip](https://github.com/git-lfs/git-lfs/files/7244626/git-lfs-darwin-arm64-v3.0.1-pre.zip)
[git-lfs-freebsd-386-v3.0.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/7244627/git-lfs-freebsd-386-v3.0.1-pre.tar.gz)
[git-lfs-freebsd-amd64-v3.0.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/7244628/git-lfs-freebsd-amd64-v3.0.1-pre.tar.gz)
[git-lfs-linux-386-v3.0.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/7244629/git-lfs-linux-386-v3.0.1-pre.tar.gz)
[git-lfs-linux-amd64-v3.0.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/7244630/git-lfs-linux-amd64-v3.0.1-pre.tar.gz)
[git-lfs-linux-arm64-v3.0.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/7244631/git-lfs-linux-arm64-v3.0.1-pre.tar.gz)
[git-lfs-linux-arm-v3.0.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/7244632/git-lfs-linux-arm-v3.0.1-pre.tar.gz)
[git-lfs-linux-ppc64le-v3.0.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/7244633/git-lfs-linux-ppc64le-v3.0.1-pre.tar.gz)
[git-lfs-linux-s390x-v3.0.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/7244634/git-lfs-linux-s390x-v3.0.1-pre.tar.gz)
[git-lfs-v3.0.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/7244636/git-lfs-v3.0.1-pre.tar.gz)
[git-lfs-windows-386-v3.0.1-pre.zip](https://github.com/git-lfs/git-lfs/files/7244637/git-lfs-windows-386-v3.0.1-pre.zip)
[git-lfs-windows-amd64-v3.0.1-pre.zip](https://github.com/git-lfs/git-lfs/files/7244638/git-lfs-windows-amd64-v3.0.1-pre.zip)
[git-lfs-windows-arm64-v3.0.1-pre.zip](https://github.com/git-lfs/git-lfs/files/7244639/git-lfs-windows-arm64-v3.0.1-pre.zip)

In addition, the CI system will produce artifacts for Windows, Linux, and macOS if you prefer to use those; they should be equivalent.

/cc @git-lfs/core
/cc @git-lfs/implementers
/cc @git-lfs/releases