### PR TITLE
[DRAFT] Include shell path in restricted `PATH` in credential help path test

### DIFF
--- a/t/t-path.sh
+++ b/t/t-path.sh
@@ -39,6 +39,7 @@ begin_test "does not look in current directory for git with credential helper"
   git add .gitattributes
 
   GITPATH="$(dirname "$(command -v git)")"
+  SHELLPATH="$(dirname "$(command -v sh)")"
 
   # We add our malicious Git to the index and then remove it from the
   # work tree so it is not found early, before we perform our key test.
@@ -52,7 +53,7 @@ begin_test "does not look in current directory for git with credential helper"
   # (which contains the malicious Git), so for now we remove the malicious
   # Git as soon as possible.
   cp "$BINPATH/lfstest-badpathcheck$X" "git$X"
-  PATH="$BINPATH:$GITPATH" "$GITPATH/git$X" add "git$X"
+  PATH="$BINPATH:$GITPATH:$SHELLPATH" "$GITPATH/git$X" add "git$X"
   rm "git$X"
 
   git commit -m "Add files"


### PR DESCRIPTION
In commit 11092ef2b17eaa67f3363edc68b59331b979f7ee as part of our response to CVE-2022-24826 we revised the `"does not look in current directory for git with credential helper"` test (which was first added in commit 10c4ffc6b888eee8f2134a7009a0db1bc393e17b to check for the issue in CVE-2021-21237) to use a new helper program which simulates a malicious Git executable.

In order to avoid invoking this executable while setting up our test conditions we generally remove it from the working directory as soon as possible, but we have to at least leave it there while running `git add git.exe` in order to add it to the current Git index.  Therefore we now explicitly set the `PATH` environment variable before running this command to include a minimal set of necessary directories, specifically the ones for the real Git executable and our test Git LFS executable.

However, since in some cases our CI tests fail because `git add` wants to run a shell script and the `sh.exe` binary is not available in our restricted `PATH`, we add that binary's location to the `PATH` we use when running `git add git.exe` in this test.