### PR TITLE
script/upload: don't require empty bin/releases for finalize

### DIFF
--- a/script/upload
+++ b/script/upload
@@ -228,13 +228,14 @@ filter_files () {
 upload_assets () {
   local version="$1"
   local upload_url="$2"
+  local src="$3"
   local file desc base ct encdesc encbase
 
   curl https://api.github.com/repos/$REPO/releases | \
     jq -r '.[] | select(.name == "'"$version"'") | .assets | .[] | .name' \
     > "$WORKDIR/existing-assets"
 
-  for file in $(release_files "$version" | filter_files "$WORKDIR/existing-assets")
+  for file in $(release_files "$version" "$src" | filter_files "$WORKDIR/existing-assets")
   do
     base=$(basename "$file")
     desc=$(categorize_asset "$base")
@@ -306,11 +307,13 @@ finalize () {
   local version="$1"
   local inspect="$2"
   local downloads="$WORKDIR/finalize"
+  local uploads="$WORKDIR/finalize-uploads"
 
   say "Finalizing the release process..."
   say "Downloading assets..."
 
   mkdir "$downloads"
+  mkdir "$uploads"
   download_assets "$version" "$downloads"
 
   if [ -n "$inspect" ]
@@ -338,8 +341,8 @@ finalize () {
   local upload_url=$(patch_release "$version" "$bodyfile")
 
   say "Uploading final versions of assets..."
-  cp "$downloads/sha256sums.asc" bin/releases
-  upload_assets "$version" "$upload_url"
+  cp "$downloads/sha256sums.asc" "$uploads"
+  upload_assets "$version" "$upload_url" "$uploads"
 
   # Verification occurs in caller below.
 }
@@ -366,10 +369,8 @@ sanity_check () {
   local finalize="$2"
 
   say "Checking that you've got some release artifacts..."
-  if [ -n "$(release_files "$version")" ]
+  if [ -z "$(release_files "$version")" ]
   then
-    [ -z "$finalize" ] || abort "You'll need an empty bin/releases directory to continue."
-  else
     [ -n "$finalize" ] || abort "I couldn't find any release files for $version."
   fi
 
@@ -433,7 +434,7 @@ main () {
     local upload_url=$(create_release "$version" "$bodyfile")
 
     say "Uploading assets to GitHub..."
-    upload_assets "$version" "$upload_url"
+    upload_assets "$version" "$upload_url" bin/releases
   fi
 
   if [ -z "$SKIP_VERIFY" ]


### PR DESCRIPTION
When the upload script is used in finalize mode, which is a manual part of the release process, it currently requires the `bin/releases` directory to be empty.  This is because it uses the `upload_assets` function, which uploads everything in that directory, and we obviously don't want to upload whatever the developer may have in that directory as part of our release, only the signed hashes.

Since the person doing the release is usually the person who has built the pre-release assets for the pull request, this means that we invariably bother this person, which, while not the end of the world, is a minor annoyance.  Let's make this experience better for the core team member doing the release and lift this restriction.

Make the `upload_assets` function take a location of assets to upload, and when we're uploading assets in non-finalize mode (which is now effectively restricted to our release workflow) use the `bin/releases` directory, but use a temporary directory for the finalize step.  Remove the check an empty bin/releases directory, since we no longer need it.
