### PR TITLE
creds: gracefully handle lack of askpass helper

### DIFF
--- a/creds/creds.go
+++ b/creds/creds.go
@@ -86,13 +86,15 @@ func NewCredentialHelperContext(gitEnv config.Environment, osEnv config.Environm
 	if !ok {
 		askpass, _ = osEnv.Get("SSH_ASKPASS")
 	}
-	askpassfile, err := tools.TranslateCygwinPath(askpass)
-	if err != nil {
-		tracerx.Printf("Error reading askpass helper %q: %v", askpassfile, err)
-	}
-	if len(askpassfile) > 0 {
-		c.askpassCredHelper = &AskPassCredentialHelper{
-			Program: askpassfile,
+	if len(askpass) > 0 {
+		askpassfile, err := tools.TranslateCygwinPath(askpass)
+		if err != nil {
+			tracerx.Printf("Error reading askpass helper %q: %v", askpassfile, err)
+		}
+		if len(askpassfile) > 0 {
+			c.askpassCredHelper = &AskPassCredentialHelper{
+				Program: askpassfile,
+			}
 		}
 	}
 


### PR DESCRIPTION
If `SSH_ASKPASS` is unset on Windows, it's possible that the invocation of `cygpath -w` can fail, since we'd pass it an empty string, which it doesn't like.  Let's fix this by first checking for an empty string and only if it is not empty, passing it to cygpath.
