### PR TITLE
ssh: avoid using -- where possible

### DIFF
--- a/ssh/ssh_test.go
+++ b/ssh/ssh_test.go
@@ -22,7 +22,6 @@ func TestSSHGetLFSExeAndArgs(t *testing.T) {
 	exe, args := ssh.GetLFSExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, "git-lfs-authenticate", "download", false)
 	assert.Equal(t, "ssh", exe)
 	assert.Equal(t, []string{
-		"--",
 		"user@foo.com",
 		"git-lfs-authenticate user/repo download",
 	}, args)
@@ -30,7 +29,6 @@ func TestSSHGetLFSExeAndArgs(t *testing.T) {
 	exe, args = ssh.GetLFSExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, "git-lfs-authenticate", "upload", false)
 	assert.Equal(t, "ssh", exe)
 	assert.Equal(t, []string{
-		"--",
 		"user@foo.com",
 		"git-lfs-authenticate user/repo upload",
 	}, args)
@@ -48,7 +46,7 @@ func TestSSHGetExeAndArgsSsh(t *testing.T) {
 
 	exe, args := ssh.FormatArgs(ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false))
 	assert.Equal(t, "ssh", exe)
-	assert.Equal(t, []string{"--", "user@foo.com"}, args)
+	assert.Equal(t, []string{"user@foo.com"}, args)
 }
 
 func TestSSHGetExeAndArgsSshCustomPort(t *testing.T) {
@@ -64,7 +62,7 @@ func TestSSHGetExeAndArgsSshCustomPort(t *testing.T) {
 
 	exe, args := ssh.FormatArgs(ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false))
 	assert.Equal(t, "ssh", exe)
-	assert.Equal(t, []string{"-p", "8888", "--", "user@foo.com"}, args)
+	assert.Equal(t, []string{"-p", "8888", "user@foo.com"}, args)
 }
 
 func TestSSHGetExeAndArgsPlink(t *testing.T) {
@@ -156,7 +154,7 @@ func TestSSHGetExeAndArgsPlinkCustomPortExplicitEnvironmentSsh(t *testing.T) {
 
 	exe, args := ssh.FormatArgs(ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false))
 	assert.Equal(t, plink, exe)
-	assert.Equal(t, []string{"-p", "8888", "--", "user@foo.com"}, args)
+	assert.Equal(t, []string{"-p", "8888", "user@foo.com"}, args)
 }
 
 func TestSSHGetExeAndArgsTortoisePlink(t *testing.T) {
@@ -312,7 +310,7 @@ func TestSSHGetExeAndArgsSshCommandCustomPort(t *testing.T) {
 
 	exe, args := ssh.FormatArgs(ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false))
 	assert.Equal(t, "sh", exe)
-	assert.Equal(t, []string{"-c", "sshcmd -p 8888 -- user@foo.com"}, args)
+	assert.Equal(t, []string{"-c", "sshcmd -p 8888 user@foo.com"}, args)
 }
 
 func TestSSHGetExeAndArgsCoreSshCommand(t *testing.T) {
@@ -328,7 +326,7 @@ func TestSSHGetExeAndArgsCoreSshCommand(t *testing.T) {
 
 	exe, args := ssh.FormatArgs(ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false))
 	assert.Equal(t, "sh", exe)
-	assert.Equal(t, []string{"-c", "sshcmd --args 2 -- user@foo.com"}, args)
+	assert.Equal(t, []string{"-c", "sshcmd --args 2 user@foo.com"}, args)
 }
 
 func TestSSHGetExeAndArgsCoreSshCommandArgsWithMixedQuotes(t *testing.T) {
@@ -342,7 +340,7 @@ func TestSSHGetExeAndArgsCoreSshCommandArgsWithMixedQuotes(t *testing.T) {
 
 	exe, args := ssh.FormatArgs(ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false))
 	assert.Equal(t, "sh", exe)
-	assert.Equal(t, []string{"-c", "sshcmd foo 'bar \"baz\"' -- user@foo.com"}, args)
+	assert.Equal(t, []string{"-c", "sshcmd foo 'bar \"baz\"' user@foo.com"}, args)
 }
 
 func TestSSHGetExeAndArgsConfigVersusEnv(t *testing.T) {
@@ -356,7 +354,7 @@ func TestSSHGetExeAndArgsConfigVersusEnv(t *testing.T) {
 
 	exe, args := ssh.FormatArgs(ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false))
 	assert.Equal(t, "sh", exe)
-	assert.Equal(t, []string{"-c", "sshcmd --args 1 -- user@foo.com"}, args)
+	assert.Equal(t, []string{"-c", "sshcmd --args 1 user@foo.com"}, args)
 }
 
 func TestSSHGetExeAndArgsPlinkCommand(t *testing.T) {
@@ -519,7 +517,7 @@ func TestSSHGetExeAndArgsInvalidOptionsAsPath(t *testing.T) {
 
 	exe, args, needShell := ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &e.SSHMetadata, false)
 	assert.Equal(t, "ssh", exe)
-	assert.Equal(t, []string{"--", "git@git-host.com"}, args)
+	assert.Equal(t, []string{"git@git-host.com"}, args)
 	assert.Equal(t, false, needShell)
 }
 

--- a/t/cmd/lfs-ssh-echo.go
+++ b/t/cmd/lfs-ssh-echo.go
@@ -44,38 +44,34 @@ func spawnCommand(command string) error {
 	return err
 }
 
