### PR TITLE
filter-process: don't print large file warning on fixed versions

### DIFF
--- a/commands/command_filter_process.go
+++ b/commands/command_filter_process.go
@@ -212,7 +212,7 @@ func filterCommand(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	if len(malformedOnWindows) > 0 && cfg.Git.Bool("lfs.largefilewarning", true) {
+	if len(malformedOnWindows) > 0 && cfg.Git.Bool("lfs.largefilewarning", !git.IsGitVersionAtLeast("2.34.0")) {
 		fmt.Fprintf(os.Stderr, "Encountered %d file(s) that may not have been copied correctly on Windows:\n", len(malformedOnWindows))
 
 		for _, m := range malformedOnWindows {

--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -111,8 +111,9 @@ be scoped inside the configuration for a remote.
 * `lfs.largefilewarning`
 
   Warn when a file is 4 GiB or larger. Such files will be corrupted when using
-  Windows (unless smudging is disabled) due to a limitation in Git.  Default:
-  true.
+  Windows (unless smudging is disabled) with a Git for Windows version less than
+  2.34.0 due to a limitation in Git.  Default: true if the version is less than
+  2.34.0, false otherwise.
 
 ### Transfer (upload / download) settings
 

--- a/docs/man/git-lfs-smudge.1.ronn
+++ b/docs/man/git-lfs-smudge.1.ronn
@@ -29,10 +29,9 @@ standard output.
 
 ## KNOWN BUGS
 
-On Windows, Git does not handle files in the working tree larger than 4
-gigabytes.
-
-For more information, see: https://github.com/git-lfs/git-lfs/issues/2434.
+On Windows, Git before 2.34.0 does not handle files in the working tree larger
+than 4 gigabytes.  Newer versions of Git, as well as Unix versions, are
+unaffected.
 
 ## SEE ALSO
 


### PR DESCRIPTION
In Git for Windows 2.34.0 and the upcoming Git 2.35.0, the issue that's caused corruption on Windows has been fixed.  Let's avoid warning users that there's a problem if they're using 2.34.0 or newer unless they've specifically set the option to true.  Note that we only consider 2.34.0 and not 2.35 since Unix has never had this issue.  Update the documentation as well to reflect the new default.

Fixes #4744