### PR TITLE
Update and correct several error message strings

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -178,7 +178,7 @@ func installHooks(force bool) error {
 // uninstallHooks removes all hooks in range of the `hooks` var.
 func uninstallHooks() error {
 	if !cfg.InRepo() {
-		return errors.New(tr.Tr.Get("Not in a git repository"))
+		return errors.New(tr.Tr.Get("Not in a Git repository"))
 	}
 
 	hookDir, err := cfg.HookDir()

--- a/git/git.go
+++ b/git/git.go
@@ -1324,17 +1324,17 @@ func GetFilesChanged(from, to string) ([]string, error) {
 	cmd := gitNoLFS(args...)
 	outp, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, errors.New(tr.Tr.Get("failed to call `git diff`: %v", err))
+		return nil, errors.New(tr.Tr.Get("failed to call `git diff-tree`: %v", err))
 	}
 	if err := cmd.Start(); err != nil {
-		return nil, errors.New(tr.Tr.Get("failed to start `git diff`: %v", err))
+		return nil, errors.New(tr.Tr.Get("failed to start `git diff-tree`: %v", err))
 	}
 	scanner := bufio.NewScanner(outp)
 	for scanner.Scan() {
 		files = append(files, strings.TrimSpace(scanner.Text()))
 	}
 	if err := cmd.Wait(); err != nil {
-		return nil, errors.New(tr.Tr.Get("`git diff` failed: %v", err))
+		return nil, errors.New(tr.Tr.Get("`git diff-tree` failed: %v", err))
 	}
 
 	return files, err


### PR DESCRIPTION
In commit d91980f2dad3c7620feaa5ae6d5cf90ef0603330 of PR #1822 the `GetFilesChanged()` function was updated to use `git diff-tree` rather than `git diff`.  However, the relevant error messages were not updated at the same time, so we do that now.

Also, we convert a message that is output when uninstalling Git hooks back to using a capitalized "Git" project name instead of the lowercase variant.  This message was accidentally changed in commit 04abbd843622600279baeb31c92862c4d73e419e in PR #4846 when making it into a translatable string.