### PR TITLE
avoid panic on checkout with --to but no path and update checkout manual

### DIFF
--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -28,6 +28,9 @@ func checkoutCommand(cmd *cobra.Command, args []string) {
 	}
 
 	if checkoutTo != "" && stage != git.IndexStageDefault {
+		if len(args) != 1 {
+			Exit("--to requires exactly one Git LFS object file path")
+		}
 		checkoutConflict(rootedPaths(args)[0], stage)
 		return
 	} else if checkoutTo != "" || stage != git.IndexStageDefault {

--- a/docs/man/git-lfs-checkout.1.ronn
+++ b/docs/man/git-lfs-checkout.1.ronn
@@ -3,26 +3,29 @@ git-lfs-checkout(1) -- Update working copy with file content if available
 
 ## SYNOPSIS
 
-`git lfs checkout` <filespec>...
-`git lfs checkout` --to <path> { --ours | --theirs | --base } <file>...
+`git lfs checkout` [<glob-pattern>...]<br>
+`git lfs checkout` --to <file> {--base|--ours|--theirs} <conflict-obj-path>
 
 ## DESCRIPTION
 
 Try to ensure that the working copy contains file content for Git LFS objects
 for the current ref, if the object data is available. Does not download any
-content, see git-lfs-fetch(1) for that.
+content; see git-lfs-fetch(1) for that.
 
 Checkout scans the current ref for all LFS objects that would be required, then
 where a file is either missing in the working copy, or contains placeholder
 pointer content with the same SHA, the real file content is written, provided
 we have it in the local store. Modified files are never overwritten.
 
-Filespecs can be provided as arguments to restrict the files which are updated.
+One or more <glob-pattern>s may be provided as arguments to restrict the
+set of files that are updated. Glob patterns are matched as per the format
+described in gitignore(5).
 
 When used with `--to` and the working tree is in a conflicted state due to a
-merge, this option checks out one of the three stages of the conflict into a
-separate file. This can make using diff tools to inspect and resolve merges
-easier.
+merge, this option checks out one of the three stages a conflicting Git LFS
+object into a separate file (which can be outside of the work tree).
+This can make using diff tools to inspect and resolve merges easier.
+A single Git LFS object's file path must be provided in <conflict-obj-path>.
 
 ## OPTIONS
 
@@ -43,17 +46,42 @@ easier.
 
 ## EXAMPLES
 
-* Checkout all files that are missing or placeholders
+* Checkout all files that are missing or placeholders:
 
-  `git lfs checkout`
+```
+$ git lfs checkout
+```
 
-* Checkout a specific couple of files
+* Checkout a specific couple of files:
 
-  `git lfs checkout path/to/file1.png path/to.file2.png`
+```
+$ git lfs checkout path/to/file1.png path/to.file2.png
+```
+
+* Checkout a path with a merge conflict into separate files:
+
+```
+# Attempt merge with a branch that has a merge conflict
+$ git merge conflicting-branch
+CONFLICT (content): Merge conflict in path/to/conflicting/file.dat
+
+# Checkout versions of the conflicting file into temp files
+$ git lfs checkout ours.dat --ours path/to/conflicting/file.dat
+$ git lfs checkout theirs.dat --theirs path/to/conflicting/file.dat
+
+# Compare conflicting versions in ours.dat and theirs.dat,
+# then resolve conflict (e.g., by choosing one version over
+# the other, or creating a new version)
+
+# Cleanup and continue with merge
+$ rm ours.dat theirs.dat
+$ git add path/to/conflicting/file.dat
+$ git merge --continue
+```
 
 ## SEE ALSO
 
-git-lfs-fetch(1), git-lfs-pull(1).
+git-lfs-fetch(1), git-lfs-pull(1), gitignore(5).
 
 Part of the git-lfs(1) suite.
 


### PR DESCRIPTION
At present if the `git lfs checkout` command is invoked with the `--to` option, a file path, and a "stage" option (one of --, but without any object path, a Go panic is reported, because there is an attempt to reference the non-existent first element of the `args` slice.  For example, `git lfs checkout --to foo --base` reports a panic.

We address this issue by exiting with an error message if the number of additional arguments is not exactly one when `--to` is supplied along with accompanying file path and one of the "stage" options.

This also covers the situation where the user supplies these options plus spurious additional arguments beyond a single Git LFS object path, since only a single object can be checked out at a given stage into the file specified with `--to`.  (Note that
this object path is not treated as a filepath pattern, unlike the normal `git lfs checkout` mode of operation.)

To validate this change we expand our `"checkout: conficts"` test to check the relevant cases, and we also add some checks for other invalid options and arguments, such as when no "stage" option is given, when too many "stage" options are set, or when paths to conflicting files are provided which do not correspond to Git LFS objects.

Note that while our new checks will not catch a Go panic in particular, they would still cause the test to fail if our previous commit's change was not in place, because the expected new error message would not appear.

To accord with our change we also update the `git-lfs-checkout(1)` manual page to clarify that only a single path should be provided in this case, and that it must reference a conflicting Git LFS object file, not just any file with a merge conflict.

We also add some missing formatting in the Synposis section to ensure the two alternative invocation formats are clearly separated, and we adjust the terminology of some of the user-provided arguments to align better with Git's manual and with other Git LFS manual pages.

Specifically, we use `<file>` to indicate any file in the filesystem (e.g., as [seen](https://git-scm.com/docs/git-log#Documentation/git-log.txt---outputltfilegt) in `git log --output=<file>`), `<glob-pattern>` to indicate a Git LFS glob pathspec pattern matched according to `gitignore(5)` rules (similar to the [usage](https://git-scm.com/docs/git-log#Documentation/git-log.txt---globltglob-patterngt) in `git log --glob=<glob-pattern>`, although we match files in the index rather than under `.git/refs`), and `<path>` (in this case, `<conflict-obj-path>`) to indicate a path within the repository.  And we expand on the details of each of these terms in the text of the manual page as well.

Finally, we refine and expand the Examples section by adding an example use case for the `--to` option, and making all the examples follow the same formatting style.