### PR TITLE
Update tests to check `prune` command excludes `lfs.fetchexclude` paths

### DIFF
--- a/t/t-prune-worktree.sh
+++ b/t/t-prune-worktree.sh
@@ -18,15 +18,19 @@ begin_test "prune worktree"
 
   content_head="First checkout HEAD"
   content_worktree1head="Worktree 1 head"
+  content_worktree1excluded="Worktree 1 excluded by filter"
   content_worktree2head="Worktree 2 head"
+  content_worktree2excluded="Worktree 2 excluded by filter"
   content_oldcommit1="Always pruned 1"
   content_oldcommit2="Always pruned 2"
   content_oldcommit3="Always pruned 3"
 
   oid_head=$(calc_oid "$content_head")
   oid_worktree1head=$(calc_oid "$content_worktree1head")
+  oid_worktree1excluded=$(calc_oid "$content_worktree1excluded")
   oid_worktree2head=$(calc_oid "$content_worktree2head")
-  oid_oldcommit1=$(calc_oid "$content_oldcommit1")
+  oid_worktree2excluded=$(calc_oid "$content_worktree2excluded")
+  oid_oldcommit1=$(calc_oid "$content_oldcommit1"])
   oid_oldcommit2=$(calc_oid "$content_oldcommit2")
   oid_oldcommit3=$(calc_oid "$content_oldcommit3")
 
