### PR TITLE
use gitattributes filepath matching for migrate filter options

### DIFF
--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/git-lfs/git-lfs/v3/errors"
+	"github.com/git-lfs/git-lfs/v3/filepathfilter"
 	"github.com/git-lfs/git-lfs/v3/git"
 	"github.com/git-lfs/git-lfs/v3/git/githistory"
 	"github.com/git-lfs/git-lfs/v3/tasklog"
@@ -307,7 +308,7 @@ func currentRefToMigrate() (*git.Ref, error) {
 // filter given by the --include and --exclude arguments.
 func getHistoryRewriter(cmd *cobra.Command, db *gitobj.ObjectDatabase, l *tasklog.Logger) *githistory.Rewriter {
 	include, exclude := getIncludeExcludeArgs(cmd)
-	filter := buildFilepathFilter(cfg, include, exclude, false)
+	filter := buildFilepathFilterWithPatternType(cfg, include, exclude, false, filepathfilter.GitAttributes)
 
 	return githistory.NewRewriter(db,
 		githistory.WithFilter(filter), githistory.WithLogger(l))

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -129,8 +129,12 @@ func currentRemoteRef() *git.Ref {
 }
 
 func buildFilepathFilter(config *config.Configuration, includeArg, excludeArg *string, useFetchOptions bool) *filepathfilter.Filter {
+	return buildFilepathFilterWithPatternType(config, includeArg, excludeArg, useFetchOptions, filepathfilter.GitIgnore)
+}
+
+func buildFilepathFilterWithPatternType(config *config.Configuration, includeArg, excludeArg *string, useFetchOptions bool, patternType filepathfilter.PatternType) *filepathfilter.Filter {
 	inc, exc := determineIncludeExcludePaths(config, includeArg, excludeArg, useFetchOptions)
-	return filepathfilter.New(inc, exc, filepathfilter.GitIgnore)
+	return filepathfilter.New(inc, exc, patternType)
 }
 
 func downloadTransfer(p *lfs.WrappedPointer) (name, path, oid string, size int64, missing bool, err error) {

--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -320,6 +320,11 @@ matching format of `.gitattributes`.  In addition to simple file extension
 matches (e.g., `*.gif`) patterns may also specify directory paths, in which
 case the `path/**` format may be used to match recursively.
 
+Note that this form of pattern matching for the `--include` and `--exclude`
+options used by the `git lfs migrate` command is unique among the suite of
+`git lfs` commands.  Other commands which also take these options, such as
+`git lfs ls-files`, use the gitignore(5) form of pattern matching instead.
+
 ## INCLUDE AND EXCLUDE (REFS)
 
 You can specify that `git lfs migrate` should only convert files added
@@ -451,6 +456,7 @@ $ git lfs migrate import --no-rewrite \
 
 ## SEE ALSO
 
-git-lfs-checkout(1), git-lfs-track(1), git-lfs-untrack(1), gitattributes(5).
+git-lfs-checkout(1), git-lfs-ls-files(1), git-lfs-track(1),
+git-lfs-untrack(1), gitattributes(5), gitignore(5).
 
 Part of the git-lfs(1) suite.

--- a/t/fixtures/migrate.sh
+++ b/t/fixtures/migrate.sh
@@ -607,6 +607,30 @@ setup_single_local_branch_deep_trees() {
   git commit -m "initial commit"
 }
 
+# setup_single_local_branch_same_file_tree_ext creates a repository as follows:
+#
+#   A
+#    \
+#     refs/heads/main
+#
+# - Commit 'A' has 120 bytes of data in each of 'a.txt`, `foo/a.txt',
+#   `bar.txt/b.md`, and `bar.txt/b.txt`.
+setup_single_local_branch_same_file_tree_ext() {
+  set -e
+
+  reponame="migrate-single-local-branch-with-same-file-tree-ext"
+  remove_and_create_local_repo "$reponame"
+
+  mkdir -p foo bar.txt
+  base64 < /dev/urandom | head -c 120 > a.txt
+  base64 < /dev/urandom | head -c 120 > foo/a.txt
+  base64 < /dev/urandom | head -c 120 > bar.txt/b.md
+  base64 < /dev/urandom | head -c 120 > bar.txt/b.txt
+
+  git add a.txt foo bar.txt
+  git commit -m "initial commit"
+}
+
 # setup_local_branch_with_symlink creates a repository as follows:
 #
 #   A


### PR DESCRIPTION
The `--include` and `--exclude` (`-I` and `-X`) options to the `git lfs migrate` command allow the user to specify filepath filters which select matching files to migrate and which are also used to populate any `.gitattributes` files written by the import or export operations.

This latter functionality implies that we need to parse any filepath patterns supplied by these options using `gitattributes(5)` rules, since the patterns will be copied directly into `.gitattributes` files.  (See the [use](https://github.com/git-lfs/git-lfs/blob/283d21ef896231e6c83fd961ac0d66ea129257e4/commands/command_migrate_import.go#L132) of the [`trackedFromFilter()`](https://github.com/git-lfs/git-lfs/blob/283d21ef896231e6c83fd961ac0d66ea129257e4/commands/command_migrate_import.go#L291-L306) and [`trackedFromExportFilter()`](https://github.com/git-lfs/git-lfs/blob/283d21ef896231e6c83fd961ac0d66ea129257e4/commands/command_migrate_export.go#L181-L198) functions in particular.)

However, all other Git LFS commands which parse `--include` and `--exclude` options, such as `git lfs fetch` and `git lfs ls-files`, expect to treat any supplied patterns [according](https://github.com/git-lfs/git-lfs/blob/283d21ef896231e6c83fd961ac0d66ea129257e4/commands/commands.go#L133) to `gitignore(5)` rules.  (This aligns with, for instance, how the `-x` option to `git ls-files` works.)

We therefore introduce a `buildFilepathFilterWithPatternType()` function which the `git lfs migrate` command can use to specify the `filepathfilter.GitAttributes` matching mode for its filter, while the other commands continue to use the `filepathfilter.GitIgnore` mode.

Note that this change change will have several consequences.  On one hand, patterns such as `*.bin` will only match against files, not directories, which will restore the behaviour of `git lfs migrate` in this regard prior to v3.0.0 and the changes from PR #4556.

On the other hand, patterns such as `foo` will no longer recursively match everything inside a directory, and `foo/**` must be used instead.  This is in line with how Git's native `gitattributes(5)` matching works.

We therefore adjust one existing test to use a directory match of the form `foo/**` instead of `foo`, and add one new test which confirms that only files named `*.txt` match a pattern of that form, instead of all files in any directory whose name has that form, such as a file like `foo.txt/bar.md`.  This new test fails without the changes to the `git lfs migrate` command introduced in this commit.

And we add a note in the `git-lfs-migrate` man page that the filepath filter matching mode for that command's `--include` and `--exclude` options differs from all other Git LFS commands' mode; i.e., it uses the `gitattributes(5)` matching mode instead of the `gitignore(5)` mode used elsewhere.

Fixes #4751.
/cc @rolandas-rimkus as reporter.