### PR TITLE
release: v3.1.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
     - run: script/cibuild
   build-windows:
     name: Build on Windows
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build-windows:
     name: Build Windows Assets
-    runs-on: windows-latest
+    runs-on: windows-2019
     strategy:
       matrix:
         go: ['1.17.x']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Git LFS Changelog
 
+## 3.1.4 (19 Apr 2022)
+
+This release is a bugfix release to fix some problems during the build of
+v3.1.3.  There are otherwise no substantial changes from v3.1.3.
+
+### Misc
+
+* Use only Windows Server 2019 runners for CI in GitHub Actions #4883 (@chrisd8088)
+* remove unused `Pipe[Media]Command()` functions #4942 (@chrisd8088)
+
 ## 3.1.3 (19 Apr 2022)
 
 This release introduces a security fix for Windows systems, which has been

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -281,18 +281,6 @@ func Cleanup() {
 	}
 }
 
-func PipeMediaCommand(name string, args ...string) error {
-	return PipeCommand("bin/"+name, args...)
-}
-
-func PipeCommand(name string, args ...string) error {
-	cmd := subprocess.ExecCommand(name, args...)
-	cmd.Stdin = os.Stdin
-	cmd.Stderr = os.Stderr
-	cmd.Stdout = os.Stdout
-	return cmd.Run()
-}
-
 func requireStdin(msg string) {
 	var out string
 

--- a/config/version.go
+++ b/config/version.go
@@ -13,7 +13,7 @@ var (
 )
 
 const (
-	Version = "3.1.3"
+	Version = "3.1.4"
 )
 
 func init() {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+git-lfs (3.1.4) stable; urgency=low
+
+  * New upstream version
+
+ -- brian m. carlson <bk2204@github.com>  Tue, 19 Apr 2022 14:29:00 -0000
+
 git-lfs (3.1.3) stable; urgency=low
 
   * New upstream version

--- a/rpm/SPECS/git-lfs.spec
+++ b/rpm/SPECS/git-lfs.spec
@@ -1,5 +1,5 @@
 Name:           git-lfs
-Version:        3.1.3
+Version:        3.1.4
 Release:        1%{?dist}
 Summary:        Git extension for versioning large files
 

--- a/t/Makefile
+++ b/t/Makefile
@@ -13,6 +13,7 @@ TEST_CMDS += ../bin/git-credential-lfstest$X
 TEST_CMDS += ../bin/lfs-askpass$X
 TEST_CMDS += ../bin/lfs-ssh-echo$X
 TEST_CMDS += ../bin/lfs-ssh-proxy-test$X
+TEST_CMDS += ../bin/lfstest-badpathcheck$X
 TEST_CMDS += ../bin/lfstest-count-tests$X
 TEST_CMDS += ../bin/lfstest-customadapter$X
 TEST_CMDS += ../bin/lfstest-gitserver$X

--- a/t/cmd/lfstest-badpathcheck.go
+++ b/t/cmd/lfstest-badpathcheck.go
@@ -1,0 +1,19 @@
+//go:build testtools
+// +build testtools
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Println("exploit")
+	fmt.Fprintln(os.Stderr, "exploit")
+
+	f, err := os.Create("exploit")
+	if err != nil {
+		f.Close()
+	}
+}

--- a/t/t-path.sh
+++ b/t/t-path.sh
@@ -9,16 +9,18 @@ begin_test "does not look in current directory for git"
   reponame="$(basename "$0" ".sh")"
   git init "$reponame"
   cd "$reponame"
-  export PATH="$(echo "$PATH" | sed -e "s/:.:/:/g" -e "s/::/:/g")"
 
-  printf "#!/bin/sh\necho exploit >&2\n" > git
-  chmod +x git || true
-  printf "echo exploit 1>&2\n" > git.bat
+  cp "$BINPATH/lfstest-badpathcheck$X" "git$X"
 
-  # This needs to succeed.  If it fails, that could be because our malicious
-  # "git" is broken but got invoked anyway.
-  git lfs env > output.log 2>&1
-  ! grep -q 'exploit' output.log
+  # This should always succeed, even if git-lfs is incorrectly searching for
+  # executables in the current directory first, because the "git-lfs env"
+  # command ignores all errors when it runs "git config".  So we should always
+  # pass this step and then, if our malicious Git was executed, detect
+  # its output below.  If this command does fail, something else is wrong.
+  PATH="$BINPATH" PATHEXT="$X" "git-lfs$X" env >output.log 2>&1
+
+  grep "exploit" output.log && false
+  [ ! -f exploit ]
 )
 end_test
 
