### PR TITLE
Fall back from Negotiate to Basic

### DIFF
--- a/creds/access.go
+++ b/creds/access.go
@@ -31,3 +31,12 @@ func (a *Access) Mode() AccessMode {
 func (a *Access) URL() string {
 	return a.url
 }
+
+// AllAccessModes returns all access modes in the order they should be tried.
+func AllAccessModes() []AccessMode {
+	return []AccessMode{
+		NoneAccess,
+		NegotiateAccess,
+		BasicAccess,
+	}
+}

--- a/lfsapi/lfsapi.go
+++ b/lfsapi/lfsapi.go
@@ -17,6 +17,7 @@ type Client struct {
 
 	client  *lfshttp.Client
 	context lfshttp.Context
+	access  []creds.AccessMode
 }
 
 func NewClient(ctx lfshttp.Context) (*Client, error) {
@@ -37,6 +38,7 @@ func NewClient(ctx lfshttp.Context) (*Client, error) {
 		client:      httpClient,
 		context:     ctx,
 		credContext: creds.NewCredentialHelperContext(gitEnv, osEnv),
+		access:      creds.AllAccessModes(),
 	}
 
 	return c, nil

--- a/lfshttp/client.go
+++ b/lfshttp/client.go
@@ -3,6 +3,7 @@ package lfshttp
 import (
 	"context"
 	"crypto/tls"
+	goerrors "errors"
 	"fmt"
 	"io"
 	"net"
@@ -301,6 +302,11 @@ func (c *Client) DoWithRedirect(cli *http.Client, req *http.Request, remote stri
 
 	if err != nil {
 		c.traceResponse(req, tracedReq, nil)
+		// SPNEGO (Negotiate) errors are authentication errors.
+		var spnegoErr *spnego.Error
+		if goerrors.As(err, &spnegoErr) {
+			return nil, nil, errors.NewAuthError(err)
+		}
 		return nil, nil, err
 	}
 


### PR DESCRIPTION
The Negotiate authentication scheme can support multiple different types of authentication.  The two most popular are NTLM and Kerberos.  When we supported NTLM, we'd first try Kerberos, and if it failed, fall back to NTLM.

However, we no longer support NTLM, but some people still have server configuration that uses NTLM via Negotiate.  For these people, authentication may be broken.  Let's fall back to Basic in such a case by keeping track of which authentication mechanisms we've tried, keeping only the supported mechanisms if we got a response, and stripping out failing mechanisms, falling back to Basic.

To help with servers that support both Negotiate and Basic, we specifically consider SPNEGO (Negotiate) errors as authentication errors.  This is because if the server supports Kerberos but the client does not have a ticket, then we'll get an error trying to read the client's tickets, which will manifest in this way.