### PR TITLE
ls-files: don't process empty files as pointers

### DIFF
--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -68,6 +68,10 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 			return
 		}
 
+		if p.Size == 0 {
+			return
+		}
+
 		if !lsFilesScanAll && !scanRange {
 			if _, ok := seen[p.Name]; ok {
 				return


### PR DESCRIPTION
In 3.0, we started processing empty files as pointers, since they are their own pointer files.  However, this caused git lfs ls-files to process empty files that are not tracked by LFS as pointer files as well, which breaks various things.

Ideally, we'd filter these out such that empty LFS files are pointers and others are not, but this is not efficiently implementable with our current codebase, so let's revert to the old approach.

Fixes #4660