@@ -30,32 +32,122 @@ begin_test "does not look in current directory for git with credential helper"
   setup_remote_repo "$reponame"
 
   clone_repo "$reponame" credentials-1
-  export PATH="$(echo "$PATH" | sed -e "s/:.:/:/g" -e "s/::/:/g")"
-
-  printf "#!/bin/sh\necho exploit >&2\ntouch exploit\n" > git
-  chmod +x git || true
-  printf "echo exploit 1>&2\r\necho >exploit" > git.bat
 
   git lfs track "*.dat"
   printf abc > z.dat
   git add z.dat
   git add .gitattributes
-  git add git git.bat
-  git commit -m "Add files"
 
+  GITPATH="$(dirname "$(command -v git)")"
+
+  # We add our malicious Git to the index and then remove it from the
+  # work tree so it is not found early, before we perform our key test.
+  # Specifically, our "git push" below will run git-lfs, which then runs
+  # "git credential", so if we are looking for Git in the current directory
+  # first when running a credential helper, we will fail at that point
+  # because our malicious Git will be found first.
+  #
+  # We prefer to check for this behavior during our "git-lfs pull" further
+  # below when we are populating LFS objects into a clone of this repo
+  # (which contains the malicious Git), so for now we remove the malicious
+  # Git as soon as possible.
+  cp "$BINPATH/lfstest-badpathcheck$X" "git$X"
+  PATH="$BINPATH:$GITPATH" "$GITPATH/git$X" add "git$X"
+  rm "git$X"
+
+  git commit -m "Add files"
   git push origin HEAD
   cd ..
 
   unset GIT_ASKPASS SSH_ASKPASS
 
-  # This needs to succeed.  If it fails, that could be because our malicious
-  # "git" is broken but got invoked anyway.
-  GIT_LFS_SKIP_SMUDGE=1 clone_repo "$reponame" credentials-2
+  # When we call "git clone" below, it will run git-lfs as a smudge filter
+  # during the post-clone checkout phase, and specifically will run git-lfs
+  # in the newly cloned repository directory which contains a copy of our
+  # malicious Git.  So, if we are looking for Git in the current directory
+  # first in most cases (and not just when running a credential helper),
+  # then when git-lfs runs "git config" we will fail at that point because
+  # our malicious Git will be found first.  This occurs even if we specify
+  # GIT_LFS_SKIP_SMUDGE=1 because git-lfs will still run "git config".
+  #
+  # We could ignore errors from clone_repo() and then search for the output
+  # of our malicious Git in the t-path-credentials-2 directory; however,
+  # this may be somewhat fragile as clone_repo() performs other steps such
+  # as changing the current working directory to the new repo clone and
+  # attempting to run "git config" there.
+  #
+  # Instead, since our key check of "git-lfs pull" below will also detect
+  # the general failure case where we are looking for Git in the current
+  # directory first when running most commands, we temporarily uninstall
+  # Git LFS so no smudge filter will execute when "git clone" checks out the
+  # repository.
+  #
+  # We also remove any "exploit" file potentially created by our malicious
+  # Git in case it was run anywhere in clone_repo(), which may happen if
+  # PATH contains the "." directory already.  Note that we reset PATH
+  # to contain only the necessary directories in our key "git-lfs pull"
+  # check below.
+  git lfs uninstall
+  clone_repo "$reponame" t-path-credentials-2
+  rm -f exploit
+  pushd ..
+    git lfs install
+  popd
 
