### PR TITLE
script/packagecloud: update for latest distros

### DIFF
--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -45,9 +45,8 @@ $distro_name_map = {
   ],
   "centos/8" => [
     "el/8",
-    "fedora/32",
-    "fedora/33",
     "fedora/34",
+    "fedora/35",
   ],
   # Debian EOL https://wiki.debian.org/LTS/
   # Ubuntu EOL https://wiki.ubuntu.com/Releases
@@ -65,13 +64,15 @@ $distro_name_map = {
     "debian/buster",
     "linuxmint/ulyana", # EOL April 2025
     "linuxmint/ulyssa", # EOL April 2025
+    "linuxmint/uma",    # EOL April 2025
     "ubuntu/focal",     # EOL April 2025
-    "ubuntu/groovy",    # EOL July 2021
     "ubuntu/hirsute",   # EOL January 2022
   ],
   "debian/11" => [
     "debian/bullseye",  # Current stable
-    "debian/bookworm", # Current testing
+    "debian/bookworm",  # Current testing
+    "ubuntu/impish",    # EOL July 2022
+    "ubuntu/jammy",     # EOL April 2027
   ]
 }
 


### PR DESCRIPTION
Remove Fedora 32 and 33, which are EOL.  Add Fedora 35, which is the latest version.  Add the latest versions of Ubuntu and Linux Mint, and remove EOL versions of Ubuntu.  Fix the alignment of the comments.

Fixes #4767