### PR TITLE
fix merging of `.gitattributes` with execute file mode during migration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ module github.com/git-lfs/git-lfs/v3
 require (
 	github.com/avast/retry-go v2.4.2+incompatible
 	github.com/dpotapov/go-spnego v0.0.0-20210315154721-298b63a54430
-	github.com/git-lfs/gitobj/v2 v2.0.2
+	github.com/git-lfs/gitobj/v2 v2.1.0
 	github.com/git-lfs/go-netrc v0.0.0-20210914205454-f0c862dd687a
 	github.com/git-lfs/pktline v0.0.0-20210330133718-06e9096e2825
 	github.com/git-lfs/wildmatch/v2 v2.0.1

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dpotapov/go-spnego v0.0.0-20210315154721-298b63a54430 h1:oempk9HjNt6rVKyKmpdnoN7XABQv3SXLWu3pxUI7Vlk=
 github.com/dpotapov/go-spnego v0.0.0-20210315154721-298b63a54430/go.mod h1:AVSs/gZKt1bOd2AhkhbS7Qh56Hv7klde22yXVbwYJhc=
-github.com/git-lfs/gitobj/v2 v2.0.2 h1:p8rWlhEyiSsC+4Qc+EdufySatf8sDtvJIrHAHgf7Ar8=
-github.com/git-lfs/gitobj/v2 v2.0.2/go.mod h1:q6aqxl6Uu3gWsip5GEKpw+7459F97er8COmU45ncAxw=
+github.com/git-lfs/gitobj/v2 v2.1.0 h1:5BUDAMga0Sv9msMXolrn6xplkiG5RaVEkOir2HSznog=
+github.com/git-lfs/gitobj/v2 v2.1.0/go.mod h1:q6aqxl6Uu3gWsip5GEKpw+7459F97er8COmU45ncAxw=
 github.com/git-lfs/go-netrc v0.0.0-20210914205454-f0c862dd687a h1:6pskVZacdMUL93pCpMAYnMDLjH1yDFhssPYGe32sjdk=
 github.com/git-lfs/go-netrc v0.0.0-20210914205454-f0c862dd687a/go.mod h1:70O4NAtvWn1jW8V8V+OKrJJYcxDLTmIozfi2fmSz5SI=
 github.com/git-lfs/pktline v0.0.0-20210330133718-06e9096e2825 h1:riQhgheTL7tMF4d5raz9t3+IzoR1i1wqxE1kZC6dY+U=

--- a/t/fixtures/migrate.sh
+++ b/t/fixtures/migrate.sh
@@ -25,6 +25,9 @@ assert_ref_unmoved() {
 #         refs/heads/main
 #
 # - Commit 'A' has 120, in a.txt, and a corresponding entry in .gitattributes.
+#
+#   If "0755" is passed as an argument, the .gitattributes file is created
+#   with that permissions mode.
 setup_local_branch_with_gitattrs() {
   set -e
 
@@ -39,6 +42,10 @@ setup_local_branch_with_gitattrs() {
 
   git lfs track "*.txt"
   git lfs track "*.other"
+
+  if [[ $1 == "0755" ]]; then
+    chmod +x .gitattributes
+  fi
 
   git add .gitattributes
   git commit -m "add .gitattributes"
@@ -118,6 +125,9 @@ setup_single_local_branch_untracked() {
 #
 # - Commit 'A' has 120, in a.txt and 140 in a.md, with both files tracked as
 #   pointers in Git LFS
+#
+#   If "0755" is passed as an argument, the .gitattributes file is created
+#   with that permissions mode.
 setup_single_local_branch_tracked() {
   set -e
 
@@ -127,6 +137,10 @@ setup_single_local_branch_tracked() {
 
   echo "*.txt filter=lfs diff=lfs merge=lfs -text" > .gitattributes
   echo "*.md filter=lfs diff=lfs merge=lfs -text" >> .gitattributes
+
+  if [[ $1 == "0755" ]]; then
+    chmod +x .gitattributes
+  fi
 
   git add .gitattributes
   git commit -m "initial commit"

--- a/t/fixtures/migrate.sh
+++ b/t/fixtures/migrate.sh
@@ -28,7 +28,7 @@ assert_ref_unmoved() {
 setup_local_branch_with_gitattrs() {
   set -e
 
-  reponame="migrate-single-remote-branch-with-attrs"
+  reponame="migrate-single-local-branch-with-attrs"
 
   remove_and_create_local_repo "$reponame"
 
@@ -56,7 +56,7 @@ setup_local_branch_with_gitattrs() {
 setup_local_branch_with_nested_gitattrs() {
   set -e
 
-  reponame="nested-attrs"
+  reponame="migrate-single-local-branch-nested-attrs"
 
   remove_and_create_local_repo "$reponame"
 
@@ -97,7 +97,7 @@ setup_single_local_branch_untracked() {
 
   local name="${1:-a.md}"
 
-  reponame="single-local-branch-untracked"
+  reponame="migrate-single-local-branch-untracked"
 
   remove_and_create_local_repo "$reponame"
 
@@ -121,7 +121,7 @@ setup_single_local_branch_untracked() {
 setup_single_local_branch_tracked() {
   set -e
 
-  reponame="migrate-single-remote-branch-with-attrs"
+  reponame="migrate-single-local-branch-tracked"
 
   remove_and_create_local_repo "$reponame"
 

--- a/t/t-migrate-import.sh
+++ b/t/t-migrate-import.sh
@@ -560,6 +560,52 @@ EOF)
 )
 end_test
 
+begin_test "migrate import (existing .gitattributes with different permissions)"
+(
+  set -e
+
+  # Windows lacks POSIX permissions.
+  [ "$IS_WINDOWS" -eq 1 ] && exit 0
+
+  setup_local_branch_with_gitattrs 0755
+
+  main="$(git rev-parse refs/heads/main)"
+
+  txt_main_oid="$(calc_oid "$(git cat-file -p "$main:a.txt")")"
+
+  [ -x .gitattributes ]
+
+  git lfs migrate import --yes --include-ref=refs/heads/main --include="*.txt"
+
+  [ ! -x .gitattributes ]
+
+  assert_local_object "$txt_main_oid" "120"
+
+  main="$(git rev-parse refs/heads/main)"
+  prev="$(git rev-parse refs/heads/main^1)"
+
+  diff -u <(git cat-file -p $main:.gitattributes) <(cat <<-EOF
+*.txt filter=lfs diff=lfs merge=lfs -text
+*.other filter=lfs diff=lfs merge=lfs -text
+EOF
+  )
+
+  diff -u <(git cat-file -p $prev:.gitattributes) <(cat <<-EOF
+*.txt filter=lfs diff=lfs merge=lfs -text
+EOF
+  )
+
+  attrs_main_sha="$(git show $main:.gitattributes | git hash-object --stdin)"
+  txt_main_sha="$(git show $main:a.txt | git hash-object --stdin)"
+
+  diff -u <(git ls-tree $main) <(cat <<-EOF
+100644 blob $attrs_main_sha	.gitattributes
+100644 blob $txt_main_sha	a.txt
+EOF
+  )
+)
+end_test
+
 begin_test "migrate import (identical contents, different permissions)"
 (
   set -e

--- a/t/t-migrate-import.sh
+++ b/t/t-migrate-import.sh
@@ -502,7 +502,6 @@ begin_test "migrate import (above with include or exclude)"
 )
 end_test
 
-
 begin_test "migrate import (existing .gitattributes)"
 (
   set -e
@@ -580,12 +579,12 @@ begin_test "migrate import (identical contents, different permissions)"
   git commit -m "make file executable"
 
   # Verify we have executable permissions.
-  ls -la foo.dat | grep 'rwx'
+  [ -x foo.dat ]
 
   git lfs migrate import --everything --include="*.dat"
 
   # Verify we have executable permissions.
-  ls -la foo.dat | grep 'rwx'
+  [ -x foo.dat ]
 )
 end_test
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -8,7 +8,7 @@ github.com/avast/retry-go
 github.com/davecgh/go-spew/spew
 # github.com/dpotapov/go-spnego v0.0.0-20210315154721-298b63a54430
 github.com/dpotapov/go-spnego
-# github.com/git-lfs/gitobj/v2 v2.0.2
+# github.com/git-lfs/gitobj/v2 v2.1.0
 github.com/git-lfs/gitobj/v2
 github.com/git-lfs/gitobj/v2/errors
 github.com/git-lfs/gitobj/v2/pack


### PR DESCRIPTION
We currently generate incorrect duplicate `.gitattributes` entries when performing an import or export migration if an existing `.gitattributes` file has execute file permissions and we intend to merge new attribute filter lines into that file.

We first add a pair of tests for this condition, one each for the migration import and export operations, which each check for a single `.gitattributes` file after migration and therefore will fail with the current behaviour.

We then bump our `git-lfs/gitobj` module to v2.1.0, as it fixes merges of tree entries where an existing tree entry has a different file permissions mode than the tree entry being merged with it.  This should resolve the problem and allow our new tests to pass.

We also revise the names used for several test repositories created by the `git lfs migrate` tests, aligning them with their actual contents and with the majority of the other names used by the test suite.  And we slightly simplify some execute permission mode checks on a file in an existing test to use the shell `-x` operator, since that's what we're using in our new tests as well.

Note that handling of `.gitattributes` tree entries which are symbolic links is left for a subsequent PR.

Fixes #4796.
/cc @yhe13 as reporter.