### PR TITLE
release: v3.1.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,7 @@ jobs:
         go: ['1.17.x']
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
     - uses: actions/setup-go@v2
       with:
@@ -43,9 +41,7 @@ jobs:
         go: ['1.13.x', '1.14.x']
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    - uses: actions/checkout@v1
     - uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go }}
@@ -54,9 +50,7 @@ jobs:
     name: Build on Windows
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
     - uses: actions/setup-go@v2
       with:
@@ -112,9 +106,7 @@ jobs:
         os: [ubuntu-20.04, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    - uses: actions/checkout@v1
     - run: git clone -b master https://github.com/git/git.git "$HOME/git"
     - run: script/build-git "$HOME/git"
     - run: GIT_DEFAULT_HASH=sha256 script/cibuild
@@ -125,9 +117,7 @@ jobs:
         os: [ubuntu-20.04, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    - uses: actions/checkout@v1
     - run: git clone -b v2.0.0 https://github.com/git/git.git "$HOME/git"
     - run: script/build-git "$HOME/git"
     - run: script/cibuild
@@ -135,9 +125,7 @@ jobs:
     name: Build Linux packages
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
     - run: git clone https://github.com/git-lfs/build-dockers.git "$HOME/build-dockers"
     - run: (cd "$HOME/build-dockers" && ./build_dockers.bsh)
@@ -150,9 +138,7 @@ jobs:
         arch: [arm64]
         container: [debian_11]
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
     - run: |
         echo '{"experimental": true}' | sudo tee /etc/docker/daemon.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,6 +160,7 @@ jobs:
         sudo systemctl restart docker.service
         docker version -f '{{.Server.Experimental}}'
     - uses: docker/setup-qemu-action@v1
+    - run: gem install packagecloud-ruby
     - run: git clone https://github.com/git-lfs/build-dockers.git "$HOME/build-dockers"
     - run: (cd "$HOME/build-dockers" && ./build_dockers.bsh --arch=$ARCH $CONTAINER)
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,7 @@ jobs:
       matrix:
         go: ['1.17.x']
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
     - uses: actions/setup-go@v2
       with:
@@ -65,9 +63,7 @@ jobs:
       matrix:
         go: ['1.17.x']
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
     - uses: actions/setup-go@v2
       with:
@@ -103,9 +99,7 @@ jobs:
       matrix:
         go: ['1.17.x']
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
     - uses: actions/setup-go@v2
       with:
@@ -131,9 +125,7 @@ jobs:
     name: Build Linux Packages
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
     - run: gem install packagecloud-ruby
     - run: git clone https://github.com/git-lfs/build-dockers.git "$HOME/build-dockers"
@@ -151,9 +143,7 @@ jobs:
         arch: [arm64]
         container: [debian_11]
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
     - run: |
         echo '{"experimental": true}' | sudo tee /etc/docker/daemon.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Git LFS Changelog
 
+## 3.1.2 (16 Feb 2022)
+
+This is a bugfix release which fixes a bug in `git lfs install` and some issues
+in our CI release processes, including one that prevented arm64 packages for
+Debian 11 from being uploaded.
+
+### Bugs
+
+* lfs: add old hook content to the list of old hooks #4878 (@bk2204)
+
+### Misc
+
+* Revert "Merge pull request #4795 from bk2204/actions-checkout-v2" #4877 (@bk2204)
+* .github/workflows: install packagecloud gem #4873 (@bk2204)
+
 ## 3.1.1 (14 Feb 2022)
 
 This is a bugfix release which fixes a syntax error in the release workflow.

--- a/config/version.go
+++ b/config/version.go
@@ -13,7 +13,7 @@ var (
 )
 
 const (
-	Version = "3.1.1"
+	Version = "3.1.2"
 )
 
 func init() {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+git-lfs (3.1.2) stable; urgency=low
+
+  * New upstream version
+
+ -- brian m. carlson <bk2204@github.com>  Wed, 16 Feb 2022 14:29:00 -0000
+
 git-lfs (3.1.1) stable; urgency=low
 
   * New upstream version

--- a/rpm/SPECS/git-lfs.spec
+++ b/rpm/SPECS/git-lfs.spec
@@ -1,5 +1,5 @@
 Name:           git-lfs
-Version:        3.1.1
+Version:        3.1.2
 Release:        1%{?dist}
 Summary:        Git extension for versioning large files
 

--- a/versioninfo.json
+++ b/versioninfo.json
@@ -4,7 +4,7 @@
 		"FileVersion": {
 			"Major": 3,
 			"Minor": 1,
-			"Patch": 1,
+			"Patch": 2,
 			"Build": 0
 		}
 	},
@@ -13,7 +13,7 @@
 		"FileDescription": "Git LFS",
 		"LegalCopyright": "GitHub, Inc. and Git LFS contributors",
 		"ProductName": "Git Large File Storage (LFS)",
-		"ProductVersion": "3.1.1"
+		"ProductVersion": "3.1.2"
 	},
 	"IconPath": "script/windows-installer/git-lfs-logo.ico"
 }


### PR DESCRIPTION
This is an in-progress look at the next release of Git LFS, v3.1.2, which is scheduled for tomorrow, Wednesday, February 16, 2022.

I've attached some builds below for people to use for testing:

[git-lfs-darwin-amd64-v3.1.2-pre.zip](https://github.com/git-lfs/git-lfs/files/8074298/git-lfs-darwin-amd64-v3.1.2-pre.zip)
[git-lfs-darwin-arm64-v3.1.2-pre.zip](https://github.com/git-lfs/git-lfs/files/8074299/git-lfs-darwin-arm64-v3.1.2-pre.zip)
[git-lfs-freebsd-386-v3.1.2-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8074300/git-lfs-freebsd-386-v3.1.2-pre.tar.gz)
[git-lfs-freebsd-amd64-v3.1.2-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8074301/git-lfs-freebsd-amd64-v3.1.2-pre.tar.gz)
[git-lfs-linux-386-v3.1.2-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8074302/git-lfs-linux-386-v3.1.2-pre.tar.gz)
[git-lfs-linux-amd64-v3.1.2-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8074303/git-lfs-linux-amd64-v3.1.2-pre.tar.gz)
[git-lfs-linux-arm64-v3.1.2-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8074305/git-lfs-linux-arm64-v3.1.2-pre.tar.gz)
[git-lfs-linux-arm-v3.1.2-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8074306/git-lfs-linux-arm-v3.1.2-pre.tar.gz)
[git-lfs-linux-ppc64le-v3.1.2-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8074307/git-lfs-linux-ppc64le-v3.1.2-pre.tar.gz)
[git-lfs-linux-s390x-v3.1.2-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8074308/git-lfs-linux-s390x-v3.1.2-pre.tar.gz)
[git-lfs-v3.1.2-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8074309/git-lfs-v3.1.2-pre.tar.gz)
[git-lfs-windows-386-v3.1.2-pre.zip](https://github.com/git-lfs/git-lfs/files/8074310/git-lfs-windows-386-v3.1.2-pre.zip)
[git-lfs-windows-amd64-v3.1.2-pre.zip](https://github.com/git-lfs/git-lfs/files/8074311/git-lfs-windows-amd64-v3.1.2-pre.zip)
[git-lfs-windows-arm64-v3.1.2-pre.zip](https://github.com/git-lfs/git-lfs/files/8074313/git-lfs-windows-arm64-v3.1.2-pre.zip)


In addition, the CI system will produce artifacts for Windows, Linux, and macOS if you prefer to use those; they should be equivalent.

/cc @git-lfs/core 
/cc @git-lfs/implementers
/cc @git-lfs/releases