-func main() {
-	// expect args:
-	//   lfs-ssh-echo -p PORT -- git@127.0.0.1 "git-lfs-authenticate REPO OPERATION"
-	//   lfs-ssh-echo -p PORT -- git@127.0.0.1 "git-lfs-transfer REPO OPERATION"
-	//   lfs-ssh-echo -- git@127.0.0.1 "git-lfs-transfer REPO OPERATION"
-	//   lfs-ssh-echo git@127.0.0.1 "git-upload-pack REPO"
-	//   lfs-ssh-echo git@127.0.0.1 "git-receive-pack REPO"
-	if len(os.Args) < 3 {
-		fmt.Fprintf(os.Stderr, "got %d args: %v", len(os.Args), os.Args)
-		os.Exit(1)
-	}
-
-	offset := 4
-	if os.Args[1] == "--" {
-		offset = 2
-	} else if os.Args[1] == "git@127.0.0.1" {
-		offset = 1
-	} else if os.Args[1] != "-p" {
-		fmt.Fprintf(os.Stderr, "$1 expected \"-p\", got %q", os.Args[1])
-		os.Exit(1)
-	} else if os.Args[3] != "--" {
-		fmt.Fprintf(os.Stderr, "$3 expected \"--\", got %q", os.Args[3])
-		os.Exit(1)
-	}
-
+func checkSufficientArgs(offset int) {
 	if len(os.Args) < offset+2 {
 		fmt.Fprintf(os.Stderr, "got %d args: %v", len(os.Args), os.Args)
 		os.Exit(1)
 	}
+}
 
+func main() {
+	// expect args:
+	//   lfs-ssh-echo [-p PORT [--]] git@127.0.0.1 "git-lfs-authenticate REPO OPERATION"
+	//   lfs-ssh-echo [-p PORT [--]] git@127.0.0.1 "git-lfs-transfer REPO OPERATION"
+	//   lfs-ssh-echo git@127.0.0.1 "git-upload-pack REPO"
+	//   lfs-ssh-echo git@127.0.0.1 "git-receive-pack REPO"
+	offset := 1
+
+	checkSufficientArgs(offset)
+	if os.Args[offset] == "-p" {
+		offset += 2
+	}
+
+	checkSufficientArgs(offset)
+	if os.Args[offset] == "--" {
+		offset += 1
+	}
+
+	checkSufficientArgs(offset)
 	if os.Args[offset] != "git@127.0.0.1" {
-		fmt.Fprintf(os.Stderr, "$4 expected \"git@127.0.0.1\", got %q", os.Args[offset])
+		fmt.Fprintf(os.Stderr, "expected \"git@127.0.0.1\", got %q", os.Args[offset])
 		os.Exit(1)
 	}
 

--- a/t/t-ssh.sh
+++ b/t/t-ssh.sh
@@ -2,11 +2,11 @@
 
 . "$(dirname "$0")/testlib.sh"
 
-begin_test "ssh with proxy command in lfs.url"
+begin_test "ssh with proxy command in lfs.url (default variant)"
 (
   set -e
 
-  reponame="batch-ssh-proxy"
+  reponame="batch-ssh-proxy-default"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"
 
@@ -20,6 +20,7 @@ begin_test "ssh with proxy command in lfs.url"
   git add .gitattributes test.dat
   git commit -m "initial commit"
 
+  unset GIT_SSH_VARIANT
   GIT_TRACE=1 git push origin main 2>&1 | tee push.log
   if [ "0" -eq "${PIPESTATUS[0]}" ]; then
     echo >&2 "fatal: push succeeded"
@@ -28,5 +29,35 @@ begin_test "ssh with proxy command in lfs.url"
 
   grep 'expected.*git@127.0.0.1' push.log
   grep "lfs-ssh-echo -- -oProxyCommand" push.log
+)
+end_test
+
+begin_test "ssh with proxy command in lfs.url (custom variant)"
+(
+  set -e
+
+  reponame="batch-ssh-proxy-simple"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  sshurl="${GITSERVER/http:\/\//ssh://-oProxyCommand=ssh-proxy-test/}/$reponame"
+  git config lfs.url "$sshurl"
+
+  contents="test"
+  oid="$(calc_oid "$contents")"
+  git lfs track "*.dat"
+  printf "%s" "$contents" > test.dat
+  git add .gitattributes test.dat
+  git commit -m "initial commit"
+
+  export GIT_SSH_VARIANT=simple
+  GIT_TRACE=1 git push origin main 2>&1 | tee push.log
+  if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: push succeeded"
+    exit 1
+  fi
+
+  grep 'expected.*git@127.0.0.1' push.log
+  grep "lfs-ssh-echo oProxyCommand" push.log
 )
 end_test


### PR DESCRIPTION
In Git LFS version 3.0, we added support for understanding the GIT_SSH_VARIANT environment variable and its corresponding configuration option.  When we did so, we dropped the special-casing for program names and instead always used the -- setting for the default variant, "ssh". This variant represents OpenSSH, which as a program with normal POSIX option handling, supports -- just fine.

Unfortunately, not all clients do.  TeamCity's SSH client doesn't set the variant and also doesn't understand --.  We need to handle this case to prevent option injection in case someone tries to use a URL like "ssh://-oProxyCommand=exploit/", which could otherwise lead to arbitrary code execution.

However, we don't have to add this all the time, but only when the user-and-host portion starts with a dash.  The reason is that the only other place an attacker could inject an option is in the path, and the path is not a separate option by itself.  The path is always preceded by a command (either "git-lfs-authenticate" or "git-lfs-transfer" in a single option that contains the name of the command, the path, and the operation, separated by spaces.  As a result, option injection is not possible in the path since those commands don't take options.

Note that Git just dies in this case with a message like so:

  fatal: strange hostname '-oProxyCommand=exploit' blocked

Let's adopt this approach of using -- less often so that we can more gracefully deal with this case and fix some SSH clients, even if they really should learn to understand this option.

Fixes #4733