-  git lfs pull | tee output.log
+  # As noted, if we are looking for Git in the current directory first
+  # only when running a credential helper, then when this runs
+  # "git credential", it will find our malicious Git in the current directory
+  # and execute it.
+  #
+  # If we are looking for Git in the current directory first when running
+  # most commands (and not just when running a credential helper), then this
+  # will also find our malicious Git.  However, in this case it will find it
+  # earlier when we try to run "git config" rather than later when we try
+  # to run "git credential".
+  #
+  # We use a pipeline with "tee" here so as to avoid an early failure in the
+  # case that our "git-lfs pull" command executes our malicious Git.
+  # Unlike "git-lfs env" in the other tests, "git-lfs pull" will halt when
+  # it does not receive the normal output from Git.  This in turn halts
+  # our test due to our use of the "set -e" option, unless we terminate a
+  # pipeline with successful command like "tee".
+  PATH="$BINPATH:$GITPATH" PATHEXT="$X" "git-lfs$X" pull 2>&1 | tee output.log
 
-  ! grep -q 'exploit' output.log
-  [ ! -f ../exploit ]
+  grep "exploit" output.log && false
+  [ ! -f exploit ]
+)
+end_test
+
+begin_test "does not look in current directory for wrong binary using PATHEXT"
+(
+  set -e
+
+  # Windows is the only platform where Go searches for executable files
+  # by appending file extensions from PATHEXT.
+  [ "$IS_WINDOWS" -eq 0 ] && exit 0
+
+  reponame="$(basename "$0" ".sh")-notfound"
+  git init "$reponame"
+  cd "$reponame"
+
+  # Go on Windows always looks in the current directory first when creating
+  # a command handler, so we need a dummy git.exe for it to find there since
+  # we will restrict PATH to exclude the real Git when we run "git-lfs env"
+  # below.  If our git-lfs incorrectly proceeds to run the command handler
+  # despite not finding Git in PATH either, Go may then search for a file
+  # named "." with any path extension from PATHEXT and execute that file
+  # instead, so we create a malicious file named "..exe" to check this case.
+  touch "git$X"
+  cp "$BINPATH/lfstest-badpathcheck$X" ".$X"
+
+  # This should always succeed, even if git-lfs is incorrectly searching for
+  # executables in the current directory first, because the "git-lfs env"
+  # command ignores all errors when it runs "git config".  So we should always
+  # pass this step and then, if our malicious program was executed, detect
+  # its output below.  If this command does fail, something else is wrong.
+  PATH="$BINPATH" PATHEXT="$X" "git-lfs$X" env >output.log 2>&1
+
+  grep "exploit" output.log && false
   [ ! -f exploit ]
 )
 end_test

--- a/t/testenv.sh
+++ b/t/testenv.sh
@@ -6,12 +6,14 @@ set -e
 UNAME=$(uname -s)
 IS_WINDOWS=0
 IS_MAC=0
+X=""
 SHASUM="shasum -a 256"
 PATH_SEPARATOR="/"
 
 if [[ $UNAME == MINGW* || $UNAME == MSYS* || $UNAME == CYGWIN* ]]
 then
   IS_WINDOWS=1
+  X=".exe"
 
   # Windows might be MSYS2 which does not have the shasum Perl wrapper
   # script by default, so use sha256sum directly. MacOS on the other hand

--- a/versioninfo.json
+++ b/versioninfo.json
@@ -4,7 +4,7 @@
 		"FileVersion": {
 			"Major": 3,
 			"Minor": 1,
-			"Patch": 3,
+			"Patch": 4,
 			"Build": 0
 		}
 	},
@@ -13,7 +13,7 @@
 		"FileDescription": "Git LFS",
 		"LegalCopyright": "GitHub, Inc. and Git LFS contributors",
 		"ProductName": "Git Large File Storage (LFS)",
-		"ProductVersion": "3.1.3"
+		"ProductVersion": "3.1.4"
 	},
 	"IconPath": "script/windows-installer/git-lfs-logo.ico"
 }


### PR DESCRIPTION
This is an in-progress look at the next release of Git LFS, v3.1.2, which is scheduled for today, Tuesday, April 19, 2022.

The CI system will produce artifacts for Windows, Linux, and macOS if you'd like to use those for testing.

/cc https://github.com/orgs/git-lfs/teams/core
/cc https://github.com/orgs/git-lfs/teams/implementers
/cc https://github.com/orgs/git-lfs/teams/releases