### PR TITLE
Avoid pruning when identical files both match and do not match `lfs.fetchexclude`

### DIFF
--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -73,7 +73,7 @@ func checkoutCommand(cmd *cobra.Command, args []string) {
 
 	chgitscanner.Filter = filepathfilter.New(rootedPaths(args), nil, filepathfilter.GitIgnore)
 
-	if err := chgitscanner.ScanTree(ref.Sha); err != nil {
+	if err := chgitscanner.ScanTree(ref.Sha, nil); err != nil {
 		ExitWithError(err)
 	}
 	chgitscanner.Close()

--- a/commands/command_dedup.go
+++ b/commands/command_dedup.go
@@ -87,7 +87,7 @@ func dedupCommand(cmd *cobra.Command, args []string) {
 	})
 	defer gitScanner.Close()
 
-	if err := gitScanner.ScanTree("HEAD"); err != nil {
+	if err := gitScanner.ScanTree("HEAD", nil); err != nil {
 		ExitWithError(err)
 	}
 

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -135,7 +135,7 @@ func pointersToFetchForRef(ref string, filter *filepathfilter.Filter) ([]*lfs.Wr
 
 	tempgitscanner.Filter = filter
 
-	if err := tempgitscanner.ScanTree(ref); err != nil {
+	if err := tempgitscanner.ScanTree(ref, nil); err != nil {
 		return nil, err
 	}
 

--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -137,7 +137,7 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 		} else if scanRange {
 			err = gitscanner.ScanRefRange(includeRef, ref, nil)
 		} else {
-			err = gitscanner.ScanTree(ref)
+			err = gitscanner.ScanTree(ref, nil)
 		}
 
 		if err != nil {

--- a/commands/command_prune.go
+++ b/commands/command_prune.go
@@ -352,7 +352,7 @@ func pruneTaskGetRetainedAtRef(gitscanner *lfs.GitScanner, ref string, retainCha
 	defer sem.Release(1)
 	defer waitg.Done()
 
-	err := gitscanner.ScanRef(ref, func(p *lfs.WrappedPointer, err error) {
+	err := gitscanner.ScanTree(ref, func(p *lfs.WrappedPointer, err error) {
 		if err != nil {
 			errorChan <- err
 			return

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -87,7 +87,7 @@ func pull(filter *filepathfilter.Filter) {
 	}()
 
 	processQueue := time.Now()
-	if err := gitscanner.ScanTree(ref.Sha); err != nil {
+	if err := gitscanner.ScanTree(ref.Sha, nil); err != nil {
 		singleCheckout.Close()
 		ExitWithError(err)
 	}

--- a/lfs/gitscanner.go
+++ b/lfs/gitscanner.go
@@ -208,8 +208,8 @@ func (s *GitScanner) ScanAll(cb GitScannerFoundPointer) error {
 // ScanTree takes a ref and returns WrappedPointer objects in the tree at that
 // ref. Differs from ScanRefs in that multiple files in the tree with the same
 // content are all reported.
-func (s *GitScanner) ScanTree(ref string) error {
-	callback, err := firstGitScannerCallback(s.FoundPointer)
+func (s *GitScanner) ScanTree(ref string, cb GitScannerFoundPointer) error {
+	callback, err := firstGitScannerCallback(cb, s.FoundPointer)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In PR #2851 the `git lfs prune` command was changed to respect the `lfs.fetchexclude` configuration option such that objects would always be pruned if they were referenced by files whose paths matched one of the patterns in the configuration option (unless they were referenced by an unpushed commit).

However, this filter is applied [using](https://github.com/git-lfs/git-lfs/blob/0df26c176a2f345d547b77f46ec2e18f40da6cf7/commands/command_prune.go#L355) the `GitScanner.ScanRef()` method, which [indirectly](https://github.com/git-lfs/git-lfs/blob/0df26c176a2f345d547b77f46ec2e18f40da6cf7/lfs/gitscanner.go#L177) [utilizes](https://github.com/git-lfs/git-lfs/blob/0df26c176a2f345d547b77f46ec2e18f40da6cf7/lfs/gitscanner_refs.go#L103) the internal `scanRefsToChan()` [function](https://github.com/git-lfs/git-lfs/blob/0df26c176a2f345d547b77f46ec2e18f40da6cf7/lfs/gitscanner_refs.go#L36-L94), and that function only visits unique Git LFS OIDs a [single time](https://github.com/git-lfs/git-lfs/blob/0df26c176a2f345d547b77f46ec2e18f40da6cf7/lfs/gitscanner_refs.go#L39-L40) each, even if they are referenced by multiple tree entries (i.e., if there are multiple files with the same content).

This means that if an LFS object appears in both a file that matches a pattern from `lfs.fetchexclude` and in a file that
does not match, the object may be pruned if the file path seen during the scan is the matching one regardless of whether the non-matching file would otherwise have its object retained.

To resolve this we change the `pruneTaskGetRetainedAtRef()` [function](https://github.com/git-lfs/git-lfs/blob/0df26c176a2f345d547b77f46ec2e18f40da6cf7/commands/command_prune.go#L349-L368) to use the `GitScanner.ScanTree()` [method](https://github.com/git-lfs/git-lfs/blob/0df26c176a2f345d547b77f46ec2e18f40da6cf7/lfs/gitscanner.go#L208-L217) instead of `ScanRef()`, because `ScanTree()` visits all file paths in each commit.  We need to pass our callback to the `ScanTree()` method so that we can save all non-matching files' OIDs into our list of OIDs to be retained; therefore we need to add a callback argument to `ScanTree()` in the same [manner](https://github.com/git-lfs/git-lfs/blob/0df26c176a2f345d547b77f46ec2e18f40da6cf7/lfs/gitscanner.go#L169) as is done for `ScanRef()` and [various](https://github.com/git-lfs/git-lfs/blob/0df26c176a2f345d547b77f46ec2e18f40da6cf7/lfs/gitscanner.go#L183) [other](https://github.com/git-lfs/git-lfs/blob/0df26c176a2f345d547b77f46ec2e18f40da6cf7/lfs/gitscanner.go#L149) `GitScanner` methods.

We also introduce additional checks in our `"prune all excluded paths"` [test](https://github.com/git-lfs/git-lfs/blob/0df26c176a2f345d547b77f46ec2e18f40da6cf7/t/t-prune.sh#L99-L163) to ensure that we always retain objects when they appear in a commit to be retained and at least one of the files referencing that object ID does not match the `lfs.fetchexclude` filter.

/cc @larsxschneider as author of #2851.