### PR TITLE
Match pointer parsing to pointer specification

### DIFF
--- a/errors/types.go
+++ b/errors/types.go
@@ -135,17 +135,6 @@ func IsProtocolError(err error) bool {
 	return false
 }
 
-// If an error is abad pointer error of any type, returns NotAPointerError
-func StandardizeBadPointerError(err error) error {
-	if IsBadPointerKeyError(err) {
-		badErr := err.(badPointerKeyError)
-		if badErr.Expected == "version" {
-			return NewNotAPointerError(err)
-		}
-	}
-	return err
-}
-
 // IsDownloadDeclinedError indicates that the smudge operation should not download.
 // TODO: I don't really like using errors to control that flow, it should be refactored.
 func IsDownloadDeclinedError(err error) bool {
@@ -375,9 +364,6 @@ func NewPointerScanError(err error, treeishOid, path string) error {
 }
 
 type badPointerKeyError struct {
-	Expected string
-	Actual   string
-
 	*wrappedError
 }
 
@@ -385,9 +371,8 @@ func (e badPointerKeyError) BadPointerKeyError() bool {
 	return true
 }
 
-func NewBadPointerKeyError(expected, actual string) error {
-	err := Errorf(tr.Tr.Get("Expected key %s, got %s", expected, actual))
-	return badPointerKeyError{expected, actual, newWrappedError(err, tr.Tr.Get("pointer parsing"))}
+func NewBadPointerKeyError(err error) error {
+	return badPointerKeyError{newWrappedError(err, tr.Tr.Get("Pointer parsing error"))}
 }
 
 // Definitions for IsDownloadDeclinedError()


### PR DESCRIPTION
Fixes https://github.com/git-lfs/git-lfs/issues/4922

From https://github.com/git-lfs/git-lfs/blob/main/docs/spec.md
- Keys MUST only use the characters [a-z] [0-9] . -.
- Lines of key/value pairs MUST be sorted alphabetically in ascending order
  (with the exception of version, which is always first).

And:
- Tools that parse and regenerate pointer files MUST preserve keys that
  they don't know or care about.

Git LFS itself doesn't exactly follow these rules:
- it doesn't allow any keys it doesn't recognize
- it allows extensions (which is fine) but it allows them to in the
  wrong order

This change makes Git LFS pointer parsing code match the specification:
- extra keys that are not recognized are allowed, and have no effect
  (except for making the pointer non-canonical)
- unless the extra keys use disallowed characters, in which case they
  cause pointer parsing to fail
- extensions are no longer allowed to be out of order since that
  would violate the alphabetically sorted rule