### PR TITLE
Multiple hash support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ the file you want like so:
 $ gpg -d sha256sums.asc | grep git-lfs-linux-amd64-v2.10.0.tar.gz | shasum -a 256 -c
 ```
 
+For the convenience of distributors, we also provide a wider variety of signed
+hashes in the `hashes.asc` file.  Those hashes are in the tagged BSD format, but
+can be verified with Perl's `shasum` or the GNU hash utilities, just like the
+ones in `sha256sums.asc`.
+
 ## Example Usage
 
 To begin using Git LFS within a Git repository that is not already configured

--- a/script/hash-files
+++ b/script/hash-files
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+
+require "openssl"
+
+# This maps the OpenSSL name to the name used in the output file.
+# The order used is the order they should appear in the output file.
+DIGESTS = {
+  'BLAKE2b512' => 'BLAKE2b',
+  'BLAKE2s256' => 'BLAKE2s',
+  'SHA256' => 'SHA256',
+  'SHA384' => 'SHA384',
+  'SHA512' => 'SHA512',
+  'SHA512-256' => 'SHA512/256',
+  'SHA3-256' => 'SHA3-256',
+  'SHA3-384' => 'SHA3-384',
+  'SHA3-512' => 'SHA3-512',
+}
+
+class Hasher
+  def initialize(file)
+    @file = file
+    @hashers = DIGESTS.map do |openssl, output|
+      [output, OpenSSL::Digest.new(openssl)]
+    end.to_h
+  end
+
+  def update(s)
+    @hashers.values.each { |h| h.update(s) }
+  end
+
+  def to_a
+    @hashers.map do |name, ctx|
+      "#{name} (#{@file}) = #{ctx.digest.unpack("H*")[0]}\n"
+    end.to_a
+  end
+end
+
+results = []
+ARGV.each do |file|
+  f = File.open(file)
+  h = Hasher.new(file)
+  while chunk = f.read(65536) do
+    h.update(chunk)
+  end
+  results += h.to_a
+end
+
+# Sort entries first by order of algorithm name in DIGESTS, then by filename,
+# then print them.
+
+# Create a mapping of output name digest to order in the hash.
+names = DIGESTS.values.each_with_index.to_a.to_h
+results.sort_by do |s|
+  # Split into digest name and remainder.  The remainder starts with the
+  # filename.
+  pair = s.split(' ', 2).to_a
+  # Order by the index of the digest and then the filename.
+  [names[pair[0]], pair[1]]
+end.each { |l| puts l }

--- a/script/upload
+++ b/script/upload
@@ -72,6 +72,10 @@ categorize_asset () {
       echo "Unsigned SHA-256 Hashes";;
     sha256sums.asc)
       echo "Signed SHA-256 Hashes";;
+    hashes)
+      echo "Unsigned Hashes";;
+    hashes.asc)
+      echo "Signed Hashes";;
     *)
       printf "%s %s\n" "$(categorize_os "$os")" "$(categorize_arch "$arch")";;
   esac
@@ -88,7 +92,7 @@ content_type () {
       echo "application/gzip";;
     *.exe)
       echo "application/octet-stream";;
-    *.asc|sha256sums*)
+    *.asc|sha256sums*|hashes*)
       echo "text/plain";;
   esac
 }
@@ -166,8 +170,9 @@ release_files () {
       -name '*amd64*.zip' -o \
       -name '*arm64*.zip' -o \
       -name '*.exe' -o \
-      -name 'sha256sums.asc' | \
-    grep -E "$version|sha256sums.asc" | \
+      -name 'sha256sums.asc' -o \
+      -name 'hashes.asc' | \
+    grep -E "$version|sha256sums.asc|hashes.asc" | \
     grep -v "assets" | \
     LC_ALL=C sort
 }
@@ -284,6 +289,16 @@ verify_assets () {
   # shasum will then fail.
   say "Checking assets for integrity..."
   (cd "$dir" && gpg -d sha256sums.asc | shasum -a 256 -c)
+  (cd "$dir" && gpg -d hashes.asc | grep 'SHA[0-9][^-]' | shasum -c)
+  if command -v sha3sum >/dev/null 2>&1
+  then
+    (cd "$dir" && gpg -d hashes.asc | grep 'SHA3-' | sha3sum -c)
+  fi
+  if command -v b2sum >/dev/null 2>&1
+  then
+    # b2sum on Linux does not handle BLAKE2s, only BLAKE2b.
+    (cd "$dir" && gpg -d hashes.asc | grep 'BLAKE2b' | b2sum -c)
+  fi
 
   say "\nAssets look good!"
 }
@@ -326,9 +341,12 @@ finalize () {
 
   say "Signing asset manifest..."
   (
+    root="$(git rev-parse --show-toplevel)" &&
     cd "$downloads" && \
-    shasum -a256 -b * | grep -vE '(assets|sha256sums)' | \
-        gpg --digest-algo SHA256 --clearsign >sha256sums.asc
+    shasum -a256 -b * | grep -vE '(assets|sha256sums|hashes)' | \
+        gpg --digest-algo SHA256 --clearsign >sha256sums.asc &&
+    "$root/script/hash-files" * | grep -vE '(assets|sha256sums|hashes)' | \
+        gpg --digest-algo SHA512 --clearsign >hashes.asc
   )
 
   say "Formatting the final body of the GitHub release now..."
@@ -341,7 +359,7 @@ finalize () {
   local upload_url=$(patch_release "$version" "$bodyfile")
 
   say "Uploading final versions of assets..."
-  cp "$downloads/sha256sums.asc" "$uploads"
+  cp "$downloads/sha256sums.asc" "$downloads/hashes.asc" "$uploads"
   upload_assets "$version" "$upload_url" "$uploads"
 
   # Verification occurs in caller below.
@@ -356,9 +374,12 @@ Usage: $0 VERSION
 Create a draft GitHub release for Git LFS using the tag specified by VERSION and
 the changelog specified in the file CHANGELOG. Before running this script, the
 release assets should be built and ready for upload, including the signed
-sha256sums.asc file.
+sha256sums.asc and hashes.asc files.
 
-This script requires ruby, gpg, curl, shasum, and jq.
+This script requires ruby, gpg, curl, shasum, and jq.  sha3sum and b2sum will be
+used if available, but are optional.
+
+This command must be run from within the repository.
 EOM
   exit $status
 }


### PR DESCRIPTION
Right now, we provide signed SHA-256 hashes for our releases.  This is fine and sufficient, and also cryptographically secure.  However, many distributors use other algorithms, and it would be convenient if we could provide easy access to those hashes as well.  For example, NetBSD uses SHA-512 and BLAKE2s.

Let's add an additional file, hashes.asc, which contains a general set of hashes in the BSD format. The advantage of the BSD format over the traditional GNU format is that it includes the hash algorithm, which allows us to distinguish between hashes of the same length, such as SHA-256, SHA-512/256, and SHA3-256.  It is generated by shasum, sha*sum, sha3sum, and b2sum with the --tag format, and all of these programs accept it for verification with no problems.

Using the BSD format means that we need only provide one additional file with all the additional algorithms.  There is therefore no need to add multiple new files, and if we desire to add additional algorithms in the future, that's easily done without modification.

I don't love the name `hashes` and would prefer something different, but I am, as usual, bad at naming things, so suggestions are welcome.

Fixes #4937