### PR TITLE
Avoid errors in git lfs env

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/git-lfs/git-lfs/v3/errors"
 	"github.com/git-lfs/git-lfs/v3/fs"
 	"github.com/git-lfs/git-lfs/v3/git"
 	"github.com/git-lfs/git-lfs/v3/tools"
@@ -375,8 +376,7 @@ func (c *Configuration) loadGitDirs() {
 	if err != nil {
 		errMsg := err.Error()
 		tracerx.Printf("Error running 'git rev-parse': %s", errMsg)
-		if !strings.Contains(strings.ToLower(errMsg),
-			"not a git repository") {
+		if errors.ExitStatus(err) != 128 {
 			fmt.Fprintf(os.Stderr, "Error: %s\n", errMsg)
 		}
 		c.gitDir = &gitdir

--- a/errors/types.go
+++ b/errors/types.go
@@ -1,9 +1,12 @@
 package errors
 
 import (
+	goerrors "errors"
 	"fmt"
 	"net/url"
+	"os/exec"
 	"strconv"
+	"syscall"
 	"time"
 
 	"github.com/pkg/errors"
@@ -486,4 +489,15 @@ func parentOf(err error) error {
 	}
 
 	return nil
+}
+
+func ExitStatus(err error) int {
+	var eerr *exec.ExitError
+	if goerrors.As(err, &eerr) {
+		ws, ok := eerr.ProcessState.Sys().(syscall.WaitStatus)
+		if ok {
+			return ws.ExitStatus()
+		}
+	}
+	return -1
 }

--- a/git/config.go
+++ b/git/config.go
@@ -140,31 +140,29 @@ func (c *Configuration) Sources(dir string, optionalFilename string) ([]*Configu
 	if err != nil {
 		return nil, err
 	}
+	configs := make([]*ConfigurationSource, 0, 2)
 
 	bare, err := IsBare()
-	if err != nil {
-		return nil, err
-	}
-
-	// First try to read from the working directory and then the index if
-	// the file is missing from the working directory.
-	var fileconfig *ConfigurationSource
-	if !bare {
-		fileconfig, err = c.FileSource(filepath.Join(dir, optionalFilename))
-		if err != nil {
-			if !os.IsNotExist(err) {
-				return nil, err
+	if err == nil {
+		// First try to read from the working directory and then the index if
+		// the file is missing from the working directory.
+		var fileconfig *ConfigurationSource
+		if !bare {
+			fileconfig, err = c.FileSource(filepath.Join(dir, optionalFilename))
+			if err != nil {
+				if !os.IsNotExist(err) {
+					return nil, err
+				}
+				fileconfig, _ = c.RevisionSource(fmt.Sprintf(":%s", optionalFilename))
 			}
-			fileconfig, _ = c.RevisionSource(fmt.Sprintf(":%s", optionalFilename))
 		}
-	}
-	if fileconfig == nil {
-		fileconfig, _ = c.RevisionSource(fmt.Sprintf("HEAD:%s", optionalFilename))
-	}
+		if fileconfig == nil {
+			fileconfig, _ = c.RevisionSource(fmt.Sprintf("HEAD:%s", optionalFilename))
+		}
 
-	configs := make([]*ConfigurationSource, 0, 2)
-	if fileconfig != nil {
-		configs = append(configs, fileconfig)
+		if fileconfig != nil {
+			configs = append(configs, fileconfig)
+		}
 	}
 
 	return append(configs, gitconfig), nil

--- a/git/git.go
+++ b/git/git.go
@@ -780,7 +780,7 @@ func GitDir() (string, error) {
 	out, err := cmd.Output()
 
 	if err != nil {
-		return "", fmt.Errorf("failed to call git rev-parse --git-dir: %v %v: %v", err, string(out), buf.String())
+		return "", fmt.Errorf("failed to call git rev-parse --git-dir: %w %v: %v", err, string(out), buf.String())
 	}
 	path := strings.TrimSpace(string(out))
 	return tools.CanonicalizePath(path, false)

--- a/git/git.go
+++ b/git/git.go
@@ -14,13 +14,11 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	lfserrors "github.com/git-lfs/git-lfs/v3/errors"
@@ -733,13 +731,9 @@ func GitAndRootDirs() (string, string, error) {
 		// If we got a fatal error, it's possible we're on a newer
 		// (2.24+) Git and we're not in a worktree, so fall back to just
 		// looking up the repo directory.
-		if e, ok := err.(*exec.ExitError); ok {
-			var ws syscall.WaitStatus
-			ws, ok = e.ProcessState.Sys().(syscall.WaitStatus)
-			if ok && ws.ExitStatus() == 128 {
-				absGitDir, err := GitDir()
-				return absGitDir, "", err
-			}
+		if lfserrors.ExitStatus(err) == 128 {
+			absGitDir, err := GitDir()
+			return absGitDir, "", err
 		}
 		return "", "", fmt.Errorf("failed to call git rev-parse --git-dir --show-toplevel: %q", buf.String())
 	}


### PR DESCRIPTION
There are a couple different cases in which we can get errors when running `git lfs env` outside of a repository.  One of these can also cause us to fail to load Git configuration, which makes the output confusing, and another only shows up when the user (like the author) is using a non-English language.  Let's fix these issues and add a test to be sure we don't regress the behavior.

Each commit contains an explanatory commit message.  Note that this PR is probably best reviewed with whitespace differences turned off.

Fixes #4712 