### PR TITLE
halt migration when `.gitattributes` symbolic link encountered

### DIFF
--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -196,7 +196,6 @@ func migrateImportCommand(cmd *cobra.Command, args []string) {
 				if err != nil {
 					return err
 				}
-				return nil
 			}
 			return nil
 		},
@@ -322,8 +321,12 @@ func trackedFromAttrs(db *gitobj.ObjectDatabase, t *gitobj.Tree) (*tools.Ordered
 
 	for _, e := range t.Entries {
 		if strings.ToLower(e.Name) == ".gitattributes" && e.Type() == gitobj.BlobObjectType {
-			oid = e.Oid
-			break
+			if e.IsLink() {
+				return nil, errors.Errorf("migrate: %s", tr.Tr.Get("expected '.gitattributes' to be a file, got a symbolic link"))
+			} else {
+				oid = e.Oid
+				break
+			}
 		}
 	}
 

--- a/commands/command_migrate_info.go
+++ b/commands/command_migrate_info.go
@@ -164,15 +164,24 @@ func migrateInfoCommand(cmd *cobra.Command, args []string) {
 		},
 
 		TreePreCallbackFn: func(path string, t *gitobj.Tree) error {
-			if migrateFixup && path == "/" {
-				var err error
+			if migrateFixup {
+				if path == "/" {
+					var err error
 
-				fixups, err = gitattr.New(db, t)
-				if err != nil {
-					return err
+					fixups, err = gitattr.New(db, t)
+					if err != nil {
+						return err
+					}
 				}
 				return nil
 			}
+
+			for _, e := range t.Entries {
+				if e.Name == ".gitattributes" && e.IsLink() {
+					return errors.Errorf("migrate: %s", tr.Tr.Get("expected '.gitattributes' to be a file, got a symbolic link"))
+				}
+			}
+
 			return nil
 		},
 	})

--- a/commands/command_migrate_info.go
+++ b/commands/command_migrate_info.go
@@ -177,8 +177,12 @@ func migrateInfoCommand(cmd *cobra.Command, args []string) {
 			}
 
 			for _, e := range t.Entries {
-				if e.Name == ".gitattributes" && e.IsLink() {
-					return errors.Errorf("migrate: %s", tr.Tr.Get("expected '.gitattributes' to be a file, got a symbolic link"))
+				if strings.ToLower(e.Name) == ".gitattributes" && e.Type() == gitobj.BlobObjectType {
+					if e.IsLink() {
+						return errors.Errorf("migrate: %s", tr.Tr.Get("expected '.gitattributes' to be a file, got a symbolic link"))
+					} else {
+						break
+					}
 				}
 			}
 

--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -53,7 +53,9 @@ in [INCLUDE AND EXCLUDE].
 As typical Git LFS usage depends on tracking specific file types using
 filename patterns defined in `.gitattributes` files, the `git lfs migrate`
 command will examine, create, and modify `.gitattributes` files as
-necessary.
+necessary.  The `.gitattributes` files will always be assigned the default
+read/write permissions mode (i.e., without execute permissions).  Any
+symbolic links with that name will cause the migration to halt prematurely.
 
 The `import` mode (see [IMPORT]) will convert Git objects of the file types
 specified (e.g., with `--include`) to Git LFS pointers, and will add entries

--- a/git/gitattr/tree.go
+++ b/git/gitattr/tree.go
@@ -3,6 +3,8 @@ package gitattr
 import (
 	"strings"
 
+	"github.com/git-lfs/git-lfs/v3/errors"
+	"github.com/git-lfs/git-lfs/v3/tr"
 	"github.com/git-lfs/gitobj/v2"
 )
 
@@ -63,6 +65,9 @@ func linesInTree(db *gitobj.ObjectDatabase, t *gitobj.Tree) ([]*Line, string, er
 	var at int = -1
 	for i, e := range t.Entries {
 		if e.Name == ".gitattributes" {
+			if e.IsLink() {
+				return nil, "", errors.Errorf("migrate: %s", tr.Tr.Get("expected '.gitattributes' to be a file, got a symbolic link"))
+			}
 			at = i
 			break
 		}

--- a/t/fixtures/migrate.sh
+++ b/t/fixtures/migrate.sh
@@ -28,6 +28,8 @@ assert_ref_unmoved() {
 #
 #   If "0755" is passed as an argument, the .gitattributes file is created
 #   with that permissions mode.
+#   If "link" is passed as an argument, the .gitattributes file is created
+#   as a symlink to a gitattrs file.
 setup_local_branch_with_gitattrs() {
   set -e
 
@@ -45,6 +47,12 @@ setup_local_branch_with_gitattrs() {
 
   if [[ $1 == "0755" ]]; then
     chmod +x .gitattributes
+  elif [[ $1 == "link" ]]; then
+    mv .gitattributes gitattrs
+
+    add_symlink gitattrs .gitattributes
+
+    git add gitattrs
   fi
 
   git add .gitattributes
@@ -128,6 +136,8 @@ setup_single_local_branch_untracked() {
 #
 #   If "0755" is passed as an argument, the .gitattributes file is created
 #   with that permissions mode.
+#   If "link" is passed as an argument, the .gitattributes file is created
+#   as a symlink to a gitattrs file.
 setup_single_local_branch_tracked() {
   set -e
 
@@ -150,6 +160,14 @@ setup_single_local_branch_tracked() {
 
   git add a.txt a.md
   git commit -m "add a.{txt,md}"
+
+  if [[ $1 == "link" ]]; then
+    git mv .gitattributes gitattrs
+
+    add_symlink gitattrs .gitattributes
+
+    git commit -m "link .gitattributes"
+  fi
 }
 
 # setup_single_local_branch_complex_tracked creates a repository as follows:
@@ -191,6 +209,9 @@ setup_single_local_branch_complex_tracked() {
 #
 # - Commit 'A' has 120 bytes of random data in a.txt, and tracks *.txt under Git
 #   LFS, but a.txt is not stored as an LFS object.
+#
+#   If "link" is passed as an argument, the .gitattributes file is created
+#   as a symlink to a gitattrs file.
 setup_single_local_branch_tracked_corrupt() {
   set -e
 
@@ -202,6 +223,14 @@ setup_single_local_branch_tracked_corrupt() {
   git lfs uninstall
 
   base64 < /dev/urandom | head -c 120 > a.txt
+
+ if [[ $1 == "link" ]]; then
+    mv .gitattributes gitattrs
+
+    add_symlink gitattrs .gitattributes
+
+    git add .gitattributes
+  fi
 
   git add .gitattributes a.txt
   git commit -m "initial commit"


### PR DESCRIPTION
As [discussed](https://github.com/git-lfs/git-lfs/issues/4796#issuecomment-1015782841) in issue #4796 and PR #4835, we add checks to the `git lfs migrate` command so that in all of its modes, if a symbolic link named `.gitattributes` is encountered, the migration halts with an error.  This will occur regardless of whether the migration would normally modify a `.gitattributes` file in the same location.

We add tests for the `import`, `export`, and `info` sub-commands which exercise this new behaviour, including with and without the `--fixup` option for the `import` and `info` sub-commands.

Note that this is an unexpected condition because `.gitattributes` tree entries should never be symbolic links; Git itself will complain about them with `"Too many levels of symbolic links"` warning messages.

In the manual page for the `git lfs migrate` command, we add notes to clarify this new behaviour, and also explain that any existing `.gitattributes` files with execute permissions will have those removed, as per PR #4835.