### PR TITLE
Move `err` checking to before the value was used

### DIFF
--- a/t/git-lfs-test-server-api/main.go
+++ b/t/git-lfs-test-server-api/main.go
@@ -150,12 +150,12 @@ func buildManifest(r *t.Repo) (*tq.Manifest, error) {
 	}
 
 	apiClient, err := lfsapi.NewClient(r)
+	if err != nil {
+		return nil, err
+	}
 	apiClient.Endpoints = &constantEndpoint{
 		e:              endp,
 		EndpointFinder: apiClient.Endpoints,
-	}
-	if err != nil {
-		return nil, err
 	}
 	return tq.NewManifest(r.Filesystem(), apiClient, "", ""), nil
 }


### PR DESCRIPTION
Or else `apiClient` might not have an `Endpoints` attribute and just be `nil` when accessed