### PR TITLE
Add support for ARM64 Debian packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,3 +114,27 @@ jobs:
     - run: git clone https://github.com/git-lfs/build-dockers.git "$HOME/build-dockers"
     - run: (cd "$HOME/build-dockers" && ./build_dockers.bsh)
     - run: DOCKER_AUTOPULL=0 ./docker/run_dockers.bsh --prune
+  build-docker-cross:
+    name: Build Cross Linux packages
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        arch: [arm64]
+        container: [debian_11]
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-ruby@v1
+    - run: |
+        echo '{"experimental": true}' | sudo tee /etc/docker/daemon.json
+        sudo systemctl restart docker.service
+        docker version -f '{{.Server.Experimental}}'
+    - uses: docker/setup-qemu-action@v1
+    - run: git clone https://github.com/git-lfs/build-dockers.git "$HOME/build-dockers"
+    - run: (cd "$HOME/build-dockers" && ./build_dockers.bsh --arch=$ARCH $CONTAINER)
+      env:
+        ARCH: ${{matrix.arch}}
+        CONTAINER: ${{matrix.container}}
+    - run: DOCKER_AUTOPULL=0 ./docker/run_dockers.bsh --prune --arch=$ARCH $CONTAINER
+      env:
+        ARCH: ${{matrix.arch}}
+        CONTAINER: ${{matrix.container}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,3 +122,30 @@ jobs:
     - run: '[ -z "${GITHUB_REF%%refs/tags/*-pre*}" ] || ./script/packagecloud.rb'
       env:
         PACKAGECLOUD_TOKEN: ${{secrets.PACKAGECLOUD_TOKEN}}
+  build-docker-cross:
+    name: Build Cross Linux packages
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        arch: [arm64]
+        container: [debian_11]
+    - uses: actions/checkout@v1
+    - uses: actions/setup-ruby@v1
+    - run: |
+        echo '{"experimental": true}' | sudo tee /etc/docker/daemon.json
+        sudo systemctl restart docker.service
+        docker version -f '{{.Server.Experimental}}'
+    - uses: docker/setup-qemu-action@v1
+    - run: git clone https://github.com/git-lfs/build-dockers.git "$HOME/build-dockers"
+    - run: (cd "$HOME/build-dockers" && ./build_dockers.bsh --arch=$ARCH $CONTAINER)
+      env:
+        ARCH: ${{matrix.arch}}
+        CONTAINER: ${{matrix.container}}
+    - run: DOCKER_AUTOPULL=0 ./docker/run_dockers.bsh --prune --arch=$ARCH $CONTAINER
+      env:
+        ARCH: ${{matrix.arch}}
+        CONTAINER: ${{matrix.container}}
+    # If this is a pre-release tag, don't upload anything to packagecloud.
+    - run: '[ -z "${GITHUB_REF%%refs/tags/*-pre*}" ] || ./script/packagecloud.rb'
+      env:
+        PACKAGECLOUD_TOKEN: ${{secrets.PACKAGECLOUD_TOKEN}}

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ built from source using the latest version of [Go](https://golang.org), and the
 available instructions in our
 [Wiki](https://github.com/git-lfs/git-lfs/wiki/Installation#source).
 
+Note that Debian and RPM packages are built for all OSes for amd64 and i386.
+For arm64, only Debian packages for the latest Debian release are built due to the cost of building in emulation.
+
 ### Installing
 
 #### From binary

--- a/docker/run_dockers.bsh
+++ b/docker/run_dockers.bsh
@@ -43,9 +43,12 @@ function split_image_name()
 # Parse Arguments
 IMAGES=()
 PRUNE=
-while [[ $# > 0 ]]; do
+ARCH=amd64
+while [[ $# -gt 0 ]]; do
   if [ "$1" = "--prune" ]; then
     PRUNE=t
+  elif [[ "$1" == --arch=* ]]; then
+    ARCH="${1#--arch=}"
   elif [ "$1" == "--" ]; then
     shift
     DOCKER_CMD="${@}"
@@ -109,6 +112,7 @@ for IMAGE_NAME in "${IMAGES[@]}"; do
                    -e FINAL_GID=${FINAL_GID} \
                    -v "${MINGW_PATCH}${REPO_DIR}:/src" \
                    -v "${MINGW_PATCH}${IMAGE_REPO_DIR}:/repo" \
+                   --platform "$ARCH" \
                    gitlfs/build-dockers:${IMAGE_NAME} ${DOCKER_CMD-}
 
   if [ -n "$PRUNE" ]


### PR DESCRIPTION
Users have recently requested packages for arm64, which is an increasingly popular architecture.  In addition, it is the architecture used on newer Macs and some Windows systems, which may commonly run Linux VMs or WSL.

However, GitHub Actions does not support arm64 natively, so we must build in emulation.  This is extraordinarily slow, so we'll build only for the latest Debian release.  All Debian-based images use our Debian images, and Debian is by far the most portable mainstream Linux distribution in terms of architecture support, so the cost to add additional architectures should be extremely minimal.  Users who would like versions for older releases may build their own packages with our tooling.

Build these packages in both CI and for releases.

Fixes #4546
