### PR TITLE
.github: fix syntax error in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,6 +150,7 @@ jobs:
       matrix:
         arch: [arm64]
         container: [debian_11]
+    steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0


### PR DESCRIPTION
A key for the steps is required.