### PR TITLE
migrate: properly escape blob filenames

### DIFF
--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -179,7 +179,7 @@ func migrateImportCommand(cmd *cobra.Command, args []string) {
 			if ext := filepath.Ext(path); len(ext) > 0 && above == 0 {
 				exts.Add(fmt.Sprintf("*%s filter=lfs diff=lfs merge=lfs -text", ext))
 			} else {
-				exts.Add(fmt.Sprintf("/%s filter=lfs diff=lfs merge=lfs -text", path))
+				exts.Add(fmt.Sprintf("/%s filter=lfs diff=lfs merge=lfs -text", escapeGlobCharacters(path)))
 			}
 
 			return &gitobj.Blob{

--- a/t/fixtures/migrate.sh
+++ b/t/fixtures/migrate.sh
@@ -674,6 +674,28 @@ setup_local_branch_with_copied_file() {
   git commit -m "initial commit"
 }
 
+# setup_local_branch_with_special_character_files creates a repository as follows:
+#
+#   A
+#    \
+#     refs/heads/main
+#
+# - Commit 'A' has binary files with special characters
+setup_local_branch_with_special_character_files() {
+  set -e
+
+  reponame="migrate-single-local-branch-with-special-filenames"
+  remove_and_create_local_repo "$reponame"
+
+  head -c 80 /dev/urandom > './test - special.bin'
+  head -c 100 /dev/urandom > './test (test2) special.bin'
+  # Windows does not allow creation of files with '*'
+  [ "$IS_WINDOWS" -eq '1' ] || head -c 120 /dev/urandom > './test * ** special.bin'
+
+  git add *.bin
+  git commit -m "initial commit"
+}
+
 # make_bare converts the existing full checkout of a repository into a bare one,
 # and then `cd`'s into it.
 make_bare() {

--- a/t/t-migrate-import.sh
+++ b/t/t-migrate-import.sh
@@ -1016,3 +1016,17 @@ begin_test "migrate import (copied file)"
   fi
 )
 end_test
+
+begin_test "migrate import (filename special characters)"
+(
+  set -e
+  setup_local_branch_with_special_character_files
+  git lfs migrate import --above=1b
+  # Windows does not allow creation of files with '*', so expect 2 files, not 3
+  if [ "$IS_WINDOWS" -eq "1" ] ; then
+    test "$(git check-attr filter -- *.bin |grep lfs | wc -l)" -eq 2 || exit 1
+  else
+    test "$(git check-attr filter -- *.bin |grep lfs | wc -l)" -eq 3 || exit 1
+  fi
+)
+end_test


### PR DESCRIPTION
Please consider this minor PR to fix the below bug. I added a unit test. I hope this is straightforward.

**Describe the bug**
When files have a combination of spaces and parentheses/dashes, git lfs migrate import produces invalid filenames in .gitattributes 

**To Reproduce**
Steps to reproduce the behavior:

```
#!/bin/bash -ex
mkdir testrepo
cd testrepo
git init .
dd if=/dev/urandom of='./test - special.bin' bs=1M count=1
dd if=/dev/urandom of='./test (test2) special.bin' bs=1M count=1
dd if=/dev/urandom of='./test * ** special.bin' bs=1M count=1
git add .
git commit -am 'my first commit'
git lfs migrate import --everything --above 512KB
git add .gitattributes
cat .gitattributes
```

**Expected behavior**
.gitattributes should escape the filenames. Ideally they should be in double quotes (c-style escaping), but pattern escaping also should be OK.

**System environment**
Debian 10.10 and git lfs 3.0.1

**Output of `git lfs env`**
The output of running `git lfs env` as a code block.

```
$ git lfs env
git-lfs/3.0.1 (GitHub; linux amd64; go 1.17.1)
git version 2.33.0

LocalWorkingDir=/home/andrewp/testing/testrepo
LocalGitDir=/home/andrewp/testing/testrepo/.git
LocalGitStorageDir=/home/andrewp/testing/testrepo/.git
LocalMediaDir=/home/andrewp/testing/testrepo/.git/lfs/objects
LocalReferenceDirs=
TempDir=/home/andrewp/testing/testrepo/.git/lfs/tmp
ConcurrentTransfers=8
TusTransfers=false
BasicTransfersOnly=false
SkipDownloadErrors=false
FetchRecentAlways=false
FetchRecentRefsDays=7
FetchRecentCommitsDays=0
FetchRecentRefsIncludeRemotes=true
PruneOffsetDays=3
PruneVerifyRemoteAlways=false
PruneRemoteName=origin
LfsStorageDir=/home/andrewp/testing/testrepo/.git/lfs
AccessDownload=none
AccessUpload=none
DownloadTransfers=basic,lfs-standalone-file,ssh
UploadTransfers=basic,lfs-standalone-file,ssh
GIT_EXEC_PATH=/home/andrewp/local/libexec/git-core
git config filter.lfs.process = "git-lfs filter-process"
git config filter.lfs.smudge = "git-lfs smudge -- %f"
git config filter.lfs.clean = "git-lfs clean -- %f"
```