### PR TITLE
Add CODEOWNERS to automatically ping on review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @git-lfs/core


### PR DESCRIPTION
Currently, when someone opens a PR, they either have to ping the @git-lfs/core team as reviewers or hope that someone sees the PR.  Let's help the users out by automatically pinging the team for review by adding a CODEOWNERs, which we can then work into our branch protection rules.