### PR TITLE
Revert "Merge pull request #4795 from bk2204/actions-checkout-v2"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,7 @@ jobs:
         go: ['1.17.x']
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
     - uses: actions/setup-go@v2
       with:
@@ -43,9 +41,7 @@ jobs:
         go: ['1.13.x', '1.14.x']
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    - uses: actions/checkout@v1
     - uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go }}
@@ -54,9 +50,7 @@ jobs:
     name: Build on Windows
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
     - uses: actions/setup-go@v2
       with:
@@ -112,9 +106,7 @@ jobs:
         os: [ubuntu-20.04, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    - uses: actions/checkout@v1
     - run: git clone -b master https://github.com/git/git.git "$HOME/git"
     - run: script/build-git "$HOME/git"
     - run: GIT_DEFAULT_HASH=sha256 script/cibuild
@@ -125,9 +117,7 @@ jobs:
         os: [ubuntu-20.04, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    - uses: actions/checkout@v1
     - run: git clone -b v2.0.0 https://github.com/git/git.git "$HOME/git"
     - run: script/build-git "$HOME/git"
     - run: script/cibuild
@@ -135,9 +125,7 @@ jobs:
     name: Build Linux packages
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
     - run: git clone https://github.com/git-lfs/build-dockers.git "$HOME/build-dockers"
     - run: (cd "$HOME/build-dockers" && ./build_dockers.bsh)
@@ -150,9 +138,7 @@ jobs:
         arch: [arm64]
         container: [debian_11]
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
     - run: |
         echo '{"experimental": true}' | sudo tee /etc/docker/daemon.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,7 @@ jobs:
       matrix:
         go: ['1.17.x']
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
     - uses: actions/setup-go@v2
       with:
@@ -65,9 +63,7 @@ jobs:
       matrix:
         go: ['1.17.x']
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
     - uses: actions/setup-go@v2
       with:
@@ -103,9 +99,7 @@ jobs:
       matrix:
         go: ['1.17.x']
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
     - uses: actions/setup-go@v2
       with:
@@ -131,9 +125,7 @@ jobs:
     name: Build Linux Packages
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
     - run: gem install packagecloud-ruby
     - run: git clone https://github.com/git-lfs/build-dockers.git "$HOME/build-dockers"
@@ -151,9 +143,7 @@ jobs:
         arch: [arm64]
         container: [debian_11]
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
     - run: |
         echo '{"experimental": true}' | sudo tee /etc/docker/daemon.json


### PR DESCRIPTION
actions/checkout@v2 "helpfully" overwrites the tag with the data from the ref, erasing the annotated tag, and therefore breaking git describe, which by default only checks annotated tags.  Note that every tag except the one for the current head is preserved, so git describe uses an annotation that is based off the most recent tag.  This behavior is described in actions/checkout#290.

The original reporter claiming that a security fix had been applied has not provided details, and the behavior described should not be a vulnerability in a single-tenant Actions VM.  Therefore, revert to actions/checkout@v1 to preserve functionality at the expense of a behavior which does not appear to describe an actual vulnerability.

This reverts commit e3893b1402349b9481ccd8e1cd876d9e355cf848, reversing changes made to eb0dc945e92a9a17116a5c2fdde572991ac12ac2.