### PR TITLE
commands/update: add --append option

### DIFF
--- a/commands/command_clean.go
+++ b/commands/command_clean.go
@@ -92,7 +92,7 @@ func clean(gf *lfs.GitFilter, to io.Writer, from io.Reader, fileName string, fil
 func cleanCommand(cmd *cobra.Command, args []string) {
 	requireStdin(tr.Tr.Get("This command should be run by the Git 'clean' filter"))
 	setupRepository()
-	installHooks(false)
+	installHooks(false, false)
 
 	var fileName string
 	if len(args) > 0 {

--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -97,7 +97,7 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 		// If --skip-repo wasn't given, install repo-level hooks while
 		// we're still in the checkout directory.
 
-		if err := installHooks(false); err != nil {
+		if err := installHooks(false, false); err != nil {
 			ExitWithError(err)
 		}
 	}

--- a/commands/command_filter_process.go
+++ b/commands/command_filter_process.go
@@ -39,7 +39,7 @@ var filterSmudgeSkip bool
 func filterCommand(cmd *cobra.Command, args []string) {
 	requireStdin(tr.Tr.Get("This command should be run by the Git filter process"))
 	setupRepository()
-	installHooks(false)
+	installHooks(false, false)
 
 	s := git.NewFilterProcessScanner(os.Stdin, os.Stdout)
 

--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -44,7 +44,7 @@ func (p corruptPointer) String() string {
 // NOTE(zeroshirts): Ideally git would have hooks for fsck such that we could
 // chain a lfs-fsck, but I don't think it does.
 func fsckCommand(cmd *cobra.Command, args []string) {
-	installHooks(false)
+	installHooks(false, false)
 	setupRepository()
 
 	useIndex := false

--- a/commands/command_install.go
+++ b/commands/command_install.go
@@ -17,6 +17,7 @@ var (
 	systemInstall     = false
 	skipSmudgeInstall = false
 	skipRepoInstall   = false
+	appendInstall     = false
 )
 
 func installCommand(cmd *cobra.Command, args []string) {
@@ -92,6 +93,7 @@ func init() {
 		cmd.Flags().BoolVarP(&skipSmudgeInstall, "skip-smudge", "s", false, "Skip automatic downloading of objects on clone or pull.")
 		cmd.Flags().BoolVarP(&skipRepoInstall, "skip-repo", "", false, "Skip repo setup, just install global filters.")
 		cmd.Flags().BoolVarP(&manualInstall, "manual", "m", false, "Print instructions for manual install.")
+		cmd.Flags().BoolVarP(&appendInstall, "append", "a", false, "Append to existing hooks.")
 		cmd.AddCommand(NewCommand("hooks", installHooksCommand))
 	})
 }

--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -40,7 +40,7 @@ func migrateImportCommand(cmd *cobra.Command, args []string) {
 	// To avoid confusion later, let's make sure that we've installed the
 	// necessary hooks so that a newly migrated repository is `git
 	// push`-able immediately following a `git lfs migrate import`.
-	installHooks(false)
+	installHooks(false, false)
 
 	if migrateNoRewrite {
 		if migrateFixup {

--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -149,7 +149,7 @@ func smudge(gf *lfs.GitFilter, to io.Writer, from io.Reader, filename string, sk
 func smudgeCommand(cmd *cobra.Command, args []string) {
 	requireStdin(tr.Tr.Get("This command should be run by the Git 'smudge' filter"))
 	setupRepository()
-	installHooks(false)
+	installHooks(false, false)
 
 	if !smudgeSkip && cfg.Os.Bool("GIT_LFS_SKIP_SMUDGE", false) {
 		smudgeSkip = true

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -36,7 +36,7 @@ func trackCommand(cmd *cobra.Command, args []string) {
 	setupWorkingCopy()
 
 	if !cfg.Os.Bool("GIT_LFS_TRACK_NO_INSTALL_HOOKS", false) {
-		installHooks(false)
+		installHooks(false, false)
 	}
 
 	if len(args) == 0 {

--- a/commands/command_untrack.go
+++ b/commands/command_untrack.go
@@ -15,7 +15,7 @@ import (
 func untrackCommand(cmd *cobra.Command, args []string) {
 	setupWorkingCopy()
 
-	installHooks(false)
+	installHooks(false, false)
 
 	if len(args) < 1 {
 		Print("git lfs untrack <path> [path]*")

--- a/commands/command_update.go
+++ b/commands/command_update.go
@@ -10,6 +10,7 @@ import (
 var (
 	updateForce  = false
 	updateManual = false
+	updateAppend = false
 )
 
 // updateCommand is used for updating parts of Git LFS that reside under
@@ -38,18 +39,19 @@ func updateCommand(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	if updateForce && updateManual {
-		Exit(tr.Tr.Get("You cannot use --force and --manual options together"))
+	if (updateForce && updateAppend) || (updateForce && updateManual) || (updateAppend && updateManual) {
+		Exit(tr.Tr.Get("Options --force, --manual, and --append are mutually exclusive."))
 	}
 
 	if updateManual {
 		Print(getHookInstallSteps())
 	} else {
-		if err := installHooks(updateForce); err != nil {
+		if err := installHooks(updateForce, updateAppend); err != nil {
 			Error(err.Error())
-			Exit("%s\n  1: %s\n  2: %s",
+			Exit("%s\n  1: %s\n  2: %s\n  3: %s",
 				tr.Tr.Get("To resolve this, either:"),
 				tr.Tr.Get("run `git lfs update --manual` for instructions on how to merge hooks."),
+				tr.Tr.Get("run `git lfs update --append` to append to your existing hook."),
 				tr.Tr.Get("run `git lfs update --force` to overwrite your hook."))
 		} else {
 			Print(tr.Tr.Get("Updated Git hooks."))
@@ -62,5 +64,6 @@ func init() {
 	RegisterCommand("update", updateCommand, func(cmd *cobra.Command) {
 		cmd.Flags().BoolVarP(&updateForce, "force", "f", false, "Overwrite existing hooks.")
 		cmd.Flags().BoolVarP(&updateManual, "manual", "m", false, "Print instructions for manual install.")
+		cmd.Flags().BoolVarP(&updateAppend, "append", "a", false, "Append to existing hooks.")
 	})
 }

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -160,14 +160,14 @@ func getHookInstallSteps() string {
 	return strings.Join(steps, "\n\n")
 }
 
-func installHooks(force bool) error {
+func installHooks(force bool, append bool) error {
 	hookDir, err := cfg.HookDir()
 	if err != nil {
 		return err
 	}
 	hooks := lfs.LoadHooks(hookDir, cfg)
 	for _, h := range hooks {
-		if err := h.Install(force); err != nil {
+		if err := h.Install(force, append); err != nil {
 			return err
 		}
 	}

--- a/t/t-install.sh
+++ b/t/t-install.sh
@@ -354,3 +354,42 @@ begin_test "can install when multiple global values registered"
   git lfs install --force
 )
 end_test
+
+begin_test "install with --append"
+(
+  set -e
+  git init install-append-repo
+  cd install-append-repo
+
+  pre_push_hook="
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/pre-push'.\\n\"; exit 2; }
+git lfs pre-push \"\$@\""
+
+  post_checkout_hook="
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/post-checkout'.\\n\"; exit 2; }
+git lfs post-checkout \"\$@\""
+
+  post_commit_hook="
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/post-commit'.\\n\"; exit 2; }
+git lfs post-commit \"\$@\""
+
+  post_merge_hook="
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/post-merge'.\\n\"; exit 2; }
+git lfs post-merge \"\$@\""
+
+  echo "test" > .git/hooks/pre-push
+  echo "test" > .git/hooks/post-checkout
+  echo "test" > .git/hooks/post-commit
+  echo "test" > .git/hooks/post-merge
+  [ "Updated Git hooks.
+Git LFS initialized." = "$(git lfs install --append)" ]
+  [ "test
+$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
+  [ "test
+$post_checkout_hook" = "$(cat .git/hooks/post-checkout)" ]
+  [ "test
+$post_commit_hook" = "$(cat .git/hooks/post-commit)" ]
+  [ "test
+$post_merge_hook" = "$(cat .git/hooks/post-merge)" ]
+)
+end_test

--- a/t/t-update.sh
+++ b/t/t-update.sh
@@ -101,6 +101,17 @@ To resolve this, either:
   [ "test" = "$(cat .git/hooks/post-commit)" ]
   [ "test" = "$(cat .git/hooks/post-merge)" ]
 
+  # append to existing hooks
+  [ "Updated Git hooks." = "$(git lfs update --append)" ]
+  [ "test
+${pre_push_hook/#*\n/}" = "$(cat .git/hooks/pre-push)" ]
+  [ "test
+${post_checkout_hook/#*\n/}" = "$(cat .git/hooks/post-checkout)" ]
+  [ "test
+${post_commit_hook/#*\n/}" = "$(cat .git/hooks/post-commit)" ]
+  [ "test
+${post_merge_hook/#*\n/}" = "$(cat .git/hooks/post-merge)" ]
+
   # Make sure returns non-zero
   set +e
   git lfs update


### PR DESCRIPTION
This option can be used to append the LFS hooks to existing git hooks.

I have pre-existing `post-checkout`, `post-merge`, and `post-commit` hooks, which means each time I want to initialize git-lfs in a repo I have to run `git lfs install --manual` and manually append the LFS hooks to each of my pre-existing hooks. This is a bit tedious, so I thought it might be handy if git-lfs had a way to do this automatically.

N.B. I was unable to run the tests locally. I get the following error:

```
No subtests run

Test Summary Report
-------------------
t-update.sh (Wstat: 0 Tests: 0 Failed: 0)
  Parse errors: No plan found in TAP output
```

I searched through the project documentation and online, but wasn't able to figure out the problem. As far as I can tell it's a Perl issue. I'm hoping the CI can run the tests and I can fix any issues found there until I can figure this out locally.