### PR TITLE
docs/howto: remind core team member to check Actions workflows

### DIFF
--- a/docs/howto/release-git-lfs.md
+++ b/docs/howto/release-git-lfs.md
@@ -96,6 +96,9 @@ equal to 0, we say that we are releasing a MINOR version of Git LFS, in the
      Notify the `@git-lfs/release` team, a collection of humans who are
      interested in Git LFS releases.
 
+     Verify that the Actions tab contains no indications of errors for the
+     workflows, especially the release workflow.
+
   3. Once approved and verified, merge the pull request you created in the
      previous step. Locally, create a GPG-signed tag on the merge commit called
      `v2.n.m`:


### PR DESCRIPTION
The syntax error which occurred most recently for v3.1.0 could have been detected by looking at the Actions tab.  Let's suggest to the core team member doing the build that they inspect this to prevent any future problems.