### PR TITLE
Correct t-lock regular expression to be musl compatible

### DIFF
--- a/t/t-lock.sh
+++ b/t/t-lock.sh
@@ -113,7 +113,7 @@ begin_test "lock multiple files (JSON)"
   git push origin main:other
 
   git lfs lock --json *.dat | tee lock.json
-  grep -E '\[{"id":"[^"]+","path":"a\.dat","owner":{"name":"Git LFS Tests"},"locked_at":"[^"]+"},{"id":"[^"]+","path":"b\.dat","owner":{"name":"Git LFS Tests"},"locked_at":"[^"]+"}\]' lock.json
+  grep -E '\[\{"id":"[^"]+","path":"a\.dat","owner":\{"name":"Git LFS Tests"\},"locked_at":"[^"]+"\},\{"id":"[^"]+","path":"b\.dat","owner":\{"name":"Git LFS Tests"\},"locked_at":"[^"]+"\}\]' lock.json
 )
 end_test
 


### PR DESCRIPTION
This MR corrects a regular expression within `t/t-lock.sh` to make it compatible with the musl version of libc (see https://wiki.musl-libc.org/functional-differences-from-glibc.html#regular-expressions), as it's used in e.g. Alpine Linux. There is no functional change, just a format one.

I'm currently in the process of bumping *git-lfs* to version *3.0.1* in Alpine Linux (see https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/26213), but running the integration tests (specifically this one regular expression) as part of the packaging process fail. This can also be reproduced locally:

```sh
% docker run -ti alpine /bin/sh
$ grep -E '\[{"id":"[^"]+","path":"a\.dat","owner":{"name":"Git LFS Tests"},"locked_at":"[^"]+"},{"id":"[^"]+","path":"b\.dat","owner":{"name":"Git LFS Tests"},"locked_at":"[^"]+"}\]' lock.json 
grep: bad regex '\[{"id":"[^"]+","path":"a\.dat","owner":{"name":"Git LFS Tests"},"locked_at":"[^"]+"},{"id":"[^"]+","path":"b\.dat","owner":{"name":"Git LFS Tests"},"locked_at":"[^"]+"}\]': Invalid contents of {}
```

/cc @bk2204