### PR TITLE
script/upload: correct RHEL 8 package repo

### DIFF
--- a/script/upload
+++ b/script/upload
@@ -190,7 +190,7 @@ finalize_body_message () {
 Up to date packages are available on [PackageCloud](https://packagecloud.io/github/git-lfs) and [Homebrew](http://brew.sh/).
 
 [RPM RHEL 7/CentOS 7](https://packagecloud.io/github/git-lfs/packages/el/7/git-lfs-VERSION-1.el7.x86_64.rpm/download)
-[RPM RHEL 8/CentOS 8](https://packagecloud.io/github/git-lfs/packages/el/8/git-lfs-VERSION-1.el8.x86_64.rpm/download)
+[RPM RHEL 8/CentOS 8](https://packagecloud.io/github/git-lfs/packages/el/8/git-lfs-VERSION-1.x86_64.rpm/download)
 [Debian 9](https://packagecloud.io/github/git-lfs/packages/debian/stretch/git-lfs_VERSION_amd64.deb/download)
 [Debian 10](https://packagecloud.io/github/git-lfs/packages/debian/buster/git-lfs_VERSION_amd64.deb/download)
 [Debian 11](https://packagecloud.io/github/git-lfs/packages/debian/bullseye/git-lfs_VERSION_amd64.deb/download)


### PR DESCRIPTION
Because CentOS 8 is now EOL, we've switched to Rocky Linux for building RHEL 8-compatible packages.  However, those packages don't end up containing the ".el8" segment, so the link is broken.  Fix this by removing that segment from the URL.

Fixes #4934