### PR TITLE
release: v3.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,6 +150,7 @@ jobs:
       matrix:
         arch: [arm64]
         container: [debian_11]
+    steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Git LFS Changelog
 
+## 3.1.1 (14 Feb 2022)
+
+This is a bugfix release which fixes a syntax error in the release workflow.
+
+### Misc
+
+* .github: fix syntax error in release workflow #4866 (@bk2204)
+
 ## 3.1.0 (14 Feb 2022)
 
 This release is a feature release which includes support for fallback from

--- a/config/version.go
+++ b/config/version.go
@@ -13,7 +13,7 @@ var (
 )
 
 const (
-	Version = "3.1.0"
+	Version = "3.1.1"
 )
 
 func init() {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+git-lfs (3.1.1) stable; urgency=low
+
+  * New upstream version
+
+ -- brian m. carlson <bk2204@github.com>  Mon, 14 Feb 2022 14:29:00 -0000
+
 git-lfs (3.1.0) stable; urgency=low
 
   * New upstream version

--- a/rpm/SPECS/git-lfs.spec
+++ b/rpm/SPECS/git-lfs.spec
@@ -1,5 +1,5 @@
 Name:           git-lfs
-Version:        3.1.0
+Version:        3.1.1
 Release:        1%{?dist}
 Summary:        Git extension for versioning large files
 

--- a/versioninfo.json
+++ b/versioninfo.json
@@ -4,7 +4,7 @@
 		"FileVersion": {
 			"Major": 3,
 			"Minor": 1,
-			"Patch": 0,
+			"Patch": 1,
 			"Build": 0
 		}
 	},
@@ -13,7 +13,7 @@
 		"FileDescription": "Git LFS",
 		"LegalCopyright": "GitHub, Inc. and Git LFS contributors",
 		"ProductName": "Git Large File Storage (LFS)",
-		"ProductVersion": "3.1.0"
+		"ProductVersion": "3.1.1"
 	},
 	"IconPath": "script/windows-installer/git-lfs-logo.ico"
 }


### PR DESCRIPTION
This is an in-progress look at the next release of Git LFS, v2.13.3, which is scheduled for today, Monday, February 14, 2022.

I've attached some builds below for people to use for testing:

[git-lfs-darwin-amd64-v3.1.1-pre.zip](https://github.com/git-lfs/git-lfs/files/8063197/git-lfs-darwin-amd64-v3.1.1-pre.zip)
[git-lfs-darwin-arm64-v3.1.1-pre.zip](https://github.com/git-lfs/git-lfs/files/8063198/git-lfs-darwin-arm64-v3.1.1-pre.zip)
[git-lfs-freebsd-386-v3.1.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8063199/git-lfs-freebsd-386-v3.1.1-pre.tar.gz)
[git-lfs-freebsd-amd64-v3.1.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8063200/git-lfs-freebsd-amd64-v3.1.1-pre.tar.gz)
[git-lfs-linux-386-v3.1.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8063201/git-lfs-linux-386-v3.1.1-pre.tar.gz)
[git-lfs-linux-amd64-v3.1.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8063202/git-lfs-linux-amd64-v3.1.1-pre.tar.gz)
[git-lfs-linux-arm-v3.1.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8063205/git-lfs-linux-arm-v3.1.1-pre.tar.gz)
[git-lfs-linux-arm64-v3.1.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8063203/git-lfs-linux-arm64-v3.1.1-pre.tar.gz)
[git-lfs-linux-ppc64le-v3.1.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8063206/git-lfs-linux-ppc64le-v3.1.1-pre.tar.gz)
[git-lfs-linux-s390x-v3.1.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8063207/git-lfs-linux-s390x-v3.1.1-pre.tar.gz)
[git-lfs-v3.1.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8063208/git-lfs-v3.1.1-pre.tar.gz)
[git-lfs-windows-386-v3.1.1-pre.zip](https://github.com/git-lfs/git-lfs/files/8063209/git-lfs-windows-386-v3.1.1-pre.zip)
[git-lfs-windows-amd64-v3.1.1-pre.zip](https://github.com/git-lfs/git-lfs/files/8063210/git-lfs-windows-amd64-v3.1.1-pre.zip)
[git-lfs-windows-arm64-v3.1.1-pre.zip](https://github.com/git-lfs/git-lfs/files/8063211/git-lfs-windows-arm64-v3.1.1-pre.zip)

In addition, the CI system will produce artifacts for Windows, Linux, and macOS if you prefer to use those; they should be equivalent.

/cc @git-lfs/core
/cc @git-lfs/implementers
/cc @git-lfs/releases
