### PR TITLE
post-checkout: don't modify permissions of untracked files

### DIFF
--- a/git/attribs.go
+++ b/git/attribs.go
@@ -177,7 +177,7 @@ func findAttributeFiles(workingDir, gitDir string) []attrFile {
 		paths = append(paths, attrFile{path: repoAttributes, readMacros: true})
 	}
 
-	lsFiles, err := NewLsFiles(workingDir, true)
+	lsFiles, err := NewLsFiles(workingDir, true, true)
 	if err != nil {
 		tracerx.Printf("Error finding .gitattributes: %v", err)
 		return paths

--- a/git/ls_files.go
+++ b/git/ls_files.go
@@ -20,17 +20,19 @@ type LsFiles struct {
 	FilesByName map[string][]*lsFileInfo
 }
 
-func NewLsFiles(workingDir string, standardExclude bool) (*LsFiles, error) {
+func NewLsFiles(workingDir string, standardExclude bool, untracked bool) (*LsFiles, error) {
 
 	args := []string{
 		"ls-files",
 		"-z", // Use a NUL separator. This also disables the escaping of special characters.
-		"--others",
 		"--cached",
 	}
 
 	if standardExclude {
 		args = append(args, "--exclude-standard")
+	}
+	if untracked {
+		args = append(args, "--others")
 	}
 	cmd := gitNoLFS(args...)
 	cmd.Dir = workingDir

--- a/locking/lockable.go
+++ b/locking/lockable.go
@@ -113,7 +113,7 @@ func (c *Client) FixFileWriteFlagsInDir(dir string, lockablePatterns, unlockable
 func (c *Client) fixFileWriteFlags(absPath, workingDir string, lockable, unlockable *filepathfilter.Filter) error {
 
 	// Build a list of files
-	lsFiles, err := git.NewLsFiles(workingDir, !c.ModifyIgnoredFiles)
+	lsFiles, err := git.NewLsFiles(workingDir, !c.ModifyIgnoredFiles, false)
 	if err != nil {
 		return err
 	}

--- a/t/t-post-checkout.sh
+++ b/t/t-post-checkout.sh
@@ -62,6 +62,8 @@ begin_test "post-checkout"
 
   # this will be main
 
+  touch untracked.dat
+
   [ "$(cat file1.dat)" == "file 1 updated commit 2" ]
   [ "$(cat file2.dat)" == "file 2 updated commit 3" ]
   [ "$(cat file3.big)" == "file 3 creation" ]
@@ -71,6 +73,7 @@ begin_test "post-checkout"
   # without the post-checkout hook, any changed files would now be writeable
   refute_file_writeable file1.dat
   refute_file_writeable file2.dat
+  assert_file_writeable untracked.dat
   assert_file_writeable file3.big
   assert_file_writeable file4.big
 
@@ -81,6 +84,7 @@ begin_test "post-checkout"
   refute_file_writeable file1.dat
   refute_file_writeable file2.dat
   refute_file_writeable file5.dat
+  assert_file_writeable untracked.dat
   assert_file_writeable file3.big
   assert_file_writeable file4.big
   assert_file_writeable file6.big

--- a/t/t-track.sh
+++ b/t/t-track.sh
@@ -446,6 +446,7 @@ begin_test "track lockable read-only/read-write"
   mkdir subfolder
   echo "sub blah blah" > subfolder/test.bin
   echo "sub foo bar" > subfolder/test.dat
+  git add *.bin *.dat subfolder
   # should start writeable
   assert_file_writeable test.bin
   assert_file_writeable test.dat


### PR DESCRIPTION
Git doesn't know about untracked files, so we should avoid modifying them when we adjust permissions in the post-checkout hook.  Add an option to our invocation of git ls-files that controls the use of the `--others` flag (which controls listing untracked files), and disable it when we're looking for files to process with the post-checkout hook.

Fixes #4757
/cc @rainwf as reporter