### PR TITLE
fix `git lfs fsck --objects A..B` handling and drop all left/right ref terminology

### DIFF
--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -113,6 +113,9 @@ func fsckCommand(cmd *cobra.Command, args []string) {
 			continue
 		}
 		if err := os.Rename(srcFile, badFile); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
 			ExitWithError(err)
 		}
 	}

--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -151,7 +151,7 @@ func doFsckObjects(include, exclude string, useIndex bool) []string {
 			ExitWithError(err)
 		}
 	} else {
-		if err := gitscanner.ScanRefRange(exclude, include, nil); err != nil {
+		if err := gitscanner.ScanRefRange(include, exclude, nil); err != nil {
 			ExitWithError(err)
 		}
 	}

--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -204,7 +204,7 @@ func doFsckPointers(include, exclude string) []corruptPointer {
 			ExitWithError(err)
 		}
 	} else {
-		if err := gitscanner.ScanRefRangeByTree(exclude, include, nil); err != nil {
+		if err := gitscanner.ScanRefRangeByTree(include, exclude, nil); err != nil {
 			ExitWithError(err)
 		}
 	}

--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -82,11 +82,11 @@ func fsckCommand(cmd *cobra.Command, args []string) {
 	var corruptOids []string
 	var corruptPointers []corruptPointer
 	if fsckObjects {
-		corruptOids = doFsckObjects(exclude, include, useIndex)
+		corruptOids = doFsckObjects(include, exclude, useIndex)
 		ok = ok && len(corruptOids) == 0
 	}
 	if fsckPointers {
-		corruptPointers = doFsckPointers(exclude, include)
+		corruptPointers = doFsckPointers(include, exclude)
 		ok = ok && len(corruptPointers) == 0
 	}
 
@@ -123,7 +123,7 @@ func fsckCommand(cmd *cobra.Command, args []string) {
 }
 
 // doFsckObjects checks that the objects in the given ref are correct and exist.
-func doFsckObjects(exclude, include string, useIndex bool) []string {
+func doFsckObjects(include, exclude string, useIndex bool) []string {
 	var corruptOids []string
 	gitscanner := lfs.NewGitScanner(cfg, func(p *lfs.WrappedPointer, err error) {
 		if err == nil {
@@ -167,7 +167,7 @@ func doFsckObjects(exclude, include string, useIndex bool) []string {
 }
 
 // doFsckPointers checks that the pointers in the given ref are correct and canonical.
-func doFsckPointers(exclude, include string) []corruptPointer {
+func doFsckPointers(include, exclude string) []corruptPointer {
 	var corruptPointers []corruptPointer
 	gitscanner := lfs.NewGitScanner(cfg, func(p *lfs.WrappedPointer, err error) {
 		if p != nil {

--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -25,7 +25,7 @@ func lockCommand(cmd *cobra.Command, args []string) {
 
 	refUpdate := git.NewRefUpdate(cfg.Git, cfg.PushRemote(), cfg.CurrentRef(), nil)
 	lockClient := newLockClient()
-	lockClient.RemoteRef = refUpdate.Right()
+	lockClient.RemoteRef = refUpdate.RemoteRef()
 	defer lockClient.Close()
 
 	success := true

--- a/commands/command_locks.go
+++ b/commands/command_locks.go
@@ -30,7 +30,7 @@ func locksCommand(cmd *cobra.Command, args []string) {
 
 	refUpdate := git.NewRefUpdate(cfg.Git, cfg.PushRemote(), cfg.CurrentRef(), nil)
 	lockClient := newLockClient()
-	lockClient.RemoteRef = refUpdate.Right()
+	lockClient.RemoteRef = refUpdate.RemoteRef()
 	defer lockClient.Close()
 
 	if locksCmdFlags.Cached {

--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -24,7 +24,7 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 	setupRepository()
 
 	var ref string
-	var otherRef string
+	var includeRef string
 	var scanRange = false
 	if len(args) > 0 {
 		if lsFilesScanAll {
@@ -44,7 +44,7 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 			if lsFilesScanDeleted {
 				Exit(tr.Tr.Get("Cannot use --deleted with reference range"))
 			}
-			otherRef = args[1]
+			includeRef = args[1]
 			scanRange = true
 		}
 	} else {
@@ -130,7 +130,7 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 		if lsFilesScanDeleted {
 			err = gitscanner.ScanRefWithDeleted(ref, nil)
 		} else if scanRange {
-			err = gitscanner.ScanRefRange(otherRef, ref, nil)
+			err = gitscanner.ScanRefRange(includeRef, ref, nil)
 		} else {
 			err = gitscanner.ScanTree(ref)
 		}

--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -83,12 +83,12 @@ func prePushRefs(r io.Reader) []*git.RefUpdate {
 
 		tracerx.Printf("pre-push: %s", line)
 
-		left, right := decodeRefs(line)
-		if git.IsZeroObjectID(left.Sha) {
+		localRef, remoteRef := decodeRefs(line)
+		if git.IsZeroObjectID(localRef.Sha) {
 			continue
 		}
 
-		refs = append(refs, git.NewRefUpdate(cfg.Git, cfg.PushRemote(), left, right))
+		refs = append(refs, git.NewRefUpdate(cfg.Git, cfg.PushRemote(), localRef, remoteRef))
 	}
 
 	return refs
@@ -102,9 +102,9 @@ func decodeRefs(input string) (*git.Ref, *git.Ref) {
 		refs = append(refs, "")
 	}
 
-	leftRef := git.ParseRef(refs[0], refs[1])
-	rightRef := git.ParseRef(refs[2], refs[3])
-	return leftRef, rightRef
+	localRef := git.ParseRef(refs[0], refs[1])
+	remoteRef := git.ParseRef(refs[2], refs[3])
+	return localRef, remoteRef
 }
 
 func init() {

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -122,11 +122,11 @@ func lfsPushRefs(refnames []string, pushAll bool) ([]*git.RefUpdate, error) {
 
 	refs := make([]*git.RefUpdate, len(refnames))
 	for i, name := range refnames {
-		if left, ok := reflookup[name]; ok {
-			refs[i] = git.NewRefUpdate(cfg.Git, cfg.PushRemote(), left, nil)
+		if ref, ok := reflookup[name]; ok {
+			refs[i] = git.NewRefUpdate(cfg.Git, cfg.PushRemote(), ref, nil)
 		} else {
-			left := &git.Ref{Name: name, Type: git.RefTypeOther, Sha: name}
-			refs[i] = git.NewRefUpdate(cfg.Git, cfg.PushRemote(), left, nil)
+			ref := &git.Ref{Name: name, Type: git.RefTypeOther, Sha: name}
+			refs[i] = git.NewRefUpdate(cfg.Git, cfg.PushRemote(), ref, nil)
 		}
 	}
 

--- a/commands/command_unlock.go
+++ b/commands/command_unlock.go
@@ -60,7 +60,7 @@ func unlockCommand(cmd *cobra.Command, args []string) {
 
 	refUpdate := git.NewRefUpdate(cfg.Git, cfg.PushRemote(), cfg.CurrentRef(), nil)
 	lockClient := newLockClient()
-	lockClient.RemoteRef = refUpdate.Right()
+	lockClient.RemoteRef = refUpdate.RemoteRef()
 	defer lockClient.Close()
 
 	locks := make([]unlockResponse, 0, len(args))

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -126,7 +126,7 @@ func newDownloadQueue(manifest *tq.Manifest, remote string, options ...tq.Option
 }
 
 func currentRemoteRef() *git.Ref {
-	return git.NewRefUpdate(cfg.Git, cfg.PushRemote(), cfg.CurrentRef(), nil).Right()
+	return git.NewRefUpdate(cfg.Git, cfg.PushRemote(), cfg.CurrentRef(), nil).RemoteRef()
 }
 
 func buildFilepathFilter(config *config.Configuration, includeArg, excludeArg *string, useFetchOptions bool) *filepathfilter.Filter {

--- a/commands/lockverifier.go
+++ b/commands/lockverifier.go
@@ -25,7 +25,7 @@ const (
 
 func verifyLocksForUpdates(lv *lockVerifier, updates []*git.RefUpdate) {
 	for _, update := range updates {
-		lv.Verify(update.Right())
+		lv.Verify(update.RemoteRef())
 	}
 }
 

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -62,12 +62,7 @@ func uploadLeftOrAll(g *lfs.GitScanner, ctx *uploadContext, q *tq.TransferQueue,
 			return err
 		}
 	} else {
-		left := update.LeftCommitish()
-		right := update.Right().Sha
-		if left == right {
-			right = ""
-		}
-		if err := g.ScanMultiRangeToRemote(left, bases, cb); err != nil {
+		if err := g.ScanMultiRangeToRemote(update.LeftCommitish(), bases, cb); err != nil {
 			return err
 		}
 	}

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -34,9 +34,9 @@ func uploadForRefUpdates(ctx *uploadContext, updates []*git.RefUpdate, pushAll b
 	verifyLocksForUpdates(ctx.lockVerifier, updates)
 	exclude := make([]string, 0, len(updates))
 	for _, update := range updates {
-		right := update.RemoteRef().Sha
-		if update.LocalRefCommitish() != right {
-			exclude = append(exclude, right)
+		remoteRefSha := update.RemoteRef().Sha
+		if update.LocalRefCommitish() != remoteRefSha {
+			exclude = append(exclude, remoteRefSha)
 		}
 	}
 	for _, update := range updates {

--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -202,8 +202,9 @@ func NewRewriter(db *gitobj.ObjectDatabase, opts ...rewriterOption) *Rewriter {
 	return rewriter
 }
 
-// Rewrite rewrites the range of commits given by *RewriteOptions.{Left,Right}
-// using the BlobRewriteFn to rewrite the individual blobs.
+// Rewrite rewrites the range of commits given by
+// *RewriteOptions.{Include,Exclude} using the BlobRewriteFn to rewrite
+// the individual blobs.
 func (r *Rewriter) Rewrite(opt *RewriteOptions) ([]byte, error) {
 	// First, obtain a list of commits to rewrite.
 	commits, err := r.commitsToMigrate(opt)

--- a/git/refs.go
+++ b/git/refs.go
@@ -7,78 +7,78 @@ import (
 )
 
 type RefUpdate struct {
-	git    Env
-	remote string
-	left   *Ref
-	right  *Ref
+	git       Env
+	remote    string
+	localRef  *Ref
+	remoteRef *Ref
 }
 
-func NewRefUpdate(g Env, remote string, l, r *Ref) *RefUpdate {
+func NewRefUpdate(g Env, remote string, localRef, remoteRef *Ref) *RefUpdate {
 	return &RefUpdate{
-		git:    g,
-		remote: remote,
-		left:   l,
-		right:  r,
+		git:       g,
+		remote:    remote,
+		localRef:  localRef,
+		remoteRef: remoteRef,
 	}
 }
 
-func (u *RefUpdate) Left() *Ref {
-	return u.left
+func (u *RefUpdate) LocalRef() *Ref {
+	return u.localRef
 }
 
-func (u *RefUpdate) LeftCommitish() string {
-	return refCommitish(u.Left())
+func (u *RefUpdate) LocalRefCommitish() string {
+	return refCommitish(u.LocalRef())
 }
 
-func (u *RefUpdate) Right() *Ref {
-	if u.right == nil {
-		u.right = defaultRemoteRef(u.git, u.remote, u.Left())
+func (u *RefUpdate) RemoteRef() *Ref {
+	if u.remoteRef == nil {
+		u.remoteRef = defaultRemoteRef(u.git, u.remote, u.LocalRef())
 	}
-	return u.right
+	return u.remoteRef
 }
 
 // defaultRemoteRef returns the remote ref receiving a push based on the current
 // repository config and local ref being pushed.
 //
 // See push.default rules in https://git-scm.com/docs/git-config
-func defaultRemoteRef(g Env, remote string, left *Ref) *Ref {
+func defaultRemoteRef(g Env, remote string, localRef *Ref) *Ref {
 	pushMode, _ := g.Get("push.default")
 	switch pushMode {
 	case "", "simple":
-		brRemote, _ := g.Get(fmt.Sprintf("branch.%s.remote", left.Name))
+		brRemote, _ := g.Get(fmt.Sprintf("branch.%s.remote", localRef.Name))
 		if brRemote == remote {
 			// in centralized workflow, work like 'upstream' with an added safety to
 			// refuse to push if the upstream branch’s name is different from the
 			// local one.
-			return trackingRef(g, left)
+			return trackingRef(g, localRef)
 		}
 
 		// When pushing to a remote that is different from the remote you normally
 		// pull from, work as current.
-		return left
+		return localRef
 	case "upstream", "tracking":
 		// push the current branch back to the branch whose changes are usually
 		// integrated into the current branch
-		return trackingRef(g, left)
+		return trackingRef(g, localRef)
 	case "current":
 		// push the current branch to update a branch with the same name on the
 		// receiving end.
-		return left
+		return localRef
 	default:
 		tracerx.Printf("WARNING: %q push mode not supported", pushMode)
-		return left
+		return localRef
 	}
 }
 
-func trackingRef(g Env, left *Ref) *Ref {
-	if merge, ok := g.Get(fmt.Sprintf("branch.%s.merge", left.Name)); ok {
+func trackingRef(g Env, localRef *Ref) *Ref {
+	if merge, ok := g.Get(fmt.Sprintf("branch.%s.merge", localRef.Name)); ok {
 		return ParseRef(merge, "")
 	}
-	return left
+	return localRef
 }
 
-func (u *RefUpdate) RightCommitish() string {
-	return refCommitish(u.Right())
+func (u *RefUpdate) RemoteRefCommitish() string {
+	return refCommitish(u.RemoteRef())
 }
 
 func refCommitish(r *Ref) string {

--- a/git/refs_test.go
+++ b/git/refs_test.go
@@ -10,14 +10,14 @@ func TestRefUpdateDefault(t *testing.T) {
 	pushModes := []string{"simple", ""}
 	for _, pushMode := range pushModes {
 		env := newEnv(map[string][]string{
-			"push.default":       []string{pushMode},
-			"branch.left.remote": []string{"ignore"},
-			"branch.left.merge":  []string{"me"},
+			"push.default":        []string{pushMode},
+			"branch.local.remote": []string{"ignore"},
+			"branch.local.merge":  []string{"me"},
 		})
 
-		u := NewRefUpdate(env, "origin", ParseRef("refs/heads/left", ""), nil)
-		assert.Equal(t, "left", u.Right().Name, "pushmode=%q", pushMode)
-		assert.Equal(t, RefTypeLocalBranch, u.Right().Type, "pushmode=%q", pushMode)
+		u := NewRefUpdate(env, "origin", ParseRef("refs/heads/local", ""), nil)
+		assert.Equal(t, "local", u.RemoteRef().Name, "pushmode=%q", pushMode)
+		assert.Equal(t, RefTypeLocalBranch, u.RemoteRef().Type, "pushmode=%q", pushMode)
 	}
 }
 
@@ -25,45 +25,45 @@ func TestRefUpdateTrackedDefault(t *testing.T) {
 	pushModes := []string{"simple", "upstream", "tracking", ""}
 	for _, pushMode := range pushModes {
 		env := newEnv(map[string][]string{
-			"push.default":       []string{pushMode},
-			"branch.left.remote": []string{"origin"},
-			"branch.left.merge":  []string{"refs/heads/tracked"},
+			"push.default":        []string{pushMode},
+			"branch.local.remote": []string{"origin"},
+			"branch.local.merge":  []string{"refs/heads/tracked"},
 		})
 
-		u := NewRefUpdate(env, "origin", ParseRef("refs/heads/left", ""), nil)
-		assert.Equal(t, "tracked", u.Right().Name, "pushmode=%s", pushMode)
-		assert.Equal(t, RefTypeLocalBranch, u.Right().Type, "pushmode=%q", pushMode)
+		u := NewRefUpdate(env, "origin", ParseRef("refs/heads/local", ""), nil)
+		assert.Equal(t, "tracked", u.RemoteRef().Name, "pushmode=%s", pushMode)
+		assert.Equal(t, RefTypeLocalBranch, u.RemoteRef().Type, "pushmode=%q", pushMode)
 	}
 }
 
 func TestRefUpdateCurrentDefault(t *testing.T) {
 	env := newEnv(map[string][]string{
-		"push.default":       []string{"current"},
-		"branch.left.remote": []string{"origin"},
-		"branch.left.merge":  []string{"tracked"},
+		"push.default":        []string{"current"},
+		"branch.local.remote": []string{"origin"},
+		"branch.local.merge":  []string{"tracked"},
 	})
 
-	u := NewRefUpdate(env, "origin", ParseRef("refs/heads/left", ""), nil)
-	assert.Equal(t, "left", u.Right().Name)
-	assert.Equal(t, RefTypeLocalBranch, u.Right().Type)
+	u := NewRefUpdate(env, "origin", ParseRef("refs/heads/local", ""), nil)
+	assert.Equal(t, "local", u.RemoteRef().Name)
+	assert.Equal(t, RefTypeLocalBranch, u.RemoteRef().Type)
 }
 
-func TestRefUpdateExplicitLeftAndRight(t *testing.T) {
-	u := NewRefUpdate(nil, "", ParseRef("refs/heads/left", "abc123"), ParseRef("refs/heads/right", "def456"))
-	assert.Equal(t, "left", u.Left().Name)
-	assert.Equal(t, "abc123", u.Left().Sha)
-	assert.Equal(t, "abc123", u.LeftCommitish())
-	assert.Equal(t, "right", u.Right().Name)
-	assert.Equal(t, "def456", u.Right().Sha)
-	assert.Equal(t, "def456", u.RightCommitish())
+func TestRefUpdateExplicitLocalAndRemoteRefs(t *testing.T) {
+	u := NewRefUpdate(nil, "", ParseRef("refs/heads/local", "abc123"), ParseRef("refs/heads/remote", "def456"))
+	assert.Equal(t, "local", u.LocalRef().Name)
+	assert.Equal(t, "abc123", u.LocalRef().Sha)
+	assert.Equal(t, "abc123", u.LocalRefCommitish())
+	assert.Equal(t, "remote", u.RemoteRef().Name)
+	assert.Equal(t, "def456", u.RemoteRef().Sha)
+	assert.Equal(t, "def456", u.RemoteRefCommitish())
 
-	u = NewRefUpdate(nil, "", ParseRef("refs/heads/left", ""), ParseRef("refs/heads/right", ""))
-	assert.Equal(t, "left", u.Left().Name)
-	assert.Equal(t, "", u.Left().Sha)
-	assert.Equal(t, "left", u.LeftCommitish())
-	assert.Equal(t, "right", u.Right().Name)
-	assert.Equal(t, "", u.Right().Sha)
-	assert.Equal(t, "right", u.RightCommitish())
+	u = NewRefUpdate(nil, "", ParseRef("refs/heads/local", ""), ParseRef("refs/heads/remote", ""))
+	assert.Equal(t, "local", u.LocalRef().Name)
+	assert.Equal(t, "", u.LocalRef().Sha)
+	assert.Equal(t, "local", u.LocalRefCommitish())
+	assert.Equal(t, "remote", u.RemoteRef().Name)
+	assert.Equal(t, "", u.RemoteRef().Sha)
+	assert.Equal(t, "remote", u.RemoteRefCommitish())
 }
 
 func newEnv(m map[string][]string) *mapEnv {

--- a/git/rev_list_scanner.go
+++ b/git/rev_list_scanner.go
@@ -77,7 +77,7 @@ type ScanRefsOptions struct {
 	// Mode is the scan mode to apply, see above.
 	Mode ScanningMode
 	// Remote is the current remote to scan against, if using
-	// ScanLeftToRemoveMode.
+	// ScanRangeToRemoteMode.
 	Remote string
 	// SkipDeletedBlobs specifies whether or not to traverse into commit
 	// ancestry (revealing potentially deleted (unreferenced) blobs, trees,

--- a/git/rev_list_scanner_test.go
+++ b/git/rev_list_scanner_test.go
@@ -51,7 +51,7 @@ var (
 
 func TestRevListArgs(t *testing.T) {
 	for desc, c := range map[string]*ArgsTestCase{
-		"scan refs deleted, left and right": {
+		"scan refs deleted, include and exclude": {
 			Include: []string{s1}, Exclude: []string{s2}, Opt: &ScanRefsOptions{
 				Mode:             ScanRefsMode,
 				SkipDeletedBlobs: false,
@@ -59,7 +59,7 @@ func TestRevListArgs(t *testing.T) {
 			ExpectedStdin: fmt.Sprintf("%s\n^%s", s1, s2),
 			ExpectedArgs:  []string{"rev-list", "--objects", "--do-walk", "--stdin", "--"},
 		},
-		"scan refs not deleted, left and right": {
+		"scan refs not deleted, include and exclude": {
 			Include: []string{s1}, Exclude: []string{s2}, Opt: &ScanRefsOptions{
 				Mode:             ScanRefsMode,
 				SkipDeletedBlobs: true,
@@ -67,7 +67,7 @@ func TestRevListArgs(t *testing.T) {
 			ExpectedStdin: fmt.Sprintf("%s\n^%s", s1, s2),
 			ExpectedArgs:  []string{"rev-list", "--objects", "--no-walk", "--stdin", "--"},
 		},
-		"scan refs deleted, left only": {
+		"scan refs deleted, include only": {
 			Include: []string{s1}, Opt: &ScanRefsOptions{
 				Mode:             ScanRefsMode,
 				SkipDeletedBlobs: false,
@@ -75,7 +75,7 @@ func TestRevListArgs(t *testing.T) {
 			ExpectedStdin: s1,
 			ExpectedArgs:  []string{"rev-list", "--objects", "--do-walk", "--stdin", "--"},
 		},
-		"scan refs not deleted, left only": {
+		"scan refs not deleted, include only": {
 			Include: []string{s1}, Opt: &ScanRefsOptions{
 				Mode:             ScanRefsMode,
 				SkipDeletedBlobs: true,
@@ -89,7 +89,7 @@ func TestRevListArgs(t *testing.T) {
 			},
 			ExpectedArgs: []string{"rev-list", "--objects", "--all", "--stdin", "--"},
 		},
-		"scan left to remote, no skipped refs": {
+		"scan include to remote, no skipped refs": {
 			Include: []string{s1}, Opt: &ScanRefsOptions{
 				Mode:        ScanRangeToRemoteMode,
 				Remote:      "origin",
@@ -98,7 +98,7 @@ func TestRevListArgs(t *testing.T) {
 			ExpectedStdin: s1,
 			ExpectedArgs:  []string{"rev-list", "--objects", "--ignore-missing", "--not", "--remotes=origin", "--stdin", "--"},
 		},
-		"scan left to remote, skipped refs": {
+		"scan include to remote, skipped refs": {
 			Include: []string{s1}, Exclude: []string{s2}, Opt: &ScanRefsOptions{
 				Mode:        ScanRangeToRemoteMode,
 				Remote:      "origin",

--- a/lfs/gitfilter.go
+++ b/lfs/gitfilter.go
@@ -22,5 +22,5 @@ func (f *GitFilter) ObjectPath(oid string) (string, error) {
 }
 
 func (f *GitFilter) RemoteRef() *git.Ref {
-	return git.NewRefUpdate(f.cfg.Git, f.cfg.PushRemote(), f.cfg.CurrentRef(), nil).Right()
+	return git.NewRefUpdate(f.cfg.Git, f.cfg.PushRemote(), f.cfg.CurrentRef(), nil).RemoteRef()
 }

--- a/lfs/gitscanner.go
+++ b/lfs/gitscanner.go
@@ -151,7 +151,7 @@ func (s *GitScanner) ScanRefRangeByTree(left, right string, cb GitScannerFoundPo
 	opts := s.opts(ScanRefsMode)
 	opts.SkipDeletedBlobs = false
 	opts.CommitsOnly = true
-	return scanRefsByTree(s, callback, []string{right}, []string{left}, s.cfg.GitEnv(), s.cfg.OSEnv(), opts)
+	return scanRefsByTree(s, callback, []string{left}, []string{right}, s.cfg.GitEnv(), s.cfg.OSEnv(), opts)
 }
 
 // ScanRefWithDeleted scans through all objects in the given ref, including

--- a/lfs/gitscanner.go
+++ b/lfs/gitscanner.go
@@ -79,7 +79,7 @@ func (s *GitScanner) RemoteForPush(r string) error {
 // ScanRangeToRemote scans through all commits starting at the left ref but not
 // including the right ref (if given)that the given remote does not have. See
 // RemoteForPush().
-func (s *GitScanner) ScanRangeToRemote(left, right string, cb GitScannerFoundPointer) error {
+func (s *GitScanner) ScanRangeToRemote(include, exclude string, cb GitScannerFoundPointer) error {
 	callback, err := firstGitScannerCallback(cb, s.FoundPointer)
 	if err != nil {
 		return err
@@ -88,17 +88,17 @@ func (s *GitScanner) ScanRangeToRemote(left, right string, cb GitScannerFoundPoi
 	s.mu.Lock()
 	if len(s.remote) == 0 {
 		s.mu.Unlock()
-		return errors.New(tr.Tr.Get("unable to scan starting at %q: no remote set", left))
+		return errors.New(tr.Tr.Get("unable to scan starting at %q: no remote set", include))
 	}
 	s.mu.Unlock()
 
-	return scanLeftRightToChan(s, callback, left, right, s.cfg.GitEnv(), s.cfg.OSEnv(), s.opts(ScanRangeToRemoteMode))
+	return scanLeftRightToChan(s, callback, include, exclude, s.cfg.GitEnv(), s.cfg.OSEnv(), s.opts(ScanRangeToRemoteMode))
 }
 
 // ScanMultiRangeToRemote scans through all commits starting at the left ref but
 // not including the right ref (if given) that the given remote does not have.
 // See RemoteForPush().
-func (s *GitScanner) ScanMultiRangeToRemote(left string, rights []string, cb GitScannerFoundPointer) error {
+func (s *GitScanner) ScanMultiRangeToRemote(include string, exclude []string, cb GitScannerFoundPointer) error {
 	callback, err := firstGitScannerCallback(cb, s.FoundPointer)
 	if err != nil {
 		return err
@@ -107,11 +107,11 @@ func (s *GitScanner) ScanMultiRangeToRemote(left string, rights []string, cb Git
 	s.mu.Lock()
 	if len(s.remote) == 0 {
 		s.mu.Unlock()
-		return errors.New(tr.Tr.Get("unable to scan starting at %q: no remote set", left))
+		return errors.New(tr.Tr.Get("unable to scan starting at %q: no remote set", include))
 	}
 	s.mu.Unlock()
 
-	return scanMultiLeftRightToChan(s, callback, left, rights, s.cfg.GitEnv(), s.cfg.OSEnv(), s.opts(ScanRangeToRemoteMode))
+	return scanMultiLeftRightToChan(s, callback, include, exclude, s.cfg.GitEnv(), s.cfg.OSEnv(), s.opts(ScanRangeToRemoteMode))
 }
 
 // ScanRefs through all commits reachable by refs contained in "include" and
@@ -129,7 +129,7 @@ func (s *GitScanner) ScanRefs(include, exclude []string, cb GitScannerFoundPoint
 
 // ScanRefRange scans through all commits from the given left and right refs,
 // including git objects that have been modified or deleted.
-func (s *GitScanner) ScanRefRange(left, right string, cb GitScannerFoundPointer) error {
+func (s *GitScanner) ScanRefRange(include, exclude string, cb GitScannerFoundPointer) error {
 	callback, err := firstGitScannerCallback(cb, s.FoundPointer)
 	if err != nil {
 		return err
@@ -137,12 +137,12 @@ func (s *GitScanner) ScanRefRange(left, right string, cb GitScannerFoundPointer)
 
 	opts := s.opts(ScanRefsMode)
 	opts.SkipDeletedBlobs = false
-	return scanLeftRightToChan(s, callback, left, right, s.cfg.GitEnv(), s.cfg.OSEnv(), opts)
+	return scanLeftRightToChan(s, callback, include, exclude, s.cfg.GitEnv(), s.cfg.OSEnv(), opts)
 }
 
 // ScanRefRangeByTree scans through all trees from the given left and right
 // refs.
-func (s *GitScanner) ScanRefRangeByTree(left, right string, cb GitScannerFoundPointer) error {
+func (s *GitScanner) ScanRefRangeByTree(include, exclude string, cb GitScannerFoundPointer) error {
 	callback, err := firstGitScannerCallback(cb, s.FoundPointer)
 	if err != nil {
 		return err
@@ -151,7 +151,7 @@ func (s *GitScanner) ScanRefRangeByTree(left, right string, cb GitScannerFoundPo
 	opts := s.opts(ScanRefsMode)
 	opts.SkipDeletedBlobs = false
 	opts.CommitsOnly = true
-	return scanRefsByTree(s, callback, []string{left}, []string{right}, s.cfg.GitEnv(), s.cfg.OSEnv(), opts)
+	return scanRefsByTree(s, callback, []string{include}, []string{exclude}, s.cfg.GitEnv(), s.cfg.OSEnv(), opts)
 }
 
 // ScanRefWithDeleted scans through all objects in the given ref, including

--- a/lfs/gitscanner.go
+++ b/lfs/gitscanner.go
@@ -62,7 +62,7 @@ func (s *GitScanner) Close() {
 }
 
 // RemoteForPush sets up this *GitScanner to scan for objects to push to the
-// given remote. Needed for ScanLeftToRemote().
+// given remote. Needed for ScanRangeToRemote().
 func (s *GitScanner) RemoteForPush(r string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -76,9 +76,9 @@ func (s *GitScanner) RemoteForPush(r string) error {
 	return nil
 }
 
-// ScanRangeToRemote scans through all commits starting at the left ref but not
-// including the right ref (if given)that the given remote does not have. See
-// RemoteForPush().
+// ScanRangeToRemote scans through all unique objects reachable from the
+// "include" ref but not reachable from the "exclude" ref and which the
+// given remote does not have. See RemoteForPush().
 func (s *GitScanner) ScanRangeToRemote(include, exclude string, cb GitScannerFoundPointer) error {
 	callback, err := firstGitScannerCallback(cb, s.FoundPointer)
 	if err != nil {
@@ -95,9 +95,9 @@ func (s *GitScanner) ScanRangeToRemote(include, exclude string, cb GitScannerFou
 	return scanRefsToChanSingleIncludeExclude(s, callback, include, exclude, s.cfg.GitEnv(), s.cfg.OSEnv(), s.opts(ScanRangeToRemoteMode))
 }
 
-// ScanMultiRangeToRemote scans through all commits starting at the left ref but
-// not including the right ref (if given) that the given remote does not have.
-// See RemoteForPush().
+// ScanMultiRangeToRemote scans through all unique objects reachable from the
+// "include" ref but not reachable from any "exclude" refs and which the
+// given remote does not have. See RemoteForPush().
 func (s *GitScanner) ScanMultiRangeToRemote(include string, exclude []string, cb GitScannerFoundPointer) error {
 	callback, err := firstGitScannerCallback(cb, s.FoundPointer)
 	if err != nil {
@@ -114,8 +114,9 @@ func (s *GitScanner) ScanMultiRangeToRemote(include string, exclude []string, cb
 	return scanRefsToChanSingleIncludeMultiExclude(s, callback, include, exclude, s.cfg.GitEnv(), s.cfg.OSEnv(), s.opts(ScanRangeToRemoteMode))
 }
 
-// ScanRefs through all commits reachable by refs contained in "include" and
-// not reachable by any refs included in "excluded"
+// ScanRefs scans through all unique objects reachable from the "include" refs
+// but not reachable from any "exclude" refs, including objects that have
+// been modified or deleted.
 func (s *GitScanner) ScanRefs(include, exclude []string, cb GitScannerFoundPointer) error {
 	callback, err := firstGitScannerCallback(cb, s.FoundPointer)
 	if err != nil {
@@ -127,8 +128,9 @@ func (s *GitScanner) ScanRefs(include, exclude []string, cb GitScannerFoundPoint
 	return scanRefsToChan(s, callback, include, exclude, s.cfg.GitEnv(), s.cfg.OSEnv(), opts)
 }
 
-// ScanRefRange scans through all commits from the given left and right refs,
-// including git objects that have been modified or deleted.
+// ScanRefRange scans through all unique objects reachable from the "include"
+// ref but not reachable from the "exclude" ref, including objects that have
+// been modified or deleted.
 func (s *GitScanner) ScanRefRange(include, exclude string, cb GitScannerFoundPointer) error {
 	callback, err := firstGitScannerCallback(cb, s.FoundPointer)
 	if err != nil {
@@ -140,8 +142,10 @@ func (s *GitScanner) ScanRefRange(include, exclude string, cb GitScannerFoundPoi
 	return scanRefsToChanSingleIncludeExclude(s, callback, include, exclude, s.cfg.GitEnv(), s.cfg.OSEnv(), opts)
 }
 
-// ScanRefRangeByTree scans through all trees from the given left and right
-// refs.
+// ScanRefRangeByTree scans through all objects reachable from the "include"
+// ref but not reachable from the "exclude" ref, including objects that have
+// been modified or deleted.  Objects which appear in multiple trees will
+// be visited once per tree.
 func (s *GitScanner) ScanRefRangeByTree(include, exclude string, cb GitScannerFoundPointer) error {
 	callback, err := firstGitScannerCallback(cb, s.FoundPointer)
 	if err != nil {
@@ -154,14 +158,14 @@ func (s *GitScanner) ScanRefRangeByTree(include, exclude string, cb GitScannerFo
 	return scanRefsByTree(s, callback, []string{include}, []string{exclude}, s.cfg.GitEnv(), s.cfg.OSEnv(), opts)
 }
 
-// ScanRefWithDeleted scans through all objects in the given ref, including
-// git objects that have been modified or deleted.
+// ScanRefWithDeleted scans through all unique objects in the given ref,
+// including objects that have been modified or deleted.
 func (s *GitScanner) ScanRefWithDeleted(ref string, cb GitScannerFoundPointer) error {
 	return s.ScanRefRange(ref, "", cb)
 }
 
-// ScanRef scans through all objects in the current ref, excluding git objects
-// that have been modified or deleted before the ref.
+// ScanRef scans through all unique objects in the current ref, excluding
+// objects that have been modified or deleted before the ref.
 func (s *GitScanner) ScanRef(ref string, cb GitScannerFoundPointer) error {
 	callback, err := firstGitScannerCallback(cb, s.FoundPointer)
 	if err != nil {
@@ -173,7 +177,9 @@ func (s *GitScanner) ScanRef(ref string, cb GitScannerFoundPointer) error {
 	return scanRefsToChanSingleIncludeExclude(s, callback, ref, "", s.cfg.GitEnv(), s.cfg.OSEnv(), opts)
 }
 
-// ScanRefByTree scans through all trees in the current ref.
+// ScanRefByTree scans through all objects in the current ref, excluding
+// objects that have been modified or deleted before the ref.  Objects which
+// appear in multiple trees will be visited once per tree.
 func (s *GitScanner) ScanRefByTree(ref string, cb GitScannerFoundPointer) error {
 	callback, err := firstGitScannerCallback(cb, s.FoundPointer)
 	if err != nil {
@@ -186,7 +192,8 @@ func (s *GitScanner) ScanRefByTree(ref string, cb GitScannerFoundPointer) error 
 	return scanRefsByTree(s, callback, []string{ref}, []string{}, s.cfg.GitEnv(), s.cfg.OSEnv(), opts)
 }
 
-// ScanAll scans through all objects in the git repository.
+// ScanAll scans through all unique objects in the repository, including
+// objects that have been modified or deleted.
 func (s *GitScanner) ScanAll(cb GitScannerFoundPointer) error {
 	callback, err := firstGitScannerCallback(cb, s.FoundPointer)
 	if err != nil {

--- a/lfs/gitscanner.go
+++ b/lfs/gitscanner.go
@@ -92,7 +92,7 @@ func (s *GitScanner) ScanRangeToRemote(include, exclude string, cb GitScannerFou
 	}
 	s.mu.Unlock()
 
-	return scanLeftRightToChan(s, callback, include, exclude, s.cfg.GitEnv(), s.cfg.OSEnv(), s.opts(ScanRangeToRemoteMode))
+	return scanRefsToChanSingleIncludeExclude(s, callback, include, exclude, s.cfg.GitEnv(), s.cfg.OSEnv(), s.opts(ScanRangeToRemoteMode))
 }
 
 // ScanMultiRangeToRemote scans through all commits starting at the left ref but
@@ -111,7 +111,7 @@ func (s *GitScanner) ScanMultiRangeToRemote(include string, exclude []string, cb
 	}
 	s.mu.Unlock()
 
-	return scanMultiLeftRightToChan(s, callback, include, exclude, s.cfg.GitEnv(), s.cfg.OSEnv(), s.opts(ScanRangeToRemoteMode))
+	return scanRefsToChanSingleIncludeMultiExclude(s, callback, include, exclude, s.cfg.GitEnv(), s.cfg.OSEnv(), s.opts(ScanRangeToRemoteMode))
 }
 
 // ScanRefs through all commits reachable by refs contained in "include" and
@@ -137,7 +137,7 @@ func (s *GitScanner) ScanRefRange(include, exclude string, cb GitScannerFoundPoi
 
 	opts := s.opts(ScanRefsMode)
 	opts.SkipDeletedBlobs = false
-	return scanLeftRightToChan(s, callback, include, exclude, s.cfg.GitEnv(), s.cfg.OSEnv(), opts)
+	return scanRefsToChanSingleIncludeExclude(s, callback, include, exclude, s.cfg.GitEnv(), s.cfg.OSEnv(), opts)
 }
 
 // ScanRefRangeByTree scans through all trees from the given left and right
@@ -170,7 +170,7 @@ func (s *GitScanner) ScanRef(ref string, cb GitScannerFoundPointer) error {
 
 	opts := s.opts(ScanRefsMode)
 	opts.SkipDeletedBlobs = true
-	return scanLeftRightToChan(s, callback, ref, "", s.cfg.GitEnv(), s.cfg.OSEnv(), opts)
+	return scanRefsToChanSingleIncludeExclude(s, callback, ref, "", s.cfg.GitEnv(), s.cfg.OSEnv(), opts)
 }
 
 // ScanRefByTree scans through all trees in the current ref.
@@ -195,7 +195,7 @@ func (s *GitScanner) ScanAll(cb GitScannerFoundPointer) error {
 
 	opts := s.opts(ScanAllMode)
 	opts.SkipDeletedBlobs = false
-	return scanLeftRightToChan(s, callback, "", "", s.cfg.GitEnv(), s.cfg.OSEnv(), opts)
+	return scanRefsToChanSingleIncludeExclude(s, callback, "", "", s.cfg.GitEnv(), s.cfg.OSEnv(), opts)
 }
 
 // ScanTree takes a ref and returns WrappedPointer objects in the tree at that

--- a/lfs/gitscanner_refs.go
+++ b/lfs/gitscanner_refs.go
@@ -95,7 +95,7 @@ func scanRefsToChan(scanner *GitScanner, pointerCb GitScannerFoundPointer, inclu
 // scanLeftRightToChan takes a ref and returns a channel of WrappedPointer objects
 // for all Git LFS pointers it finds for that ref.
 // Reports unique oids once only, not multiple times if >1 file uses the same content
-func scanLeftRightToChan(scanner *GitScanner, pointerCb GitScannerFoundPointer, include, exclude string, gitEnv, osEnv config.Environment, opt *ScanRefsOptions) error {
+func scanRefsToChanSingleIncludeExclude(scanner *GitScanner, pointerCb GitScannerFoundPointer, include, exclude string, gitEnv, osEnv config.Environment, opt *ScanRefsOptions) error {
 	return scanRefsToChan(scanner, pointerCb, []string{include}, []string{exclude}, gitEnv, osEnv, opt)
 }
 
@@ -103,7 +103,7 @@ func scanLeftRightToChan(scanner *GitScanner, pointerCb GitScannerFoundPointer, 
 // of WrappedPointer objects for all Git LFS pointers it finds for that ref.
 // Reports unique oids once only, not multiple times if >1 file uses the same
 // content
-func scanMultiLeftRightToChan(scanner *GitScanner, pointerCb GitScannerFoundPointer, include string, exclude []string, gitEnv, osEnv config.Environment, opt *ScanRefsOptions) error {
+func scanRefsToChanSingleIncludeMultiExclude(scanner *GitScanner, pointerCb GitScannerFoundPointer, include string, exclude []string, gitEnv, osEnv config.Environment, opt *ScanRefsOptions) error {
 	return scanRefsToChan(scanner, pointerCb, []string{include}, exclude, gitEnv, osEnv, opt)
 }
 

--- a/lfs/gitscanner_refs.go
+++ b/lfs/gitscanner_refs.go
@@ -95,16 +95,16 @@ func scanRefsToChan(scanner *GitScanner, pointerCb GitScannerFoundPointer, inclu
 // scanLeftRightToChan takes a ref and returns a channel of WrappedPointer objects
 // for all Git LFS pointers it finds for that ref.
 // Reports unique oids once only, not multiple times if >1 file uses the same content
-func scanLeftRightToChan(scanner *GitScanner, pointerCb GitScannerFoundPointer, refLeft, refRight string, gitEnv, osEnv config.Environment, opt *ScanRefsOptions) error {
-	return scanRefsToChan(scanner, pointerCb, []string{refLeft}, []string{refRight}, gitEnv, osEnv, opt)
+func scanLeftRightToChan(scanner *GitScanner, pointerCb GitScannerFoundPointer, include, exclude string, gitEnv, osEnv config.Environment, opt *ScanRefsOptions) error {
+	return scanRefsToChan(scanner, pointerCb, []string{include}, []string{exclude}, gitEnv, osEnv, opt)
 }
 
 // scanMultiLeftRightToChan takes a ref and a set of bases and returns a channel
 // of WrappedPointer objects for all Git LFS pointers it finds for that ref.
 // Reports unique oids once only, not multiple times if >1 file uses the same
 // content
-func scanMultiLeftRightToChan(scanner *GitScanner, pointerCb GitScannerFoundPointer, refLeft string, bases []string, gitEnv, osEnv config.Environment, opt *ScanRefsOptions) error {
-	return scanRefsToChan(scanner, pointerCb, []string{refLeft}, bases, gitEnv, osEnv, opt)
+func scanMultiLeftRightToChan(scanner *GitScanner, pointerCb GitScannerFoundPointer, include string, exclude []string, gitEnv, osEnv config.Environment, opt *ScanRefsOptions) error {
+	return scanRefsToChan(scanner, pointerCb, []string{include}, exclude, gitEnv, osEnv, opt)
 }
 
 // scanRefsByTree scans through all commits reachable by refs contained in

--- a/lfs/gitscanner_refs.go
+++ b/lfs/gitscanner_refs.go
@@ -33,10 +33,11 @@ func (s *lockableNameSet) Check(blobSha string) (string, bool) {
 
 func noopFoundLockable(name string) {}
 
-// scanRefsToChan scans through all commits reachable by refs contained in
-// "include" and not reachable by any refs included in "exclude" and invokes
-// the provided callback for each pointer file, valid or invalid, that it finds.
-// Reports unique oids once only, not multiple times if >1 file uses the same content
+// scanRefsToChan scans through all unique objects reachable from the
+// "include" refs and not reachable from any "exclude" refs and invokes the
+// provided callback for each pointer file, valid or invalid, that it finds.
+// Reports unique OIDs once only, not multiple times if more than one file
+// has the same content.
 func scanRefsToChan(scanner *GitScanner, pointerCb GitScannerFoundPointer, include, exclude []string, gitEnv, osEnv config.Environment, opt *ScanRefsOptions) error {
 	if opt == nil {
 		panic(tr.Tr.Get("no scan ref options"))
@@ -92,25 +93,30 @@ func scanRefsToChan(scanner *GitScanner, pointerCb GitScannerFoundPointer, inclu
 	return nil
 }
 
-// scanLeftRightToChan takes a ref and returns a channel of WrappedPointer objects
-// for all Git LFS pointers it finds for that ref.
-// Reports unique oids once only, not multiple times if >1 file uses the same content
+// scanRefsToChanSingleIncludeExclude scans through all unique objects
+// reachable from the "include" ref and not reachable from the "exclude" ref
+// and invokes the provided callback for each pointer file, valid or invalid,
+// that it finds.
+// Reports unique OIDs once only, not multiple times if more than one file
+// has the same content.
 func scanRefsToChanSingleIncludeExclude(scanner *GitScanner, pointerCb GitScannerFoundPointer, include, exclude string, gitEnv, osEnv config.Environment, opt *ScanRefsOptions) error {
 	return scanRefsToChan(scanner, pointerCb, []string{include}, []string{exclude}, gitEnv, osEnv, opt)
 }
 
-// scanMultiLeftRightToChan takes a ref and a set of bases and returns a channel
-// of WrappedPointer objects for all Git LFS pointers it finds for that ref.
-// Reports unique oids once only, not multiple times if >1 file uses the same
-// content
+// scanRefsToChanSingleIncludeMultiExclude scans through all unique objects
+// reachable from the "include" ref and not reachable from any "exclude" refs
+// and invokes the provided callback for each pointer file, valid or invalid,
+// that it finds.
+// Reports unique OIDs once only, not multiple times if more than one file
+// has the same content.
 func scanRefsToChanSingleIncludeMultiExclude(scanner *GitScanner, pointerCb GitScannerFoundPointer, include string, exclude []string, gitEnv, osEnv config.Environment, opt *ScanRefsOptions) error {
 	return scanRefsToChan(scanner, pointerCb, []string{include}, exclude, gitEnv, osEnv, opt)
 }
 
-// scanRefsByTree scans through all commits reachable by refs contained in
-// "include" and not reachable by any refs included in "exclude" and invokes
-// the provided callback for each pointer file, valid or invalid, that it finds.
-// Reports unique oids once only, not multiple times if >1 file uses the same content
+// scanRefsByTree scans through all objects reachable from the "include" refs
+// and not reachable from any "exclude" refs and invokes the provided callback
+// for each pointer file, valid or invalid, that it finds.
+// Objects which appear in multiple trees will be visited once per tree.
 func scanRefsByTree(scanner *GitScanner, pointerCb GitScannerFoundPointer, include, exclude []string, gitEnv, osEnv config.Environment, opt *ScanRefsOptions) error {
 	if opt == nil {
 		panic(tr.Tr.Get("no scan ref options"))

--- a/t/t-fsck.sh
+++ b/t/t-fsck.sh
@@ -127,8 +127,8 @@ begin_test "fsck: outside git repository"
   set +e
   git lfs fsck 2>&1 > fsck.log
   res=$?
-
   set -e
+
   if [ "$res" = "0" ]; then
     echo "Passes because $GIT_LFS_TEST_DIR is unset."
     exit 0
@@ -193,6 +193,7 @@ begin_test "fsck detects invalid pointers with GIT_OBJECT_DIRECTORY"
   git init "$reponame-2"
   gitdir="$(lfstest-realpath "$reponame-2/.git")"
   GIT_WORK_TREE="$reponame-2" GIT_DIR="$gitdir" GIT_OBJECT_DIRECTORY="$objdir" git update-ref refs/heads/main "$head"
+
   set +e
   GIT_WORK_TREE="$reponame-2" GIT_DIR="$gitdir" GIT_OBJECT_DIRECTORY="$objdir" git lfs fsck --pointers >test.log 2>&1
   RET=$?
@@ -280,6 +281,7 @@ setup_invalid_objects () {
   echo "CORRUPTION" >>".git/lfs/objects/${oid1:0:2}/${oid1:2:2}/$oid1"
   rm ".git/lfs/objects/${oid2:0:2}/${oid2:2:2}/$oid2"
 }
+
 begin_test "fsck detects invalid objects"
 (
   set -e

--- a/t/t-fsck.sh
+++ b/t/t-fsck.sh
@@ -292,7 +292,7 @@ begin_test "fsck detects invalid objects"
   RET=$?
   set -e
 
-  [ "$RET" -eq 2 ]
+  [ "$RET" -eq 1 ]
   [ $(grep -c 'objects: corruptObject: a.dat (.*) is corrupt' test.log) -eq 1 ]
   [ $(grep -c 'objects: openError: b.dat (.*) could not be checked: .*' test.log) -eq 1 ]
   [ $(grep -c 'objects: repair: moving corrupt objects to .*' test.log) -eq 1 ]
@@ -306,7 +306,7 @@ begin_test "fsck detects invalid objects"
   RET=$?
   set -e
 
-  [ "$RET" -eq 2 ]
+  [ "$RET" -eq 1 ]
   [ $(grep -c 'objects: corruptObject: a.dat (.*) is corrupt' test.log) -eq 1 ]
   [ $(grep -c 'objects: openError: b.dat (.*) could not be checked: .*' test.log) -eq 1 ]
   [ $(grep -c 'objects: repair: moving corrupt objects to .*' test.log) -eq 1 ]


### PR DESCRIPTION
As described in https://github.com/git-lfs/git-lfs/issues/4855#issuecomment-1030769273, the `git lfs fsck --objects` command currently handles refs expressed on the command line in two-dot range notation backwards, so we resolve that problem, add tests to confirm it is working as intended, and also revise some internal variable and function names to remove the ambiguity of the terms "left" and "right" as they apply to Git ref names.

This PR is probably most easily reviewed in a commit-by-commit manner, although it should be feasible to review it as a single diff as well.

#### Reversed Ref Arguments

The unintended reversal of the ref names in a `git lfs fsck --objects A..B` command is due to the fact that we [pass](https://github.com/git-lfs/git-lfs/blob/12a957202906667343ef9fc62b312ee53353f266/commands/command_fsck.go#L151) the first ref (i.e., `A`, identifying everything to be excluded) as the `left` argument to the gitscanner.ScanRefRange(), and the second ref (i.e., `B`) as the `right` argument.  That would seem to be correct, except that in the `GitScanner` methods, `left` is meant to define all the commits to include, while `right` is meant to define the ones to exclude.

When these arguments are [passed](https://github.com/git-lfs/git-lfs/blob/12a957202906667343ef9fc62b312ee53353f266/lfs/gitscanner.go#L140) to `scanLeftRightToChan()` and then [passed](https://github.com/git-lfs/git-lfs/blob/12a957202906667343ef9fc62b312ee53353f266/lfs/gitscanner_refs.go#L99) to `scanRefsToChan()`, the `left` argument [becomes](https://github.com/git-lfs/git-lfs/blob/12a957202906667343ef9fc62b312ee53353f266/lfs/gitscanner_refs.go#L40) the `include` argument and the `right` one becomes the `exclude` one.

This terminology likely stems from the way refs are [delivered](https://github.com/git-lfs/git-lfs/blob/12a957202906667343ef9fc62b312ee53353f266/commands/command_pre_push.go#L25-L26) to the `git lfs pre-push` hook command, with the local one coming first (on the left), and the remote one coming second:

```
  <local ref> <local sha> <remote ref> <remote sha>
```

Since in that context we want to exclude all the objects already on the remote, `right` (remote) becomes the `exclude` ref, while `left` (local) becomes the `include` one.  However, outside of this context, `left` and `right` are ambiguous
terms.

For the `git lfs fsck --objects` command we can simply reverse the two arguments to `gitscanner.ScanRefRange()`.

For the `--pointers` command option, we similarly reverse the two arguments to `gitscanner.ScanRefRangeByTree()`, but we also need to reverse the way those arguments are then [passed](https://github.com/git-lfs/git-lfs/blob/12a957202906667343ef9fc62b312ee53353f266/lfs/gitscanner.go#L154) to `scanRefsByTree()` because at the moment they are flipped, which is why the `git lfs fsck --pointers` command performs as expected and hence why the existing test suite does not fail.

#### Expanded Tests

Another reason the test suite does not fail now although there are various tests of the default `git lfs fsck` option, which implicitly performs the actions of both the `--objects` and `--pointers` options, the ones which happen to test the `A..B` two-dot range notation do not set up any corrupt Git LFS object files, and therefore pass.  There are also no explicit tests of the `--objects` option.

So we first add a pair of tests dedicated to the `--objects` option, one checking for expected output when Git LFS object files are corrupt or missing, and one checking for no output when no Git LFS objects exist in the repository.

Then we expand the `"fsck operates on specified refs"` [test](https://github.com/git-lfs/git-lfs/blob/12a957202906667343ef9fc62b312ee53353f266/t/t-fsck.sh#L267-L2900 so that it explicitly checks both the `--pointers` and `--objects options`, checking the former against a commit with bad Git LFS pointer objects, and checking the latter against a different commit with an object file with incorrect contents, using `A..B` notation in each case.  This new second new check would fail without the changes made in this PR to resolve the ordering of the refs passed to the `gitscanner.ScanRefRange()` method by the `git lfs fsck` command.

#### Revised Terminology

We then reorder and rename various arguments, functions, and structure members, and rewrite various comments, in order to replace the terms `left` and `right` throughout the codebase wherever they pertain to Git ref names.

In PR #2308 many internal functions which take arguments that determine the set of Git objects to scan for Git LFS pointers already had those arguments renamed from `left` and `right` to `include` and `exclude`.  However, some of the `GitScanner` methods still use the older terminology, although they are used in many contexts other than processing pre-push Git hook input.  Therefore we try to complete this change in terms, using `include` and `exclude` wherever possible.

We also update some comments to better describe the functionality of various object scanning methods.

Since at least PR #2706, and indeed earlier, the local and remote refs which are part of the `RefUpdate` [structure ](https://github.com/git-lfs/git-lfs/blob/12a957202906667343ef9fc62b312ee53353f266/git/refs.go#L12-L13) have been referred to as the `left` and `right` refs, which demonstrates the origin of these terms in the development of the pre-push hook command.  In this context, `include` and `exclude` make less sense than `local` and `remote`, so we replace the older terms with `local` and `remote` wherever they appear.

#### Proceeding Despite Missing Files

Lastly, when the `git lfs fsck` command detects one or more missing or corrupt Git LFS object files, it attempts to move them into the `.git/lfs/bad` directory.  If a file is missing, though, the command immediately [exits](https://github.com/git-lfs/git-lfs/blob/12a957202906667343ef9fc62b312ee53353f266/commands/command_fsck.go#L116) with exit code 2, rather than the exit code 1 which it would otherwise produce.

Aside from the exit code difference, this behaviour also has the effect that a single missing object file may prevent all other corrupt ones from being moved into the `bad` directory.

We therefore ignore any "file not found" errors in this loop and attempt to move/rename all invalid object files, which means we then always exit with exit code 1 when any object files are corrupt or missing (unless an exceptional circumstance occurs, such as being unable to create the `.git/lfs/bad` directory or failing to move an object file due to permissions issues or something like that), and we update our tests to match this new behaviour.

Fixes #4855.
/cc @danny0838 as reporter.