### PR TITLE
remove unused `Pipe[Media]Command()` functions

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -281,18 +281,6 @@ func Cleanup() {
 	}
 }
 
-func PipeMediaCommand(name string, args ...string) error {
-	return PipeCommand("bin/"+name, args...)
-}
-
-func PipeCommand(name string, args ...string) error {
-	cmd := subprocess.ExecCommand(name, args...)
-	cmd.Stdin = os.Stdin
-	cmd.Stderr = os.Stderr
-	cmd.Stdout = os.Stdout
-	return cmd.Run()
-}
-
 func requireStdin(msg string) {
 	var out string
 


### PR DESCRIPTION
The `PipeCommand()` function was added in commit 8b18f62242426ab9352925929ad0fbbee0edd51b in the initial prototype work on this project in order to run the original `bin/git-media-{clean,smudge`} programs.  The `PipeMediaCommand()` function was then added in commit 9cff651e5073f29c28ed418ba721731e7bbee848 to abstract the addition of the `bin/` prefix to the program names into a single function.

As of commit 24b1939d45cc59dd1cd3ad7cb4657289a60ad595 in 2014, however, which was also part of that early prototyping phase, the `bin/git-media-{clean,smudge}` programs were replaced with `git media clean|smudge`, precursors of our contemporary `git lfs clean|smudge` programs, and the `Pipe[Media]Command()` functions stopped being used to communicate with the programs.

No other users of these functions have appeared since that time, so we just remove them now; they can always be recovered from our commit history if pipe wrapper functions are needed again in the future.