### PR TITLE
Update and mark message strings for translation

### DIFF
--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -31,7 +31,7 @@ func checkoutCommand(cmd *cobra.Command, args []string) {
 
 	if checkoutTo != "" && stage != git.IndexStageDefault {
 		if len(args) != 1 {
-			Exit("--to requires exactly one Git LFS object file path")
+			Exit(tr.Tr.Get("--to requires exactly one Git LFS object file path"))
 		}
 		checkoutConflict(rootedPaths(args)[0], stage)
 		return
@@ -155,7 +155,7 @@ func whichCheckout() (stage git.IndexStage, err error) {
 func rootedPaths(args []string) []string {
 	pathConverter, err := lfs.NewCurrentToRepoPatternConverter(cfg)
 	if err != nil {
-		Panic(err, "Could not checkout")
+		Panic(err, tr.Tr.Get("Could not checkout"))
 	}
 
 	rootedpaths := make([]string, 0, len(args))

--- a/commands/command_clean.go
+++ b/commands/command_clean.go
@@ -74,12 +74,12 @@ func clean(gf *lfs.GitFilter, to io.Writer, from io.Reader, fileName string, fil
 
 	if stat, _ := os.Stat(mediafile); stat != nil {
 		if stat.Size() != cleaned.Size && len(cleaned.Pointer.Extensions) == 0 {
-			Exit(tr.Tr.Get("Files don't match:\n%s\n%s", mediafile, tmpfile))
+			Exit("%s\n%s\n%s", tr.Tr.Get("Files don't match:"), mediafile, tmpfile)
 		}
 		Debug("%s exists", mediafile)
 	} else {
 		if err := os.Rename(tmpfile, mediafile); err != nil {
-			Panic(err, tr.Tr.Get("Unable to move %s to %s\n", tmpfile, mediafile))
+			Panic(err, tr.Tr.Get("Unable to move %s to %s", tmpfile, mediafile))
 		}
 
 		Debug(tr.Tr.Get("Writing %s", mediafile))

--- a/commands/command_clean.go
+++ b/commands/command_clean.go
@@ -63,7 +63,7 @@ func clean(gf *lfs.GitFilter, to io.Writer, from io.Reader, fileName string, fil
 	}
 
 	if err != nil {
-		ExitWithError(errors.Wrap(err, tr.Tr.Get("Error cleaning LFS object")))
+		ExitWithError(errors.Wrap(err, tr.Tr.Get("Error cleaning Git LFS object")))
 	}
 
 	tmpfile := cleaned.Filename

--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -38,7 +38,7 @@ speeds to 'git lfs clone'.
 	// We pass all args to git clone
 	err := git.CloneWithoutFilters(cloneFlags, args)
 	if err != nil {
-		Exit(tr.Tr.Get("Error(s) during clone:\n%v", err))
+		Exit("%s\n%v", tr.Tr.Get("Error(s) during clone:"), err)
 	}
 
 	// now execute pull (need to be inside dir)

--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -25,12 +25,13 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 	requireGitVersion()
 
 	if git.IsGitVersionAtLeast("2.15.0") {
-		msg := tr.Tr.Get(`WARNING: 'git lfs clone' is deprecated and will not be updated
-          with new flags from 'git clone'
-
-'git clone' has been updated in upstream Git to have comparable
-speeds to 'git lfs clone'.
-`)
+		// TRANSLATORS: Individual lines should not exceed 80
+		// characters, and any additional lines in the first message
+		// should be indented to align with the first line's text
+		// following the warning prefix and punctuation.
+		msg := fmt.Sprintf("%s\n\n%s",
+			tr.Tr.Get("WARNING: `git lfs clone` is deprecated and will not be updated\n          with new flags from `git clone`"),
+			tr.Tr.Get("`git clone` has been updated in upstream Git to have comparable\nspeeds to `git lfs clone`."))
 
 		fmt.Fprintln(os.Stderr, msg)
 	}
@@ -87,7 +88,7 @@ speeds to 'git lfs clone'.
 			pull(filter)
 			err := postCloneSubmodules(args)
 			if err != nil {
-				Exit(tr.Tr.Get("Error performing 'git lfs pull' for submodules: %v", err))
+				Exit(tr.Tr.Get("Error performing `git lfs pull` for submodules: %v", err))
 			}
 		}
 	}

--- a/commands/command_dedup.go
+++ b/commands/command_dedup.go
@@ -29,7 +29,7 @@ func dedupTestCommand(*cobra.Command, []string) {
 
 	if supported, err := tools.CheckCloneFileSupported(cfg.TempDir()); err != nil || !supported {
 		if err == nil {
-			err = errors.New("Unknown reason")
+			err = errors.New(tr.Tr.Get("Unknown reason"))
 		}
 		Exit(tr.Tr.Get("This system does not support de-duplication: %s", err))
 	}
@@ -38,7 +38,7 @@ func dedupTestCommand(*cobra.Command, []string) {
 		Exit(tr.Tr.Get("This platform supports file de-duplication, however, Git LFS extensions are configured and therefore de-duplication can not be used."))
 	}
 
-	Print("OK: This platform and repository support file de-duplication.")
+	Print(tr.Tr.Get("OK: This platform and repository support file de-duplication."))
 }
 
 func dedupCommand(cmd *cobra.Command, args []string) {
@@ -79,7 +79,7 @@ func dedupCommand(cmd *cobra.Command, args []string) {
 		} else if !success {
 			Error(tr.Tr.Get("Skipped: %s (Size: %d)", p.Name, p.Size))
 		} else if success {
-			Print("Success: %s (Size: %d)", p.Name, p.Size)
+			Print(tr.Tr.Get("Success: %s (Size: %d)", p.Name, p.Size))
 
 			atomic.AddInt64(&dedupStats.totalProcessedCount, 1)
 			atomic.AddInt64(&dedupStats.totalProcessedSize, p.Size)
@@ -91,11 +91,15 @@ func dedupCommand(cmd *cobra.Command, args []string) {
 		ExitWithError(err)
 	}
 
-	Print("\n\nFinished successfully.\n"+
-		"  De-duplicated  size: %d bytes\n"+
-		"                count: %d",
-		dedupStats.totalProcessedSize,
-		dedupStats.totalProcessedCount)
+	// TRANSLATORS: The second and third strings should have the colons
+	// aligned in a column.
+	Print("\n\n%s\n  %s\n  %s", tr.Tr.Get("Finished successfully."),
+		tr.Tr.GetN(
+			"De-duplicated  size: %d byte",
+			"De-duplicated  size: %d bytes",
+			int(dedupStats.totalProcessedSize),
+			dedupStats.totalProcessedSize),
+		tr.Tr.Get("              count: %d", dedupStats.totalProcessedCount))
 }
 
 // dedup executes
@@ -104,7 +108,7 @@ func dedup(p *lfs.WrappedPointer) (success bool, err error) {
 	// PRECONDITION, check ofs object exists or skip this file.
 	if !cfg.LFSObjectExists(p.Oid, p.Size) { // Not exists,
 		// Basically, this is not happens because executing 'git status' in `git.IsWorkingCopyDirty()` recover it.
-		return false, errors.New("Git LFS object file does not exist")
+		return false, errors.New(tr.Tr.Get("Git LFS object file does not exist"))
 	}
 
 	// DO de-dup
@@ -126,7 +130,7 @@ func dedup(p *lfs.WrappedPointer) (success bool, err error) {
 	if ok, err := tools.CloneFileByPath(dstFile, srcFile); err != nil {
 		return false, err
 	} else if !ok {
-		return false, errors.Errorf("unknown clone file error")
+		return false, errors.Errorf(tr.Tr.Get("unknown clone file error"))
 	}
 
 	// Recover original state

--- a/commands/command_dedup.go
+++ b/commands/command_dedup.go
@@ -72,6 +72,9 @@ func dedupCommand(cmd *cobra.Command, args []string) {
 		}
 
 		if success, err := dedup(p); err != nil {
+			// TRANSLATORS: Leading spaces should be included on
+			// the second line so the format specifier aligns with
+			// with the first format specifier on the first line.
 			Error(tr.Tr.Get("Skipped: %s (Size: %d)\n          %s", p.Name, p.Size, err))
 		} else if !success {
 			Error(tr.Tr.Get("Skipped: %s (Size: %d)", p.Name, p.Size))

--- a/commands/command_dedup.go
+++ b/commands/command_dedup.go
@@ -29,9 +29,9 @@ func dedupTestCommand(*cobra.Command, []string) {
 
 	if supported, err := tools.CheckCloneFileSupported(cfg.TempDir()); err != nil || !supported {
 		if err == nil {
-			err = errors.New("Unknown reason.")
+			err = errors.New("Unknown reason")
 		}
-		Exit(tr.Tr.Get("This system does not support deduplication. %s", err))
+		Exit(tr.Tr.Get("This system does not support deduplication: %s", err))
 	}
 
 	if len(cfg.Extensions()) > 0 {
@@ -88,7 +88,7 @@ func dedupCommand(cmd *cobra.Command, args []string) {
 		ExitWithError(err)
 	}
 
-	Print("\n\nSuccessfully finished.\n"+
+	Print("\n\nFinished successfully.\n"+
 		"  De-duplicated  size: %d bytes\n"+
 		"                count: %d",
 		dedupStats.totalProcessedSize,

--- a/commands/command_dedup.go
+++ b/commands/command_dedup.go
@@ -31,7 +31,7 @@ func dedupTestCommand(*cobra.Command, []string) {
 		if err == nil {
 			err = errors.New("Unknown reason")
 		}
-		Exit(tr.Tr.Get("This system does not support deduplication: %s", err))
+		Exit(tr.Tr.Get("This system does not support de-duplication: %s", err))
 	}
 
 	if len(cfg.Extensions()) > 0 {
@@ -51,7 +51,7 @@ func dedupCommand(cmd *cobra.Command, args []string) {
 	if gitDir, err := git.GitDir(); err != nil {
 		ExitWithError(err)
 	} else if supported, err := tools.CheckCloneFileSupported(gitDir); err != nil || !supported {
-		Exit(tr.Tr.Get("This system does not support deduplication."))
+		Exit(tr.Tr.Get("This system does not support de-duplication."))
 	}
 
 	if len(cfg.Extensions()) > 0 {
@@ -101,7 +101,7 @@ func dedup(p *lfs.WrappedPointer) (success bool, err error) {
 	// PRECONDITION, check ofs object exists or skip this file.
 	if !cfg.LFSObjectExists(p.Oid, p.Size) { // Not exists,
 		// Basically, this is not happens because executing 'git status' in `git.IsWorkingCopyDirty()` recover it.
-		return false, errors.New("mediafile is not exist")
+		return false, errors.New("Git LFS object file does not exist")
 	}
 
 	// DO de-dup

--- a/commands/command_env.go
+++ b/commands/command_env.go
@@ -12,7 +12,7 @@ func envCommand(cmd *cobra.Command, args []string) {
 
 	gitV, err := git.Version()
 	if err != nil {
-		gitV = "Error getting git version: " + err.Error()
+		gitV = "Error getting Git version: " + err.Error()
 	}
 
 	Print(config.VersionDesc)

--- a/commands/command_env.go
+++ b/commands/command_env.go
@@ -4,6 +4,7 @@ import (
 	"github.com/git-lfs/git-lfs/v3/config"
 	"github.com/git-lfs/git-lfs/v3/git"
 	"github.com/git-lfs/git-lfs/v3/lfs"
+	"github.com/git-lfs/git-lfs/v3/tr"
 	"github.com/spf13/cobra"
 )
 
@@ -12,7 +13,7 @@ func envCommand(cmd *cobra.Command, args []string) {
 
 	gitV, err := git.Version()
 	if err != nil {
-		gitV = "Error getting Git version: " + err.Error()
+		gitV = tr.Tr.Get("Error getting Git version: %s", err.Error())
 	}
 
 	Print(config.VersionDesc)

--- a/commands/command_ext.go
+++ b/commands/command_ext.go
@@ -37,10 +37,10 @@ func printAllExts() {
 }
 
 func printExt(ext config.Extension) {
-	Print(tr.Tr.Get(`Extension: %s
-    clean = %s
+	Print(tr.Tr.Get("Extension: %s", ext.Name))
+	Print(`    clean = %s
     smudge = %s
-    priority = %d`, ext.Name, ext.Clean, ext.Smudge, ext.Priority))
+    priority = %d`, ext.Clean, ext.Smudge, ext.Priority)
 }
 
 func init() {

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -93,7 +93,7 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 
 		// Fetch refs sequentially per arg order; duplicates in later refs will be ignored
 		for _, ref := range refs {
-			Print(tr.Tr.Get("fetch: Fetching reference %s", ref.Refspec()))
+			Print("fetch: %s", tr.Tr.Get("Fetching reference %s", ref.Refspec()))
 			s := fetchRef(ref.Sha, filter)
 			success = success && s
 		}
@@ -177,7 +177,7 @@ func pointersToFetchForRefs(refs []string) ([]*lfs.WrappedPointer, error) {
 		}
 
 		numObjs++
-		task.Logf(tr.Tr.GetN("fetch: %d object found", "fetch: %d objects found", int(numObjs), numObjs))
+		task.Logf("fetch: %s", tr.Tr.GetN("%d object found", "%d objects found", int(numObjs), numObjs))
 		pointers = append(pointers, p)
 	})
 
@@ -235,9 +235,9 @@ func fetchRecent(fetchconf lfs.FetchPruneConfig, alreadyFetchedRefs []*git.Ref, 
 	}
 	// First find any other recent refs
 	if fetchconf.FetchRecentRefsDays > 0 {
-		Print(tr.Tr.GetN(
-			"fetch: Fetching recent branches within %v day",
-			"fetch: Fetching recent branches within %v days",
+		Print("fetch: %s", tr.Tr.GetN(
+			"Fetching recent branches within %v day",
+			"Fetching recent branches within %v days",
 			fetchconf.FetchRecentRefsDays,
 			fetchconf.FetchRecentRefsDays,
 		))
@@ -254,7 +254,7 @@ func fetchRecent(fetchconf lfs.FetchPruneConfig, alreadyFetchedRefs []*git.Ref, 
 				}
 			} else {
 				uniqueRefShas[ref.Sha] = ref.Name
-				Print(tr.Tr.Get("fetch: Fetching reference %s", ref.Name))
+				Print("fetch: %s", tr.Tr.Get("Fetching reference %s", ref.Name))
 				k := fetchRef(ref.Sha, filter)
 				ok = ok && k
 			}
@@ -269,9 +269,9 @@ func fetchRecent(fetchconf lfs.FetchPruneConfig, alreadyFetchedRefs []*git.Ref, 
 				Error(tr.Tr.Get("Couldn't scan commits at %v: %v", refName, err))
 				continue
 			}
-			Print(tr.Tr.GetN(
-				"fetch: Fetching changes within %v day of %v",
-				"fetch: Fetching changes within %v days of %v",
+			Print("fetch: %s", tr.Tr.GetN(
+				"Fetching changes within %v day of %v",
+				"Fetching changes within %v days of %v",
 				fetchconf.FetchRecentCommitsDays,
 				fetchconf.FetchRecentCommitsDays,
 				refName,
@@ -287,7 +287,7 @@ func fetchRecent(fetchconf lfs.FetchPruneConfig, alreadyFetchedRefs []*git.Ref, 
 
 func fetchAll() bool {
 	pointers := scanAll()
-	Print(tr.Tr.Get("fetch: Fetching all references..."))
+	Print("fetch: %s", tr.Tr.Get("Fetching all references..."))
 	return fetchAndReportToChan(pointers, nil, nil)
 }
 
@@ -316,7 +316,7 @@ func scanAll() []*lfs.WrappedPointer {
 		}
 
 		numObjs++
-		task.Logf(tr.Tr.GetN("fetch: %d object found", "fetch: %d objects found", int(numObjs), numObjs))
+		task.Logf("fetch: %s", tr.Tr.GetN("%d object found", "%d objects found", int(numObjs), numObjs))
 		pointers = append(pointers, p)
 	})
 

--- a/commands/command_filter_process.go
+++ b/commands/command_filter_process.go
@@ -206,9 +206,9 @@ func filterCommand(cmd *cobra.Command, args []string) {
 	}
 
 	if len(malformed) > 0 {
-		fmt.Fprintf(os.Stderr, tr.Tr.GetN(
-			"Encountered %d file that should have been pointers, but wasn't:\n",
-			"Encountered %d files that should have been pointers, but weren't:\n",
+		fmt.Fprintln(os.Stderr, tr.Tr.GetN(
+			"Encountered %d file that should have been pointers, but wasn't:",
+			"Encountered %d files that should have been pointers, but weren't:",
 			len(malformed),
 			len(malformed),
 		))
@@ -218,9 +218,9 @@ func filterCommand(cmd *cobra.Command, args []string) {
 	}
 
 	if len(malformedOnWindows) > 0 && cfg.Git.Bool("lfs.largefilewarning", !git.IsGitVersionAtLeast("2.34.0")) {
-		fmt.Fprintf(os.Stderr, tr.Tr.GetN(
-			"Encountered %d file that may not have been copied correctly on Windows:\n",
-			"Encountered %d files that may not have been copied correctly on Windows:\n",
+		fmt.Fprintln(os.Stderr, tr.Tr.GetN(
+			"Encountered %d file that may not have been copied correctly on Windows:",
+			"Encountered %d files that may not have been copied correctly on Windows:",
 			len(malformedOnWindows),
 			len(malformedOnWindows),
 		))
@@ -229,7 +229,7 @@ func filterCommand(cmd *cobra.Command, args []string) {
 			fmt.Fprintf(os.Stderr, "\t%s\n", m)
 		}
 
-		fmt.Fprintf(os.Stderr, tr.Tr.Get("\nSee: `git lfs help smudge` for more details.\n"))
+		fmt.Fprint(os.Stderr, "\n", tr.Tr.Get("See: `git lfs help smudge` for more details."), "\n")
 	}
 
 	if err := s.Err(); err != nil && err != io.EOF {

--- a/commands/command_filter_process.go
+++ b/commands/command_filter_process.go
@@ -207,7 +207,7 @@ func filterCommand(cmd *cobra.Command, args []string) {
 
 	if len(malformed) > 0 {
 		fmt.Fprintln(os.Stderr, tr.Tr.GetN(
-			"Encountered %d file that should have been pointers, but wasn't:",
+			"Encountered %d file that should have been a pointer, but wasn't:",
 			"Encountered %d files that should have been pointers, but weren't:",
 			len(malformed),
 			len(malformed),

--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -192,7 +192,7 @@ func doFsckPointers(start, end string) []corruptPointer {
 				corruptPointers = append(corruptPointers, cp)
 			}
 		} else {
-			Panic(err, "Error checking Git LFS files")
+			Panic(err, tr.Tr.Get("Error checking Git LFS files"))
 		}
 	})
 

--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -173,7 +173,7 @@ func doFsckPointers(start, end string) []corruptPointer {
 				cp := corruptPointer{
 					blobOid: p.Sha1,
 					lfsOid:  p.Oid,
-					message: fmt.Sprintf(tr.Tr.Get("Pointer for %s (blob %s) was not canonical", p.Oid, p.Sha1)),
+					message: tr.Tr.Get("Pointer for %s (blob %s) was not canonical", p.Oid, p.Sha1),
 					kind:    "nonCanonicalPointer",
 				}
 				Print("pointer: %s", cp.String())
@@ -185,7 +185,7 @@ func doFsckPointers(start, end string) []corruptPointer {
 				cp := corruptPointer{
 					treeOid: psErr.OID(),
 					path:    psErr.Path(),
-					message: fmt.Sprintf(tr.Tr.Get("%q (treeish %s) should have been a pointer but was not", psErr.Path(), psErr.OID())),
+					message: tr.Tr.Get("%q (treeish %s) should have been a pointer but was not", psErr.Path(), psErr.OID()),
 					kind:    "unexpectedGitObject",
 				}
 				Print("pointer: %s", cp.String())

--- a/commands/command_install.go
+++ b/commands/command_install.go
@@ -53,7 +53,7 @@ func cmdInstallOptions() *lfs.FilterOptions {
 	// since we can't detect it correctly.
 	uid := os.Geteuid()
 	if systemInstall && uid != 0 && uid != -1 {
-		Print("warning: current user is not root/admin, system install is likely to fail.")
+		Print(tr.Tr.Get("warning: current user is not root/admin, system install is likely to fail."))
 	}
 
 	return &lfs.FilterOptions{

--- a/commands/command_install.go
+++ b/commands/command_install.go
@@ -21,7 +21,8 @@ var (
 
 func installCommand(cmd *cobra.Command, args []string) {
 	if err := cmdInstallOptions().Install(); err != nil {
-		Print(tr.Tr.Get("warning: %s\nRun `git lfs install --force` to reset Git configuration.", err.Error()))
+		Print(tr.Tr.Get("warning: %s", err.Error()))
+		Print(tr.Tr.Get("Run `git lfs install --force` to reset Git configuration."))
 		os.Exit(2)
 	}
 

--- a/commands/command_install.go
+++ b/commands/command_install.go
@@ -21,7 +21,7 @@ var (
 
 func installCommand(cmd *cobra.Command, args []string) {
 	if err := cmdInstallOptions().Install(); err != nil {
-		Print(tr.Tr.Get("warning: %s\nRun `git lfs install --force` to reset git config.", err.Error()))
+		Print(tr.Tr.Get("warning: %s\nRun `git lfs install --force` to reset Git configuration.", err.Error()))
 		os.Exit(2)
 	}
 

--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -103,7 +103,7 @@ func lockPath(file string) (string, error) {
 	if filepath.IsAbs(file) {
 		abs, err = tools.CanonicalizeSystemPath(file)
 		if err != nil {
-			return "", errors.New(tr.Tr.Get("lfs: unable to canonicalize path %q: %v", file, err))
+			return "", errors.New(tr.Tr.Get("unable to canonicalize path %q: %v", file, err))
 		}
 	} else {
 		abs = filepath.Join(wd, file)
@@ -115,11 +115,11 @@ func lockPath(file string) (string, error) {
 
 	path = filepath.ToSlash(path)
 	if strings.HasPrefix(path, "../") {
-		return "", errors.New(tr.Tr.Get("lfs: unable to canonicalize path %q", path))
+		return "", errors.New(tr.Tr.Get("unable to canonicalize path %q", path))
 	}
 
 	if stat, err := os.Stat(abs); err == nil && stat.IsDir() {
-		return path, errors.New(tr.Tr.Get("lfs: cannot lock directory: %s", file))
+		return path, errors.New(tr.Tr.Get("cannot lock directory: %s", file))
 	}
 
 	return filepath.ToSlash(path), nil

--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -36,7 +36,7 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 			//
 			// So, let's check early that the caller invoked the
 			// command correctly.
-			Exit(tr.Tr.Get("Did you mean \"git lfs ls-files --all --\" ?"))
+			Exit(tr.Tr.Get("Did you mean `git lfs ls-files --all --` ?"))
 		}
 
 		ref = args[0]

--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -86,7 +86,7 @@ func migrate(args []string, r *githistory.Rewriter, l *tasklog.Logger, opts *git
 func getObjectDatabase() (*gitobj.ObjectDatabase, error) {
 	dir, err := git.GitCommonDir()
 	if err != nil {
-		return nil, errors.Wrap(err, "cannot open root")
+		return nil, errors.Wrap(err, tr.Tr.Get("cannot open root"))
 	}
 
 	return git.ObjectDatabase(cfg.OSEnv(), cfg.GitEnv(), dir, cfg.TempDir())

--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -361,9 +361,9 @@ func ensureWorkingCopyClean(in io.Reader, out io.Writer) {
 	}
 
 	if proceed {
-		fmt.Fprintf(out, "migrate: %s", tr.Tr.Get("changes in your working copy will be overridden ...\n"))
+		fmt.Fprintf(out, "migrate: %s\n", tr.Tr.Get("changes in your working copy will be overridden ..."))
 	} else {
-		Exit(tr.Tr.Get("migrate: working copy must not be dirty"))
+		Exit("migrate: %s", tr.Tr.Get("working copy must not be dirty"))
 	}
 }
 

--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -271,7 +271,7 @@ func generateMigrateCommitMessage(cmd *cobra.Command, patterns string) string {
 	if cmd.Flag("message").Changed {
 		return migrateCommitMessage
 	}
-	return fmt.Sprintf(tr.Tr.Get("%s: convert to Git LFS", patterns))
+	return tr.Tr.Get("%s: convert to Git LFS", patterns)
 }
 
 // checkoutNonBare forces a checkout of the current reference, so long as the

--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -66,14 +66,14 @@ func migrateImportCommand(cmd *cobra.Command, args []string) {
 
 		filter := git.GetAttributeFilter(cfg.LocalWorkingDir(), cfg.LocalGitDir())
 		if len(filter.Include()) == 0 {
-			ExitWithError(errors.Errorf(tr.Tr.Get("No Git LFS filters found in .gitattributes")))
+			ExitWithError(errors.Errorf(tr.Tr.Get("No Git LFS filters found in '.gitattributes'")))
 		}
 
 		gf := lfs.NewGitFilter(cfg)
 
 		for _, file := range args {
 			if !filter.Allows(file) {
-				ExitWithError(errors.Errorf(tr.Tr.Get("File %s did not match any Git LFS filters in .gitattributes", file)))
+				ExitWithError(errors.Errorf(tr.Tr.Get("File %s did not match any Git LFS filters in '.gitattributes'", file)))
 			}
 		}
 

--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -435,7 +435,7 @@ func rewriteTree(gf *lfs.GitFilter, db *gitobj.ObjectDatabase, root []byte, path
 
 		subtreeEntry := tree.Entries[index]
 		if subtreeEntry.Type() != gitobj.TreeObjectType {
-			return nil, errors.Errorf(tr.Tr.Get("migrate: expected %s to be a tree, got %s", head, subtreeEntry.Type()))
+			return nil, errors.Errorf("migrate: %s", tr.Tr.Get("expected %s to be a tree, got %s", head, subtreeEntry.Type()))
 		}
 
 		rewrittenSubtree, err := rewriteTree(gf, db, subtreeEntry.Oid, tail)

--- a/commands/command_migrate_info.go
+++ b/commands/command_migrate_info.go
@@ -306,13 +306,13 @@ func (e EntriesBySize) Print(to io.Writer) (int, error) {
 		// TRANSLATORS: The strings here are intended to have the same
 		// display width including spaces, so please insert trailing
 		// spaces as necessary for your language.
-		stat := fmt.Sprintf(tr.Tr.GetN(
+		stat := tr.Tr.GetN(
 			"%d/%d file ",
 			"%d/%d files",
 			int(total),
 			above,
 			total,
-		))
+		)
 
 		percentage := fmt.Sprintf("%.0f%%", percentAbove)
 

--- a/commands/command_pointer.go
+++ b/commands/command_pointer.go
@@ -90,7 +90,7 @@ func pointerCommand(cmd *cobra.Command, args []string) {
 		}
 
 		ptr := lfs.NewPointer(hex.EncodeToString(oidHash.Sum(nil)), size, nil)
-		fmt.Fprintf(os.Stderr, tr.Tr.Get("Git LFS pointer for %s\n\n", pointerFile))
+		fmt.Fprint(os.Stderr, tr.Tr.Get("Git LFS pointer for %s", pointerFile), "\n\n")
 		buf := &bytes.Buffer{}
 		lfs.EncodePointer(io.MultiWriter(os.Stdout, buf), ptr)
 
@@ -100,7 +100,7 @@ func pointerCommand(cmd *cobra.Command, args []string) {
 				Error(err.Error())
 				os.Exit(1)
 			}
-			fmt.Fprintf(os.Stderr, tr.Tr.Get("\nGit blob OID: %s\n\n", buildOid))
+			fmt.Fprint(os.Stderr, "\n", tr.Tr.Get("Git blob OID: %s", buildOid), "\n\n")
 		}
 	} else {
 		comparing = false
@@ -123,7 +123,7 @@ func pointerCommand(cmd *cobra.Command, args []string) {
 		if !pointerStdin {
 			pointerName = pointerCompare
 		}
-		fmt.Fprintf(os.Stderr, tr.Tr.Get("Pointer from %s\n\n", pointerName))
+		fmt.Fprint(os.Stderr, tr.Tr.Get("Pointer from %s", pointerName), "\n\n")
 
 		if err != nil {
 			Error(err.Error())
@@ -137,12 +137,12 @@ func pointerCommand(cmd *cobra.Command, args []string) {
 				Error(err.Error())
 				os.Exit(1)
 			}
-			fmt.Fprintf(os.Stderr, tr.Tr.Get("\nGit blob OID: %s\n", compareOid))
+			fmt.Fprint(os.Stderr, "\n", tr.Tr.Get("Git blob OID: %s", compareOid), "\n")
 		}
 	}
 
 	if comparing && buildOid != compareOid {
-		fmt.Fprintf(os.Stderr, tr.Tr.Get("\nPointers do not match\n"))
+		fmt.Fprint(os.Stderr, "\n", tr.Tr.Get("Pointers do not match"), "\n")
 		os.Exit(1)
 	}
 

--- a/commands/command_post_checkout.go
+++ b/commands/command_post_checkout.go
@@ -55,7 +55,7 @@ func postCheckoutRevChange(client *locking.Client, pre, post string) {
 	files, err := git.GetFilesChanged(pre, post)
 
 	if err != nil {
-		LoggedError(err, tr.Tr.Get("Warning: post-checkout rev diff %v:%v failed: %v\nFalling back on full scan.", pre, post, err))
+		LoggedError(err, "%s\n%s", tr.Tr.Get("Warning: post-checkout rev diff %v:%v failed: %v", pre, post, err), tr.Tr.Get("Falling back on full scan."))
 		postCheckoutFileChange(client)
 	}
 	tracerx.Printf("post-checkout: checking write flags on %v", files)

--- a/commands/command_prune.go
+++ b/commands/command_prune.go
@@ -239,7 +239,7 @@ func pruneCheckVerified(prunableObjects []string, reachableObjects, verifiedObje
 	// deleted but that's incorrect; bad state has occurred somehow, might need
 	// push --all to resolve
 	if problems.Len() > 0 {
-		Exit(tr.Tr.Get("These objects to be pruned are missing on remote:\n%v", problems.String()))
+		Exit("%s\n%v", tr.Tr.Get("These objects to be pruned are missing on remote:"), problems.String())
 	}
 }
 
@@ -313,7 +313,8 @@ func pruneDeleteFiles(prunableObjects []string, logger *tasklog.Logger) {
 	for _, oid := range prunableObjects {
 		mediaFile, err := cfg.Filesystem().ObjectPath(oid)
 		if err != nil {
-			problems.WriteString(tr.Tr.Get("Unable to find media path for %v: %v\n", oid, err))
+			problems.WriteString(tr.Tr.Get("Unable to find media path for %v: %v", oid, err))
+			problems.WriteRune('\n')
 			continue
 		}
 		if mediaFile == os.DevNull {
@@ -321,7 +322,8 @@ func pruneDeleteFiles(prunableObjects []string, logger *tasklog.Logger) {
 		}
 		err = os.Remove(mediaFile)
 		if err != nil {
-			problems.WriteString(tr.Tr.Get("Failed to remove file %v: %v\n", mediaFile, err))
+			problems.WriteString(tr.Tr.Get("Failed to remove file %v: %v", mediaFile, err))
+			problems.WriteRune('\n')
 			continue
 		}
 		deletedFiles++

--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -175,7 +175,7 @@ func smudgeFilename(args []string) string {
 	if len(args) > 0 {
 		return args[0]
 	}
-	return tr.Tr.Get("<unknown file>")
+	return fmt.Sprintf("<%s>", tr.Tr.Get("unknown file"))
 }
 
 func possiblyMalformedObjectSize(n int64) bool {

--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -57,7 +57,7 @@ func statusCommand(cmd *cobra.Command, args []string) {
 
 	wd = tools.ResolveSymlinks(wd)
 
-	Print(tr.Tr.Get("\nObjects to be committed:\n"))
+	Print("\n%s\n", tr.Tr.Get("Objects to be committed:"))
 	for _, entry := range staged {
 		// Find a path from the current working directory to the
 		// absolute path of each side of the entry.
@@ -72,7 +72,7 @@ func statusCommand(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	Print(tr.Tr.Get("\nObjects not staged for commit:\n"))
+	Print("\n%s\n", tr.Tr.Get("Objects not staged for commit:"))
 	for _, entry := range unstaged {
 		src := relativize(wd, filepath.Join(repo, entry.SrcName))
 
@@ -243,7 +243,7 @@ func statusScanRefRange(ref *git.Ref) {
 	})
 	defer gitscanner.Close()
 
-	Print(tr.Tr.Get("Objects to be pushed to %s:\n", remoteRef.Name))
+	Print("%s\n", tr.Tr.Get("Objects to be pushed to %s:", remoteRef.Name))
 	if err := gitscanner.ScanRefRange(ref.Sha, remoteRef.Sha, nil); err != nil {
 		Panic(err, tr.Tr.Get("Could not scan for Git LFS objects"))
 	}

--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -129,7 +129,7 @@ func blobInfo(s *lfs.PointerScanner, blobSha, name string) (sha, from string, er
 		s.Scan(blobSha)
 		if err := s.Err(); err != nil {
 			if git.IsMissingObject(err) {
-				return tr.Tr.Get("<missing>"), "?", nil
+				return fmt.Sprintf("<%s>", tr.Tr.Get("missing")), "?", nil
 			}
 			return "", "", err
 		}

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -119,13 +119,13 @@ ArgsLoop:
 		attribContents, err = ioutil.ReadFile(".gitattributes")
 		// it's fine for file to not exist
 		if err != nil && !os.IsNotExist(err) {
-			Print("Error reading .gitattributes file")
+			Print("Error reading '.gitattributes' file")
 			return
 		}
 		// Re-generate the file with merge of old contents and new (to deal with changes)
 		attributesFile, err = os.OpenFile(".gitattributes", os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0660)
 		if err != nil {
-			Print("Error opening .gitattributes file")
+			Print("Error opening '.gitattributes' file")
 			return
 		}
 		defer attributesFile.Close()
@@ -189,7 +189,7 @@ ArgsLoop:
 		var matchedBlocklist bool
 		for _, f := range gittracked {
 			if forbidden := blocklistItem(f); forbidden != "" {
-				Print(tr.Tr.Get("Pattern %s matches forbidden file %s. If you would like to track %s, modify .gitattributes manually.", pattern, f, f))
+				Print(tr.Tr.Get("Pattern '%s' matches forbidden file '%s'. If you would like to track %s, modify '.gitattributes' manually.", pattern, f, f))
 				matchedBlocklist = true
 			}
 		}

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -119,13 +119,13 @@ ArgsLoop:
 		attribContents, err = ioutil.ReadFile(".gitattributes")
 		// it's fine for file to not exist
 		if err != nil && !os.IsNotExist(err) {
-			Print("Error reading '.gitattributes' file")
+			Print(tr.Tr.Get("Error reading '.gitattributes' file"))
 			return
 		}
 		// Re-generate the file with merge of old contents and new (to deal with changes)
 		attributesFile, err = os.OpenFile(".gitattributes", os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0660)
 		if err != nil {
-			Print("Error opening '.gitattributes' file")
+			Print(tr.Tr.Get("Error opening '.gitattributes' file"))
 			return
 		}
 		defer attributesFile.Close()

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -60,7 +60,7 @@ func trackCommand(cmd *cobra.Command, args []string) {
 	wd = tools.ResolveSymlinks(wd)
 	relpath, err := filepath.Rel(cfg.LocalWorkingDir(), wd)
 	if err != nil {
-		Exit(tr.Tr.Get("Current directory %q outside of git working directory %q.", wd, cfg.LocalWorkingDir()))
+		Exit(tr.Tr.Get("Current directory %q outside of Git working directory %q.", wd, cfg.LocalWorkingDir()))
 	}
 
 	changedAttribLines := make(map[string]string)

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -199,7 +199,7 @@ ArgsLoop:
 
 		for _, f := range gittracked {
 			if trackVerboseLoggingFlag || trackDryRunFlag {
-				Print(tr.Tr.Get("Git LFS: touching %q", f))
+				Print(tr.Tr.Get("Touching %q", f))
 			}
 
 			if !trackDryRunFlag {

--- a/commands/command_unlock.go
+++ b/commands/command_unlock.go
@@ -91,7 +91,7 @@ func unlockCommand(cmd *cobra.Command, args []string) {
 			}
 
 			if !locksCmdFlags.JSON {
-				Print("Unlocked %s", path)
+				Print(tr.Tr.Get("Unlocked %s", path))
 				continue
 			}
 			locks = append(locks, unlockResponse{

--- a/commands/command_untrack.go
+++ b/commands/command_untrack.go
@@ -18,7 +18,7 @@ func untrackCommand(cmd *cobra.Command, args []string) {
 	installHooks(false)
 
 	if len(args) < 1 {
-		Print(tr.Tr.Get("git lfs untrack <path> [path]*"))
+		Print("git lfs untrack <path> [path]*")
 		return
 	}
 

--- a/commands/command_untrack.go
+++ b/commands/command_untrack.go
@@ -31,7 +31,7 @@ func untrackCommand(cmd *cobra.Command, args []string) {
 
 	attributesFile, err := os.Create(".gitattributes")
 	if err != nil {
-		Print(tr.Tr.Get("Error opening .gitattributes for writing"))
+		Print(tr.Tr.Get("Error opening '.gitattributes' for writing"))
 		return
 	}
 	defer attributesFile.Close()

--- a/commands/command_update.go
+++ b/commands/command_update.go
@@ -49,7 +49,7 @@ func updateCommand(cmd *cobra.Command, args []string) {
 			Error(err.Error())
 			Exit(tr.Tr.Get("To resolve this, either:\n  1: run `git lfs update --manual` for instructions on how to merge hooks.\n  2: run `git lfs update --force` to overwrite your hook."))
 		} else {
-			Print(tr.Tr.Get("Updated git hooks."))
+			Print(tr.Tr.Get("Updated Git hooks."))
 		}
 	}
 

--- a/commands/command_update.go
+++ b/commands/command_update.go
@@ -39,7 +39,7 @@ func updateCommand(cmd *cobra.Command, args []string) {
 	}
 
 	if updateForce && updateManual {
-		Exit("You cannot use --force and --manual options together")
+		Exit(tr.Tr.Get("You cannot use --force and --manual options together"))
 	}
 
 	if updateManual {

--- a/commands/command_update.go
+++ b/commands/command_update.go
@@ -47,7 +47,10 @@ func updateCommand(cmd *cobra.Command, args []string) {
 	} else {
 		if err := installHooks(updateForce); err != nil {
 			Error(err.Error())
-			Exit(tr.Tr.Get("To resolve this, either:\n  1: run `git lfs update --manual` for instructions on how to merge hooks.\n  2: run `git lfs update --force` to overwrite your hook."))
+			Exit("%s\n  1: %s\n  2: %s",
+				tr.Tr.Get("To resolve this, either:"),
+				tr.Tr.Get("run `git lfs update --manual` for instructions on how to merge hooks."),
+				tr.Tr.Get("run `git lfs update --force` to overwrite your hook."))
 		} else {
 			Print(tr.Tr.Get("Updated Git hooks."))
 		}

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -152,7 +152,7 @@ func getHookInstallSteps() string {
 	steps := make([]string, 0, len(hooks))
 	for _, h := range hooks {
 		steps = append(steps, fmt.Sprintf(
-			"Add the following to .git/hooks/%s:\n\n%s",
+			"Add the following to '.git/hooks/%s':\n\n%s",
 			h.Type, tools.Indent(h.Contents)))
 	}
 
@@ -263,7 +263,7 @@ func LoggedError(err error, format string, args ...interface{}) {
 	file := handlePanic(err)
 
 	if len(file) > 0 {
-		fmt.Fprintf(os.Stderr, "\nErrors logged to %s.\nUse `git lfs logs last` to view the log.\n", file)
+		fmt.Fprintf(os.Stderr, "\nErrors logged to '%s'.\nUse `git lfs logs last` to view the log.\n", file)
 	}
 }
 
@@ -416,12 +416,12 @@ func logPanic(loggedError error) string {
 
 	if err := tools.MkdirAll(cfg.LocalLogDir(), cfg); err != nil {
 		full = ""
-		fmt.Fprintf(fmtWriter, "Unable to log panic to %s: %s\n\n", cfg.LocalLogDir(), err.Error())
+		fmt.Fprintf(fmtWriter, "Unable to log panic to '%s': %s\n\n", cfg.LocalLogDir(), err.Error())
 	} else if file, err := os.Create(full); err != nil {
 		filename := full
 		full = ""
 		defer func() {
-			fmt.Fprintf(fmtWriter, "Unable to log panic to %s\n\n", filename)
+			fmt.Fprintf(fmtWriter, "Unable to log panic to '%s'\n\n", filename)
 			logPanicToWriter(fmtWriter, err, lineEnding)
 		}()
 	} else {

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -177,7 +177,7 @@ func installHooks(force bool) error {
 // uninstallHooks removes all hooks in range of the `hooks` var.
 func uninstallHooks() error {
 	if !cfg.InRepo() {
-		return errors.New("Not in a git repository")
+		return errors.New("Not in a Git repository")
 	}
 
 	hookDir, err := cfg.HookDir()
@@ -310,7 +310,7 @@ func requireStdin(msg string) {
 
 func requireInRepo() {
 	if !cfg.InRepo() {
-		Print("Not in a git repository.")
+		Print("Not in a Git repository.")
 		os.Exit(128)
 	}
 }
@@ -479,7 +479,7 @@ func logPanicToWriter(w io.Writer, loggedError error, le string) {
 	// log the version
 	gitV, err := git.Version()
 	if err != nil {
-		gitV = "Error getting git version: " + err.Error()
+		gitV = "Error getting Git version: " + err.Error()
 	}
 
 	fmt.Fprint(w, config.VersionDesc+le)
@@ -556,8 +556,8 @@ func requireGitVersion() {
 	if !git.IsGitVersionAtLeast(minimumGit) {
 		gitver, err := git.Version()
 		if err != nil {
-			Exit("Error getting git version: %s", err)
+			Exit("Error getting Git version: %s", err)
 		}
-		Exit("git version %s or higher is required for Git LFS; your version: %s", minimumGit, gitver)
+		Exit("Git version %s or higher is required for Git LFS; your version: %s", minimumGit, gitver)
 	}
 }

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -482,8 +482,8 @@ func logPanicToWriter(w io.Writer, loggedError error, le string) {
 		gitV = "Error getting Git version: " + err.Error()
 	}
 
-	fmt.Fprint(w, config.VersionDesc+le)
-	fmt.Fprint(w, gitV+le)
+	fmt.Fprint(w, config.VersionDesc, le)
+	fmt.Fprint(w, gitV, le)
 
 	// log the command that was run
 	fmt.Fprint(w, le)
@@ -497,26 +497,26 @@ func logPanicToWriter(w io.Writer, loggedError error, le string) {
 	w.Write(ErrorBuffer.Bytes())
 	fmt.Fprint(w, le)
 
-	fmt.Fprintf(w, "%+v"+le, loggedError)
+	fmt.Fprintf(w, "%+v%s", loggedError, le)
 
 	for key, val := range errors.Context(err) {
-		fmt.Fprintf(w, "%s=%v"+le, key, val)
+		fmt.Fprintf(w, "%s=%v%s", key, val, le)
 	}
 
-	fmt.Fprint(w, le+"Current time in UTC: "+le)
-	fmt.Fprint(w, time.Now().UTC().Format("2006-01-02 15:04:05")+le)
+	fmt.Fprint(w, le, "Current time in UTC:", le)
+	fmt.Fprint(w, time.Now().UTC().Format("2006-01-02 15:04:05"), le)
 
-	fmt.Fprint(w, le+"Environment:"+le)
+	fmt.Fprint(w, le, "Environment:", le)
 
 	// log the environment
 	for _, env := range lfs.Environ(cfg, getTransferManifest(), oldEnv) {
-		fmt.Fprint(w, env+le)
+		fmt.Fprint(w, env, le)
 	}
 
-	fmt.Fprint(w, le+"Client IP addresses:"+le)
+	fmt.Fprint(w, le, "Client IP addresses:", le)
 
 	for _, ip := range ipAddresses() {
-		fmt.Fprint(w, ip+le)
+		fmt.Fprint(w, ip, le)
 	}
 }
 

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -22,6 +22,7 @@ import (
 	"github.com/git-lfs/git-lfs/v3/subprocess"
 	"github.com/git-lfs/git-lfs/v3/tools"
 	"github.com/git-lfs/git-lfs/v3/tq"
+	"github.com/git-lfs/git-lfs/v3/tr"
 )
 
 // Populate man pages
@@ -99,7 +100,7 @@ func newLockClient() *locking.Client {
 	}
 
 	if err != nil {
-		Exit("Unable to create lock system: %v", err.Error())
+		Exit(tr.Tr.Get("Unable to create lock system: %v", err.Error()))
 	}
 
 	// Configure dirs
@@ -151,9 +152,9 @@ func getHookInstallSteps() string {
 	hooks := lfs.LoadHooks(hookDir, cfg)
 	steps := make([]string, 0, len(hooks))
 	for _, h := range hooks {
-		steps = append(steps, fmt.Sprintf(
-			"Add the following to '.git/hooks/%s':\n\n%s",
-			h.Type, tools.Indent(h.Contents)))
+		steps = append(steps, fmt.Sprintf("%s\n\n%s",
+			tr.Tr.Get("Add the following to '.git/hooks/%s':", h.Type),
+			tools.Indent(h.Contents)))
 	}
 
 	return strings.Join(steps, "\n\n")
@@ -177,7 +178,7 @@ func installHooks(force bool) error {
 // uninstallHooks removes all hooks in range of the `hooks` var.
 func uninstallHooks() error {
 	if !cfg.InRepo() {
-		return errors.New("Not in a Git repository")
+		return errors.New(tr.Tr.Get("Not in a git repository"))
 	}
 
 	hookDir, err := cfg.HookDir()
@@ -263,7 +264,7 @@ func LoggedError(err error, format string, args ...interface{}) {
 	file := handlePanic(err)
 
 	if len(file) > 0 {
-		fmt.Fprintf(os.Stderr, "\nErrors logged to '%s'.\nUse `git lfs logs last` to view the log.\n", file)
+		fmt.Fprintf(os.Stderr, "\n%s\n", tr.Tr.Get("Errors logged to '%s'.\nUse `git lfs logs last` to view the log.", file))
 	}
 }
 
@@ -276,7 +277,7 @@ func Panic(err error, format string, args ...interface{}) {
 
 func Cleanup() {
 	if err := cfg.Cleanup(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error clearing old temporary files: %s\n", err)
+		fmt.Fprintln(os.Stderr, tr.Tr.Get("Error clearing old temporary files: %s", err))
 	}
 }
 
@@ -297,9 +298,9 @@ func requireStdin(msg string) {
 
 	stat, err := os.Stdin.Stat()
 	if err != nil {
-		out = fmt.Sprintf("Cannot read from STDIN: %s (%s)", msg, err)
+		out = tr.Tr.Get("Cannot read from STDIN: %s (%s)", msg, err)
 	} else if (stat.Mode() & os.ModeCharDevice) != 0 {
-		out = fmt.Sprintf("Cannot read from STDIN: %s", msg)
+		out = tr.Tr.Get("Cannot read from STDIN: %s", msg)
 	}
 
 	if len(out) > 0 {
@@ -310,7 +311,7 @@ func requireStdin(msg string) {
 
 func requireInRepo() {
 	if !cfg.InRepo() {
-		Print("Not in a Git repository.")
+		Print(tr.Tr.Get("Not in a Git repository."))
 		os.Exit(128)
 	}
 }
@@ -320,7 +321,7 @@ func requireInRepo() {
 // be determined), this function will terminate the program.
 func requireWorkingCopy() {
 	if cfg.LocalWorkingDir() == "" {
-		Print("This operation must be run in a work tree.")
+		Print(tr.Tr.Get("This operation must be run in a work tree."))
 		os.Exit(128)
 	}
 }
@@ -330,7 +331,7 @@ func setupRepository() {
 	bare, err := git.IsBare()
 	if err != nil {
 		ExitWithError(errors.Wrap(
-			err, "Could not determine bareness"))
+			err, tr.Tr.Get("Could not determine bareness")))
 	}
 	verifyRepositoryVersion()
 
@@ -345,7 +346,7 @@ func verifyRepositoryVersion() {
 	if val == "" {
 		cfg.SetGitLocalKey(key, "0")
 	} else if val != "0" {
-		Print("Unknown repository format version: %s", val)
+		Print(tr.Tr.Get("Unknown repository format version: %s", val))
 		os.Exit(128)
 	}
 }
@@ -362,12 +363,12 @@ func changeToWorkingCopy() {
 	cwd, err := tools.Getwd()
 	if err != nil {
 		ExitWithError(errors.Wrap(
-			err, "Could not determine current working directory"))
+			err, tr.Tr.Get("Could not determine current working directory")))
 	}
 	cwd, err = tools.CanonicalizeSystemPath(cwd)
 	if err != nil {
 		ExitWithError(errors.Wrap(
-			err, "Could not canonicalize current working directory"))
+			err, tr.Tr.Get("Could not canonicalize current working directory")))
 	}
 
 	// If the current working directory is not within the repository's
@@ -416,12 +417,12 @@ func logPanic(loggedError error) string {
 
 	if err := tools.MkdirAll(cfg.LocalLogDir(), cfg); err != nil {
 		full = ""
-		fmt.Fprintf(fmtWriter, "Unable to log panic to '%s': %s\n\n", cfg.LocalLogDir(), err.Error())
+		fmt.Fprintf(fmtWriter, "%s\n\n", tr.Tr.Get("Unable to log panic to '%s': %s", cfg.LocalLogDir(), err.Error()))
 	} else if file, err := os.Create(full); err != nil {
 		filename := full
 		full = ""
 		defer func() {
-			fmt.Fprintf(fmtWriter, "Unable to log panic to '%s'\n\n", filename)
+			fmt.Fprintf(fmtWriter, "%s\n\n", tr.Tr.Get("Unable to log panic to '%s'", filename))
 			logPanicToWriter(fmtWriter, err, lineEnding)
 		}()
 	} else {
@@ -439,7 +440,7 @@ func ipAddresses() []string {
 	ips := make([]string, 0, 1)
 	ifaces, err := net.Interfaces()
 	if err != nil {
-		ips = append(ips, "Error getting network interface: "+err.Error())
+		ips = append(ips, tr.Tr.Get("Error getting network interface: %s", err.Error()))
 		return ips
 	}
 	for _, i := range ifaces {
@@ -452,7 +453,7 @@ func ipAddresses() []string {
 		addrs, _ := i.Addrs()
 		l := make([]string, 0, 1)
 		if err != nil {
-			ips = append(ips, "Error getting IP address: "+err.Error())
+			ips = append(ips, tr.Tr.Get("Error getting IP address: %s", err.Error()))
 			continue
 		}
 		for _, addr := range addrs {
@@ -479,7 +480,7 @@ func logPanicToWriter(w io.Writer, loggedError error, le string) {
 	// log the version
 	gitV, err := git.Version()
 	if err != nil {
-		gitV = "Error getting Git version: " + err.Error()
+		gitV = tr.Tr.Get("Error getting Git version: %s", err.Error())
 	}
 
 	fmt.Fprint(w, config.VersionDesc, le)
@@ -503,17 +504,17 @@ func logPanicToWriter(w io.Writer, loggedError error, le string) {
 		fmt.Fprintf(w, "%s=%v%s", key, val, le)
 	}
 
-	fmt.Fprint(w, le, "Current time in UTC:", le)
+	fmt.Fprint(w, le, tr.Tr.Get("Current time in UTC:"), le)
 	fmt.Fprint(w, time.Now().UTC().Format("2006-01-02 15:04:05"), le)
 
-	fmt.Fprint(w, le, "Environment:", le)
+	fmt.Fprint(w, le, tr.Tr.Get("Environment:"), le)
 
 	// log the environment
 	for _, env := range lfs.Environ(cfg, getTransferManifest(), oldEnv) {
 		fmt.Fprint(w, env, le)
 	}
 
-	fmt.Fprint(w, le, "Client IP addresses:", le)
+	fmt.Fprint(w, le, tr.Tr.Get("Client IP addresses:"), le)
 
 	for _, ip := range ipAddresses() {
 		fmt.Fprint(w, ip, le)
@@ -556,8 +557,8 @@ func requireGitVersion() {
 	if !git.IsGitVersionAtLeast(minimumGit) {
 		gitver, err := git.Version()
 		if err != nil {
-			Exit("Error getting Git version: %s", err)
+			Exit(tr.Tr.Get("Error getting Git version: %s", err))
 		}
-		Exit("Git version %s or higher is required for Git LFS; your version: %s", minimumGit, gitver)
+		Exit(tr.Tr.Get("Git version %s or higher is required for Git LFS; your version: %s", minimumGit, gitver))
 	}
 }

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -263,7 +263,7 @@ func LoggedError(err error, format string, args ...interface{}) {
 	file := handlePanic(err)
 
 	if len(file) > 0 {
-		fmt.Fprintf(os.Stderr, "\nErrors logged to %s\nUse `git lfs logs last` to view the log.\n", file)
+		fmt.Fprintf(os.Stderr, "\nErrors logged to %s.\nUse `git lfs logs last` to view the log.\n", file)
 	}
 }
 
@@ -276,7 +276,7 @@ func Panic(err error, format string, args ...interface{}) {
 
 func Cleanup() {
 	if err := cfg.Cleanup(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error clearing old temp files: %s\n", err)
+		fmt.Fprintf(os.Stderr, "Error clearing old temporary files: %s\n", err)
 	}
 }
 
@@ -297,9 +297,9 @@ func requireStdin(msg string) {
 
 	stat, err := os.Stdin.Stat()
 	if err != nil {
-		out = fmt.Sprintf("Cannot read from STDIN. %s (%s)", msg, err)
+		out = fmt.Sprintf("Cannot read from STDIN: %s (%s)", msg, err)
 	} else if (stat.Mode() & os.ModeCharDevice) != 0 {
-		out = fmt.Sprintf("Cannot read from STDIN. %s", msg)
+		out = fmt.Sprintf("Cannot read from STDIN: %s", msg)
 	}
 
 	if len(out) > 0 {
@@ -506,7 +506,7 @@ func logPanicToWriter(w io.Writer, loggedError error, le string) {
 	fmt.Fprint(w, le+"Current time in UTC: "+le)
 	fmt.Fprint(w, time.Now().UTC().Format("2006-01-02 15:04:05")+le)
 
-	fmt.Fprint(w, le+"ENV:"+le)
+	fmt.Fprint(w, le+"Environment:"+le)
 
 	// log the environment
 	for _, env := range lfs.Environ(cfg, getTransferManifest(), oldEnv) {
@@ -558,6 +558,6 @@ func requireGitVersion() {
 		if err != nil {
 			Exit("Error getting git version: %s", err)
 		}
-		Exit("git version >= %s is required for Git LFS, your version: %s", minimumGit, gitver)
+		Exit("git version %s or higher is required for Git LFS; your version: %s", minimumGit, gitver)
 	}
 }

--- a/commands/lockverifier.go
+++ b/commands/lockverifier.go
@@ -69,7 +69,7 @@ func (lv *lockVerifier) Verify(ref *git.Ref) {
 					Exit(tr.Tr.Get("error: Authentication error: %s", err))
 				}
 			} else {
-				Print(tr.Tr.Get("Remote %q does not support the LFS locking API. Consider disabling it with:", cfg.PushRemote()))
+				Print(tr.Tr.Get("Remote %q does not support the Git LFS locking API. Consider disabling it with:", cfg.PushRemote()))
 				Print("  $ git config lfs.%s.locksverify false", lv.endpoint.Url)
 				if lv.verifyState == verifyStateEnabled {
 					ExitWithError(err)

--- a/commands/lockverifier.go
+++ b/commands/lockverifier.go
@@ -78,7 +78,7 @@ func (lv *lockVerifier) Verify(ref *git.Ref) {
 		}
 	} else if lv.verifyState == verifyStateUnknown {
 		Print(tr.Tr.Get("Locking support detected on remote %q. Consider enabling it with:", cfg.PushRemote()))
-		Print("$ git config lfs.%s.locksverify true", lv.endpoint.Url)
+		Print("  $ git config lfs.%s.locksverify true", lv.endpoint.Url)
 	}
 
 	lv.addLocks(ref, ours, lv.ourLocks)

--- a/commands/lockverifier.go
+++ b/commands/lockverifier.go
@@ -48,7 +48,7 @@ type lockVerifier struct {
 
 func (lv *lockVerifier) Verify(ref *git.Ref) {
 	if ref == nil {
-		panic("no ref specified for verification")
+		panic(tr.Tr.Get("no ref specified for verification"))
 	}
 
 	if lv.verifyState == verifyStateDisabled || lv.verifiedRefs[ref.Refspec()] {

--- a/commands/pull.go
+++ b/commands/pull.go
@@ -107,7 +107,7 @@ func (c *singleCheckout) RunToPath(p *lfs.WrappedPointer, path string) error {
 
 func (c *singleCheckout) Close() {
 	if err := c.gitIndexer.Close(); err != nil {
-		LoggedError(err, tr.Tr.Get("Error updating the git index:\n%s", c.gitIndexer.Output()))
+		LoggedError(err, tr.Tr.Get("Error updating the Git index:\n%s", c.gitIndexer.Output()))
 	}
 }
 

--- a/commands/pull.go
+++ b/commands/pull.go
@@ -107,7 +107,7 @@ func (c *singleCheckout) RunToPath(p *lfs.WrappedPointer, path string) error {
 
 func (c *singleCheckout) Close() {
 	if err := c.gitIndexer.Close(); err != nil {
-		LoggedError(err, tr.Tr.Get("Error updating the Git index:\n%s", c.gitIndexer.Output()))
+		LoggedError(err, "%s\n%s", tr.Tr.Get("Error updating the Git index:"), c.gitIndexer.Output())
 	}
 }
 

--- a/commands/run.go
+++ b/commands/run.go
@@ -151,14 +151,14 @@ func setupHTTPLogger(cmd *cobra.Command, args []string) {
 
 	logBase := filepath.Join(cfg.LocalLogDir(), "http")
 	if err := tools.MkdirAll(logBase, cfg); err != nil {
-		fmt.Fprint(os.Stderr, tr.Tr.Get("Error logging http stats: %s\n", err))
+		fmt.Fprint(os.Stderr, tr.Tr.Get("Error logging HTTP stats: %s\n", err))
 		return
 	}
 
 	logFile := fmt.Sprintf("http-%d.log", time.Now().Unix())
 	file, err := os.Create(filepath.Join(logBase, logFile))
 	if err != nil {
-		fmt.Fprint(os.Stderr, tr.Tr.Get("Error logging http stats: %s\n", err))
+		fmt.Fprint(os.Stderr, tr.Tr.Get("Error logging HTTP stats: %s\n", err))
 	} else {
 		getAPIClient().LogHTTPStats(file)
 	}

--- a/commands/run.go
+++ b/commands/run.go
@@ -78,7 +78,7 @@ Simply type ` + root.Name() + ` help [path to command] for full details.`,
 				cmd, _, e = c.Root().Find([]string{"help"})
 			}
 			if cmd == nil || e != nil {
-				c.Print(tr.Tr.Get("Unknown help topic %#q\n", args))
+				c.Println(tr.Tr.Get("Unknown help topic %#q", args))
 				c.Root().Usage()
 			} else {
 				c.HelpFunc()(cmd, args)

--- a/commands/run.go
+++ b/commands/run.go
@@ -138,9 +138,9 @@ func printHelp(commandName string) {
 		commandName = "git-lfs"
 	}
 	if txt, ok := ManPages[commandName]; ok {
-		fmt.Fprintf(os.Stdout, "%s\n", strings.TrimSpace(txt))
+		fmt.Println(strings.TrimSpace(txt))
 	} else {
-		fmt.Fprint(os.Stdout, tr.Tr.Get("Sorry, no usage text found for %q\n", commandName))
+		fmt.Println(tr.Tr.Get("Sorry, no usage text found for %q", commandName))
 	}
 }
 
@@ -151,14 +151,14 @@ func setupHTTPLogger(cmd *cobra.Command, args []string) {
 
 	logBase := filepath.Join(cfg.LocalLogDir(), "http")
 	if err := tools.MkdirAll(logBase, cfg); err != nil {
-		fmt.Fprint(os.Stderr, tr.Tr.Get("Error logging HTTP stats: %s\n", err))
+		fmt.Fprintln(os.Stderr, tr.Tr.Get("Error logging HTTP stats: %s", err))
 		return
 	}
 
 	logFile := fmt.Sprintf("http-%d.log", time.Now().Unix())
 	file, err := os.Create(filepath.Join(logBase, logFile))
 	if err != nil {
-		fmt.Fprint(os.Stderr, tr.Tr.Get("Error logging HTTP stats: %s\n", err))
+		fmt.Fprintln(os.Stderr, tr.Tr.Get("Error logging HTTP stats: %s", err))
 	} else {
 		getAPIClient().LogHTTPStats(file)
 	}

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -245,7 +245,7 @@ func (c *uploadContext) UploadPointers(q *tq.TransferQueue, unfiltered ...*lfs.W
 				continue
 			}
 
-			Print(tr.Tr.Get("push %s => %s", p.Oid, p.Name))
+			Print("%s %s => %s", tr.Tr.Get("push"), p.Oid, p.Name)
 			c.SetUploaded(p.Oid)
 		}
 

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -295,7 +295,7 @@ func (c *uploadContext) ReportErrors() {
 			action = tr.Tr.Get("failed")
 		}
 
-		Print(tr.Tr.Get("LFS upload %s:", action))
+		Print(tr.Tr.Get("Git LFS upload %s:", action))
 		for name, oid := range c.missing {
 			// TRANSLATORS: Leading spaces should be preserved.
 			Print(tr.Tr.Get("  (missing) %s (%s)", name, oid))

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -308,7 +308,7 @@ func (c *uploadContext) ReportErrors() {
 		if !c.allowMissing {
 			pushMissingHint := []string{
 				tr.Tr.Get("hint: Your push was rejected due to missing or corrupt local objects."),
-				tr.Tr.Get("hint: You can disable this check with: 'git config lfs.allowincompletepush true'"),
+				tr.Tr.Get("hint: You can disable this check with: `git config lfs.allowincompletepush true`"),
 			}
 			Print(strings.Join(pushMissingHint, "\n"))
 			os.Exit(2)

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -48,7 +48,7 @@ func uploadForRefUpdates(ctx *uploadContext, updates []*git.RefUpdate, pushAll b
 		ctx.CollectErrors(q)
 
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("ref %q:", update.Left().Name))
+			return errors.Wrap(err, tr.Tr.Get("ref %q:", update.Left().Name))
 		}
 	}
 

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -48,7 +48,7 @@ func uploadForRefUpdates(ctx *uploadContext, updates []*git.RefUpdate, pushAll b
 		ctx.CollectErrors(q)
 
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("ref %s:", update.Left().Name))
+			return errors.Wrap(err, fmt.Sprintf("ref %q:", update.Left().Name))
 		}
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -80,7 +80,7 @@ func NewIn(workdir, gitdir string) *Configuration {
 		callback: func() Environment {
 			sources, err := gitConf.Sources(c.LocalWorkingDir(), ".lfsconfig")
 			if err != nil {
-				fmt.Fprintln(os.Stderr, tr.Tr.Get("Error reading git config: %s", err))
+				fmt.Fprintln(os.Stderr, tr.Tr.Get("Error reading `git config`: %s", err))
 			}
 			return c.readGitConfig(sources...)
 		},

--- a/config/config.go
+++ b/config/config.go
@@ -165,7 +165,7 @@ func NewFrom(v Values) *Configuration {
 				// This branch should only ever trigger in
 				// tests, and only if they'd be broken.
 				if !isCaseSensitive && hasUpper {
-					panic(fmt.Sprintf("key %q has uppercase, shouldn't", key))
+					panic(tr.Tr.Get("key %q has uppercase, shouldn't", key))
 				}
 				for _, value := range values {
 					fmt.Printf("Config: %s=%s\n", key, value)
@@ -378,7 +378,7 @@ func (c *Configuration) loadGitDirs() {
 		errMsg := err.Error()
 		tracerx.Printf("Error running 'git rev-parse': %s", errMsg)
 		if errors.ExitStatus(err) != 128 {
-			fmt.Fprintf(os.Stderr, "Error: %s\n", errMsg)
+			fmt.Fprintln(os.Stderr, tr.Tr.Get("Error: %s", errMsg))
 		}
 		c.gitDir = &gitdir
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -80,7 +80,7 @@ func NewIn(workdir, gitdir string) *Configuration {
 		callback: func() Environment {
 			sources, err := gitConf.Sources(c.LocalWorkingDir(), ".lfsconfig")
 			if err != nil {
-				fmt.Fprintf(os.Stderr, tr.Tr.Get("Error reading git config: %s\n", err))
+				fmt.Fprintln(os.Stderr, tr.Tr.Get("Error reading git config: %s", err))
 			}
 			return c.readGitConfig(sources...)
 		},

--- a/config/git_fetcher.go
+++ b/config/git_fetcher.go
@@ -40,7 +40,7 @@ func readGitConfig(configs ...*git.ConfigurationSource) (gf *GitFetcher, extensi
 
 			if origKey, ok := uniqKeys[key]; ok {
 				if ShowConfigWarnings && len(vals[key]) > 0 && vals[key][len(vals[key])-1] != val && strings.HasPrefix(key, gitConfigWarningPrefix) {
-					fmt.Fprintln(os.Stderr, tr.Tr.Get("warning: These git config values clash:"))
+					fmt.Fprintln(os.Stderr, tr.Tr.Get("warning: These `git config` values clash:"))
 					fmt.Fprintf(os.Stderr, "  git config %q = %q\n", origKey, vals[key])
 					fmt.Fprintf(os.Stderr, "  git config %q = %q\n", pieces[0], val)
 				}

--- a/config/git_fetcher.go
+++ b/config/git_fetcher.go
@@ -40,7 +40,7 @@ func readGitConfig(configs ...*git.ConfigurationSource) (gf *GitFetcher, extensi
 
 			if origKey, ok := uniqKeys[key]; ok {
 				if ShowConfigWarnings && len(vals[key]) > 0 && vals[key][len(vals[key])-1] != val && strings.HasPrefix(key, gitConfigWarningPrefix) {
-					fmt.Fprint(os.Stderr, tr.Tr.Get("warning: These git config values clash:\n"))
+					fmt.Fprintln(os.Stderr, tr.Tr.Get("warning: These git config values clash:"))
 					fmt.Fprintf(os.Stderr, "  git config %q = %q\n", origKey, vals[key])
 					fmt.Fprintf(os.Stderr, "  git config %q = %q\n", pieces[0], val)
 				}
@@ -102,7 +102,7 @@ func readGitConfig(configs ...*git.ConfigurationSource) (gf *GitFetcher, extensi
 	}
 
 	if len(ignored) > 0 {
-		fmt.Fprintf(os.Stderr, tr.Tr.Get("warning: These unsafe lfsconfig keys were ignored:\n\n"))
+		fmt.Fprint(os.Stderr, tr.Tr.Get("warning: These unsafe lfsconfig keys were ignored:"), "\n\n")
 		for _, key := range ignored {
 			fmt.Fprintf(os.Stderr, "  %s\n", key)
 		}

--- a/config/git_fetcher.go
+++ b/config/git_fetcher.go
@@ -102,7 +102,7 @@ func readGitConfig(configs ...*git.ConfigurationSource) (gf *GitFetcher, extensi
 	}
 
 	if len(ignored) > 0 {
-		fmt.Fprint(os.Stderr, tr.Tr.Get("warning: These unsafe lfsconfig keys were ignored:"), "\n\n")
+		fmt.Fprint(os.Stderr, tr.Tr.Get("warning: These unsafe '.lfsconfig' keys were ignored:"), "\n\n")
 		for _, key := range ignored {
 			fmt.Fprintf(os.Stderr, "  %s\n", key)
 		}

--- a/creds/creds.go
+++ b/creds/creds.go
@@ -335,7 +335,7 @@ func (h *commandCredentialHelper) exec(subcommand string, input Creds) (Creds, e
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("`git credential %s` error: %s\n", subcommand, err.Error())
+		return nil, errors.New(tr.Tr.Get("`git credential %s` error: %s", subcommand, err.Error()))
 	}
 
 	creds := make(Creds)
@@ -529,7 +529,7 @@ func (s *CredentialHelpers) skipped(i int) bool {
 type nullCredentialHelper struct{}
 
 var (
-	nullCredError = errors.New("No credential helper configured")
+	nullCredError = errors.New(tr.Tr.Get("No credential helper configured"))
 	NullCreds     = &nullCredentialHelper{}
 )
 

--- a/creds/creds.go
+++ b/creds/creds.go
@@ -335,7 +335,7 @@ func (h *commandCredentialHelper) exec(subcommand string, input Creds) (Creds, e
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("'git credential %s' error: %s\n", subcommand, err.Error())
+		return nil, fmt.Errorf("`git credential %s` error: %s\n", subcommand, err.Error())
 	}
 
 	creds := make(Creds)

--- a/creds/creds.go
+++ b/creds/creds.go
@@ -37,7 +37,7 @@ type CredentialHelper interface {
 func (credWrapper *CredentialHelperWrapper) FillCreds() error {
 	creds, err := credWrapper.CredentialHelper.Fill(credWrapper.Input)
 	if creds == nil || len(creds) < 1 {
-		errmsg := fmt.Sprintf(tr.Tr.Get("Git credentials for %s not found", credWrapper.Url))
+		errmsg := tr.Tr.Get("Git credentials for %s not found", credWrapper.Url)
 		if err != nil {
 			errmsg = fmt.Sprintf("%s:\n%s", errmsg, err.Error())
 		} else {

--- a/filepathfilter/filepathfilter.go
+++ b/filepathfilter/filepathfilter.go
@@ -3,6 +3,7 @@ package filepathfilter
 import (
 	"strings"
 
+	"github.com/git-lfs/git-lfs/v3/tr"
 	"github.com/git-lfs/wildmatch/v2"
 	"github.com/rubyist/tracerx"
 )
@@ -160,7 +161,7 @@ func NewPattern(p string, ptype PatternType) Pattern {
 			),
 		}
 	default:
-		panic("unreachable")
+		panic(tr.Tr.Get("unreachable"))
 	}
 }
 

--- a/git-lfs.go
+++ b/git-lfs.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 
 	"github.com/git-lfs/git-lfs/v3/commands"
+	"github.com/git-lfs/git-lfs/v3/tr"
 )
 
 func main() {
@@ -20,7 +21,7 @@ func main() {
 		for {
 			sig := <-c
 			once.Do(commands.Cleanup)
-			fmt.Fprintf(os.Stderr, "\nExiting because of %q signal.\n", sig)
+			fmt.Fprintf(os.Stderr, "\n%s\n", tr.Tr.Get("Exiting because of %q signal.", sig))
 
 			exitCode := 1
 			if sysSig, ok := sig.(syscall.Signal); ok {

--- a/git/config.go
+++ b/git/config.go
@@ -9,10 +9,11 @@ import (
 	"sync"
 
 	"github.com/git-lfs/git-lfs/v3/subprocess"
+	"github.com/git-lfs/git-lfs/v3/tr"
 )
 
 var (
-	ErrReadOnly = errors.New("configuration is read-only")
+	ErrReadOnly = errors.New(tr.Tr.Get("configuration is read-only"))
 )
 
 // Environment is a restricted version of config.Environment that only provides

--- a/git/filter_process_scanner.go
+++ b/git/filter_process_scanner.go
@@ -3,11 +3,11 @@
 package git
 
 import (
-	"fmt"
 	"io"
 	"strings"
 
 	"github.com/git-lfs/git-lfs/v3/errors"
+	"github.com/git-lfs/git-lfs/v3/tr"
 	"github.com/git-lfs/pktline"
 	"github.com/rubyist/tracerx"
 )
@@ -73,23 +73,23 @@ func (o *FilterProcessScanner) Init() error {
 
 	initMsg, err := o.pl.ReadPacketText()
 	if err != nil {
-		return errors.Wrap(err, "reading filter-process initialization")
+		return errors.Wrap(err, tr.Tr.Get("reading filter-process initialization"))
 	}
 	if initMsg != "git-filter-client" {
-		return fmt.Errorf("invalid filter-process pkt-line welcome message: %s", initMsg)
+		return errors.New(tr.Tr.Get("invalid filter-process pkt-line welcome message: %s", initMsg))
 	}
 
 	supVers, err := o.pl.ReadPacketList()
 	if err != nil {
-		return errors.Wrap(err, "reading filter-process versions")
+		return errors.Wrap(err, tr.Tr.Get("reading filter-process versions"))
 	}
 	if !isStringInSlice(supVers, reqVer) {
-		return fmt.Errorf("filter '%s' not supported (your Git supports: %s)", reqVer, supVers)
+		return errors.New(tr.Tr.Get("filter '%s' not supported (your Git supports: %s)", reqVer, supVers))
 	}
 
 	err = o.pl.WritePacketList([]string{"git-filter-server", reqVer})
 	if err != nil {
-		return errors.Wrap(err, "writing filter-process initialization failed")
+		return errors.Wrap(err, tr.Tr.Get("writing filter-process initialization failed"))
 	}
 	return nil
 }
@@ -104,7 +104,7 @@ func (o *FilterProcessScanner) NegotiateCapabilities() ([]string, error) {
 
 	supCaps, err := o.pl.ReadPacketList()
 	if err != nil {
-		return nil, fmt.Errorf("reading filter-process capabilities failed with %s", err)
+		return nil, errors.New(tr.Tr.Get("reading filter-process capabilities failed with %s", err))
 	}
 
 	for _, sup := range supCaps {
@@ -116,13 +116,13 @@ func (o *FilterProcessScanner) NegotiateCapabilities() ([]string, error) {
 
 	for _, reqCap := range reqCaps {
 		if !isStringInSlice(supCaps, reqCap) {
-			return nil, fmt.Errorf("filter '%s' not supported (your Git supports: %s)", reqCap, supCaps)
+			return nil, errors.New(tr.Tr.Get("filter '%s' not supported (your Git supports: %s)", reqCap, supCaps))
 		}
 	}
 
 	err = o.pl.WritePacketList(reqCaps)
 	if err != nil {
-		return nil, fmt.Errorf("writing filter-process capabilities failed with %s", err)
+		return nil, errors.New(tr.Tr.Get("writing filter-process capabilities failed with %s", err))
 	}
 
 	return supCaps, nil

--- a/git/filter_process_status.go
+++ b/git/filter_process_status.go
@@ -29,5 +29,5 @@ func (s FilterProcessStatus) String() string {
 		return "error"
 	}
 
-	panic(fmt.Sprintf("git: unknown FilterProcessStatus '%d'", s))
+	panic(fmt.Sprintf("unknown FilterProcessStatus '%d'", s))
 }

--- a/git/filter_process_status.go
+++ b/git/filter_process_status.go
@@ -1,6 +1,6 @@
 package git
 
-import "fmt"
+import "github.com/git-lfs/git-lfs/v3/tr"
 
 // FilterProcessStatus is a constant type representing the various valid
 // responses for `status=` in the Git filtering process protocol.
@@ -29,5 +29,5 @@ func (s FilterProcessStatus) String() string {
 		return "error"
 	}
 
-	panic(fmt.Sprintf("unknown FilterProcessStatus '%d'", s))
+	panic(tr.Tr.Get("unknown FilterProcessStatus '%d'", s))
 }

--- a/git/git.go
+++ b/git/git.go
@@ -1372,7 +1372,7 @@ func IsFileModified(filepath string) (bool, error) {
 		}
 	}
 	if err := cmd.Wait(); err != nil {
-		return false, lfserrors.Wrap(err, "Git status failed")
+		return false, lfserrors.Wrap(err, "git status failed")
 	}
 
 	return matched, nil

--- a/git/git.go
+++ b/git/git.go
@@ -1230,7 +1230,7 @@ func AllRefsIn(wd string) ([]*Ref, error) {
 		parts := strings.SplitN(scanner.Text(), "\x00", 2)
 		if len(parts) != 2 {
 			return nil, lfserrors.Errorf(
-				"git: invalid for-each-ref line: %q", scanner.Text())
+				"invalid git for-each-ref line: %q", scanner.Text())
 		}
 
 		sha := parts[0]

--- a/git/git.go
+++ b/git/git.go
@@ -230,7 +230,7 @@ func DiffIndex(ref string, cached bool, refresh bool) (*bufio.Scanner, error) {
 	if refresh {
 		_, err := gitSimple("update-index", "-q", "--refresh")
 		if err != nil {
-			return nil, lfserrors.Wrap(err, "Failed to run git update-index")
+			return nil, lfserrors.Wrap(err, "Failed to run `git update-index`")
 		}
 	}
 
@@ -384,7 +384,7 @@ func RemoteList() ([]string, error) {
 
 	outp, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, fmt.Errorf("failed to call git remote: %v", err)
+		return nil, fmt.Errorf("failed to call `git remote`: %v", err)
 	}
 	cmd.Start()
 	defer cmd.Wait()
@@ -404,7 +404,7 @@ func RemoteURLs(push bool) (map[string][]string, error) {
 
 	outp, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, fmt.Errorf("failed to call git remote -v: %v", err)
+		return nil, fmt.Errorf("failed to call `git remote -v`: %v", err)
 	}
 	cmd.Start()
 	defer cmd.Wait()
@@ -454,7 +454,7 @@ func LocalRefs() ([]*Ref, error) {
 
 	outp, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, fmt.Errorf("failed to call git show-ref: %v", err)
+		return nil, fmt.Errorf("failed to call `git show-ref`: %v", err)
 	}
 
 	var refs []*Ref
@@ -468,7 +468,7 @@ func LocalRefs() ([]*Ref, error) {
 		line := strings.TrimSpace(scanner.Text())
 		parts := strings.SplitN(line, " ", 2)
 		if len(parts) != 2 || !HasValidObjectIDLength(parts[0]) || len(parts[1]) < 1 {
-			tracerx.Printf("Invalid line from git show-ref: %q", line)
+			tracerx.Printf("Invalid line from `git show-ref`: %q", line)
 			continue
 		}
 
@@ -593,7 +593,7 @@ func RecentBranches(since time.Time, includeRemoteBranches bool, onlyRemote stri
 		"refs")
 	outp, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, fmt.Errorf("failed to call git for-each-ref: %v", err)
+		return nil, fmt.Errorf("failed to call `git for-each-ref`: %v", err)
 	}
 	cmd.Start()
 	defer cmd.Wait()
@@ -691,7 +691,7 @@ func GetCommitSummary(commit string) (*CommitSummary, error) {
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("failed to call git show: %v %v", err, string(out))
+		return nil, fmt.Errorf("failed to call `git show`: %v %v", err, string(out))
 	}
 
 	// At most 10 substrings so subject line is not split on anything
@@ -715,7 +715,7 @@ func GetCommitSummary(commit string) (*CommitSummary, error) {
 		}
 		return ret, nil
 	} else {
-		msg := fmt.Sprintf("Unexpected output from git show: %v", string(out))
+		msg := fmt.Sprintf("Unexpected output from `git show`: %v", string(out))
 		return nil, errors.New(msg)
 	}
 }
@@ -735,14 +735,14 @@ func GitAndRootDirs() (string, string, error) {
 			absGitDir, err := GitDir()
 			return absGitDir, "", err
 		}
-		return "", "", fmt.Errorf("failed to call git rev-parse --git-dir --show-toplevel: %q", buf.String())
+		return "", "", fmt.Errorf("failed to call `git rev-parse --git-dir --show-toplevel`: %q", buf.String())
 	}
 
 	paths := strings.Split(output, "\n")
 	pathLen := len(paths)
 
 	if pathLen == 0 {
-		return "", "", fmt.Errorf("bad git rev-parse output: %q", output)
+		return "", "", fmt.Errorf("bad `git rev-parse` output: %q", output)
 	}
 
 	absGitDir, err := tools.CanonicalizePath(paths[0], false)
@@ -762,7 +762,7 @@ func RootDir() (string, error) {
 	cmd := gitNoLFS("rev-parse", "--show-toplevel")
 	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("failed to call git rev-parse --show-toplevel: %v %v", err, string(out))
+		return "", fmt.Errorf("failed to call `git rev-parse --show-toplevel`: %v %v", err, string(out))
 	}
 
 	path := strings.TrimSpace(string(out))
@@ -780,7 +780,7 @@ func GitDir() (string, error) {
 	out, err := cmd.Output()
 
 	if err != nil {
-		return "", fmt.Errorf("failed to call git rev-parse --git-dir: %w %v: %v", err, string(out), buf.String())
+		return "", fmt.Errorf("failed to call `git rev-parse --git-dir`: %w %v: %v", err, string(out), buf.String())
 	}
 	path := strings.TrimSpace(string(out))
 	return tools.CanonicalizePath(path, false)
@@ -799,7 +799,7 @@ func GitCommonDir() (string, error) {
 	buf := &bytes.Buffer{}
 	cmd.Stderr = buf
 	if err != nil {
-		return "", fmt.Errorf("failed to call git rev-parse --git-common-dir: %v %v: %v", err, string(out), buf.String())
+		return "", fmt.Errorf("failed to call `git rev-parse --git-common-dir`: %v %v: %v", err, string(out), buf.String())
 	}
 	path := strings.TrimSpace(string(out))
 	path, err = tools.TranslateCygwinPath(path)
@@ -1061,12 +1061,12 @@ func CloneWithoutFilters(flags CloneFlags, args []string) error {
 
 	err := cmd.Start()
 	if err != nil {
-		return fmt.Errorf("failed to start git clone: %v", err)
+		return fmt.Errorf("failed to start `git clone`: %v", err)
 	}
 
 	err = cmd.Wait()
 	if err != nil {
-		return fmt.Errorf("git clone failed: %v", err)
+		return fmt.Errorf("`git clone` failed: %v", err)
 	}
 
 	return nil
@@ -1103,7 +1103,7 @@ func CachedRemoteRefs(remoteName string) ([]*Ref, error) {
 
 	outp, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, fmt.Errorf("failed to call git show-ref: %v", err)
+		return nil, fmt.Errorf("failed to call `git show-ref`: %v", err)
 	}
 	cmd.Start()
 	scanner := bufio.NewScanner(outp)
@@ -1158,7 +1158,7 @@ func RemoteRefs(remoteName string) ([]*Ref, error) {
 
 	outp, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, fmt.Errorf("failed to call git ls-remote: %v", err)
+		return nil, fmt.Errorf("failed to call `git ls-remote`: %v", err)
 	}
 	cmd.Start()
 	scanner := bufio.NewScanner(outp)
@@ -1230,7 +1230,7 @@ func AllRefsIn(wd string) ([]*Ref, error) {
 		parts := strings.SplitN(scanner.Text(), "\x00", 2)
 		if len(parts) != 2 {
 			return nil, lfserrors.Errorf(
-				"invalid git for-each-ref line: %q", scanner.Text())
+				"invalid `git for-each-ref` line: %q", scanner.Text())
 		}
 
 		sha := parts[0]
@@ -1268,7 +1268,7 @@ func GetTrackedFiles(pattern string) ([]string, error) {
 
 	outp, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, fmt.Errorf("failed to call git ls-files: %v", err)
+		return nil, fmt.Errorf("failed to call `git ls-files`: %v", err)
 	}
 	cmd.Start()
 	scanner := bufio.NewScanner(outp)
@@ -1321,17 +1321,17 @@ func GetFilesChanged(from, to string) ([]string, error) {
 	cmd := gitNoLFS(args...)
 	outp, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, fmt.Errorf("failed to call git diff: %v", err)
+		return nil, fmt.Errorf("failed to call `git diff`: %v", err)
 	}
 	if err := cmd.Start(); err != nil {
-		return nil, fmt.Errorf("failed to start git diff: %v", err)
+		return nil, fmt.Errorf("failed to start `git diff`: %v", err)
 	}
 	scanner := bufio.NewScanner(outp)
 	for scanner.Scan() {
 		files = append(files, strings.TrimSpace(scanner.Text()))
 	}
 	if err := cmd.Wait(); err != nil {
-		return nil, fmt.Errorf("git diff failed: %v", err)
+		return nil, fmt.Errorf("`git diff` failed: %v", err)
 	}
 
 	return files, err
@@ -1352,10 +1352,10 @@ func IsFileModified(filepath string) (bool, error) {
 	cmd := git(args...)
 	outp, err := cmd.StdoutPipe()
 	if err != nil {
-		return false, lfserrors.Wrap(err, "Failed to call git status")
+		return false, lfserrors.Wrap(err, "Failed to call `git status`")
 	}
 	if err := cmd.Start(); err != nil {
-		return false, lfserrors.Wrap(err, "Failed to start git status")
+		return false, lfserrors.Wrap(err, "Failed to start `git status`")
 	}
 	matched := false
 	for scanner := bufio.NewScanner(outp); scanner.Scan(); {
@@ -1372,7 +1372,7 @@ func IsFileModified(filepath string) (bool, error) {
 		}
 	}
 	if err := cmd.Wait(); err != nil {
-		return false, lfserrors.Wrap(err, "git status failed")
+		return false, lfserrors.Wrap(err, "`git status` failed")
 	}
 
 	return matched, nil

--- a/git/git.go
+++ b/git/git.go
@@ -545,7 +545,7 @@ func ValidateRemoteURL(remote string) error {
 	case "ssh", "http", "https", "git", "file":
 		return nil
 	default:
-		return fmt.Errorf("invalid remote url protocol %q in %q", u.Scheme, remote)
+		return fmt.Errorf("invalid remote URL protocol %q in %q", u.Scheme, remote)
 	}
 }
 

--- a/git/gitattr/attr.go
+++ b/git/gitattr/attr.go
@@ -87,7 +87,7 @@ func ParseLines(r io.Reader) ([]*Line, string, error) {
 			}
 			pattern, err = strconv.Unquote(text[:last+1])
 			if err != nil {
-				return nil, "", errors.Wrapf(err, "git/gitattr")
+				return nil, "", errors.Wrapf(err, "unable to unquote: %s", text[:last+1])
 			}
 			applied = strings.TrimSpace(text[last+1:])
 		default:

--- a/git/gitattr/attr.go
+++ b/git/gitattr/attr.go
@@ -83,7 +83,7 @@ func ParseLines(r io.Reader) ([]*Line, string, error) {
 			var err error
 			last := strings.LastIndex(text, "\"")
 			if last == 0 {
-				return nil, "", errors.Errorf("git/gitattr: unbalanced quote: %s", text)
+				return nil, "", errors.Errorf("unbalanced quote: %s", text)
 			}
 			pattern, err = strconv.Unquote(text[:last+1])
 			if err != nil {

--- a/git/gitattr/attr.go
+++ b/git/gitattr/attr.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/git-lfs/git-lfs/v3/errors"
+	"github.com/git-lfs/git-lfs/v3/tr"
 	"github.com/git-lfs/wildmatch/v2"
 )
 
@@ -83,11 +84,11 @@ func ParseLines(r io.Reader) ([]*Line, string, error) {
 			var err error
 			last := strings.LastIndex(text, "\"")
 			if last == 0 {
-				return nil, "", errors.Errorf("unbalanced quote: %s", text)
+				return nil, "", errors.New(tr.Tr.Get("unbalanced quote: %s", text))
 			}
 			pattern, err = strconv.Unquote(text[:last+1])
 			if err != nil {
-				return nil, "", errors.Wrapf(err, "unable to unquote: %s", text[:last+1])
+				return nil, "", errors.Wrap(err, tr.Tr.Get("unable to unquote: %s", text[:last+1]))
 			}
 			applied = strings.TrimSpace(text[last+1:])
 		default:

--- a/git/gitattr/attr_test.go
+++ b/git/gitattr/attr_test.go
@@ -126,7 +126,7 @@ func TestParseLinesUnbalancedQuotes(t *testing.T) {
 
 	assert.Empty(t, lines)
 	assert.EqualError(t, err, fmt.Sprintf(
-		"git/gitattr: unbalanced quote: %s", text))
+		"unbalanced quote: %s", text))
 }
 
 func TestParseLinesWithNoAttributes(t *testing.T) {

--- a/git/githistory/ref_updater.go
+++ b/git/githistory/ref_updater.go
@@ -9,6 +9,7 @@ import (
 	"github.com/git-lfs/git-lfs/v3/git"
 	"github.com/git-lfs/git-lfs/v3/tasklog"
 	"github.com/git-lfs/git-lfs/v3/tools"
+	"github.com/git-lfs/git-lfs/v3/tr"
 	"github.com/git-lfs/gitobj/v2"
 )
 
@@ -39,7 +40,7 @@ type refUpdater struct {
 // It returns any error encountered, or nil if the reference update(s) was/were
 // successful.
 func (r *refUpdater) UpdateRefs() error {
-	list := r.Logger.List("migrate: Updating refs")
+	list := r.Logger.List(fmt.Sprintf("migrate: %s", tr.Tr.Get("Updating refs")))
 	defer list.Complete()
 
 	var maxNameLen int
@@ -68,7 +69,7 @@ func (r *refUpdater) updateOneTag(tag *gitobj.Tag, toObj []byte) ([]byte, error)
 	})
 
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not rewrite tag: %s", tag.Name)
+		return nil, errors.Wrap(err, tr.Tr.Get("could not rewrite tag: %s", tag.Name))
 	}
 	return newTag, nil
 }
@@ -76,7 +77,7 @@ func (r *refUpdater) updateOneTag(tag *gitobj.Tag, toObj []byte) ([]byte, error)
 func (r *refUpdater) updateOneRef(list *tasklog.ListTask, maxNameLen int, seen map[string]struct{}, ref *git.Ref) error {
 	sha1, err := hex.DecodeString(ref.Sha)
 	if err != nil {
-		return errors.Wrapf(err, "could not decode: %q", ref.Sha)
+		return errors.Wrap(err, tr.Tr.Get("could not decode: %q", ref.Sha))
 	}
 
 	refspec := ref.Refspec()
@@ -110,7 +111,7 @@ func (r *refUpdater) updateOneRef(list *tasklog.ListTask, maxNameLen int, seen m
 			}
 			updatedSha, err := hex.DecodeString(updated.Sha)
 			if err != nil {
-				return errors.Wrapf(err, "could not decode: %q", ref.Sha)
+				return errors.Wrap(err, tr.Tr.Get("could not decode: %q", ref.Sha))
 			}
 
 			newTag, err := r.updateOneTag(tag, updatedSha)

--- a/git/ls_files.go
+++ b/git/ls_files.go
@@ -84,7 +84,7 @@ func NewLsFiles(workingDir string, standardExclude bool, untracked bool) (*LsFil
 	// Check the output of the subprocess, output stderr if the command failed.
 	msg := <-errorMessages
 	if err := cmd.Wait(); err != nil {
-		return nil, errors.Errorf("Error in git %s: %v %s",
+		return nil, errors.Errorf("Error in `git %s`: %v %s",
 			strings.Join(args, " "), err, msg)
 	}
 

--- a/git/ls_files.go
+++ b/git/ls_files.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/git-lfs/git-lfs/v3/errors"
 	"github.com/git-lfs/git-lfs/v3/tools"
+	"github.com/git-lfs/git-lfs/v3/tr"
 	"github.com/rubyist/tracerx"
 )
 
@@ -84,8 +85,8 @@ func NewLsFiles(workingDir string, standardExclude bool, untracked bool) (*LsFil
 	// Check the output of the subprocess, output stderr if the command failed.
 	msg := <-errorMessages
 	if err := cmd.Wait(); err != nil {
-		return nil, errors.Errorf("Error in `git %s`: %v %s",
-			strings.Join(args, " "), err, msg)
+		return nil, errors.New(tr.Tr.Get("Error in `git %s`: %v %s",
+			strings.Join(args, " "), err, msg))
 	}
 
 	return rv, nil

--- a/git/object_scanner.go
+++ b/git/object_scanner.go
@@ -2,9 +2,9 @@ package git
 
 import (
 	"encoding/hex"
-	"fmt"
 	"io"
 
+	"github.com/git-lfs/git-lfs/v3/tr"
 	"github.com/git-lfs/gitobj/v2"
 	"github.com/git-lfs/gitobj/v2/errors"
 )
@@ -145,7 +145,7 @@ type missingErr struct {
 }
 
 func (m *missingErr) Error() string {
-	return fmt.Sprintf("missing object: %s", m.oid)
+	return tr.Tr.Get("missing object: %s", m.oid)
 }
 
 func IsMissingObject(err error) bool {

--- a/git/rev_list_scanner.go
+++ b/git/rev_list_scanner.go
@@ -206,7 +206,7 @@ func NewRevListScanner(include, excluded []string, opt *ScanRefsOptions) (*RevLi
 			// `git-rev-list(1)` does not treat ambiguous refnames
 			// as fatal (non-zero exit status), but we do.
 			if am := ambiguousRegex.FindSubmatch(msg); len(am) > 1 {
-				return errors.Errorf("ref %s is ambiguous", am[1])
+				return errors.Errorf("ref %q is ambiguous", am[1])
 			}
 			return nil
 		},

--- a/git/rev_list_scanner.go
+++ b/git/rev_list_scanner.go
@@ -196,7 +196,7 @@ func NewRevListScanner(include, excluded []string, opt *ScanRefsOptions) (*RevLi
 			// First check if there was a non-zero exit code given
 			// when Wait()-ing on the command execution.
 			if err := cmd.Wait(); err != nil {
-				return errors.Errorf("Error in git %s: %v %s",
+				return errors.Errorf("Error in `git %s`: %v %s",
 					strings.Join(args, " "), err, msg)
 			}
 

--- a/git/rev_list_scanner.go
+++ b/git/rev_list_scanner.go
@@ -349,7 +349,7 @@ func (s *RevListScanner) scan() ([]byte, string, error) {
 
 	oidhex := startsWithObjectID.FindString(line)
 	if len(oidhex) == 0 {
-		return nil, "", fmt.Errorf("missing object id in line (got %q)", line)
+		return nil, "", fmt.Errorf("missing OID in line (got %q)", line)
 	}
 	oid, err := hex.DecodeString(oidhex)
 	if err != nil {

--- a/lfs/attribute.go
+++ b/lfs/attribute.go
@@ -1,7 +1,7 @@
 package lfs
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 
 	"github.com/git-lfs/git-lfs/v3/git"
@@ -159,8 +159,8 @@ func (a *Attribute) set(gitConfig *git.Configuration, key, value string, upgrade
 		}
 		return err
 	} else if currentValue != value {
-		return fmt.Errorf(fmt.Sprintf(tr.Tr.Get("the %%q attribute should be %%q but is %%q")),
-			key, value, currentValue)
+		return errors.New(tr.Tr.Get("the %q attribute should be %q but is %q",
+			key, value, currentValue))
 	}
 
 	return nil

--- a/lfs/diff_index_scanner.go
+++ b/lfs/diff_index_scanner.go
@@ -70,7 +70,7 @@ func (s DiffIndexStatus) Format(state fmt.State, c rune) {
 			state.Write([]byte{byte(rune(s))})
 		}
 	default:
-		panic(fmt.Sprintf(tr.Tr.Get("cannot format %v for DiffIndexStatus", c)))
+		panic(tr.Tr.Get("cannot format %v for DiffIndexStatus", c))
 	}
 }
 

--- a/lfs/diff_index_scanner.go
+++ b/lfs/diff_index_scanner.go
@@ -148,7 +148,7 @@ func (s *DiffIndexScanner) Scan() bool {
 
 	s.next, s.err = s.scan(s.from.Text())
 	if s.err != nil {
-		s.err = errors.Wrap(s.err, "scan")
+		s.err = errors.Wrap(s.err, "`git diff-index` scan")
 	}
 
 	return s.err == nil

--- a/lfs/diff_index_scanner.go
+++ b/lfs/diff_index_scanner.go
@@ -148,7 +148,7 @@ func (s *DiffIndexScanner) Scan() bool {
 
 	s.next, s.err = s.scan(s.from.Text())
 	if s.err != nil {
-		s.err = errors.Wrap(s.err, "`git diff-index` scan")
+		s.err = errors.Wrap(s.err, tr.Tr.Get("`git diff-index` scan"))
 	}
 
 	return s.err == nil

--- a/lfs/extension.go
+++ b/lfs/extension.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
-	"fmt"
 	"hash"
 	"io"
 	"os"
@@ -68,7 +67,7 @@ func pipeExtensions(cfg *config.Configuration, request *pipeRequest) (response p
 		case "smudge":
 			pieces = strings.Split(e.Smudge, " ")
 		default:
-			err = fmt.Errorf("Invalid action: %s", request.action)
+			err = errors.New(tr.Tr.Get("Invalid action: %s", request.action))
 			return
 		}
 		name := strings.Trim(pieces[0], " ")

--- a/lfs/extension.go
+++ b/lfs/extension.go
@@ -68,7 +68,7 @@ func pipeExtensions(cfg *config.Configuration, request *pipeRequest) (response p
 		case "smudge":
 			pieces = strings.Split(e.Smudge, " ")
 		default:
-			err = fmt.Errorf("Invalid action: " + request.action)
+			err = fmt.Errorf("Invalid action: %s", request.action)
 			return
 		}
 		name := strings.Trim(pieces[0], " ")

--- a/lfs/gitfilter_smudge.go
+++ b/lfs/gitfilter_smudge.go
@@ -92,7 +92,7 @@ func (f *GitFilter) Smudge(writer io.Writer, ptr *Pointer, workingfile string, d
 }
 
 func (f *GitFilter) downloadFile(writer io.Writer, ptr *Pointer, workingfile, mediafile string, manifest *tq.Manifest, cb tools.CopyCallback) (int64, error) {
-	fmt.Fprintf(os.Stderr, tr.Tr.Get("Downloading %s (%s)\n", workingfile, humanize.FormatBytes(uint64(ptr.Size))))
+	fmt.Fprintln(os.Stderr, tr.Tr.Get("Downloading %s (%s)", workingfile, humanize.FormatBytes(uint64(ptr.Size))))
 
 	// NOTE: if given, "cb" is a tools.CopyCallback which writes updates
 	// to the logpath specified by GIT_LFS_PROGRESS.

--- a/lfs/gitfilter_smudge.go
+++ b/lfs/gitfilter_smudge.go
@@ -78,7 +78,7 @@ func (f *GitFilter) Smudge(writer io.Writer, ptr *Pointer, workingfile string, d
 		if download {
 			n, err = f.downloadFile(writer, ptr, workingfile, mediafile, manifest, cb)
 		} else {
-			return 0, errors.NewDownloadDeclinedError(statErr, "smudge filter")
+			return 0, errors.NewDownloadDeclinedError(statErr, tr.Tr.Get("smudge filter"))
 		}
 	} else {
 		n, err = f.readLocalFile(writer, ptr, mediafile, workingfile, cb)
@@ -143,14 +143,14 @@ func (f *GitFilter) readLocalFile(writer io.Writer, ptr *Pointer, mediafile stri
 			ext, ok := registeredExts[ptrExt.Name]
 			if !ok {
 				err := errors.New(tr.Tr.Get("extension '%s' is not configured", ptrExt.Name))
-				return 0, errors.Wrap(err, "smudge filter")
+				return 0, errors.Wrap(err, tr.Tr.Get("smudge filter"))
 			}
 			ext.Priority = ptrExt.Priority
 			extensions[ext.Name] = ext
 		}
 		exts, err := config.SortExtensions(extensions)
 		if err != nil {
-			return 0, errors.Wrap(err, "smudge filter")
+			return 0, errors.Wrap(err, tr.Tr.Get("smudge filter"))
 		}
 
 		// pipe extensions in reverse order
@@ -164,7 +164,7 @@ func (f *GitFilter) readLocalFile(writer io.Writer, ptr *Pointer, mediafile stri
 
 		response, err := pipeExtensions(f.cfg, request)
 		if err != nil {
-			return 0, errors.Wrap(err, "smudge filter")
+			return 0, errors.Wrap(err, tr.Tr.Get("smudge filter"))
 		}
 
 		actualExts := make(map[string]*pipeExtResult)
@@ -176,18 +176,18 @@ func (f *GitFilter) readLocalFile(writer io.Writer, ptr *Pointer, mediafile stri
 		oid := response.results[0].oidIn
 		if ptr.Oid != oid {
 			err = errors.New(tr.Tr.Get("actual OID %s during smudge does not match expected %s", oid, ptr.Oid))
-			return 0, errors.Wrap(err, "smudge filter")
+			return 0, errors.Wrap(err, tr.Tr.Get("smudge filter"))
 		}
 
 		for _, expected := range ptr.Extensions {
 			actual := actualExts[expected.Name]
 			if actual.name != expected.Name {
 				err = errors.New(tr.Tr.Get("actual extension name '%s' does not match expected '%s'", actual.name, expected.Name))
-				return 0, errors.Wrap(err, "smudge filter")
+				return 0, errors.Wrap(err, tr.Tr.Get("smudge filter"))
 			}
 			if actual.oidOut != expected.Oid {
 				err = errors.New(tr.Tr.Get("actual OID %s for extension '%s' does not match expected %s", actual.oidOut, expected.Name, expected.Oid))
-				return 0, errors.Wrap(err, "smudge filter")
+				return 0, errors.Wrap(err, tr.Tr.Get("smudge filter"))
 			}
 		}
 

--- a/lfs/gitfilter_smudge.go
+++ b/lfs/gitfilter_smudge.go
@@ -78,7 +78,7 @@ func (f *GitFilter) Smudge(writer io.Writer, ptr *Pointer, workingfile string, d
 		if download {
 			n, err = f.downloadFile(writer, ptr, workingfile, mediafile, manifest, cb)
 		} else {
-			return 0, errors.NewDownloadDeclinedError(statErr, "smudge")
+			return 0, errors.NewDownloadDeclinedError(statErr, "smudge filter")
 		}
 	} else {
 		n, err = f.readLocalFile(writer, ptr, mediafile, workingfile, cb)
@@ -143,14 +143,14 @@ func (f *GitFilter) readLocalFile(writer io.Writer, ptr *Pointer, mediafile stri
 			ext, ok := registeredExts[ptrExt.Name]
 			if !ok {
 				err := errors.New(tr.Tr.Get("extension '%s' is not configured", ptrExt.Name))
-				return 0, errors.Wrap(err, "smudge")
+				return 0, errors.Wrap(err, "smudge filter")
 			}
 			ext.Priority = ptrExt.Priority
 			extensions[ext.Name] = ext
 		}
 		exts, err := config.SortExtensions(extensions)
 		if err != nil {
-			return 0, errors.Wrap(err, "smudge")
+			return 0, errors.Wrap(err, "smudge filter")
 		}
 
 		// pipe extensions in reverse order
@@ -164,7 +164,7 @@ func (f *GitFilter) readLocalFile(writer io.Writer, ptr *Pointer, mediafile stri
 
 		response, err := pipeExtensions(f.cfg, request)
 		if err != nil {
-			return 0, errors.Wrap(err, "smudge")
+			return 0, errors.Wrap(err, "smudge filter")
 		}
 
 		actualExts := make(map[string]*pipeExtResult)
@@ -176,18 +176,18 @@ func (f *GitFilter) readLocalFile(writer io.Writer, ptr *Pointer, mediafile stri
 		oid := response.results[0].oidIn
 		if ptr.Oid != oid {
 			err = errors.New(tr.Tr.Get("actual oid %s during smudge does not match expected %s", oid, ptr.Oid))
-			return 0, errors.Wrap(err, "smudge")
+			return 0, errors.Wrap(err, "smudge filter")
 		}
 
 		for _, expected := range ptr.Extensions {
 			actual := actualExts[expected.Name]
 			if actual.name != expected.Name {
 				err = errors.New(tr.Tr.Get("actual extension name '%s' does not match expected '%s'", actual.name, expected.Name))
-				return 0, errors.Wrap(err, "smudge")
+				return 0, errors.Wrap(err, "smudge filter")
 			}
 			if actual.oidOut != expected.Oid {
 				err = errors.New(tr.Tr.Get("actual oid %s for extension '%s' does not match expected %s", actual.oidOut, expected.Name, expected.Oid))
-				return 0, errors.Wrap(err, "smudge")
+				return 0, errors.Wrap(err, "smudge filter")
 			}
 		}
 

--- a/lfs/gitfilter_smudge.go
+++ b/lfs/gitfilter_smudge.go
@@ -175,7 +175,7 @@ func (f *GitFilter) readLocalFile(writer io.Writer, ptr *Pointer, mediafile stri
 		// verify name, order, and oids
 		oid := response.results[0].oidIn
 		if ptr.Oid != oid {
-			err = errors.New(tr.Tr.Get("actual oid %s during smudge does not match expected %s", oid, ptr.Oid))
+			err = errors.New(tr.Tr.Get("actual OID %s during smudge does not match expected %s", oid, ptr.Oid))
 			return 0, errors.Wrap(err, "smudge filter")
 		}
 
@@ -186,7 +186,7 @@ func (f *GitFilter) readLocalFile(writer io.Writer, ptr *Pointer, mediafile stri
 				return 0, errors.Wrap(err, "smudge filter")
 			}
 			if actual.oidOut != expected.Oid {
-				err = errors.New(tr.Tr.Get("actual oid %s for extension '%s' does not match expected %s", actual.oidOut, expected.Name, expected.Oid))
+				err = errors.New(tr.Tr.Get("actual OID %s for extension '%s' does not match expected %s", actual.oidOut, expected.Name, expected.Oid))
 				return 0, errors.Wrap(err, "smudge filter")
 			}
 		}

--- a/lfs/gitscanner.go
+++ b/lfs/gitscanner.go
@@ -11,7 +11,7 @@ import (
 	"github.com/rubyist/tracerx"
 )
 
-var missingCallbackErr = errors.New("no callback given")
+var missingCallbackErr = errors.New(tr.Tr.Get("no callback given"))
 
 // IsCallbackMissing returns a boolean indicating whether the error is reporting
 // that a GitScanner is missing a required GitScannerCallback.

--- a/lfs/gitscanner_catfilebatchcheck.go
+++ b/lfs/gitscanner_catfilebatchcheck.go
@@ -50,7 +50,7 @@ func runCatFileBatchCheck(smallRevCh chan string, lockableCh chan string, lockab
 		stderr, _ := ioutil.ReadAll(cmd.Stderr)
 		err := cmd.Wait()
 		if err != nil {
-			errCh <- errors.New(tr.Tr.Get("error in git cat-file --batch-check: %v %v", err, string(stderr)))
+			errCh <- errors.New(tr.Tr.Get("error in `git cat-file --batch-check`: %v %v", err, string(stderr)))
 		}
 		close(smallRevCh)
 		close(errCh)

--- a/lfs/gitscanner_log.go
+++ b/lfs/gitscanner_log.go
@@ -102,7 +102,7 @@ func scanStashed(cb GitScannerFoundPointer, s *GitScanner) error {
 		stashMergeShas = append(stashMergeShas, fmt.Sprintf("%v^..%v", stashMergeSha, stashMergeSha))
 	}
 	if err := scanner.Err(); err != nil {
-		errors.New(tr.Tr.Get("error while scanning git log for stashed refs: %v", err))
+		errors.New(tr.Tr.Get("error while scanning `git log` for stashed refs: %v", err))
 	}
 	err = cmd.Wait()
 	if err != nil {
@@ -145,12 +145,12 @@ func parseScannerLogOutput(cb GitScannerFoundPointer, direction LogDiffDirection
 		}
 		if err := scanner.Err(); err != nil {
 			ioutil.ReadAll(cmd.Stdout)
-			ch <- gitscannerResult{Err: errors.New(tr.Tr.Get("error while scanning git log: %v", err))}
+			ch <- gitscannerResult{Err: errors.New(tr.Tr.Get("error while scanning `git log`: %v", err))}
 		}
 		stderr, _ := ioutil.ReadAll(cmd.Stderr)
 		err := cmd.Wait()
 		if err != nil {
-			ch <- gitscannerResult{Err: errors.New(tr.Tr.Get("error in git log: %v %v", err, string(stderr)))}
+			ch <- gitscannerResult{Err: errors.New(tr.Tr.Get("error in `git log`: %v %v", err, string(stderr)))}
 		}
 		close(ch)
 	}()

--- a/lfs/gitscanner_refs.go
+++ b/lfs/gitscanner_refs.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/git-lfs/git-lfs/v3/config"
 	"github.com/git-lfs/git-lfs/v3/git"
+	"github.com/git-lfs/git-lfs/v3/tr"
 )
 
 type lockableNameSet struct {
@@ -38,7 +39,7 @@ func noopFoundLockable(name string) {}
 // Reports unique oids once only, not multiple times if >1 file uses the same content
 func scanRefsToChan(scanner *GitScanner, pointerCb GitScannerFoundPointer, include, exclude []string, gitEnv, osEnv config.Environment, opt *ScanRefsOptions) error {
 	if opt == nil {
-		panic("no scan ref options")
+		panic(tr.Tr.Get("no scan ref options"))
 	}
 
 	revs, err := revListShas(include, exclude, opt)
@@ -112,7 +113,7 @@ func scanMultiLeftRightToChan(scanner *GitScanner, pointerCb GitScannerFoundPoin
 // Reports unique oids once only, not multiple times if >1 file uses the same content
 func scanRefsByTree(scanner *GitScanner, pointerCb GitScannerFoundPointer, include, exclude []string, gitEnv, osEnv config.Environment, opt *ScanRefsOptions) error {
 	if opt == nil {
-		panic("no scan ref options")
+		panic(tr.Tr.Get("no scan ref options"))
 	}
 
 	revs, err := revListShas(include, exclude, opt)

--- a/lfs/gitscanner_tree.go
+++ b/lfs/gitscanner_tree.go
@@ -116,7 +116,7 @@ func lsTreeBlobs(ref string, predicate func(*git.TreeBlob) bool) (*TreeBlobChann
 		stderr, _ := ioutil.ReadAll(cmd.Stderr)
 		err := cmd.Wait()
 		if err != nil {
-			errchan <- errors.New(tr.Tr.Get("error in git ls-tree: %v %v", err, string(stderr)))
+			errchan <- errors.New(tr.Tr.Get("error in `git ls-tree`: %v %v", err, string(stderr)))
 		}
 		close(blobs)
 		close(errchan)

--- a/lfs/hook.go
+++ b/lfs/hook.go
@@ -159,5 +159,5 @@ func (h *Hook) matchesCurrent() (bool, error) {
 		}
 	}
 
-	return false, errors.New(tr.Tr.Get("Hook already exists: %s\n\n%s\n", string(h.Type), tools.Indent(contents)))
+	return false, errors.New(fmt.Sprintf("%s\n\n%s\n", tr.Tr.Get("Hook already exists: %s", string(h.Type)), tools.Indent(contents)))
 }

--- a/lfs/hook.go
+++ b/lfs/hook.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	// The basic hook which just calls 'git lfs TYPE'
-	hookBaseContent = "#!/bin/sh\ncommand -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/{{Command}}.\\n\"; exit 2; }\ngit lfs {{Command}} \"$@\""
+	hookBaseContent = "#!/bin/sh\ncommand -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/{{Command}}'.\\n\"; exit 2; }\ngit lfs {{Command}} \"$@\""
 )
 
 // A Hook represents a githook as described in http://git-scm.com/docs/githooks.

--- a/lfs/pointer.go
+++ b/lfs/pointer.go
@@ -92,7 +92,7 @@ func EncodePointer(writer io.Writer, pointer *Pointer) (int, error) {
 func DecodePointerFromBlob(b *gitobj.Blob) (*Pointer, error) {
 	// Check size before reading
 	if b.Size >= blobSizeCutoff {
-		return nil, errors.NewNotAPointerError(errors.New("blob size exceeds lfs pointer size cutoff"))
+		return nil, errors.NewNotAPointerError(errors.New("blob size exceeds Git LFS pointer size cutoff"))
 	}
 	return DecodePointer(b.Contents)
 }
@@ -104,7 +104,7 @@ func DecodePointerFromFile(file string) (*Pointer, error) {
 		return nil, err
 	}
 	if stat.Size() >= blobSizeCutoff {
-		return nil, errors.NewNotAPointerError(errors.New(tr.Tr.Get("file size exceeds lfs pointer size cutoff")))
+		return nil, errors.NewNotAPointerError(errors.New(tr.Tr.Get("file size exceeds Git LFS pointer size cutoff")))
 	}
 	f, err := os.OpenFile(file, os.O_RDONLY, 0644)
 	if err != nil {

--- a/lfs/pointer.go
+++ b/lfs/pointer.go
@@ -92,7 +92,7 @@ func EncodePointer(writer io.Writer, pointer *Pointer) (int, error) {
 func DecodePointerFromBlob(b *gitobj.Blob) (*Pointer, error) {
 	// Check size before reading
 	if b.Size >= blobSizeCutoff {
-		return nil, errors.NewNotAPointerError(errors.New("blob size exceeds Git LFS pointer size cutoff"))
+		return nil, errors.NewNotAPointerError(errors.New(tr.Tr.Get("blob size exceeds Git LFS pointer size cutoff")))
 	}
 	return DecodePointer(b.Contents)
 }

--- a/lfs/util.go
+++ b/lfs/util.go
@@ -37,7 +37,7 @@ func (f *GitFilter) CopyCallbackFile(event, filename string, index, totalFiles i
 	}
 
 	if !filepath.IsAbs(logPath) {
-		return nil, nil, fmt.Errorf("GIT_LFS_PROGRESS must be an absolute path")
+		return nil, nil, errors.New(tr.Tr.Get("GIT_LFS_PROGRESS must be an absolute path"))
 	}
 
 	cbDir := filepath.Dir(logPath)
@@ -68,7 +68,7 @@ func (f *GitFilter) CopyCallbackFile(event, filename string, index, totalFiles i
 
 func wrapProgressError(err error, event, filename string) error {
 	if err != nil {
-		return fmt.Errorf("error writing Git LFS %s progress to %s: %s", event, filename, err.Error())
+		return errors.New(tr.Tr.Get("error writing Git LFS %s progress to %s: %s", event, filename, err.Error()))
 	}
 
 	return nil

--- a/lfsapi/auth.go
+++ b/lfsapi/auth.go
@@ -150,7 +150,7 @@ func (c *Client) getCreds(remote string, access creds.Access, req *http.Request)
 
 		credsURL, err := getCredURLForAPI(ef, operation, remote, apiEndpoint, req)
 		if err != nil {
-			return creds.CredentialHelperWrapper{CredentialHelper: creds.NullCreds, Input: nil, Url: nil, Creds: nil}, errors.Wrap(err, "credentials")
+			return creds.CredentialHelperWrapper{CredentialHelper: creds.NullCreds, Input: nil, Url: nil, Creds: nil}, errors.Wrap(err, tr.Tr.Get("credentials"))
 		}
 
 		if credsURL == nil {
@@ -170,7 +170,7 @@ func (c *Client) getCreds(remote string, access creds.Access, req *http.Request)
 
 	credsURL, err := url.Parse(apiEndpoint.Url)
 	if err != nil {
-		return creds.CredentialHelperWrapper{CredentialHelper: creds.NullCreds, Input: nil, Url: nil, Creds: nil}, errors.Wrap(err, "credentials")
+		return creds.CredentialHelperWrapper{CredentialHelper: creds.NullCreds, Input: nil, Url: nil, Creds: nil}, errors.Wrap(err, tr.Tr.Get("credentials"))
 	}
 
 	// NTLM uses creds to create the session

--- a/lfsapi/auth.go
+++ b/lfsapi/auth.go
@@ -150,7 +150,7 @@ func (c *Client) getCreds(remote string, access creds.Access, req *http.Request)
 
 		credsURL, err := getCredURLForAPI(ef, operation, remote, apiEndpoint, req)
 		if err != nil {
-			return creds.CredentialHelperWrapper{CredentialHelper: creds.NullCreds, Input: nil, Url: nil, Creds: nil}, errors.Wrap(err, "creds")
+			return creds.CredentialHelperWrapper{CredentialHelper: creds.NullCreds, Input: nil, Url: nil, Creds: nil}, errors.Wrap(err, "credentials")
 		}
 
 		if credsURL == nil {
@@ -170,7 +170,7 @@ func (c *Client) getCreds(remote string, access creds.Access, req *http.Request)
 
 	credsURL, err := url.Parse(apiEndpoint.Url)
 	if err != nil {
-		return creds.CredentialHelperWrapper{CredentialHelper: creds.NullCreds, Input: nil, Url: nil, Creds: nil}, errors.Wrap(err, "creds")
+		return creds.CredentialHelperWrapper{CredentialHelper: creds.NullCreds, Input: nil, Url: nil, Creds: nil}, errors.Wrap(err, "credentials")
 	}
 
 	// NTLM uses creds to create the session

--- a/lfsapi/endpoint_finder.go
+++ b/lfsapi/endpoint_finder.go
@@ -338,7 +338,7 @@ func storeAlias(aliases map[string]string, key string, values []string, suffix s
 	for _, value := range values {
 		url := key[len(aliasPrefix) : len(key)-len(suffix)]
 		if v, ok := aliases[value]; ok && v != url {
-			fmt.Fprintf(os.Stderr, tr.Tr.Get("warning: Multiple 'url.*.%s' keys with the same alias: %q\n", suffix, value))
+			fmt.Fprintln(os.Stderr, tr.Tr.Get("warning: Multiple 'url.*.%s' keys with the same alias: %q", suffix, value))
 		}
 		aliases[value] = url
 	}

--- a/lfsapi/lfsapi.go
+++ b/lfsapi/lfsapi.go
@@ -30,7 +30,7 @@ func NewClient(ctx lfshttp.Context) (*Client, error) {
 
 	httpClient, err := lfshttp.NewClient(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, tr.Tr.Get("error creating http client"))
+		return nil, errors.Wrap(err, tr.Tr.Get("error creating HTTP client"))
 	}
 
 	c := &Client{

--- a/lfshttp/client.go
+++ b/lfshttp/client.go
@@ -114,9 +114,9 @@ func (c *Client) URLConfig() *config.URLConfig {
 func (c *Client) NewRequest(method string, e Endpoint, suffix string, body interface{}) (*http.Request, error) {
 	if strings.HasPrefix(e.Url, "file://") {
 		// Initial `\n` to avoid overprinting `Downloading LFS...`.
-		fmt.Fprintf(os.Stderr, "\n%s\n", tr.Tr.Get(`hint: The remote resolves to a file:// URL, which can only work with a
+		fmt.Fprint(os.Stderr, "\n", tr.Tr.Get(`hint: The remote resolves to a file:// URL, which can only work with a
 hint: standalone transfer agent.  See section "Using a Custom Transfer Type
-hint: without the API server" in custom-transfers.md for details.`))
+hint: without the API server" in custom-transfers.md for details.`), "\n")
 	}
 
 	sshRes, err := c.sshResolveWithRetries(e, method)

--- a/lfshttp/client.go
+++ b/lfshttp/client.go
@@ -545,7 +545,7 @@ func newRequestForRetry(req *http.Request, location string) (*http.Request, erro
 	}
 
 	if req.URL.Scheme == "https" && newReq.URL.Scheme == "http" {
-		return nil, errors.New(tr.Tr.Get("lfsapi/client: refusing insecure redirect, https->http"))
+		return nil, errors.New(tr.Tr.Get("refusing insecure redirect: HTTPS to HTTP"))
 	}
 
 	sameHost := req.URL.Host == newReq.URL.Host

--- a/lfshttp/client_test.go
+++ b/lfshttp/client_test.go
@@ -173,7 +173,7 @@ func TestClientRedirect(t *testing.T) {
 	require.Nil(t, MarshalToRequest(req, &redirectTest{Test: "https->http"}))
 
 	_, err = c.Do(req)
-	assert.EqualError(t, err, "lfsapi/client: refusing insecure redirect, https->http")
+	assert.EqualError(t, err, "refusing insecure redirect: HTTPS to HTTP")
 }
 
 func TestNewClient(t *testing.T) {

--- a/lfshttp/errors.go
+++ b/lfshttp/errors.go
@@ -89,7 +89,7 @@ func NewStatusCodeError(res *http.Response) error {
 
 func (e *statusCodeError) Error() string {
 	req := e.response.Request
-	return fmt.Sprintf("Invalid HTTP status for %s %s: %d",
+	return tr.Tr.Get("Invalid HTTP status for %s %s: %d",
 		req.Method,
 		strings.SplitN(req.URL.String(), "?", 2)[0],
 		e.response.StatusCode,
@@ -118,9 +118,9 @@ func defaultError(res *http.Response) error {
 	if f, ok := defaultErrors[res.StatusCode]; ok {
 		msgFmt = f
 	} else if res.StatusCode < 500 {
-		msgFmt = fmt.Sprintf("Client error %%s from HTTP %d", res.StatusCode)
+		msgFmt = tr.Tr.Get("Client error %%s from HTTP %d", res.StatusCode)
 	} else {
-		msgFmt = fmt.Sprintf("Server error %%s from HTTP %d", res.StatusCode)
+		msgFmt = tr.Tr.Get("Server error %%s from HTTP %d", res.StatusCode)
 	}
 
 	return errors.Errorf(fmt.Sprintf(msgFmt), res.Request.URL)

--- a/lfshttp/lfshttp.go
+++ b/lfshttp/lfshttp.go
@@ -72,7 +72,7 @@ type decodeTypeError struct {
 func (e *decodeTypeError) TypeError() {}
 
 func (e *decodeTypeError) Error() string {
-	return fmt.Sprintf(tr.Tr.Get("Expected json type, got: %q", e.Type))
+	return fmt.Sprintf(tr.Tr.Get("Expected JSON type, got: %q", e.Type))
 }
 
 func DecodeJSON(res *http.Response, obj interface{}) error {

--- a/lfshttp/lfshttp.go
+++ b/lfshttp/lfshttp.go
@@ -2,7 +2,6 @@ package lfshttp
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"regexp"
 
@@ -72,7 +71,7 @@ type decodeTypeError struct {
 func (e *decodeTypeError) TypeError() {}
 
 func (e *decodeTypeError) Error() string {
-	return fmt.Sprintf(tr.Tr.Get("Expected JSON type, got: %q", e.Type))
+	return tr.Tr.Get("Expected JSON type, got: %q", e.Type)
 }
 
 func DecodeJSON(res *http.Response, obj interface{}) error {

--- a/lfshttp/standalone/standalone.go
+++ b/lfshttp/standalone/standalone.go
@@ -123,7 +123,7 @@ func gitDirAtPath(path string) (string, error) {
 	cmd.Cmd.Env = env
 	out, err := cmd.Output()
 	if err != nil {
-		return "", errors.Wrap(err, tr.Tr.Get("failed to call git rev-parse --git-dir"))
+		return "", errors.Wrap(err, tr.Tr.Get("failed to call `git rev-parse --git-dir`"))
 	}
 
 	gitdir, err := tools.TranslateCygwinPath(strings.TrimRight(string(out), "\n"))

--- a/lfshttp/verbose.go
+++ b/lfshttp/verbose.go
@@ -25,7 +25,7 @@ func (c *Client) traceRequest(req *http.Request) (*tracedRequest, error) {
 
 	body, ok := req.Body.(ReadSeekCloser)
 	if body != nil && !ok {
-		return nil, errors.New(tr.Tr.Get("Request body must implement io.ReadCloser and io.Seeker. Got: %T", body))
+		return nil, errors.New(tr.Tr.Get("Request body must implement io.ReadCloser and io.Seeker: %T", body))
 	}
 
 	if body != nil && ok {

--- a/locking/lockable.go
+++ b/locking/lockable.go
@@ -1,7 +1,6 @@
 package locking
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +10,7 @@ import (
 	"github.com/git-lfs/git-lfs/v3/git"
 	"github.com/git-lfs/git-lfs/v3/git/gitattr"
 	"github.com/git-lfs/git-lfs/v3/tools"
+	"github.com/git-lfs/git-lfs/v3/tr"
 )
 
 // GetLockablePatterns returns a list of patterns in .gitattributes which are
@@ -94,7 +94,7 @@ func (c *Client) FixFileWriteFlagsInDir(dir string, lockablePatterns, unlockable
 		return err
 	}
 	if !stat.IsDir() {
-		return fmt.Errorf("%q is not a valid directory", dir)
+		return errors.New(tr.Tr.Get("%q is not a valid directory", dir))
 	}
 
 	var lockableFilter *filepathfilter.Filter

--- a/locking/locks.go
+++ b/locking/locks.go
@@ -156,7 +156,7 @@ func getAbsolutePath(p string) (string, error) {
 func (c *Client) UnlockFile(path string, force bool) error {
 	id, err := c.lockIdFromPath(path)
 	if err != nil {
-		return errors.New(tr.Tr.Get("unable to get lock id: %v", err))
+		return errors.New(tr.Tr.Get("unable to get lock ID: %v", err))
 	}
 
 	return c.UnlockFileById(id, force)

--- a/locking/locks.go
+++ b/locking/locks.go
@@ -122,7 +122,7 @@ func (c *Client) LockFile(path string) (Lock, error) {
 
 	abs, err := getAbsolutePath(path)
 	if err != nil {
-		return Lock{}, errors.Wrap(err, tr.Tr.Get("make lockpath absolute"))
+		return Lock{}, errors.Wrap(err, tr.Tr.Get("make lock path absolute"))
 	}
 
 	// If the file exists, ensure that it's writeable on return
@@ -184,7 +184,7 @@ func (c *Client) UnlockFileById(id string, force bool) error {
 	if unlockRes.Lock != nil {
 		abs, err := getAbsolutePath(unlockRes.Lock.Path)
 		if err != nil {
-			return errors.Wrap(err, tr.Tr.Get("make lockpath absolute"))
+			return errors.Wrap(err, tr.Tr.Get("make lock path absolute"))
 		}
 
 		// Make non-writeable if required

--- a/locking/locks.go
+++ b/locking/locks.go
@@ -73,7 +73,7 @@ func NewClient(remote string, lfsClient *lfsapi.Client, cfg *config.Configuratio
 func (c *Client) SetupFileCache(path string) error {
 	stat, err := os.Stat(path)
 	if err != nil {
-		return errors.Wrap(err, "init lock cache")
+		return errors.Wrap(err, "lock cache initialization")
 	}
 
 	lockFile := path
@@ -83,7 +83,7 @@ func (c *Client) SetupFileCache(path string) error {
 
 	cache, err := NewLockCache(lockFile)
 	if err != nil {
-		return errors.Wrap(err, "init lock cache")
+		return errors.Wrap(err, "lock cache initialization")
 	}
 
 	c.cache = cache
@@ -105,7 +105,7 @@ func (c *Client) LockFile(path string) (Lock, error) {
 		Ref:  &lockRef{Name: c.RemoteRef.Refspec()},
 	})
 	if err != nil {
-		return Lock{}, errors.Wrap(err, "api")
+		return Lock{}, errors.Wrap(err, "locking API")
 	}
 
 	if len(lockRes.Message) > 0 {
@@ -167,7 +167,7 @@ func (c *Client) UnlockFile(path string, force bool) error {
 func (c *Client) UnlockFileById(id string, force bool) error {
 	unlockRes, _, err := c.client.Unlock(c.RemoteRef, c.Remote, id, force)
 	if err != nil {
-		return errors.Wrap(err, "api")
+		return errors.Wrap(err, "locking API")
 	}
 
 	if len(unlockRes.Message) > 0 {

--- a/locking/locks.go
+++ b/locking/locks.go
@@ -23,10 +23,10 @@ import (
 var (
 	// ErrNoMatchingLocks is an error returned when no matching locks were
 	// able to be resolved
-	ErrNoMatchingLocks = errors.New("no matching locks found")
+	ErrNoMatchingLocks = errors.New(tr.Tr.Get("no matching locks found"))
 	// ErrLockAmbiguous is an error returned when multiple matching locks
 	// were found
-	ErrLockAmbiguous = errors.New("multiple locks found; ambiguous")
+	ErrLockAmbiguous = errors.New(tr.Tr.Get("multiple locks found; ambiguous"))
 )
 
 type LockCacher interface {
@@ -73,7 +73,7 @@ func NewClient(remote string, lfsClient *lfsapi.Client, cfg *config.Configuratio
 func (c *Client) SetupFileCache(path string) error {
 	stat, err := os.Stat(path)
 	if err != nil {
-		return errors.Wrap(err, "lock cache initialization")
+		return errors.Wrap(err, tr.Tr.Get("lock cache initialization"))
 	}
 
 	lockFile := path
@@ -83,7 +83,7 @@ func (c *Client) SetupFileCache(path string) error {
 
 	cache, err := NewLockCache(lockFile)
 	if err != nil {
-		return errors.Wrap(err, "lock cache initialization")
+		return errors.Wrap(err, tr.Tr.Get("lock cache initialization"))
 	}
 
 	c.cache = cache
@@ -105,7 +105,7 @@ func (c *Client) LockFile(path string) (Lock, error) {
 		Ref:  &lockRef{Name: c.RemoteRef.Refspec()},
 	})
 	if err != nil {
-		return Lock{}, errors.Wrap(err, "locking API")
+		return Lock{}, errors.Wrap(err, tr.Tr.Get("locking API"))
 	}
 
 	if len(lockRes.Message) > 0 {
@@ -167,7 +167,7 @@ func (c *Client) UnlockFile(path string, force bool) error {
 func (c *Client) UnlockFileById(id string, force bool) error {
 	unlockRes, _, err := c.client.Unlock(c.RemoteRef, c.Remote, id, force)
 	if err != nil {
-		return errors.Wrap(err, "locking API")
+		return errors.Wrap(err, tr.Tr.Get("locking API"))
 	}
 
 	if len(unlockRes.Message) > 0 {
@@ -360,7 +360,7 @@ func (c *Client) searchRemoteLocks(filter map[string]string, limit int) ([]Lock,
 	for {
 		list, _, err := c.client.Search(c.Remote, query)
 		if err != nil {
-			return locks, errors.Wrap(err, "locking")
+			return locks, errors.Wrap(err, tr.Tr.Get("locking"))
 		}
 
 		if list.Message != "" {

--- a/locking/locks.go
+++ b/locking/locks.go
@@ -23,10 +23,10 @@ import (
 var (
 	// ErrNoMatchingLocks is an error returned when no matching locks were
 	// able to be resolved
-	ErrNoMatchingLocks = errors.New("lfs: no matching locks found")
+	ErrNoMatchingLocks = errors.New("no matching locks found")
 	// ErrLockAmbiguous is an error returned when multiple matching locks
 	// were found
-	ErrLockAmbiguous = errors.New("lfs: multiple locks found; ambiguous")
+	ErrLockAmbiguous = errors.New("multiple locks found; ambiguous")
 )
 
 type LockCacher interface {

--- a/t/t-checkout.sh
+++ b/t/t-checkout.sh
@@ -155,7 +155,7 @@ begin_test "checkout: outside git repository"
     exit 0
   fi
   [ "$res" = "128" ]
-  grep "Not in a git repository" checkout.log
+  grep "Not in a Git repository" checkout.log
 )
 end_test
 

--- a/t/t-clone-deprecated.sh
+++ b/t/t-clone-deprecated.sh
@@ -14,7 +14,8 @@ begin_test "clone (deprecated on new versions of Git)"
   mkdir -p "$reponame"
   pushd "$reponame" > /dev/null
     git lfs clone "$GITSERVER/$reponame" 2>&1 | tee clone.log
-    grep "WARNING: 'git lfs clone' is deprecated and will not be updated" clone.log
+    grep "WARNING: \`git lfs clone\` is deprecated and will not be updated" clone.log
+    grep "\`git clone\` has been updated in upstream Git to have comparable" clone.log
   popd > /dev/null
 )
 end_test

--- a/t/t-config.sh
+++ b/t/t-config.sh
@@ -252,7 +252,7 @@ begin_test "config: ignoring unsafe lfsconfig keys"
 
   git lfs env 2>&1 | tee status.log
 
-  grep "warning: These unsafe lfsconfig keys were ignored:" status.log
+  grep "warning: These unsafe '.lfsconfig' keys were ignored:" status.log
   grep "  core.askpass" status.log
 )
 end_test

--- a/t/t-dedup.sh
+++ b/t/t-dedup.sh
@@ -16,7 +16,7 @@ begin_test "dedup"
   git config lfs.extension.foo.priority 0
 
   result=$(git lfs dedup 2>&1) && true
-  if ( echo $result | grep "This system does not support deduplication." ); then
+  if ( echo $result | grep "This system does not support de-duplication." ); then
     exit
   fi
   echo "$result" | grep 'This platform supports file de-duplication, however, Git LFS extensions are configured and therefore de-duplication can not be used.'
@@ -64,7 +64,7 @@ begin_test "dedup test"
   git config lfs.extension.foo.priority 0
 
   result=$(git lfs dedup --test 2>&1) && true
-  if ( echo $result | grep "This system does not support deduplication." ); then
+  if ( echo $result | grep "This system does not support de-duplication." ); then
     exit
   fi
   echo "$result" | grep 'This platform supports file de-duplication, however, Git LFS extensions are configured and therefore de-duplication can not be used.'
@@ -97,7 +97,7 @@ begin_test "dedup dirty workdir"
 
   # DO
   result=$(git lfs dedup 2>&1) && true
-  if ( echo $result | grep "This system does not support deduplication." ); then
+  if ( echo $result | grep "This system does not support de-duplication." ); then
     exit
   fi
 

--- a/t/t-fetch.sh
+++ b/t/t-fetch.sh
@@ -487,7 +487,7 @@ begin_test "fetch: outside git repository"
     exit 0
   fi
   [ "$res" = "128" ]
-  grep "Not in a git repository" fetch.log
+  grep "Not in a Git repository" fetch.log
 )
 end_test
 

--- a/t/t-fsck.sh
+++ b/t/t-fsck.sh
@@ -134,7 +134,7 @@ begin_test "fsck: outside git repository"
     exit 0
   fi
   [ "$res" = "128" ]
-  grep "Not in a git repository" fsck.log
+  grep "Not in a Git repository" fsck.log
 )
 end_test
 

--- a/t/t-install-custom-hooks-path-unsupported.sh
+++ b/t/t-install-custom-hooks-path-unsupported.sh
@@ -21,7 +21,7 @@ begin_test "install with unsupported core.hooksPath"
   git config --local core.hooksPath "$hooks_dir"
 
   git lfs install 2>&1 | tee install.log
-  grep "Updated git hooks" install.log
+  grep "Updated Git hooks" install.log
 
   [ ! -e "$hooks_dir/pre-push" ]
   [ -e ".git/hooks/pre-push" ]

--- a/t/t-install-custom-hooks-path.sh
+++ b/t/t-install-custom-hooks-path.sh
@@ -41,7 +41,7 @@ begin_test "install with supported core.hooksPath"
   git config --local core.hooksPath "$hooks_dir"
 
   git lfs install 2>&1 | tee install.log
-  grep "Updated git hooks" install.log
+  grep "Updated Git hooks" install.log
 
   assert_hooks "$hooks_dir"
 )
@@ -62,7 +62,7 @@ begin_test "install with supported core.hooksPath in subdirectory"
   git config --local core.hooksPath "$hooks_dir"
 
   (cd subdir && git lfs install 2>&1 | tee install.log)
-  grep "Updated git hooks" subdir/install.log
+  grep "Updated Git hooks" subdir/install.log
 
   assert_hooks "$hooks_dir"
   refute_hooks "subdir/$hooks_dir"
@@ -83,7 +83,7 @@ begin_test "install with supported expandable core.hooksPath"
   git config --local core.hooksPath "$hooks_dir"
 
   git lfs install 2>&1 | tee install.log
-  grep "Updated git hooks" install.log
+  grep "Updated Git hooks" install.log
 
   assert_hooks "$HOME/custom_hooks_dir"
 )

--- a/t/t-install-worktree.sh
+++ b/t/t-install-worktree.sh
@@ -24,7 +24,7 @@ begin_test "install --worktree outside repository"
   res=$?
   set -e
 
-  [ "Not in a git repository." = "$(cat out.log)" ]
+  [ "Not in a Git repository." = "$(cat out.log)" ]
   [ "0" != "$res" ]
 )
 end_test

--- a/t/t-install.sh
+++ b/t/t-install.sh
@@ -89,7 +89,7 @@ git lfs post-commit \"\$@\""
 command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/post-merge.\\n\"; exit 2; }
 git lfs post-merge \"\$@\""
 
-  [ "Updated git hooks.
+  [ "Updated Git hooks.
 Git LFS initialized." = "$(git lfs install)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
   [ "$post_checkout_hook" = "$(cat .git/hooks/post-checkout)" ]
@@ -100,7 +100,7 @@ Git LFS initialized." = "$(git lfs install)" ]
   # more-comprehensive hook update tests are in test-update.sh
   echo "#!/bin/sh
 git lfs push --stdin \$*" > .git/hooks/pre-push
-  [ "Updated git hooks.
+  [ "Updated Git hooks.
 Git LFS initialized." = "$(git lfs install)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
@@ -134,7 +134,7 @@ To resolve this, either:
   set -e
 
   # force replace unexpected hook
-  [ "Updated git hooks.
+  [ "Updated Git hooks.
 Git LFS initialized." = "$(git lfs install --force)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
   [ "$post_checkout_hook" = "$(cat .git/hooks/post-checkout)" ]
@@ -174,7 +174,7 @@ begin_test "install outside repository directory"
   cat check.log
 
   # doesn't print this because being in a git repo is not necessary for install
-  [ "$(grep -c "Not in a git repository" check.log)" = "0" ]
+  [ "$(grep -c "Not in a Git repository" check.log)" = "0" ]
   [ "$(grep -c "Error" check.log)" = "0" ]
 )
 end_test
@@ -281,7 +281,7 @@ begin_test "install --local outside repository"
   res=$?
   set -e
 
-  [ "Not in a git repository." = "$(cat out.log)" ]
+  [ "Not in a Git repository." = "$(cat out.log)" ]
   [ "0" != "$res" ]
 )
 end_test

--- a/t/t-install.sh
+++ b/t/t-install.sh
@@ -74,19 +74,19 @@ begin_test "install updates repo hooks"
   git init
 
   pre_push_hook="#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/pre-push.\\n\"; exit 2; }
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/pre-push'.\\n\"; exit 2; }
 git lfs pre-push \"\$@\""
 
   post_checkout_hook="#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/post-checkout.\\n\"; exit 2; }
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/post-checkout'.\\n\"; exit 2; }
 git lfs post-checkout \"\$@\""
 
   post_commit_hook="#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/post-commit.\\n\"; exit 2; }
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/post-commit'.\\n\"; exit 2; }
 git lfs post-commit \"\$@\""
 
   post_merge_hook="#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/post-merge.\\n\"; exit 2; }
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/post-merge'.\\n\"; exit 2; }
 git lfs post-merge \"\$@\""
 
   [ "Updated Git hooks.

--- a/t/t-ls-files.sh
+++ b/t/t-ls-files.sh
@@ -181,7 +181,7 @@ begin_test "ls-files: outside git repository"
     exit 0
   fi
   [ "$res" = "128" ]
-  grep "Not in a git repository" ls-files.log
+  grep "Not in a Git repository" ls-files.log
 )
 end_test
 

--- a/t/t-ls-files.sh
+++ b/t/t-ls-files.sh
@@ -382,7 +382,7 @@ begin_test "ls-files: invalid --all ordering"
     echo >&2 "Expected \`git lfs ls-files -- --all\' to fail"
     exit 1
   fi
-  grep "Did you mean \"git lfs ls-files --all --\" ?" ls-files.out
+  grep "Did you mean \`git lfs ls-files --all --\` ?" ls-files.out
 )
 end_test
 

--- a/t/t-migrate-import-no-rewrite.sh
+++ b/t/t-migrate-import-no-rewrite.sh
@@ -120,7 +120,7 @@ begin_test "migrate import --no-rewrite (no .gitattributes)"
     exit 1
   fi
 
-  grep "No Git LFS filters found in .gitattributes" migrate.log
+  grep "No Git LFS filters found in '.gitattributes'" migrate.log
 )
 end_test
 
@@ -161,7 +161,7 @@ begin_test "migrate import --no-rewrite (nested .gitattributes)"
     exit 1
   fi
 
-  grep "a.md did not match any Git LFS filters in .gitattributes" migrate.log
+  grep "a.md did not match any Git LFS filters in '.gitattributes'" migrate.log
 )
 end_test
 

--- a/t/t-pre-push.sh
+++ b/t/t-pre-push.sh
@@ -834,7 +834,7 @@ begin_test "pre-push locks verify 5xx with verification enabled"
   git config "lfs.$endpoint.locksverify" true
 
   git push origin main 2>&1 | tee push.log
-  grep "\"origin\" does not support the LFS locking API" push.log
+  grep "\"origin\" does not support the Git LFS locking API" push.log
   grep "git config lfs.$endpoint.locksverify false" push.log
 
   refute_server_object "$reponame" "$contents_oid"
@@ -861,7 +861,7 @@ begin_test "pre-push disable locks verify on exact url"
   git config "lfs.$endpoint.locksverify" false
 
   git push origin main 2>&1 | tee push.log
-  [ "0" -eq "$(grep -c "\"origin\" does not support the LFS locking API" push.log)" ]
+  [ "0" -eq "$(grep -c "\"origin\" does not support the Git LFS locking API" push.log)" ]
 
   assert_server_object "$reponame" "$contents_oid"
 )
@@ -887,7 +887,7 @@ begin_test "pre-push disable locks verify on partial url"
   git config "lfs.$endpoint.locksverify" false
 
   git push origin main 2>&1 | tee push.log
-  [ "0" -eq "$(grep -c "\"origin\" does not support the LFS locking API" push.log)" ]
+  [ "0" -eq "$(grep -c "\"origin\" does not support the Git LFS locking API" push.log)" ]
 
   assert_server_object "$reponame" "$contents_oid"
 )
@@ -1004,7 +1004,7 @@ begin_test "pre-push locks verify 5xx with verification unset"
   [ -z "$(git config "lfs.$endpoint.locksverify")" ]
 
   git push origin main 2>&1 | tee push.log
-  grep "\"origin\" does not support the LFS locking API" push.log
+  grep "\"origin\" does not support the Git LFS locking API" push.log
 
   assert_server_object "$reponame" "$contents_oid"
 )

--- a/t/t-pull.sh
+++ b/t/t-pull.sh
@@ -362,6 +362,6 @@ begin_test "pull: outside git repository"
     exit 0
   fi
   [ "$res" = "128" ]
-  grep "Not in a git repository" pull.log
+  grep "Not in a Git repository" pull.log
 )
 end_test

--- a/t/t-push.sh
+++ b/t/t-push.sh
@@ -572,7 +572,7 @@ begin_test "push (retry with expired actions)"
 
   GIT_TRACE=1 git push origin main 2>&1 | tee push.log
 
-  expected="enqueue retry #1 after 0.25s for \"$contents_oid\" (size: $contents_size): LFS: tq: action \"upload\" expires at"
+  expected="enqueue retry #1 after 0.25s for \"$contents_oid\" (size: $contents_size): LFS: action \"upload\" expires at"
 
   grep "$expected" push.log
   grep "Uploading LFS objects: 100% (1/1), 21 B" push.log

--- a/t/t-status.sh
+++ b/t/t-status.sh
@@ -160,7 +160,7 @@ begin_test "status: outside git repository"
     exit 0
   fi
   [ "$res" = "128" ]
-  grep "Not in a git repository" status.log
+  grep "Not in a Git repository" status.log
 )
 end_test
 

--- a/t/t-track.sh
+++ b/t/t-track.sh
@@ -371,7 +371,7 @@ begin_test "track blocklisted files by name"
   git add .gitattributes
 
   git lfs track .gitattributes 2>&1 > track.log
-  grep "Pattern .gitattributes matches forbidden file .gitattributes" track.log
+  grep "Pattern '.gitattributes' matches forbidden file '.gitattributes'" track.log
 )
 end_test
 
@@ -388,7 +388,7 @@ begin_test "track blocklisted files with glob"
   git add .gitattributes
 
   git lfs track ".git*" 2>&1 > track.log
-  grep "Pattern .git\* matches forbidden file" track.log
+  grep "Pattern '.git\*' matches forbidden file" track.log
 )
 end_test
 

--- a/t/t-track.sh
+++ b/t/t-track.sh
@@ -91,7 +91,7 @@ begin_test "track --verbose"
   git add foo.dat
 
   git lfs track --verbose "foo.dat" 2>&1 > track.log
-  grep "touching \"foo.dat\"" track.log
+  grep "Touching \"foo.dat\"" track.log
 )
 end_test
 
@@ -109,7 +109,7 @@ begin_test "track --dry-run"
 
   git lfs track --dry-run "foo.dat" 2>&1 > track.log
   grep "Tracking \"foo.dat\"" track.log
-  grep "Git LFS: touching \"foo.dat\"" track.log
+  grep "Touching \"foo.dat\"" track.log
 
   git status --porcelain 2>&1 > status.log
   grep "A  foo.dat" status.log

--- a/t/t-uninstall-worktree.sh
+++ b/t/t-uninstall-worktree.sh
@@ -24,7 +24,7 @@ begin_test "uninstall --worktree outside repository"
   res=$?
   set -e
 
-  [ "Not in a git repository." = "$(cat out.log)" ]
+  [ "Not in a Git repository." = "$(cat out.log)" ]
   [ "0" != "$res" ]
 )
 end_test

--- a/t/t-uninstall.sh
+++ b/t/t-uninstall.sh
@@ -190,7 +190,7 @@ begin_test "uninstall --local outside repository"
   res=$?
   set -e
 
-  [ "Not in a git repository." = "$(cat out.log)" ]
+  [ "Not in a Git repository." = "$(cat out.log)" ]
   [ "0" != "$res" ]
 )
 end_test

--- a/t/t-update.sh
+++ b/t/t-update.sh
@@ -7,19 +7,19 @@ begin_test "update"
   set -e
 
   pre_push_hook="#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/pre-push.\\n\"; exit 2; }
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/pre-push'.\\n\"; exit 2; }
 git lfs pre-push \"\$@\""
 
   post_checkout_hook="#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/post-checkout.\\n\"; exit 2; }
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/post-checkout'.\\n\"; exit 2; }
 git lfs post-checkout \"\$@\""
 
   post_commit_hook="#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/post-commit.\\n\"; exit 2; }
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/post-commit'.\\n\"; exit 2; }
 git lfs post-commit \"\$@\""
 
   post_merge_hook="#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/post-merge.\\n\"; exit 2; }
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/post-merge'.\\n\"; exit 2; }
 git lfs post-merge \"\$@\""
 
   mkdir without-pre-push
@@ -111,28 +111,28 @@ To resolve this, either:
   set -e
 
   # test manual steps
-  expected="Add the following to .git/hooks/pre-push:
+  expected="Add the following to '.git/hooks/pre-push':
 
 	#!/bin/sh
-	command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/pre-push.\n\"; exit 2; }
+	command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/pre-push'.\n\"; exit 2; }
 	git lfs pre-push \"\$@\"
 
-Add the following to .git/hooks/post-checkout:
+Add the following to '.git/hooks/post-checkout':
 
 	#!/bin/sh
-	command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/post-checkout.\n\"; exit 2; }
+	command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/post-checkout'.\n\"; exit 2; }
 	git lfs post-checkout \"\$@\"
 
-Add the following to .git/hooks/post-commit:
+Add the following to '.git/hooks/post-commit':
 
 	#!/bin/sh
-	command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/post-commit.\n\"; exit 2; }
+	command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/post-commit'.\n\"; exit 2; }
 	git lfs post-commit \"\$@\"
 
-Add the following to .git/hooks/post-merge:
+Add the following to '.git/hooks/post-merge':
 
 	#!/bin/sh
-	command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/post-merge.\n\"; exit 2; }
+	command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/post-merge'.\n\"; exit 2; }
 	git lfs post-merge \"\$@\""
 
   [ "$expected" = "$(git lfs update --manual 2>&1)" ]
@@ -173,7 +173,7 @@ begin_test "update with leading spaces"
 
   # $pre_push_hook contains leading TAB '\t' characters
   pre_push_hook="#!/bin/sh
-	command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/pre-push.\\n\"; exit 2; }
+	command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/pre-push'.\\n\"; exit 2; }
 	git lfs pre-push \"\$@\""
 
   echo -n "$pre_push_hook" > .git/hooks/pre-push

--- a/t/t-update.sh
+++ b/t/t-update.sh
@@ -26,14 +26,14 @@ git lfs post-merge \"\$@\""
   cd without-pre-push
   git init
 
-  [ "Updated git hooks." = "$(git lfs update)" ]
+  [ "Updated Git hooks." = "$(git lfs update)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
   [ "$post_checkout_hook" = "$(cat .git/hooks/post-checkout)" ]
   [ "$post_commit_hook" = "$(cat .git/hooks/post-commit)" ]
   [ "$post_merge_hook" = "$(cat .git/hooks/post-merge)" ]
 
   # run it again
-  [ "Updated git hooks." = "$(git lfs update)" ]
+  [ "Updated Git hooks." = "$(git lfs update)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
   [ "$post_checkout_hook" = "$(cat .git/hooks/post-checkout)" ]
   [ "$post_commit_hook" = "$(cat .git/hooks/post-commit)" ]
@@ -42,19 +42,19 @@ git lfs post-merge \"\$@\""
   # replace old hook 1
   echo "#!/bin/sh
 git lfs push --stdin \$*" > .git/hooks/pre-push
-  [ "Updated git hooks." = "$(git lfs update)" ]
+  [ "Updated Git hooks." = "$(git lfs update)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
   # replace old hook 2
   echo "#!/bin/sh
 git lfs push --stdin \"\$@\"" > .git/hooks/pre-push
-  [ "Updated git hooks." = "$(git lfs update)" ]
+  [ "Updated Git hooks." = "$(git lfs update)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
   # replace old hook 3
   echo "#!/bin/sh
 git lfs pre-push \"\$@\"" > .git/hooks/pre-push
-  [ "Updated git hooks." = "$(git lfs update)" ]
+  [ "Updated Git hooks." = "$(git lfs update)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
   # replace blank hook
@@ -62,7 +62,7 @@ git lfs pre-push \"\$@\"" > .git/hooks/pre-push
   touch .git/hooks/pre-push
   touch .git/hooks/post-checkout
   touch .git/hooks/post-merge
-  [ "Updated git hooks." = "$(git lfs update)" ]
+  [ "Updated Git hooks." = "$(git lfs update)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
   [ "$post_checkout_hook" = "$(cat .git/hooks/post-checkout)" ]
   [ "$post_commit_hook" = "$(cat .git/hooks/post-commit)" ]
@@ -72,14 +72,14 @@ git lfs pre-push \"\$@\"" > .git/hooks/pre-push
   echo "#!/bin/sh
 command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository has been set up with Git LFS but Git LFS is not installed.\\n\"; exit 0; }
 git lfs pre-push \"$@\""
-  [ "Updated git hooks." = "$(git lfs update)" ]
+  [ "Updated Git hooks." = "$(git lfs update)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
   # replace old hook 5
   echo "#!/bin/sh
 command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository has been set up with Git LFS but Git LFS is not installed.\\n\"; exit 2; }
 git lfs pre-push \"$@\""
-  [ "Updated git hooks." = "$(git lfs update)" ]
+  [ "Updated Git hooks." = "$(git lfs update)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
   # don't replace unexpected hook
@@ -142,7 +142,7 @@ Add the following to .git/hooks/post-merge:
   [ "test" = "$(cat .git/hooks/post-merge)" ]
 
   # force replace unexpected hook
-  [ "Updated git hooks." = "$(git lfs update --force)" ]
+  [ "Updated Git hooks." = "$(git lfs update --force)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
   [ "$post_checkout_hook" = "$(cat .git/hooks/post-checkout)" ]
   [ "$post_commit_hook" = "$(cat .git/hooks/post-commit)" ]
@@ -169,7 +169,7 @@ begin_test "update with leading spaces"
   git init "$reponame"
   cd "$reponame"
 
-  [ "Updated git hooks." = "$(git lfs update)" ]
+  [ "Updated Git hooks." = "$(git lfs update)" ]
 
   # $pre_push_hook contains leading TAB '\t' characters
   pre_push_hook="#!/bin/sh
@@ -178,7 +178,7 @@ begin_test "update with leading spaces"
 
   echo -n "$pre_push_hook" > .git/hooks/pre-push
 
-  [ "Updated git hooks." = "$(git lfs update)" ]
+  [ "Updated Git hooks." = "$(git lfs update)" ]
 )
 end_test
 
@@ -199,7 +199,7 @@ begin_test "update lfs.{url}.access"
   [ "basic" = "$(git config lfs.https://example2.com.access)" ]
   [ "other" = "$(git config lfs.https://example3.com.access)" ]
 
-  expected="Updated git hooks.
+  expected="Updated Git hooks.
 Updated http://example.com access from private to basic.
 Updated https://example.com access from private to basic.
 Removed invalid https://example3.com access of other."
@@ -235,6 +235,6 @@ begin_test "update: outside git repository"
   fi
 
   cat check.log
-  grep "Not in a git repository" check.log
+  grep "Not in a Git repository" check.log
 )
 end_test

--- a/tasklog/percentage_task.go
+++ b/tasklog/percentage_task.go
@@ -5,6 +5,8 @@ import (
 	"math"
 	"sync/atomic"
 	"time"
+
+	"github.com/git-lfs/git-lfs/v3/tr"
 )
 
 // PercentageTask is a task that is performed against a known number of
@@ -44,7 +46,7 @@ func NewPercentageTask(msg string, total uint64) *PercentageTask {
 // been completed.
 func (c *PercentageTask) Count(n uint64) (new uint64) {
 	if new = atomic.AddUint64(&c.n, n); new > c.total {
-		panic("tasklog: counted too many items")
+		panic(fmt.Sprintf("tasklog: %s", tr.Tr.Get("counted too many items")))
 	}
 
 	var percentage float64

--- a/tools/cygwin_windows.go
+++ b/tools/cygwin_windows.go
@@ -5,9 +5,9 @@ package tools
 
 import (
 	"bytes"
-	"fmt"
 
 	"github.com/git-lfs/git-lfs/v3/subprocess"
+	"github.com/git-lfs/git-lfs/v3/tr"
 )
 
 type cygwinSupport byte
@@ -25,7 +25,7 @@ func (c cygwinSupport) Enabled() bool {
 	case cygwinStateDisabled:
 		return false
 	default:
-		panic(fmt.Sprintf("unknown enabled state for %v", c))
+		panic(tr.Tr.Get("unknown enabled state for %v", c))
 	}
 }
 

--- a/tools/humanize/humanize.go
+++ b/tools/humanize/humanize.go
@@ -9,6 +9,7 @@ import (
 	"unicode"
 
 	"github.com/git-lfs/git-lfs/v3/errors"
+	"github.com/git-lfs/git-lfs/v3/tr"
 )
 
 const (
@@ -77,7 +78,7 @@ func ParseBytes(str string) (uint64, error) {
 
 	f = f * float64(m)
 	if f >= math.MaxUint64 {
-		return 0, errors.New("number of bytes too large")
+		return 0, errors.New(tr.Tr.Get("number of bytes too large"))
 	}
 	return uint64(f), nil
 }
@@ -91,7 +92,7 @@ func ParseByteUnit(str string) (uint64, error) {
 	if u, ok := bytesTable[str]; ok {
 		return u, nil
 	}
-	return 0, errors.Errorf("unknown unit: %q", str)
+	return 0, errors.New(tr.Tr.Get("unknown unit: %q", str))
 }
 
 var sizes = []string{"B", "KB", "MB", "GB", "TB", "PB"}

--- a/tools/kv/keyvaluestore.go
+++ b/tools/kv/keyvaluestore.go
@@ -2,10 +2,12 @@ package kv
 
 import (
 	"encoding/gob"
-	"fmt"
 	"io"
 	"os"
 	"sync"
+
+	"github.com/git-lfs/git-lfs/v3/errors"
+	"github.com/git-lfs/git-lfs/v3/tr"
 )
 
 // Store provides an in-memory key/value store which is persisted to
@@ -144,10 +146,10 @@ func (k *Store) Save() error {
 
 	enc := gob.NewEncoder(f)
 	if err := enc.Encode(k.version); err != nil {
-		return fmt.Errorf("error while writing version data to %v: %v", k.filename, err)
+		return errors.New(tr.Tr.Get("error while writing version data to %v: %v", k.filename, err))
 	}
 	if err := enc.Encode(k.db); err != nil {
-		return fmt.Errorf("error while writing new key/value data to %v: %v", k.filename, err)
+		return errors.New(tr.Tr.Get("error while writing new key/value data to %v: %v", k.filename, err))
 	}
 	// Clear log now that it's saved
 	k.log = nil
@@ -189,7 +191,7 @@ func (k *Store) loadAndMergeReaderIfNeeded(f io.Reader) error {
 	dec := gob.NewDecoder(f)
 	err := dec.Decode(&versionOnDisk)
 	if err != nil {
-		return fmt.Errorf("problem checking version of key/value data from %v: %v", k.filename, err)
+		return errors.New(tr.Tr.Get("problem checking version of key/value data from %v: %v", k.filename, err))
 	}
 	// Totally uninitialised Version == 0, saved versions are always >=1
 	if versionOnDisk != k.version {
@@ -197,7 +199,7 @@ func (k *Store) loadAndMergeReaderIfNeeded(f io.Reader) error {
 		var dbOnDisk map[string]interface{}
 		err = dec.Decode(&dbOnDisk)
 		if err != nil {
-			return fmt.Errorf("problem reading updated key/value data from %v: %v", k.filename, err)
+			return errors.New(tr.Tr.Get("problem reading updated key/value data from %v: %v", k.filename, err))
 		}
 		k.reapplyChanges(dbOnDisk)
 		k.version = versionOnDisk

--- a/tools/os_tools.go
+++ b/tools/os_tools.go
@@ -20,7 +20,7 @@ func Getwd() (dir string, err error) {
 	if isCygwin() {
 		dir, err = translateCygwinPath(dir)
 		if err != nil {
-			return "", errors.Wrap(err, tr.Tr.Get("error converting working directory to cygwin"))
+			return "", errors.Wrap(err, tr.Tr.Get("error converting working directory to Cygwin"))
 		}
 	}
 
@@ -48,7 +48,7 @@ func translateCygwinPath(path string) (string, error) {
 		if _, ok := err.(*exec.Error); ok {
 			return path, nil
 		}
-		return path, errors.New(tr.Tr.Get("failed to translate path from cygwin to windows: %s", buf.String()))
+		return path, errors.New(tr.Tr.Get("failed to translate path from Cygwin to Windows: %s", buf.String()))
 	}
 	return output, nil
 }

--- a/tools/util_darwin.go
+++ b/tools/util_darwin.go
@@ -55,7 +55,7 @@ func checkCloneFileSupported() bool {
 // If check failed (e.g. directory is read-only), returns err.
 func CheckCloneFileSupported(dir string) (supported bool, err error) {
 	if !cloneFileSupported {
-		return false, errors.New(tr.Tr.Get("unsupported OS version. >= 10.12.x Sierra required"))
+		return false, errors.New(tr.Tr.Get("Unsupported OS version. 10.12.x Sierra or higher required."))
 	}
 
 	src, err := ioutil.TempFile(dir, "src")

--- a/tq/adapterbase.go
+++ b/tq/adapterbase.go
@@ -1,7 +1,6 @@
 package tq
 
 import (
-	"fmt"
 	"net/http"
 	"regexp"
 	"strings"
@@ -179,7 +178,7 @@ func (a *adapterBase) worker(workerNum int, ctx interface{}) {
 		// Actual transfer happens here
 		var err error
 		if t.Size < 0 {
-			err = fmt.Errorf("object %q has invalid size (got: %d)", t.Oid, t.Size)
+			err = errors.New(tr.Tr.Get("object %q has invalid size (got: %d)", t.Oid, t.Size))
 		} else {
 			err = a.transferImpl.DoTransfer(ctx, t, a.cb, authCallback)
 		}

--- a/tq/api_test.go
+++ b/tq/api_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/git-lfs/git-lfs/v3/lfsapi"
 	"github.com/git-lfs/git-lfs/v3/lfshttp"
-	"github.com/git-lfs/git-lfs/v3/tr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/xeipuuv/gojsonschema"
@@ -168,7 +167,7 @@ func getSchema(wd, relpath string) *sourcedSchema {
 	abspath := filepath.ToSlash(filepath.Join(wd, relpath))
 	s, err := gojsonschema.NewSchema(gojsonschema.NewReferenceLoader(fmt.Sprintf("file:///%s", abspath)))
 	if err != nil {
-		tr.Tr.Get("schema load error for %q: %+v\n", relpath, err)
+		fmt.Printf("schema load error for %q: %+v\n", relpath, err)
 	}
 	return &sourcedSchema{Source: relpath, Schema: s}
 }
@@ -185,6 +184,6 @@ func assertSchema(t *testing.T, schema *sourcedSchema, dataLoader gojsonschema.J
 		for _, resErr := range resErrors {
 			valErrors = append(valErrors, resErr.String())
 		}
-		t.Errorf(tr.Tr.Get("Schema: %s\n%s", schema.Source, strings.Join(valErrors, "\n")))
+		t.Errorf("Schema: %s\n%s", schema.Source, strings.Join(valErrors, "\n"))
 	}
 }

--- a/tq/basic_download.go
+++ b/tq/basic_download.go
@@ -270,7 +270,7 @@ func configureBasicDownloadAdapter(m *Manifest) {
 			bd.transferImpl = bd
 			return bd
 		case Upload:
-			panic("Should never ask this function to upload")
+			panic(tr.Tr.Get("Should never ask this function to upload"))
 		}
 		return nil
 	})

--- a/tq/basic_download.go
+++ b/tq/basic_download.go
@@ -270,7 +270,7 @@ func configureBasicDownloadAdapter(m *Manifest) {
 			bd.transferImpl = bd
 			return bd
 		case Upload:
-			panic("Should never ask this func to upload")
+			panic("Should never ask this function to upload")
 		}
 		return nil
 	})

--- a/tq/basic_upload.go
+++ b/tq/basic_upload.go
@@ -137,7 +137,7 @@ func (a *basicUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb Progres
 	// A status code of 403 likely means that an authentication token for the
 	// upload has expired. This can be safely retried.
 	if res.StatusCode == 403 {
-		err = errors.New(tr.Tr.Get("http: received status 403"))
+		err = errors.New(tr.Tr.Get("Received status %d", res.StatusCode))
 		return errors.NewRetriableError(err)
 	}
 

--- a/tq/basic_upload.go
+++ b/tq/basic_upload.go
@@ -65,7 +65,7 @@ func (a *basicUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb Progres
 
 	f, err := os.OpenFile(t.Path, os.O_RDONLY, 0644)
 	if err != nil {
-		return errors.Wrap(err, "basic upload")
+		return errors.Wrap(err, tr.Tr.Get("basic upload"))
 	}
 	defer f.Close()
 
@@ -218,7 +218,7 @@ func configureBasicUploadAdapter(m *Manifest) {
 			bu.transferImpl = bu
 			return bu
 		case Download:
-			panic("Should never ask this function to download")
+			panic(tr.Tr.Get("Should never ask this function to download"))
 		}
 		return nil
 	})

--- a/tq/basic_upload.go
+++ b/tq/basic_upload.go
@@ -218,7 +218,7 @@ func configureBasicUploadAdapter(m *Manifest) {
 			bu.transferImpl = bu
 			return bu
 		case Download:
-			panic("Should never ask this func for basic download")
+			panic("Should never ask this function to download")
 		}
 		return nil
 	})

--- a/tq/meter.go
+++ b/tq/meter.go
@@ -55,7 +55,7 @@ func (m *Meter) LoggerFromEnv(os env) *tools.SyncWriter {
 
 func (m *Meter) LoggerToFile(name string) *tools.SyncWriter {
 	printErr := func(err string) {
-		fmt.Fprintf(os.Stderr, tr.Tr.Get("Error creating progress logger: %s\n", err))
+		fmt.Fprintln(os.Stderr, tr.Tr.Get("Error creating progress logger: %s", err))
 	}
 
 	if !filepath.IsAbs(name) {

--- a/tq/ssh.go
+++ b/tq/ssh.go
@@ -349,7 +349,7 @@ func (a *SSHAdapter) upload(t *Transfer, conn *ssh.PktlineConnection, cb Progres
 		// A status code of 403 likely means that an authentication token for the
 		// upload has expired. This can be safely retried.
 		if status == 403 {
-			err = errors.New(tr.Tr.Get("http: received status 403"))
+			err = errors.New(tr.Tr.Get("Received status %d", status))
 			return errors.NewRetriableError(err)
 		}
 

--- a/tq/ssh.go
+++ b/tq/ssh.go
@@ -247,7 +247,7 @@ func (a *SSHAdapter) doDownload(t *Transfer, conn *ssh.PktlineConnection, f *os.
 		}
 	}
 	if !seenSize {
-		return errors.NewProtocolError("no size argument seen", nil)
+		return errors.NewProtocolError(tr.Tr.Get("no size argument seen"), nil)
 	}
 
 	dlfilename := f.Name()

--- a/tq/transfer.go
+++ b/tq/transfer.go
@@ -173,7 +173,7 @@ type ActionExpiredErr struct {
 }
 
 func (e ActionExpiredErr) Error() string {
-	return fmt.Sprintf("tq: action %q expires at %s",
+	return fmt.Sprintf("action %q expires at %s",
 		e.Rel, e.At.In(time.Local).Format(time.RFC822))
 }
 

--- a/tq/transfer.go
+++ b/tq/transfer.go
@@ -173,7 +173,7 @@ type ActionExpiredErr struct {
 }
 
 func (e ActionExpiredErr) Error() string {
-	return fmt.Sprintf("action %q expires at %s",
+	return tr.Tr.Get("action %q expires at %s",
 		e.Rel, e.At.In(time.Local).Format(time.RFC822))
 }
 

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -723,7 +723,7 @@ func (q *TransferQueue) partitionTransfers(transfers []*Transfer) (present []*Tr
 		var err error
 
 		if t.Size < 0 {
-			err = errors.Errorf(tr.Tr.Get("Git LFS: object %q has invalid size (got: %d)", t.Oid, t.Size))
+			err = errors.Errorf(tr.Tr.Get("object %q has invalid size (got: %d)", t.Oid, t.Size))
 		} else {
 			fd, serr := os.Stat(t.Path)
 			if serr != nil {

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -946,7 +946,7 @@ func (q *TransferQueue) Wait() {
 	}
 
 	if q.unsupportedContentType {
-		fmt.Fprintf(os.Stderr, tr.Tr.Get(`info: Uploading failed due to unsupported Content-Type header(s).
+		fmt.Fprintln(os.Stderr, tr.Tr.Get(`info: Uploading failed due to unsupported Content-Type header(s).
 info: Consider disabling Content-Type detection with:
 info:
 info:   $ git config lfs.contenttype false`))

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -600,7 +600,7 @@ func (q *TransferQueue) enqueueAndCollectRetriesFor(batch batch) (batch, error) 
 			// missing in that case, since we don't need to upload
 			// it.
 			if o.Missing && len(o.Actions) != 0 {
-				return nil, errors.Errorf("Unable to find source for object %v (try running `git lfs fetch --all`)", o.Oid)
+				return nil, errors.New(tr.Tr.Get("Unable to find source for object %v (try running `git lfs fetch --all`)", o.Oid))
 			}
 		}
 	}

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -600,7 +600,7 @@ func (q *TransferQueue) enqueueAndCollectRetriesFor(batch batch) (batch, error) 
 			// missing in that case, since we don't need to upload
 			// it.
 			if o.Missing && len(o.Actions) != 0 {
-				return nil, errors.Errorf("Unable to find source for object %v (try running git lfs fetch --all)", o.Oid)
+				return nil, errors.Errorf("Unable to find source for object %v (try running `git lfs fetch --all`)", o.Oid)
 			}
 		}
 	}

--- a/tq/tus_upload.go
+++ b/tq/tus_upload.go
@@ -76,7 +76,7 @@ func (a *tusUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb ProgressC
 	// Open file for uploading
 	f, err := os.OpenFile(t.Path, os.O_RDONLY, 0644)
 	if err != nil {
-		return errors.Wrap(err, "tus upload")
+		return errors.Wrap(err, "tus.io upload")
 	}
 	defer f.Close()
 

--- a/tq/tus_upload.go
+++ b/tq/tus_upload.go
@@ -165,7 +165,7 @@ func configureTusAdapter(m *Manifest) {
 			bu.transferImpl = bu
 			return bu
 		case Download:
-			panic("Should never ask tus.io to download")
+			panic("Should never ask this function to download")
 		}
 		return nil
 	})

--- a/tq/tus_upload.go
+++ b/tq/tus_upload.go
@@ -138,7 +138,7 @@ func (a *tusUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb ProgressC
 	// A status code of 403 likely means that an authentication token for the
 	// upload has expired. This can be safely retried.
 	if res.StatusCode == 403 {
-		err = errors.New(tr.Tr.Get("http: received status 403"))
+		err = errors.New(tr.Tr.Get("Received status %d", res.StatusCode))
 		return errors.NewRetriableError(err)
 	}
 

--- a/tq/tus_upload.go
+++ b/tq/tus_upload.go
@@ -76,7 +76,7 @@ func (a *tusUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb ProgressC
 	// Open file for uploading
 	f, err := os.OpenFile(t.Path, os.O_RDONLY, 0644)
 	if err != nil {
-		return errors.Wrap(err, "tus.io upload")
+		return errors.Wrap(err, tr.Tr.Get("tus.io upload"))
 	}
 	defer f.Close()
 
@@ -165,7 +165,7 @@ func configureTusAdapter(m *Manifest) {
 			bu.transferImpl = bu
 			return bu
 		case Download:
-			panic("Should never ask this function to download")
+			panic(tr.Tr.Get("Should never ask this function to download"))
 		}
 		return nil
 	})


### PR DESCRIPTION
Following from the work in PR #4781 and #4729, we mark a number of additional message strings for translation, and revise various message strings with the aim of improving their consistency and clarity.

This PR may be most easily reviewed in commit-by-commit fashion, although it should also be readable as a single diff.

Aside from adding messages to the set of translatable string, which we undertake in the final commit, the preceding commits attempt to address a number of issues, including:

- Using consistent capitalization for acronyms, abbreviations, and project names (e.g., "Git" and "Git LFS").
    - Note that this PR does not attempt to ensure all messages begin with a capitalized (or all-lowercase) first word.
- Improving our grammar and punctuation in a few messages.
- Removing short message prefixes where they are used inconsistently within a package and do not add particular value.
    - We leave these types of prefixes in place in [trace](https://github.com/git-lfs/git-lfs/blob/02448f5fde353bd34236f7e2679678d46198195d/tq/transfer_queue.go#L523) messages intended for debugging, however, as they have utility there.
- Moving other short message prefixes specific to a Git LFS command, such as `migrate:`, out of the translatable strings, as they are intended to reference they command's name.
- Using backticks to delimit `git ...` and `git lfs ...` commands where they appear in messages.
- Using single quotes to delimit file names and paths, e.g., `'.gitattributes'`, where they appear in messages.
    - This PR does not achieve perfect consistency in this regard, though, as many message string formats use `%q` to quote user-supplied file paths, Git remotes, Git ref names, etc.
- Making some strings untranslatable, either because they appear in Go test files, or because they are fixed strings such as Git LFS command examples, Git configuration examples, etc.
- Moving most newlines outside of the translatable strings, as this should aid the task of ensuring translations have equivalent formatting, and because we can often make use of the formatting capabilities of the function enclosing the call to `tr.Tr.Get()` to do so.
- Dropping or changing the functions enclosing calls to `tr.Tr.Get()` to ensure we never pass a translated and interpolated string as another format string.

Re the last item, because the `tr.Tr.Get()` family of methods insert arguments into `printf(3)`-style format strings after translating the format string, we can in a few cases drop a surrounding call to `fmt.Sprintf()` or a similar method, as those now take no arguments and so are redundant.  This will help us avoid situations where either the translated string or the argument values interpolated by `tr.Tr.Get()` produce an output string which itself happens to contain character sequences that resemble Go format specifiers (e.g., `%s`, `%d`, etc.)  In such cases passing the string at runtime to a method such as `fmt.Fprintf()` will result in the output containing a warning such as `%!s(MISSING)`, which is not ideal.

As an [example](https://github.com/git-lfs/git-lfs/blob/02448f5fde353bd34236f7e2679678d46198195d/commands/command_pointer.go#L93), if `pointerFile` contained `%d` then the output from `fmt.Fprintf()` would contain `%!d(MISSING)`:
```go
	fmt.Fprintf(os.Stderr, tr.Tr.Get("Git LFS pointer for %s\n\n", pointerFile))
```

In one [case](https://github.com/git-lfs/git-lfs/blob/02448f5fde353bd34236f7e2679678d46198195d/lfs/attribute.go#L162-L163), in `lfs/attribute.go`, we can now also simplify the format string to use standard format specifiers instead of double-escaped ones (e.g., `%%q`) since we can just allow `tr.Tr.Get()` to do the interpolation.

We also take the opportunity to remove explicit leading or trailing newlines from translation messages wherever it is possible to convert the enclosing function to `fmt.Print()`, `fmt.Println()`, etc., noting that the former can be used to concatenate multiple strings without intermediate spaces, while the latter will insert spaces between all its arguments.

Within the `commands` package we can also make use of the formatting provided by the `Print()`, `Error()`, etc. functions, as they ultimately [utilize](https://github.com/git-lfs/git-lfs/blob/02448f5fde353bd34236f7e2679678d46198195d/commands/commands.go#L200-L203) `fmt.Fprintln()` when no arguments are provided, so a newline is automatically appended, and when arguments are provided, the `fmt.Fprintf()` is used but these utility functions [append](https://github.com/git-lfs/git-lfs/blob/02448f5fde353bd34236f7e2679678d46198195d/commands/commands.go#L204) a newline for us to the format string we pass.  But in that instance we then need to be careful not to pass our translated string as the format string, but as an argument, as noted above.

Lastly, we include panic messages amongst our translated strings as there is [already](https://github.com/git-lfs/git-lfs/blob/02448f5fde353bd34236f7e2679678d46198195d/lfs/diff_index_scanner.go#L73) [precedent](https://github.com/git-lfs/git-lfs/blob/02448f5fde353bd34236f7e2679678d46198195d/commands/command_fetch.go#L52) for translating these.