### PR TITLE
Allow git-lfs-transfer integration tests to be skipped

### DIFF
--- a/t/testhelpers.sh
+++ b/t/testhelpers.sh
@@ -846,7 +846,7 @@ setup_pure_ssh() {
   export PATH="$ROOTDIR/t/scutiger/bin:$PATH"
   if ! command -v git-lfs-transfer >/dev/null 2>&1
   then
-    if [ -z "$CI" ]
+    if [ -z "$CI" ] || [ -n "$TEST_SKIP_LFS_TRANSFER" ]
     then
       echo "No git-lfs-transfer.  Skipping..."
       exit 0


### PR DESCRIPTION
This PR introduces the new environment variable `TEST_SKIP_LFS_TRANSFER ` which offers the possibility to skip *git-lfs-transfer* tests based on *[scutiger-lfs](https://github.com/bk2204/scutiger/tree/dev/scutiger-lfs#git-lfs-transfer)* **while also** running within CI:

```sh
make integration TEST_SKIP_LFS_TRANSFER=true
```

This is required since it's currently not possible to disable the use of *git-lfs-transfer* when running within a CI build (detected automatically via `CI` variable). Since *git-lfs-transfer* has to be installed on a systems via other means, most external CI builds will fail as they can't use the *git-lfs* Docker test image, which preinstalls *git-lfs-transfer*.

This is patch needed to make *git-lfs* packaging work for Linux distributions like Alpine Linux (e.g. see https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/26213).

An alternative to the approach used within this PR would be to change the logic to a positive one, meaning replacing the current `$CI && !$TEST_SKIP_LFS_TRANSFER` with an e.g. `$USE_GIT_LFS_TRANSFER` one. This would disable those tests on all environments, allowing the *git-lfs* CI test to explicitly enable them.

/cc @bk2204