### PR TITLE
migrate import: don't allow path filters with --above

### DIFF
--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -18,6 +18,7 @@ import (
 	"github.com/git-lfs/git-lfs/v3/tasklog"
 	"github.com/git-lfs/git-lfs/v3/tools"
 	"github.com/git-lfs/git-lfs/v3/tools/humanize"
+	"github.com/git-lfs/git-lfs/v3/tr"
 	"github.com/git-lfs/gitobj/v2"
 	"github.com/spf13/cobra"
 )
@@ -137,6 +138,12 @@ func migrateImportCommand(cmd *cobra.Command, args []string) {
 	above, err := humanize.ParseBytes(migrateImportAboveFmt)
 	if err != nil {
 		ExitWithError(errors.Wrap(err, "fatal: cannot parse --above=<n>"))
+	}
+	if above > 0 {
+		include, exclude := getIncludeExcludeArgs(cmd)
+		if include != nil || exclude != nil || migrateFixup {
+			ExitWithError(errors.Errorf(tr.Tr.Get("fatal: cannot use --above with --include, --exclude, --fixup")))
+		}
 	}
 
 	blobCache := make(map[string]bytes.Buffer)

--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -232,7 +232,8 @@ options and these additional ones:
 * `--above=<size>`
     Only migrate files whose individual filesize is above the given size. `size`
     may be specified as a number of bytes, or a number followed by a storage
-    unit, e.g., "1b", "20 MB", "3 TiB", etc.
+    unit, e.g., "1b", "20 MB", "3 TiB", etc.  This option cannot be used with
+    the `--include`, `--exclude`, and `--fixup` options.
 
 * `--object-map=<path>`
     Write to `path` a file with the mapping of each rewritten commits. The file

--- a/t/t-migrate-import.sh
+++ b/t/t-migrate-import.sh
@@ -487,6 +487,22 @@ begin_test "migrate import (above with multiple files)"
 )
 end_test
 
+begin_test "migrate import (above with include or exclude)"
+(
+  set -e
+  setup_single_local_branch_untracked
+
+  md_main_oid="$(calc_oid "$(git cat-file -p "refs/heads/main:a.md")")"
+  txt_main_oid="$(calc_oid "$(git cat-file -p "refs/heads/main:a.txt")")"
+
+  git lfs migrate import --above 121B --include "*.md" && exit 1
+  git lfs migrate import --above 121B --exclude "*.txt" && exit 1
+  git lfs migrate import --above 121B --fixup && exit 1
+  true
+)
+end_test
+
+
 begin_test "migrate import (existing .gitattributes)"
 (
   set -e


### PR DESCRIPTION
The `--include`, `--exclude`, and `--fixup` options don't work properly with `--above`, so let's print an error instead of silently doing the wrong thing.  Document this fact as well to make sure that people aren't surprised.