@@ -45,7 +49,8 @@ begin_test "prune worktree"
   {
     \"CommitDate\":\"$(get_date -20d)\",
     \"Files\":[
-      {\"Filename\":\"file.dat\",\"Size\":${#content_worktree1head}, \"Data\":\"$content_worktree1head\"}]
+      {\"Filename\":\"file.dat\",\"Size\":${#content_worktree1head}, \"Data\":\"$content_worktree1head\"},
+      {\"Filename\":\"foo/file.dat\",\"Size\":${#content_worktree1excluded}, \"Data\":\"$content_worktree1excluded\"}]
   },
   {
     \"CommitDate\":\"$(get_date -30d)\",
@@ -57,7 +62,8 @@ begin_test "prune worktree"
   {
     \"CommitDate\":\"$(get_date -15d)\",
     \"Files\":[
-      {\"Filename\":\"file.dat\",\"Size\":${#content_worktree2head}, \"Data\":\"$content_worktree2head\"}]
+      {\"Filename\":\"file.dat\",\"Size\":${#content_worktree2head}, \"Data\":\"$content_worktree2head\"},
+      {\"Filename\":\"foo/file.dat\",\"Size\":${#content_worktree2excluded}, \"Data\":\"$content_worktree2excluded\"}]
   },
   {
     \"CommitDate\":\"$(get_date -30d)\",
@@ -75,31 +81,34 @@ begin_test "prune worktree"
   git config lfs.fetchrecentremoterefs true
   git config lfs.fetchrecentcommitsdays 0
 
+  # We need to prevent MSYS from rewriting /foo into a Windows path.
+  MSYS_NO_PATHCONV=1 git config "lfs.fetchexclude" "/foo/**"
+
   # before worktree, everything except current checkout would be pruned
   git lfs prune --dry-run 2>&1 | tee prune.log
-  grep "prune: 6 local objects, 1 retained, done." prune.log
-  grep "prune: 5 files would be pruned" prune.log
+  grep "prune: 8 local objects, 1 retained, done." prune.log
+  grep "prune: 7 files would be pruned" prune.log
 
   # now add worktrees on the other branches
   git worktree add "../w1_$reponame" "branch1"
   git worktree add "../w2_$reponame" "branch2"
-  # now should retain all 3 heads
+  # now should retain all 3 heads except for paths excluded by filter
   git lfs prune --dry-run 2>&1 | tee prune.log
-  grep "prune: 6 local objects, 3 retained, done." prune.log
-  grep "prune: 3 files would be pruned" prune.log
+  grep "prune: 8 local objects, 3 retained, done." prune.log
+  grep "prune: 5 files would be pruned" prune.log
 
   # also check that the same result is obtained when inside worktree rather than main
   cd "../w1_$reponame"
   git lfs prune --dry-run 2>&1 | tee prune.log
-  grep "prune: 6 local objects, 3 retained, done." prune.log
-  grep "prune: 3 files would be pruned" prune.log
+  grep "prune: 8 local objects, 3 retained, done." prune.log
+  grep "prune: 5 files would be pruned" prune.log
 
   # now remove a worktree & prove that frees up 1 head while keeping the other
   cd "../$reponame"
   rm -rf "../w1_$reponame"
   git worktree prune # required to get git to tidy worktree metadata
   git lfs prune --dry-run 2>&1 | tee prune.log
-  grep "prune: 6 local objects, 2 retained, done." prune.log
-  grep "prune: 4 files would be pruned" prune.log
+  grep "prune: 8 local objects, 2 retained, done." prune.log
+  grep "prune: 6 files would be pruned" prune.log
 )
 end_test

--- a/t/t-prune.sh
+++ b/t/t-prune.sh
@@ -672,8 +672,12 @@ begin_test "prune keep stashed changes"
   oid_inrepo=$(calc_oid "$content_inrepo")
   content_stashed="This data will be stashed and should not be deleted"
   oid_stashed=$(calc_oid "$content_stashed")
+  content_stashedandexcluded="This data will be stashed and should not be deleted despite being excluded"
+  oid_stashedandexcluded=$(calc_oid "$content_stashedandexcluded")
   content_stashedbranch="This data will be stashed on a branch and should not be deleted"
   oid_stashedbranch=$(calc_oid "$content_stashedbranch")
+  content_stashedandexcludedbranch="This data will be stashed on a branch and should not be deleted despite being excluded"
+  oid_stashedandexcludedbranch=$(calc_oid "$content_stashedandexcludedbranch")
 
   # We need to test with older commits to ensure they get pruned as expected
   echo "[
@@ -691,13 +695,15 @@ begin_test "prune keep stashed changes"
     \"CommitDate\":\"$(get_date -4d)\",
     \"NewBranch\":\"branch_to_delete\",
     \"Files\":[
-      {\"Filename\":\"unreferenced.dat\",\"Size\":${#content_unreferenced}, \"Data\":\"$content_unreferenced\"}]
+      {\"Filename\":\"unreferenced.dat\",\"Size\":${#content_unreferenced}, \"Data\":\"$content_unreferenced\"},
+      {\"Filename\":\"foo/unreferenced.dat\",\"Size\":${#content_unreferenced}, \"Data\":\"$content_unreferenced\"}]
   },
   {
     \"CommitDate\":\"$(get_date -1d)\",
     \"ParentBranches\":[\"main\"],
     \"Files\":[
-      {\"Filename\":\"stashedfile.dat\",\"Size\":${#content_inrepo}, \"Data\":\"$content_inrepo\"}]
+      {\"Filename\":\"stashedfile.dat\",\"Size\":${#content_inrepo}, \"Data\":\"$content_inrepo\"},
+      {\"Filename\":\"foo/stashedfile.dat\",\"Size\":${#content_inrepo}, \"Data\":\"$content_inrepo\"}]
   }
   ]" | lfstest-testutils addcommits
 
@@ -707,20 +713,27 @@ begin_test "prune keep stashed changes"
   assert_local_object "$oid_unreferenced" "${#content_unreferenced}"
   assert_local_object "$oid_retain1" "${#content_retain1}"
 
-  # now modify the file, and stash it
+  # now modify the files, and stash them
   printf '%s' "$content_stashed" > stashedfile.dat
+  printf '%s' "$content_stashedandexcluded" > foo/stashedfile.dat
   git stash
 
-  # Switch to a branch, modify a file, stash it, and delete the branch
+  # Switch to a branch, modify files, stash them, and delete the branch.
   git checkout branch_to_delete
   printf '%s' "$content_stashedbranch" > unreferenced.dat
+  printf '%s' "$content_stashedandexcludedbranch" > foo/unreferenced.dat
   git stash
   git checkout main
   git branch -D branch_to_delete
 
   # Prove that the stashed data was stored in LFS (should call clean filter)
   assert_local_object "$oid_stashed" "${#content_stashed}"
+  assert_local_object "$oid_stashedandexcluded" "${#content_stashedandexcluded}"
   assert_local_object "$oid_stashedbranch" "${#content_stashedbranch}"
+  assert_local_object "$oid_stashedandexcludedbranch" "${#content_stashedandexcludedbranch}"
+
+  # We need to prevent MSYS from rewriting /foo into a Windows path.
+  MSYS_NO_PATHCONV=1 git config "lfs.fetchexclude" "/foo/**"
 
   # force color codes in git diff meta-information
   git config color.diff always
@@ -732,7 +745,9 @@ begin_test "prune keep stashed changes"
   refute_local_object "$oid_unreferenced" "${#content_unreferenced}"
   assert_local_object "$oid_retain1" "${#content_retain1}"
   assert_local_object "$oid_stashed" "${#content_stashed}"
+  assert_local_object "$oid_stashedandexcluded" "${#content_stashedandexcluded}"
   assert_local_object "$oid_stashedbranch" "${#content_stashedbranch}"
+  assert_local_object "$oid_stashedandexcludedbranch" "${#content_stashedandexcludedbranch}"
 )
 end_test
 
@@ -760,12 +775,20 @@ begin_test "prune keep stashed changes in index"
   oid_inrepo=$(calc_oid "$content_inrepo")
   content_indexstashed="This data will be stashed from the index and should not be deleted"
   oid_indexstashed=$(calc_oid "$content_indexstashed")
+  content_indexstashedandexcluded="This data will be stashed from the index and should not be deleted despite being excluded"
+  oid_indexstashedandexcluded=$(calc_oid "$content_indexstashedandexcluded")
   content_stashed="This data will be stashed and should not be deleted"
   oid_stashed=$(calc_oid "$content_stashed")
+  content_stashedandexcluded="This data will be stashed and should not be deleted despite being excluded"
+  oid_stashedandexcluded=$(calc_oid "$content_stashedandexcluded")
   content_indexstashedbranch="This data will be stashed on a branch from the index and should not be deleted"
   oid_indexstashedbranch=$(calc_oid "$content_indexstashedbranch")
+  content_indexstashedandexcludedbranch="This data will be stashed on a branch from the index and should not be deleted despite being excluded"
+  oid_indexstashedandexcludedbranch=$(calc_oid "$content_indexstashedandexcludedbranch")
   content_stashedbranch="This data will be stashed on a branch and should not be deleted"
   oid_stashedbranch=$(calc_oid "$content_stashedbranch")
+  content_stashedandexcludedbranch="This data will be stashed on a branch and should not be deleted despite being excluded"
+  oid_stashedandexcludedbranch=$(calc_oid "$content_stashedandexcludedbranch")
 
   # We need to test with older commits to ensure they get pruned as expected
   echo "[
@@ -783,13 +806,15 @@ begin_test "prune keep stashed changes in index"
     \"CommitDate\":\"$(get_date -4d)\",
     \"NewBranch\":\"branch_to_delete\",
     \"Files\":[
-      {\"Filename\":\"unreferenced.dat\",\"Size\":${#content_unreferenced}, \"Data\":\"$content_unreferenced\"}]
+      {\"Filename\":\"unreferenced.dat\",\"Size\":${#content_unreferenced}, \"Data\":\"$content_unreferenced\"},
+      {\"Filename\":\"foo/unreferenced.dat\",\"Size\":${#content_unreferenced}, \"Data\":\"$content_unreferenced\"}]
   },
   {
     \"CommitDate\":\"$(get_date -1d)\",
     \"ParentBranches\":[\"main\"],
     \"Files\":[
-      {\"Filename\":\"stashedfile.dat\",\"Size\":${#content_inrepo}, \"Data\":\"$content_inrepo\"}]
+      {\"Filename\":\"stashedfile.dat\",\"Size\":${#content_inrepo}, \"Data\":\"$content_inrepo\"},
+      {\"Filename\":\"foo/stashedfile.dat\",\"Size\":${#content_inrepo}, \"Data\":\"$content_inrepo\"}]
   }
   ]" | lfstest-testutils addcommits
 
@@ -799,29 +824,40 @@ begin_test "prune keep stashed changes in index"
   assert_local_object "$oid_unreferenced" "${#content_unreferenced}"
   assert_local_object "$oid_retain1" "${#content_retain1}"
 
-  # now modify the file, and add it to the index
+  # now modify the files, and add them to the index
   printf '%s' "$content_indexstashed" > stashedfile.dat
-  git add stashedfile.dat
+  printf '%s' "$content_indexstashedandexcluded" > foo/stashedfile.dat
+  git add stashedfile.dat foo/stashedfile.dat
 
-  # now modify the file again, and stash it
+  # now modify the files again, and stash them
   printf '%s' "$content_stashed" > stashedfile.dat
+  printf '%s' "$content_stashedandexcluded" > foo/stashedfile.dat
   git stash
 
-  # Switch to a branch, modify a file in the index and working tree, stash it,
-  # and delete the branch
+  # Switch to a branch, modify files in the index and working tree, stash them,
+  # and delete the branch.
   git checkout branch_to_delete
   printf '%s' "$content_indexstashedbranch" > unreferenced.dat
-  git add unreferenced.dat
+  printf '%s' "$content_indexstashedandexcludedbranch" > foo/unreferenced.dat
+  git add unreferenced.dat foo/unreferenced.dat
   printf '%s' "$content_stashedbranch" > unreferenced.dat
+  printf '%s' "$content_stashedandexcludedbranch" > foo/unreferenced.dat
   git stash
   git checkout main
   git branch -D branch_to_delete
 
   # Prove that the stashed data was stored in LFS (should call clean filter)
   assert_local_object "$oid_indexstashed" "${#content_indexstashed}"
+  assert_local_object "$oid_indexstashedandexcluded" "${#content_indexstashedandexcluded}"
   assert_local_object "$oid_stashed" "${#content_stashed}"
+  assert_local_object "$oid_stashedandexcluded" "${#content_stashedandexcluded}"
   assert_local_object "$oid_indexstashedbranch" "${#content_indexstashedbranch}"
+  assert_local_object "$oid_indexstashedandexcludedbranch" "${#content_indexstashedandexcludedbranch}"
   assert_local_object "$oid_stashedbranch" "${#content_stashedbranch}"
+  assert_local_object "$oid_stashedandexcludedbranch" "${#content_stashedandexcludedbranch}"
+
+  # We need to prevent MSYS from rewriting /foo into a Windows path.
+  MSYS_NO_PATHCONV=1 git config "lfs.fetchexclude" "/foo/**"
 
   # force color codes in git diff meta-information
   git config color.diff always
@@ -833,9 +869,13 @@ begin_test "prune keep stashed changes in index"
   refute_local_object "$oid_unreferenced" "${#content_unreferenced}"
   assert_local_object "$oid_retain1" "${#content_retain1}"
   assert_local_object "$oid_indexstashed" "${#content_indexstashed}"
+  assert_local_object "$oid_indexstashedandexcluded" "${#content_indexstashedandexcluded}"
   assert_local_object "$oid_stashed" "${#content_stashed}"
+  assert_local_object "$oid_stashedandexcluded" "${#content_stashedandexcluded}"
   assert_local_object "$oid_indexstashedbranch" "${#content_indexstashedbranch}"
+  assert_local_object "$oid_indexstashedandexcludedbranch" "${#content_indexstashedandexcludedbranch}"
   assert_local_object "$oid_stashedbranch" "${#content_stashedbranch}"
+  assert_local_object "$oid_stashedandexcludedbranch" "${#content_stashedandexcludedbranch}"
 )
 end_test
 
@@ -868,16 +908,28 @@ begin_test "prune keep stashed untracked files"
   oid_inrepo=$(calc_oid "$content_inrepo")
   content_indexstashed="This data will be stashed from the index and should not be deleted"
   oid_indexstashed=$(calc_oid "$content_indexstashed")
+  content_indexstashedandexcluded="This data will be stashed from the index and should not be deleted despite being excluded"
+  oid_indexstashedandexcluded=$(calc_oid "$content_indexstashedandexcluded")
   content_stashed="This data will be stashed and should not be deleted"
   oid_stashed=$(calc_oid "$content_stashed")
+  content_stashedandexcluded="This data will be stashed and should not be deleted despite being excluded"
+  oid_stashedandexcluded=$(calc_oid "$content_stashedandexcluded")
   content_untrackedstashed="This UNTRACKED FILE data will be stashed and should not be deleted"
   oid_untrackedstashed=$(calc_oid "$content_untrackedstashed")
+  content_untrackedstashedandexcluded="This UNTRACKED FILE data will be stashed and should not be deleted despite being excluded"
+  oid_untrackedstashedandexcluded=$(calc_oid "$content_untrackedstashedandexcluded")
   content_indexstashedbranch="This data will be stashed on a branch from the index and should not be deleted"
   oid_indexstashedbranch=$(calc_oid "$content_indexstashedbranch")
+  content_indexstashedandexcludedbranch="This data will be stashed on a branch from the index and should not be deleted despite being excluded"
+  oid_indexstashedandexcludedbranch=$(calc_oid "$content_indexstashedandexcludedbranch")
   content_stashedbranch="This data will be stashed on a branch and should not be deleted"
   oid_stashedbranch=$(calc_oid "$content_stashedbranch")
+  content_stashedandexcludedbranch="This data will be stashed on a branch and should not be deleted despite being excluded"
+  oid_stashedandexcludedbranch=$(calc_oid "$content_stashedandexcludedbranch")
   content_untrackedstashedbranch="This UNTRACKED FILE data will be stashed on a branch and should not be deleted"
   oid_untrackedstashedbranch=$(calc_oid "$content_untrackedstashedbranch")
+  content_untrackedstashedandexcludedbranch="This UNTRACKED FILE data will be stashed on a branch and should not be deleted despite being excluded"
+  oid_untrackedstashedandexcludedbranch=$(calc_oid "$content_untrackedstashedandexcludedbranch")
 
   # We need to test with older commits to ensure they get pruned as expected
   echo "[
@@ -895,13 +947,15 @@ begin_test "prune keep stashed untracked files"
     \"CommitDate\":\"$(get_date -4d)\",
     \"NewBranch\":\"branch_to_delete\",
     \"Files\":[
-      {\"Filename\":\"unreferenced.dat\",\"Size\":${#content_unreferenced}, \"Data\":\"$content_unreferenced\"}]
+      {\"Filename\":\"unreferenced.dat\",\"Size\":${#content_unreferenced}, \"Data\":\"$content_unreferenced\"},
+      {\"Filename\":\"foo/unreferenced.dat\",\"Size\":${#content_unreferenced}, \"Data\":\"$content_unreferenced\"}]
   },
   {
     \"CommitDate\":\"$(get_date -1d)\",
     \"ParentBranches\":[\"main\"],
     \"Files\":[
-      {\"Filename\":\"stashedfile.dat\",\"Size\":${#content_inrepo}, \"Data\":\"$content_inrepo\"}]
+      {\"Filename\":\"stashedfile.dat\",\"Size\":${#content_inrepo}, \"Data\":\"$content_inrepo\"},
+      {\"Filename\":\"foo/stashedfile.dat\",\"Size\":${#content_inrepo}, \"Data\":\"$content_inrepo\"}]
   }
   ]" | lfstest-testutils addcommits
 
@@ -911,37 +965,52 @@ begin_test "prune keep stashed untracked files"
   assert_local_object "$oid_unreferenced" "${#content_unreferenced}"
   assert_local_object "$oid_retain1" "${#content_retain1}"
 
-  # now modify the file, and add it to the index
+  # now modify the files, and add them to the index
   printf '%s' "$content_indexstashed" > stashedfile.dat
-  git add stashedfile.dat
+  printf '%s' "$content_indexstashedandexcluded" > foo/stashedfile.dat
+  git add stashedfile.dat foo/stashedfile.dat
 
-  # now modify the file again, and stash it
+  # now modify the files again, and stash them
   printf '%s' "$content_stashed" > stashedfile.dat
+  printf '%s' "$content_stashedandexcluded" > foo/stashedfile.dat
 
-  # Also create an untracked file
+  # Also create untracked files
   printf '%s' "$content_untrackedstashed" > untrackedfile.dat
+  printf '%s' "$content_untrackedstashedandexcluded" > foo/untrackedfile.dat
 
   # stash, including untracked
   git stash -u
 
-  # Switch to a branch, modify a file in the index and working tree,
-  # create an untracked file, stash them, and delete the branch
+  # Switch to a branch, modify files in the index and working tree and create
+  # untracked files, stash them, and delete the branch.
   git checkout branch_to_delete
   printf '%s' "$content_indexstashedbranch" > unreferenced.dat
-  git add unreferenced.dat
+  printf '%s' "$content_indexstashedandexcludedbranch" > foo/unreferenced.dat
+  git add unreferenced.dat foo/unreferenced.dat
   printf '%s' "$content_stashedbranch" > unreferenced.dat
+  printf '%s' "$content_stashedandexcludedbranch" > foo/unreferenced.dat
   printf '%s' "$content_untrackedstashedbranch" > untrackedfile.dat
+  printf '%s' "$content_untrackedstashedandexcludedbranch" > foo/untrackedfile.dat
   git stash -u
   git checkout main
   git branch -D branch_to_delete
 
   # Prove that ALL stashed data was stored in LFS (should call clean filter)
   assert_local_object "$oid_indexstashed" "${#content_indexstashed}"
+  assert_local_object "$oid_indexstashedandexcluded" "${#content_indexstashedandexcluded}"
   assert_local_object "$oid_stashed" "${#content_stashed}"
+  assert_local_object "$oid_stashedandexcluded" "${#content_stashedandexcluded}"
   assert_local_object "$oid_untrackedstashed" "${#content_untrackedstashed}"
+  assert_local_object "$oid_untrackedstashedandexcluded" "${#content_untrackedstashedandexcluded}"
   assert_local_object "$oid_indexstashedbranch" "${#content_indexstashedbranch}"
+  assert_local_object "$oid_indexstashedandexcludedbranch" "${#content_indexstashedandexcludedbranch}"
   assert_local_object "$oid_stashedbranch" "${#content_stashedbranch}"
+  assert_local_object "$oid_stashedandexcludedbranch" "${#content_stashedandexcludedbranch}"
   assert_local_object "$oid_untrackedstashedbranch" "${#content_untrackedstashedbranch}"
+  assert_local_object "$oid_untrackedstashedandexcludedbranch" "${#content_untrackedstashedandexcludedbranch}"
+
+  # We need to prevent MSYS from rewriting /foo into a Windows path.
+  MSYS_NO_PATHCONV=1 git config "lfs.fetchexclude" "/foo/**"
 
   # force color codes in git diff meta-information
   git config color.diff always
@@ -953,11 +1022,17 @@ begin_test "prune keep stashed untracked files"
   refute_local_object "$oid_unreferenced" "${#content_unreferenced}"
   assert_local_object "$oid_retain1" "${#content_retain1}"
   assert_local_object "$oid_indexstashed" "${#content_indexstashed}"
+  assert_local_object "$oid_indexstashedandexcluded" "${#content_indexstashedandexcluded}"
   assert_local_object "$oid_stashed" "${#content_stashed}"
+  assert_local_object "$oid_stashedandexcluded" "${#content_stashedandexcluded}"
   assert_local_object "$oid_untrackedstashed" "${#content_untrackedstashed}"
+  assert_local_object "$oid_untrackedstashedandexcluded" "${#content_untrackedstashedandexcluded}"
   assert_local_object "$oid_indexstashedbranch" "${#content_indexstashedbranch}"
+  assert_local_object "$oid_indexstashedandexcludedbranch" "${#content_indexstashedandexcludedbranch}"
   assert_local_object "$oid_stashedbranch" "${#content_stashedbranch}"
+  assert_local_object "$oid_stashedandexcludedbranch" "${#content_stashedandexcludedbranch}"
   assert_local_object "$oid_untrackedstashedbranch" "${#content_untrackedstashedbranch}"
+  assert_local_object "$oid_untrackedstashedandexcludedbranch" "${#content_untrackedstashedandexcludedbranch}"
 )
 end_test
 


### PR DESCRIPTION
Several existing tests ensure that the `git lfs prune` command always retains Git LFS objects referenced by unpushed commits, stashes, and worktrees.

However, none of these tests perform checks of the appropriate behaviour when files matching an `lfs.fetchexclude` filter option are involved.  Support for pruning Git LFS objects referenced by files matching the `lfs.fetchexclude` filter was added in PR #2851.  (Support for retaining objects referenced by stashes was added later, in PR #4209).

We therefore expand these tests to check for the expected behaviour, which varies depending on the specific case.

For Git LFS objects referenced only by files in unpushed commits or any type of stash (normal, index, or untracked), we now confirm that even if the files' names match a pattern in `lfs.fetchexclude`, we still retain the objects locally when `git lfs prune` is run.

For Git LFS objects referenced only by files in a commit at the `HEAD` of a worktree, we now confirm that if the files' names match a pattern in `lfs.fetchexclude`, then the objects are pruned locally when `git lfs prune` is run.  This matches how similar files' objects are pruned even if they are referenced by a regular working tree's `HEAD` commit.

It may be advantageous to review this PR commit-by-commit as each commit's description provides additional context and details.

Note that we explicitly use a `gitattributes(5)`-compatible form of pattern match (i.e., `/foo/**`) for the `lfs.fetchexclude` options in these changes because otherwise we will see failures as per #4945.  When that issue is addressed in a future PR we will revise these tests to use the `/foo` pattern match form in order to demonstrate that `gitignore(5)`-style matching is being performed.

/cc @larsxschneider as author of #2851.