### PR TITLE
lfs: don't flag non-LFS files as invalid pointers

### DIFF
--- a/lfs/gitscanner_tree.go
+++ b/lfs/gitscanner_tree.go
@@ -206,7 +206,7 @@ func catFileBatchTreeForPointers(treeblobs *TreeBlobChannelWrapper, gitEnv, osEn
 		patterns = append(patterns, filepathfilter.NewPattern(filepath.ToSlash(path.Path), filepathfilter.GitAttributes))
 	}
 
-	return pointers, filepathfilter.NewFromPatterns(patterns, nil), nil
+	return pointers, filepathfilter.NewFromPatterns(patterns, nil, filepathfilter.DefaultValue(false)), nil
 }
 
 func runScanTreeForPointers(cb GitScannerFoundPointer, tree string, gitEnv, osEnv config.Environment) error {

--- a/t/t-fsck.sh
+++ b/t/t-fsck.sh
@@ -204,6 +204,23 @@ begin_test "fsck detects invalid pointers with GIT_OBJECT_DIRECTORY"
 )
 end_test
 
+begin_test "fsck does not detect invalid pointers with no LFS objects"
+(
+  set -e
+
+  reponame="fsck-pointers-none"
+  git init "$reponame"
+  cd "$reponame"
+
+  echo "# README" > README.md
+  git add README.md
+  git commit -m "Add README"
+
+  git lfs fsck
+  git lfs fsck --pointers
+)
+end_test
+
 begin_test "fsck operates on specified refs"
 (
   set -e


### PR DESCRIPTION
When scanning the repository for invalid pointers, we set up a filter with all the paths from .gitattributes for that commit.  However, the default behavior of a filter with no paths is to return true for all objects.  As a result, if there is no .gitattributes file, or if it contains no filter=lfs lines, then we flag all files in the repository as LFS files and complain about all of them not being pointers.

Since this isn't the desired behavior, let's correct it by setting the default behavior of the filter to false and add a test for this case.

Fixes #4688
