### PR TITLE
Build test helper commands with `.exe` file extension on Windows

### DIFF
--- a/t/Makefile
+++ b/t/Makefile
@@ -4,7 +4,12 @@ PROVE_EXTRA_ARGS =
 DEFAULT_TEST_TARGET ?= test
 
 GO ?= go
-X =
+
+ifeq ($(OS),Windows_NT)
+X ?= .exe
+else
+X ?=
+endif
 
 TEST_CMDS =
 
@@ -30,7 +35,9 @@ TEST_API_SRCS = $(wildcard git-lfs-test-server-api/*.go)
 
 all : $(DEFAULT_TEST_TARGET)
 
-test : $(TEST_CMDS)
+test-commands : $(TEST_CMDS)
+
+test : test-commands
 	$(RM) -r remote test_count{,.lock}
 	@GIT_LFS_NO_TEST_COUNT= bash -c '. ./testenv.sh && setup'
 	$(PROVE) $(PROVE_EXTRA_ARGS) ./t-*.sh


### PR DESCRIPTION
On Windows, it is convenient to have the `.exe` file extension added to our compiled test helpers when running tests manually, so we use the `X` variable to do so in the same manner as in the primary `Makefile`.

Also, we add a `test-commands` target in `t/Makefile` which is convenient when rebuilding just the test helpers.