### PR TITLE
Call out destructive command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ $ git commit -m "add psd"
 > $ git lfs migrate import --include="*.psd" --everything
 > ```
 >
+> **Note that this will rewrite history and change all of the Git object IDs in your
+> repository, just like the export version of this command.**
+>
 > For more information, read [`git-lfs-migrate(1)`](https://github.com/git-lfs/git-lfs/blob/main/docs/man/git-lfs-migrate.1.ronn).
 
 You can confirm that Git LFS is managing your PSD file:
@@ -153,8 +156,8 @@ example:
 $ git lfs migrate export --include="*.psd" --everything
 ```
 
-Note that this will rewrite history and change all of the Git object IDs in your
-repository, just like the import version of this command.
+**Note that this will rewrite history and change all of the Git object IDs in your
+repository, just like the import version of this command.**
 
 If there's some reason that things aren't working out for you, please let us
 know in an issue, and we'll definitely try to help or get it fixed.


### PR DESCRIPTION
While it is the user's responsiblity to read the documentation and know
what impact a command will have that they choose to run on their
machine, I believe it would be helpful to draw more attention to the
destructive commands that are featured in the README that cause Git to
rewrite its commit objects.

Many users will only skim the README, and the migration command that
addresses a common use case should be called out more than it is for its
side effects, in my opinion.