### PR TITLE
Fix migrate import speed regression

### DIFF
--- a/commands/command_migrate_export.go
+++ b/commands/command_migrate_export.go
@@ -43,7 +43,7 @@ func migrateExportCommand(cmd *cobra.Command, args []string) {
 	opts := &githistory.RewriteOptions{
 		Verbose:           migrateVerbose,
 		ObjectMapFilePath: objectMapFilePath,
-		BlobFn: func(path string, oid []byte, b *gitobj.Blob) (*gitobj.Blob, error) {
+		BlobFn: func(path string, b *gitobj.Blob) (*gitobj.Blob, error) {
 			if filepath.Base(path) == ".gitattributes" {
 				return b, nil
 			}

--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -146,12 +146,10 @@ func migrateImportCommand(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	blobCache := make(map[string]bytes.Buffer)
-
 	migrate(args, rewriter, l, &githistory.RewriteOptions{
 		Verbose:           migrateVerbose,
 		ObjectMapFilePath: objectMapFilePath,
-		BlobFn: func(path string, origOid []byte, b *gitobj.Blob) (*gitobj.Blob, error) {
+		BlobFn: func(path string, b *gitobj.Blob) (*gitobj.Blob, error) {
 			if filepath.Base(path) == ".gitattributes" {
 				return b, nil
 			}
@@ -175,12 +173,8 @@ func migrateImportCommand(cmd *cobra.Command, args []string) {
 
 			var buf bytes.Buffer
 
-			buf, cached := blobCache[hex.EncodeToString(origOid)]
-			if !cached {
-				if _, err := clean(gitfilter, &buf, b.Contents, path, b.Size); err != nil {
-					return nil, err
-				}
-				blobCache[hex.EncodeToString(origOid)] = buf
+			if _, err := clean(gitfilter, &buf, b.Contents, path, b.Size); err != nil {
+				return nil, err
 			}
 
 			if ext := filepath.Ext(path); len(ext) > 0 && above == 0 {

--- a/commands/command_migrate_info.go
+++ b/commands/command_migrate_info.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
@@ -115,10 +114,8 @@ func migrateInfoCommand(cmd *cobra.Command, args []string) {
 	pointersInfoEntry := &MigrateInfoEntry{Qualifier: "LFS Objects", Separate: true}
 	var fixups *gitattr.Tree
 
-	blobSeenSet := make(map[string]struct{})
-
 	migrate(args, rewriter, l, &githistory.RewriteOptions{
-		BlobFn: func(path string, origOid []byte, b *gitobj.Blob) (*gitobj.Blob, error) {
+		BlobFn: func(path string, b *gitobj.Blob) (*gitobj.Blob, error) {
 			var entry *MigrateInfoEntry
 			var size int64
 			var p *lfs.Pointer
@@ -141,31 +138,25 @@ func migrateInfoCommand(cmd *cobra.Command, args []string) {
 				}
 			}
 
-			_, seen := blobSeenSet[hex.EncodeToString(origOid)]
-			if !seen {
-				blobSeenSet[hex.EncodeToString(origOid)] = struct{}{}
-
-				if migrateInfoPointersMode != migrateInfoPointersNoFollow {
-					p, err = lfs.DecodePointerFromBlob(b)
+			if migrateInfoPointersMode != migrateInfoPointersNoFollow {
+				p, err = lfs.DecodePointerFromBlob(b)
+			}
+			if p != nil && err == nil {
+				if migrateInfoPointersMode == migrateInfoPointersIgnore {
+					return b, nil
 				}
-				if p != nil && err == nil {
-					if migrateInfoPointersMode == migrateInfoPointersIgnore {
-						return b, nil
-					}
-					entry = pointersInfoEntry
-					size = p.Size
-				} else {
-					entry = findEntryByExtension(exts, path)
-					size = b.Size
-				}
+				entry = pointersInfoEntry
+				size = p.Size
+			} else {
+				entry = findEntryByExtension(exts, path)
+				size = b.Size
+			}
 
-				entry.Total++
+			entry.Total++
 
-				if size > int64(migrateInfoAbove) {
-					entry.TotalAbove++
-					entry.BytesAbove += size
-				}
-
+			if size > int64(migrateInfoAbove) {
+				entry.TotalAbove++
+				entry.BytesAbove += size
 			}
 
 			return b, nil

--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -383,7 +383,7 @@ func (r *Rewriter) rewriteTree(commitOID []byte, treeOID []byte, path string,
 			continue
 		}
 
-		if cached := r.uncacheEntry(entry); cached != nil {
+		if cached := r.uncacheEntry(fullpath, entry); cached != nil {
 			entries = append(entries, copyEntryMode(cached,
 				entry.Filemode))
 			continue
@@ -404,7 +404,7 @@ func (r *Rewriter) rewriteTree(commitOID []byte, treeOID []byte, path string,
 			return nil, err
 		}
 
-		entries = append(entries, r.cacheEntry(entry, &gitobj.TreeEntry{
+		entries = append(entries, r.cacheEntry(fullpath, entry, &gitobj.TreeEntry{
 			Filemode: entry.Filemode,
 			Name:     entry.Name,
 			Oid:      oid,
@@ -590,11 +590,11 @@ func (r *Rewriter) Filter() *filepathfilter.Filter {
 
 // cacheEntry caches then given "from" entry so that it is always rewritten as
 // a *TreeEntry equivalent to "to".
-func (r *Rewriter) cacheEntry(from, to *gitobj.TreeEntry) *gitobj.TreeEntry {
+func (r *Rewriter) cacheEntry(path string, from, to *gitobj.TreeEntry) *gitobj.TreeEntry {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	r.entries[r.entryKey(from)] = to
+	r.entries[r.entryKey(path, from)] = to
 
 	return to
 }
@@ -602,16 +602,16 @@ func (r *Rewriter) cacheEntry(from, to *gitobj.TreeEntry) *gitobj.TreeEntry {
 // uncacheEntry returns a *TreeEntry that is cached from the given *TreeEntry
 // "from". That is to say, it returns the *TreeEntry that "from" should be
 // rewritten to, or nil if none could be found.
-func (r *Rewriter) uncacheEntry(from *gitobj.TreeEntry) *gitobj.TreeEntry {
+func (r *Rewriter) uncacheEntry(path string, from *gitobj.TreeEntry) *gitobj.TreeEntry {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	return r.entries[r.entryKey(from)]
+	return r.entries[r.entryKey(path, from)]
 }
 
 // entryKey returns a unique key for a given *TreeEntry "e".
-func (r *Rewriter) entryKey(e *gitobj.TreeEntry) string {
-	return fmt.Sprintf("%s:%x", e.Name, e.Oid)
+func (r *Rewriter) entryKey(path string, e *gitobj.TreeEntry) string {
+	return fmt.Sprintf("%s:%x", path, e.Oid)
 }
 
 // cacheEntry caches then given "from" commit so that it is always rewritten as

--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -116,11 +116,9 @@ func (r *RewriteOptions) treeFn() TreeCallbackFn {
 // instance, a file "b.txt" in directory "dir" would be given as "/dir/b.txt",
 // where as a file "a.txt" in the root would be given as "/a.txt".
 //
-// The origOid argument is the OID (i.e. the SHA) of the blob to be rewritten.
-//
 // As above, the path separators are OS specific, and equivalent to the result
 // of filepath.Join(...) or os.PathSeparator.
-type BlobRewriteFn func(path string, origOid []byte, b *gitobj.Blob) (*gitobj.Blob, error)
+type BlobRewriteFn func(path string, b *gitobj.Blob) (*gitobj.Blob, error)
 
 // TreePreCallbackFn specifies a function to call upon opening a new tree for
 // rewriting.
@@ -178,7 +176,7 @@ var (
 
 	// noopBlobFn is a no-op implementation of the BlobRewriteFn. It returns
 	// the blob that it was given, and returns no error.
-	noopBlobFn = func(path string, origOid []byte, b *gitobj.Blob) (*gitobj.Blob, error) { return b, nil }
+	noopBlobFn = func(path string, b *gitobj.Blob) (*gitobj.Blob, error) { return b, nil }
 	// noopTreePreFn is a no-op implementation of the TreePreRewriteFn. It
 	// returns the tree that it was given, and returns no error.
 	noopTreePreFn = func(path string, t *gitobj.Tree) error { return nil }
@@ -385,6 +383,12 @@ func (r *Rewriter) rewriteTree(commitOID []byte, treeOID []byte, path string,
 			continue
 		}
 
+		if cached := r.uncacheEntry(entry); cached != nil {
+			entries = append(entries, copyEntryMode(cached,
+				entry.Filemode))
+			continue
+		}
+
 		var oid []byte
 
 		switch entry.Type() {
@@ -461,7 +465,7 @@ func (r *Rewriter) rewriteBlob(commitOID, from []byte, path string, fn BlobRewri
 		return nil, err
 	}
 
-	b, err := fn(path, from, blob)
+	b, err := fn(path, blob)
 	if err != nil {
 		return nil, err
 	}

--- a/git/githistory/rewriter_test.go
+++ b/git/githistory/rewriter_test.go
@@ -21,7 +21,7 @@ func TestRewriterRewritesHistory(t *testing.T) {
 	r := NewRewriter(db)
 
 	tip, err := r.Rewrite(&RewriteOptions{Include: []string{"refs/heads/master"},
-		BlobFn: func(path string, origOid []byte, b *gitobj.Blob) (*gitobj.Blob, error) {
+		BlobFn: func(path string, b *gitobj.Blob) (*gitobj.Blob, error) {
 			contents, err := ioutil.ReadAll(b.Contents)
 			if err != nil {
 				return nil, err
@@ -82,7 +82,7 @@ func TestRewriterRewritesOctopusMerges(t *testing.T) {
 	r := NewRewriter(db)
 
 	tip, err := r.Rewrite(&RewriteOptions{Include: []string{"refs/heads/master"},
-		BlobFn: func(path string, origOid []byte, b *gitobj.Blob) (*gitobj.Blob, error) {
+		BlobFn: func(path string, b *gitobj.Blob) (*gitobj.Blob, error) {
 			return &gitobj.Blob{
 				Contents: io.MultiReader(b.Contents, strings.NewReader("_new")),
 				Size:     b.Size + int64(len("_new")),
@@ -129,7 +129,7 @@ func TestRewriterVisitsPackedObjects(t *testing.T) {
 	var contents []byte
 
 	_, err := r.Rewrite(&RewriteOptions{Include: []string{"refs/heads/master"},
-		BlobFn: func(path string, origOid []byte, b *gitobj.Blob) (*gitobj.Blob, error) {
+		BlobFn: func(path string, b *gitobj.Blob) (*gitobj.Blob, error) {
 			var err error
 
 			contents, err = ioutil.ReadAll(b.Contents)
@@ -155,7 +155,7 @@ func TestRewriterDoesntVisitUnchangedSubtrees(t *testing.T) {
 	seen := make(map[string]int)
 
 	_, err := r.Rewrite(&RewriteOptions{Include: []string{"refs/heads/master"},
-		BlobFn: func(path string, origOid []byte, b *gitobj.Blob) (*gitobj.Blob, error) {
+		BlobFn: func(path string, b *gitobj.Blob) (*gitobj.Blob, error) {
 			seen[path] = seen[path] + 1
 
 			return b, nil
@@ -173,7 +173,7 @@ func TestRewriterVisitsUniqueEntriesWithIdenticalContents(t *testing.T) {
 	r := NewRewriter(db)
 
 	tip, err := r.Rewrite(&RewriteOptions{Include: []string{"refs/heads/master"},
-		BlobFn: func(path string, origOid []byte, b *gitobj.Blob) (*gitobj.Blob, error) {
+		BlobFn: func(path string, b *gitobj.Blob) (*gitobj.Blob, error) {
 			if path == "b.txt" {
 				return b, nil
 			}
@@ -213,7 +213,7 @@ func TestRewriterIgnoresPathsThatDontMatchFilter(t *testing.T) {
 	seen := make(map[string]int)
 
 	_, err := r.Rewrite(&RewriteOptions{Include: []string{"refs/heads/master"},
-		BlobFn: func(path string, origOid []byte, b *gitobj.Blob) (*gitobj.Blob, error) {
+		BlobFn: func(path string, b *gitobj.Blob) (*gitobj.Blob, error) {
 			seen[path] = seen[path] + 1
 
 			return b, nil
@@ -236,7 +236,7 @@ func TestRewriterAllowsAdditionalTreeEntries(t *testing.T) {
 	assert.Nil(t, err)
 
 	tip, err := r.Rewrite(&RewriteOptions{Include: []string{"refs/heads/master"},
-		BlobFn: func(path string, origOid []byte, b *gitobj.Blob) (*gitobj.Blob, error) {
+		BlobFn: func(path string, b *gitobj.Blob) (*gitobj.Blob, error) {
 			return b, nil
 		},
 
@@ -307,7 +307,7 @@ var (
 	// is received.
 	collectCalls = func(calls *[]*CallbackCall) *RewriteOptions {
 		return &RewriteOptions{Include: []string{"refs/heads/master"},
-			BlobFn: func(path string, origOid []byte, b *gitobj.Blob) (*gitobj.Blob, error) {
+			BlobFn: func(path string, b *gitobj.Blob) (*gitobj.Blob, error) {
 				*calls = append(*calls, &CallbackCall{
 					Type: "blob",
 					Path: path,
@@ -384,7 +384,7 @@ func TestHistoryRewriterTreePreCallbackPropagatesErrors(t *testing.T) {
 	r := NewRewriter(db)
 
 	_, err := r.Rewrite(&RewriteOptions{Include: []string{"refs/heads/master"},
-		BlobFn: func(path string, origOid []byte, b *gitobj.Blob) (*gitobj.Blob, error) {
+		BlobFn: func(path string, b *gitobj.Blob) (*gitobj.Blob, error) {
 			return b, nil
 		},
 
@@ -404,7 +404,7 @@ func TestHistoryRewriterUseOriginalParentsForPartialMigration(t *testing.T) {
 		Include: []string{"refs/heads/master"},
 		Exclude: []string{"refs/tags/middle"},
 
-		BlobFn: func(path string, origOid []byte, b *gitobj.Blob) (*gitobj.Blob, error) {
+		BlobFn: func(path string, b *gitobj.Blob) (*gitobj.Blob, error) {
 			return b, nil
 		},
 	})
@@ -441,7 +441,7 @@ func TestHistoryRewriterUpdatesRefs(t *testing.T) {
 
 		UpdateRefs: true,
 
-		BlobFn: func(path string, origOid []byte, b *gitobj.Blob) (*gitobj.Blob, error) {
+		BlobFn: func(path string, b *gitobj.Blob) (*gitobj.Blob, error) {
 			suffix := strings.NewReader("_suffix")
 
 			return &gitobj.Blob{

--- a/git/githistory/rewriter_test.go
+++ b/git/githistory/rewriter_test.go
@@ -148,7 +148,7 @@ func TestRewriterVisitsPackedObjects(t *testing.T) {
 	assert.Equal(t, string(contents), "Hello, world!\n")
 }
 
-func TestRewriterDoesVisitUnchangedSubtrees(t *testing.T) {
+func TestRewriterDoesntVisitUnchangedSubtrees(t *testing.T) {
 	db := DatabaseFromFixture(t, "repeated-subtrees.git")
 	r := NewRewriter(db)
 
@@ -165,7 +165,7 @@ func TestRewriterDoesVisitUnchangedSubtrees(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, 2, seen["a.txt"])
-	assert.Equal(t, 2, seen["subdir/b.txt"])
+	assert.Equal(t, 1, seen["subdir/b.txt"])
 }
 
 func TestRewriterVisitsUniqueEntriesWithIdenticalContents(t *testing.T) {
@@ -221,7 +221,7 @@ func TestRewriterIgnoresPathsThatDontMatchFilter(t *testing.T) {
 	})
 
 	assert.Nil(t, err)
-	assert.Equal(t, 2, seen["a.txt"])
+	assert.Equal(t, 1, seen["a.txt"])
 	assert.Equal(t, 0, seen["subdir/b.txt"])
 }
 
@@ -366,16 +366,15 @@ func TestHistoryRewriterCallbacksSubtrees(t *testing.T) {
 
 	assert.Nil(t, err)
 
-	assert.Len(t, calls, 9)
+	assert.Len(t, calls, 8)
 	assert.Equal(t, calls[0], &CallbackCall{Type: "tree-pre", Path: "/"})
 	assert.Equal(t, calls[1], &CallbackCall{Type: "blob", Path: "a.txt"})
 	assert.Equal(t, calls[2], &CallbackCall{Type: "tree-post", Path: "/"})
 	assert.Equal(t, calls[3], &CallbackCall{Type: "tree-pre", Path: "/"})
-	assert.Equal(t, calls[4], &CallbackCall{Type: "blob", Path: "a.txt"})
-	assert.Equal(t, calls[5], &CallbackCall{Type: "tree-pre", Path: "/subdir"})
-	assert.Equal(t, calls[6], &CallbackCall{Type: "blob", Path: "subdir/b.txt"})
-	assert.Equal(t, calls[7], &CallbackCall{Type: "tree-post", Path: "/subdir"})
-	assert.Equal(t, calls[8], &CallbackCall{Type: "tree-post", Path: "/"})
+	assert.Equal(t, calls[4], &CallbackCall{Type: "tree-pre", Path: "/subdir"})
+	assert.Equal(t, calls[5], &CallbackCall{Type: "blob", Path: "subdir/b.txt"})
+	assert.Equal(t, calls[6], &CallbackCall{Type: "tree-post", Path: "/subdir"})
+	assert.Equal(t, calls[7], &CallbackCall{Type: "tree-post", Path: "/"})
 }
 
 func TestHistoryRewriterTreePreCallbackPropagatesErrors(t *testing.T) {

--- a/t/t-migrate-import.sh
+++ b/t/t-migrate-import.sh
@@ -1053,6 +1053,25 @@ begin_test "migrate import (copied file)"
 )
 end_test
 
+begin_test "migrate import (copied file with only a single path)"
+(
+  set -e
+
+  setup_local_branch_with_copied_file
+
+  oid="$(calc_oid "$(git cat-file -p :a.txt)")"
+
+  # Prevent MSYS from rewriting /a.txt into a Windows path.
+  MSYS_NO_PATHCONV=1 git lfs migrate import --include="/a.txt" --everything
+
+  # Expect attribute for only "/a.txt".
+  if grep -q "^/dir/a.txt" ./.gitattributes || ! grep -q "^/a.txt" ./.gitattributes; then
+    exit 1
+  fi
+  refute_pointer "refs/heads/main" "dir/a.txt" "$oid" 5
+)
+end_test
+
 begin_test "migrate import (filename special characters)"
 (
   set -e


### PR DESCRIPTION
When we cache files, do so on the full path instead of just the directory entry.  This means that when we have an identical file with the same name in two different direectories, we distinguish between the two paths and ensure both are added to .gitattributes.

This is an alternate solution to #4671 which should perform better.  For compmarison, with a clone of Git's main repository with the following command, we get:

`git lfs migrate import --everything --include="*.h"`:

* v3.0.1      (broken):  608s user,   53s system,    5:34 total
* v3.0.2      (fixed): 13435s user, 1255s system, 1:43:17 total
* this commit (fixed):   716s user,   67s system,    6:59 total

This is a much better performance characteristic for equivalent results.

Preserve the integration from the earlier attempt at fixing this plus add an additional one.  Avoid using `assert_pointer` in the new test because that helper doesn't always work correctly when there are two files with the same file name.

Fixes #4750 