### PR TITLE
release: v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,106 @@
 # Git LFS Changelog
 
+## 3.1.0 (14 Feb 2022)
+
+This release is a feature release which includes support for fallback from
+Negotiate to Basic authentication, new ARM64 packages for Debian 11, a new
+localization infrastructure, and improved netrc support, in addition to various
+bug fixes.  In addition, we've addressed a performance regression for `git lfs
+migrate import` that was introduced in v3.0.2.
+
+At the moment, there are no translations available, but if you are interested in
+contributing to one, please reach out in an issue.  For compatibility with
+Windows and to retain the ability to have a single relocatable binary, the
+translations are included in the binary at build time.
+
+We would like to extend a special thanks to the following open source
+contributors:
+
+* @donno2048 for improving our error checking
+* @howardlyliao for improved netrc support
+* @HermannDppes for improving our large file warning on Windows
+* @rex4539 for fixing various typos throughout our codebase
+
+### Features
+
+* Fall back from Negotiate to Basic #4815 (@bk2204)
+* Add basic support for localization #4729 (@bk2204)
+* Add support for ARM64 Debian packages #4728 (@bk2204)
+* netrc: consider same machine may have different login names #4726 (@howardlyliao)
+
+### Bugs
+
+* smudge: honor GIT_LFS_SKIP_SMUDGE with checkout-index #4860 (@bk2204)
+* fix `git lfs fsck --objects A..B` handling and drop all left/right ref terminology #4859 (@chrisd8088)
+* halt migration when `.gitattributes` symbolic link encountered #4849 (@chrisd8088)
+* fix merging of `.gitattributes` with execute file mode during migration #4835 (@chrisd8088)
+* Fix migrate import speed regression #4813 (@bk2204)
+* Fix typos #4806 (@rex4539)
+* Move `err` checking to before the value was used #4776 (@donno2048)
+* migrate import: don't allow path filters with --above #4771 (@bk2204)
+* avoid panic on checkout with `--to` but no path, and update checkout manual #4766 (@chrisd8088)
+* creds: gracefully handle lack of askpass helper #4759 (@bk2204)
+* post-checkout: don't modify permissions of untracked files #4760 (@bk2204)
+* use gitattributes filepath matching for migrate filter options #4758 (@chrisd8088)
+* Avoid errors in git lfs env #4713 (@bk2204)
+* fs: specify a file as existing if it's empty #4654 (@bk2204)
+* Fix bound for largefilewarning #4633 (@HermannDppes)
+
+### Misc
+
+* build missing man pages and correct HTML renderings #4851 (@chrisd8088)
+* Update and mark message strings for translation #4846 (@chrisd8088)
+* Mark almost all strings for translation #4781 (@bk2204)
+* .github/workflows: switch to actions/checkout@v2 #4795 (@bk2204)
+* script/packagecloud: update for latest distros #4794 (@bk2204)
+* filter-process: don't print large file warning on fixed versions #4768 (@bk2204)
+* ssh: avoid using -- where possible #4741 (@bk2204)
+* vendor,go.*: update x/crypto and dependencies #4738 (@chrisd8088)
+* Stop supporting Go older than 1.13 #4641 (@bk2204)
+
+## 3.0.2 (28 Oct 2021)
+
+This release is a bugfix release which fixes a variety of problems seen since
+3.0.0, including problems with empty files, `git lfs fsck --pointers`, and
+the testsuite.
+
+We would like to extend a special thanks to the following open-source
+contributors:
+
+* @fh1ch for patches to make things work better on Alpine Linux
+* @pyckle for fixing our handling of filenames in `git lfs migrate import`
+* @ycongal-smile for fixing `git lfs migrate import` with similarly named files
+
+### Bugs
+
+* Fix two types of misdetection in git lfs fsck #4697 (@bk2204)
+* lfs: don't flag non-LFS files as invalid pointers #4691 (@bk2204)
+* git: honor GIT_OBJECT_DIRECTORY #4686 (@bk2204)
+* migrate: properly escape blob filenames #4683 (@pyckle)
+* ls-files: don't process empty files as pointers #4681 (@bk2204)
+* Call migrate() BlobFn on every blob #4671 (@ycongal-smile)
+* Correct t-lock regular expression to be musl compatible #4673 (@fh1ch)
+
+### Misc
+
+* Allow git-lfs-transfer integration tests to be skipped #4677 (@fh1ch)
+* Make CI environment GIT prefix grep more specific #4678 (@fh1ch)
+
+## 3.0.1 (28 Sep 2021)
+
+This release is a bugfix release which fixes the Windows ARM64 build process and
+addresses a regression in support for empty files in pull and fetch.
+
+We would like to extend a special thanks to the following open-source
+contributors:
+
+* @dennisameling for fixing support for Windows on ARM64
+
+### Bugs
+
+* Fix Windows arm64 release #4647 (@dennisameling)
+* fs: specify a file as existing if it's empty #4654 (@bk2204)
+
 ## 3.0.0 (24 Sep 2021)
 
 This release is a major new release and introduces several new features, such as

--- a/config/version.go
+++ b/config/version.go
@@ -13,7 +13,7 @@ var (
 )
 
 const (
-	Version = "3.0.0"
+	Version = "3.1.0"
 )
 
 func init() {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+git-lfs (3.1.0) stable; urgency=low
+
+  * New upstream version
+
+ -- brian m. carlson <bk2204@github.com>  Mon, 14 Feb 2022 14:29:00 -0000
+
 git-lfs (3.0.0) stable; urgency=low
 
   * New upstream version

--- a/rpm/SPECS/git-lfs.spec
+++ b/rpm/SPECS/git-lfs.spec
@@ -1,5 +1,5 @@
 Name:           git-lfs
-Version:        3.0.0
+Version:        3.1.0
 Release:        1%{?dist}
 Summary:        Git extension for versioning large files
 

--- a/versioninfo.json
+++ b/versioninfo.json
@@ -3,7 +3,7 @@
 	{
 		"FileVersion": {
 			"Major": 3,
-			"Minor": 0,
+			"Minor": 1,
 			"Patch": 0,
 			"Build": 0
 		}
@@ -13,7 +13,7 @@
 		"FileDescription": "Git LFS",
 		"LegalCopyright": "GitHub, Inc. and Git LFS contributors",
 		"ProductName": "Git Large File Storage (LFS)",
-		"ProductVersion": "3.0.0"
+		"ProductVersion": "3.1.0"
 	},
 	"IconPath": "script/windows-installer/git-lfs-logo.ico"
 }


### PR DESCRIPTION
This is an in-progress look at the next release of Git LFS, v3.1.0, which is scheduled for Monday, February 14, 2022.

We're publishing these changes early so that folks on @git-lfs/implementers  can check that things work with their various platforms. Note that as a major release, this contains several incompatible changes, most of which are outlined in the changelog. For that reason, I've opted to push out the release a little longer.

I've attached some builds below for people to use for testing:

[git-lfs-darwin-amd64-v3.1.0-pre.zip](https://github.com/git-lfs/git-lfs/files/8035611/git-lfs-darwin-amd64-v3.1.0-pre.zip)
[git-lfs-darwin-arm64-v3.1.0-pre.zip](https://github.com/git-lfs/git-lfs/files/8035612/git-lfs-darwin-arm64-v3.1.0-pre.zip)
[git-lfs-freebsd-386-v3.1.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8035613/git-lfs-freebsd-386-v3.1.0-pre.tar.gz)
[git-lfs-freebsd-amd64-v3.1.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8035614/git-lfs-freebsd-amd64-v3.1.0-pre.tar.gz)
[git-lfs-linux-386-v3.1.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8035615/git-lfs-linux-386-v3.1.0-pre.tar.gz)
[git-lfs-linux-amd64-v3.1.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8035616/git-lfs-linux-amd64-v3.1.0-pre.tar.gz)
[git-lfs-linux-arm64-v3.1.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8035618/git-lfs-linux-arm64-v3.1.0-pre.tar.gz)
[git-lfs-linux-arm-v3.1.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8035620/git-lfs-linux-arm-v3.1.0-pre.tar.gz)
[git-lfs-linux-ppc64le-v3.1.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8035621/git-lfs-linux-ppc64le-v3.1.0-pre.tar.gz)
[git-lfs-linux-s390x-v3.1.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8035623/git-lfs-linux-s390x-v3.1.0-pre.tar.gz)
[git-lfs-v3.1.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8035624/git-lfs-v3.1.0-pre.tar.gz)
[git-lfs-windows-386-v3.1.0-pre.zip](https://github.com/git-lfs/git-lfs/files/8035625/git-lfs-windows-386-v3.1.0-pre.zip)
[git-lfs-windows-amd64-v3.1.0-pre.zip](https://github.com/git-lfs/git-lfs/files/8035626/git-lfs-windows-amd64-v3.1.0-pre.zip)
[git-lfs-windows-arm64-v3.1.0-pre.zip](https://github.com/git-lfs/git-lfs/files/8035627/git-lfs-windows-arm64-v3.1.0-pre.zip)

In addition, the CI system will produce artifacts for Windows, Linux, and macOS if you prefer to use those; they should be equivalent.

/cc @git-lfs/core
/cc @git-lfs/implementers
/cc @git-lfs/releases