### PR TITLE
Use `gitignore`-style path matching for additional commands

### DIFF
--- a/commands/command_filter_process.go
+++ b/commands/command_filter_process.go
@@ -61,7 +61,7 @@ func filterCommand(cmd *cobra.Command, args []string) {
 	}
 
 	skip := filterSmudgeSkip || cfg.Os.Bool("GIT_LFS_SKIP_SMUDGE", false)
-	filter := filepathfilter.New(cfg.FetchIncludePaths(), cfg.FetchExcludePaths(), filepathfilter.GitAttributes)
+	filter := filepathfilter.New(cfg.FetchIncludePaths(), cfg.FetchExcludePaths(), filepathfilter.GitIgnore)
 
 	ptrs := make(map[string]*lfs.Pointer)
 

--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -144,7 +144,7 @@ func doFsckObjects(include, exclude string, useIndex bool) []string {
 	// objects), the "missing" ones will fail the fsck.
 	//
 	// Attach a filepathfilter to avoid _only_ the excluded paths.
-	gitscanner.Filter = filepathfilter.New(nil, cfg.FetchExcludePaths(), filepathfilter.GitAttributes)
+	gitscanner.Filter = filepathfilter.New(nil, cfg.FetchExcludePaths(), filepathfilter.GitIgnore)
 
 	if exclude == "" {
 		if err := gitscanner.ScanRef(include, nil); err != nil {

--- a/commands/command_prune.go
+++ b/commands/command_prune.go
@@ -98,7 +98,7 @@ func prune(fetchPruneConfig lfs.FetchPruneConfig, verifyRemote, dryRun, verbose 
 	retainChan := make(chan string, 100)
 
 	gitscanner := lfs.NewGitScanner(cfg, nil)
-	gitscanner.Filter = filepathfilter.New(nil, cfg.FetchExcludePaths(), filepathfilter.GitAttributes)
+	gitscanner.Filter = filepathfilter.New(nil, cfg.FetchExcludePaths(), filepathfilter.GitIgnore)
 
 	sem := semaphore.NewWeighted(int64(runtime.NumCPU() * 2))
 

--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -154,7 +154,7 @@ func smudgeCommand(cmd *cobra.Command, args []string) {
 	if !smudgeSkip && cfg.Os.Bool("GIT_LFS_SKIP_SMUDGE", false) {
 		smudgeSkip = true
 	}
-	filter := filepathfilter.New(cfg.FetchIncludePaths(), cfg.FetchExcludePaths(), filepathfilter.GitAttributes)
+	filter := filepathfilter.New(cfg.FetchIncludePaths(), cfg.FetchExcludePaths(), filepathfilter.GitIgnore)
 	gitfilter := lfs.NewGitFilter(cfg)
 
 	if n, err := smudge(gitfilter, os.Stdout, os.Stdin, smudgeFilename(args), smudgeSkip, filter); err != nil {

--- a/docs/man/git-lfs-clone.1.ronn
+++ b/docs/man/git-lfs-clone.1.ronn
@@ -39,16 +39,19 @@ You can configure Git LFS to only fetch objects to satisfy references in certain
 paths of the repo, and/or to exclude certain paths of the repo, to reduce the
 time you spend downloading things you do not use.
 
-In lfsconfig, set lfs.fetchinclude and lfs.fetchexclude to comma-separated lists
-of paths to include/exclude in the fetch (wildcard matching as per gitignore).
-Only paths which are matched by fetchinclude and not matched by fetchexclude
-will have objects fetched for them.
+In your Git configuration or in a `.lfsconfig` file, you may set either or
+both of `lfs.fetchinclude` and `lfs.fetchexclude` to comma-separated lists of
+paths.  If `lfs.fetchinclude` is defined, Git LFS objects will only be fetched
+if their path matches one in that list, and if `lfs.fetchexclude` is defined,
+Git LFS objects will only be fetched if their path does not match one
+in that list.  Paths are matched using wildcard matching as per gitignore(5).
 
 Note that using the command-line options `-I` and `-X` override the respective
-configuration settings.
+configuration settings.  Setting either option to an empty string clears the
+value.
 
 ## SEE ALSO
 
-git-clone(1), git-lfs-pull(1).
+git-clone(1), git-lfs-pull(1), gitignore(5).
 
 Part of the git-lfs(1) suite.

--- a/docs/man/git-lfs-config.5.ronn
+++ b/docs/man/git-lfs-config.5.ronn
@@ -226,13 +226,13 @@ be scoped inside the configuration for a remote.
 
   When fetching, only download objects which match any entry on this
   comma-separated list of paths/filenames. Wildcard matching is as per
-  git-ignore(1). See git-lfs-fetch(1) for examples.
+  gitignore(5). See git-lfs-fetch(1) for examples.
 
 * `lfs.fetchexclude`
 
   When fetching, do not download objects which match any item on this
   comma-separated list of paths/filenames. Wildcard matching is as per
-  git-ignore(1). See git-lfs-fetch(1) for examples.
+  gitignore(5). See git-lfs-fetch(1) for examples.
 
 * `lfs.fetchrecentrefsdays`
 
@@ -438,6 +438,6 @@ The set of keys allowed in this file is restricted for security reasons.
 
 ## SEE ALSO
 
-git-config(1), git-lfs-install(1), gitattributes(5)
+git-config(1), git-lfs-install(1), gitattributes(5), gitignore(5).
 
 Part of the git-lfs(1) suite.

--- a/docs/man/git-lfs-fetch.1.ronn
+++ b/docs/man/git-lfs-fetch.1.ronn
@@ -41,10 +41,12 @@ You can configure Git LFS to only fetch objects to satisfy references in certain
 paths of the repo, and/or to exclude certain paths of the repo, to reduce the
 time you spend downloading things you do not use.
 
-In gitconfig, set `lfs.fetchinclude` and `lfs.fetchexclude` to comma-separated
-lists of paths to include/exclude in the fetch. Only paths which are matched by
-`fetchinclude` and not matched by `fetchexclude` will have objects fetched for
-them.
+In your Git configuration or in a `.lfsconfig` file, you may set either or
+both of `lfs.fetchinclude` and `lfs.fetchexclude` to comma-separated lists of
+paths.  If `lfs.fetchinclude` is defined, Git LFS objects will only be fetched
+if their path matches one in that list, and if `lfs.fetchexclude` is defined,
+Git LFS objects will only be fetched if their path does not match one
+in that list.  Paths are matched using wildcard matching as per gitignore(5).
 
 Note that using the command-line options `-I` and `-X` override the respective
 configuration settings.  Setting either option to an empty string clears the
@@ -146,6 +148,6 @@ What changes are considered 'recent' is based on a number of gitconfig options:
 
 ## SEE ALSO
 
-git-lfs-checkout(1), git-lfs-pull(1), git-lfs-prune(1).
+git-lfs-checkout(1), git-lfs-pull(1), git-lfs-prune(1), gitconfig(5).
 
 Part of the git-lfs(1) suite.

--- a/docs/man/git-lfs-filter-process.1.ronn
+++ b/docs/man/git-lfs-filter-process.1.ronn
@@ -14,6 +14,17 @@ accepting and responding to requests to either clean or smudge a file.
 filter-process is always run by Git's filter process, and is configured by the
 repository's Git attributes.
 
+In your Git configuration or in a `.lfsconfig` file, you may set either or
+both of `lfs.fetchinclude` and `lfs.fetchexclude` to comma-separated lists of
+paths.  If `lfs.fetchinclude` is defined, Git LFS pointer files will only be
+replaced with the contents of the corresponding Git LFS object file if their
+path matches one in that list, and if `lfs.fetchexclude` is defined, Git LFS
+pointer files will only be replaced with the contents of the corresponding
+Git LFS object file if their path does not match one in that list.  Paths are
+matched using wildcard matching as per gitignore(5).  Git LFS pointer files
+that are not replaced with the contents of their corresponding object files
+are simply copied to standard output without change.
+
 The filter process uses Git's pkt-line protocol to communicate, and is
 documented in detail in gitattributes(5).
 
@@ -29,6 +40,6 @@ Without any options, filter-process accepts and responds to requests normally.
 
 ## SEE ALSO
 
-git-lfs-clean(1), git-lfs-install(1), git-lfs-smudge(1), gitattributes(5).
+git-lfs-clean(1), git-lfs-install(1), git-lfs-smudge(1), gitattributes(5), gitignore(5).
 
 Part of the git-lfs(1) suite.

--- a/docs/man/git-lfs-fsck.1.ronn
+++ b/docs/man/git-lfs-fsck.1.ronn
@@ -7,7 +7,7 @@ git-lfs-fsck(1) -- Check GIT LFS files for consistency
 
 ## DESCRIPTION
 
-Checks all GIT LFS files in the current HEAD for consistency.
+Checks all Git LFS files in the current HEAD for consistency.
 
 Corrupted files are moved to ".git/lfs/bad".
 
@@ -17,6 +17,12 @@ form), in which case that range is inspected; or omitted entirely, in which case
 HEAD (and, for --objects, the index) is examined.
 
 The default is to perform all checks.
+
+In your Git configuration or in a `.lfsconfig` file, you may set
+`lfs.fetchexclude` to a comma-separated list of paths.  If `lfs.fetchexclude`
+is defined, then any Git LFS files whose paths match one in that list will
+not be checked for consistency.  Paths are matched using wildcard matching as
+per gitignore(5).
 
 ## OPTIONS
 
@@ -29,6 +35,6 @@ The default is to perform all checks.
 
 ## SEE ALSO
 
-git-lfs-ls-files(1), git-lfs-status(1).
+git-lfs-ls-files(1), git-lfs-status(1), gitignore(5).
 
 Part of the git-lfs(1) suite.

--- a/docs/man/git-lfs-prune.1.ronn
+++ b/docs/man/git-lfs-prune.1.ronn
@@ -26,8 +26,14 @@ The reflog is not considered, only commits. Therefore LFS objects that are
 only referenced by orphaned commits are always deleted.
 
 Note: you should not run `git lfs prune` if you have different repositories
-sharing the same custom storage directory; see git-lfs-config(1) for more
+sharing the same custom storage directory; see git-lfs-config(5) for more
 details about `lfs.storage` option.
+
+In your Git configuration or in a `.lfsconfig` file, you may set
+`lfs.fetchexclude` to a comma-separated list of paths.  If `lfs.fetchexclude`
+is defined, then any Git LFS files whose paths match one in that list will
+be pruned unless they are referenced by a stash or an unpushed commit.
+Paths are matched using wildcard matching as per gitignore(5).
 
 ## OPTIONS
 
@@ -129,6 +135,6 @@ to a different remote name to check that one instead of 'origin'.
 
 ## SEE ALSO
 
-git-lfs-fetch(1)
+git-lfs-fetch(1), gitignore(5).
 
 Part of the git-lfs(1) suite.

--- a/docs/man/git-lfs-pull.1.ronn
+++ b/docs/man/git-lfs-pull.1.ronn
@@ -29,10 +29,12 @@ You can configure Git LFS to only fetch objects to satisfy references in certain
 paths of the repo, and/or to exclude certain paths of the repo, to reduce the
 time you spend downloading things you do not use.
 
-In gitconfig, set lfs.fetchinclude and lfs.fetchexclude to comma-separated lists
-of paths to include/exclude in the fetch (wildcard matching as per gitignore).
-Only paths which are matched by fetchinclude and not matched by fetchexclude
-will have objects fetched for them.
+In your Git configuration or in a `.lfsconfig` file, you may set either or
+both of `lfs.fetchinclude` and `lfs.fetchexclude` to comma-separated lists of
+paths.  If `lfs.fetchinclude` is defined, Git LFS objects will only be fetched
+if their path matches one in that list, and if `lfs.fetchexclude` is defined,
+Git LFS objects will only be fetched if their path does not match one
+in that list.  Paths are matched using wildcard matching as per gitignore(5).
 
 Note that using the command-line options `-I` and `-X` override the respective
 configuration settings.  Setting either option to an empty string clears the
@@ -46,6 +48,6 @@ first, or origin otherwise.
 
 ## SEE ALSO
 
-git-lfs-fetch(1), git-lfs-checkout(1).
+git-lfs-fetch(1), git-lfs-checkout(1), gitignore(5).
 
 Part of the git-lfs(1) suite.

--- a/docs/man/git-lfs-smudge.1.ronn
+++ b/docs/man/git-lfs-smudge.1.ronn
@@ -16,6 +16,17 @@ argument, if provided, is only used for a progress bar.
 Smudge is typically run by Git's smudge filter, configured by the repository's
 Git attributes.
 
+In your Git configuration or in a `.lfsconfig` file, you may set either or
+both of `lfs.fetchinclude` and `lfs.fetchexclude` to comma-separated lists of
+paths.  If `lfs.fetchinclude` is defined, Git LFS pointer files will only be
+replaced with the contents of the corresponding Git LFS object file if their
+path matches one in that list, and if `lfs.fetchexclude` is defined, Git LFS
+pointer files will only be replaced with the contents of the corresponding
+Git LFS object file if their path does not match one in that list.  Paths are
+matched using wildcard matching as per gitignore(5).  Git LFS pointer files
+that are not replaced with the contents of their corresponding object files
+are simply copied to standard output without change.
+
 ## OPTIONS
 
 Without any options, `git lfs smudge` outputs the raw Git LFS content to
@@ -35,6 +46,6 @@ unaffected.
 
 ## SEE ALSO
 
-git-lfs-install(1), gitattributes(5).
+git-lfs-install(1), gitattributes(5), gitignore(5).
 
 Part of the git-lfs(1) suite.

--- a/t/t-prune-worktree.sh
+++ b/t/t-prune-worktree.sh
@@ -82,7 +82,7 @@ begin_test "prune worktree"
   git config lfs.fetchrecentcommitsdays 0
 
   # We need to prevent MSYS from rewriting /foo into a Windows path.
-  MSYS_NO_PATHCONV=1 git config "lfs.fetchexclude" "/foo/**"
+  MSYS_NO_PATHCONV=1 git config "lfs.fetchexclude" "/foo"
 
   # before worktree, everything except current checkout would be pruned
   git lfs prune --dry-run 2>&1 | tee prune.log

--- a/t/t-prune.sh
+++ b/t/t-prune.sh
@@ -144,7 +144,7 @@ begin_test "prune all excluded paths"
   git config lfs.pruneoffsetdays 2
 
   # We need to prevent MSYS from rewriting /foo into a Windows path.
-  MSYS_NO_PATHCONV=1 git config "lfs.fetchexclude" "/foo/**"
+  MSYS_NO_PATHCONV=1 git config "lfs.fetchexclude" "/foo"
 
   git lfs prune --dry-run --verbose 2>&1 | tee prune.log
 
@@ -264,7 +264,7 @@ begin_test "prune keep unpushed"
   git config lfs.pruneoffsetdays 2
 
   # We need to prevent MSYS from rewriting /foo into a Windows path.
-  MSYS_NO_PATHCONV=1 git config "lfs.fetchexclude" "/foo/**"
+  MSYS_NO_PATHCONV=1 git config "lfs.fetchexclude" "/foo"
 
   # force color codes in git diff meta-information
   git config color.diff always
@@ -800,7 +800,7 @@ begin_test "prune keep stashed changes"
   assert_local_object "$oid_stashedandexcludedbranch" "${#content_stashedandexcludedbranch}"
 
   # We need to prevent MSYS from rewriting /foo into a Windows path.
-  MSYS_NO_PATHCONV=1 git config "lfs.fetchexclude" "/foo/**"
+  MSYS_NO_PATHCONV=1 git config "lfs.fetchexclude" "/foo"
 
   # force color codes in git diff meta-information
   git config color.diff always
@@ -924,7 +924,7 @@ begin_test "prune keep stashed changes in index"
   assert_local_object "$oid_stashedandexcludedbranch" "${#content_stashedandexcludedbranch}"
 
   # We need to prevent MSYS from rewriting /foo into a Windows path.
-  MSYS_NO_PATHCONV=1 git config "lfs.fetchexclude" "/foo/**"
+  MSYS_NO_PATHCONV=1 git config "lfs.fetchexclude" "/foo"
 
   # force color codes in git diff meta-information
   git config color.diff always
@@ -1077,7 +1077,7 @@ begin_test "prune keep stashed untracked files"
   assert_local_object "$oid_untrackedstashedandexcludedbranch" "${#content_untrackedstashedandexcludedbranch}"
 
   # We need to prevent MSYS from rewriting /foo into a Windows path.
-  MSYS_NO_PATHCONV=1 git config "lfs.fetchexclude" "/foo/**"
+  MSYS_NO_PATHCONV=1 git config "lfs.fetchexclude" "/foo"
 
   # force color codes in git diff meta-information
   git config color.diff always


### PR DESCRIPTION
The `lfs.fetchinclude` and `lfs.fetchexclude` Git configuration options, if set, are used to control the action of a number of Git LFS commands.  Since PR #4556, the `git lfs clone`, `git lfs fetch`, and `git lfs pull` commands have strictly applied `gitignore(5)`-style matching rules to these configuration options.

However, other commands including `git lfs filter-process` and `git lfs smudge` now apply `gitattributes(5)`-style matching rules to these same configuration options, leading to confusion.

We therefore revise all remaining uses of these configuration options to also use `gitignore`-style matching rules.

We also add new tests for the `git lfs filter-process` and `git lfs fsck` commands and adjust or expand existing tests for the `git lfs prune` and `git lfs smudge` commands in order to confirm that `gitignore`-style matching is used for all of them.  These new and updated tests fail if `gitattributes`-style matching is used instead.

As well, we update the existing manual page documentation on how these `lfs.fetch*` filter configuration options function, and add additional notes on their operation with regard to several other commands, and we fix a few related formatting issues and missing references.
    
(Note that the `git lfs migrate` command does not require any changes because it does not read the `lfs.fetch*` configuration options.  Instead, it [supplies](https://github.com/git-lfs/git-lfs/blob/0df26c176a2f345d547b77f46ec2e18f40da6cf7/commands/command_migrate.go#L312) a `false` value for the `useFetchOptions` flag to the `determineIncludeExcludePaths()` function, so any `lfs.fetch*` configuration values are ignored.  This is significant because `git lfs migrate` deliberately uses `gitattributes`-style matching for any path patterns supplied via its `-I`/`-X` command-line arguments, unlike all other commands that accept `-I`/`-X` arguments as overrides for the `lfs.fetch*` configuration options.  See #4758 and #4751 for more details.)

Fixes #4945.
/cc @nuxi as reporter.