### PR TITLE
[DRAFT] Improve SSH URL parsing and reporting

### DIFF
--- a/commands/command_env.go
+++ b/commands/command_env.go
@@ -4,6 +4,7 @@ import (
 	"github.com/git-lfs/git-lfs/v3/config"
 	"github.com/git-lfs/git-lfs/v3/git"
 	"github.com/git-lfs/git-lfs/v3/lfs"
+	"github.com/git-lfs/git-lfs/v3/ssh"
 	"github.com/git-lfs/git-lfs/v3/tr"
 	"github.com/spf13/cobra"
 )
@@ -28,7 +29,7 @@ func envCommand(cmd *cobra.Command, args []string) {
 			access := getAPIClient().Endpoints.AccessFor(endpoint.Url)
 			Print("Endpoint=%s (auth=%s)", endpoint.Url, access.Mode())
 			if len(endpoint.SSHMetadata.UserAndHost) > 0 {
-				Print("  SSH=%s:%s", endpoint.SSHMetadata.UserAndHost, endpoint.SSHMetadata.Path)
+				Print("  SSH=%s", ssh.URLFromMetadata(endpoint.SSHMetadata))
 			}
 		}
 	}
@@ -41,7 +42,8 @@ func envCommand(cmd *cobra.Command, args []string) {
 		remoteAccess := getAPIClient().Endpoints.AccessFor(remoteEndpoint.Url)
 		Print("Endpoint (%s)=%s (auth=%s)", remote, remoteEndpoint.Url, remoteAccess.Mode())
 		if len(remoteEndpoint.SSHMetadata.UserAndHost) > 0 {
-			Print("  SSH=%s:%s", remoteEndpoint.SSHMetadata.UserAndHost, remoteEndpoint.SSHMetadata.Path)
+
+			Print("  SSH=%s", ssh.URLFromMetadata(remoteEndpoint.SSHMetadata))
 		}
 	}
 

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -28,6 +28,27 @@ type SSHMetadata struct {
 	UserAndHost string
 	Port        string
 	Path        string
+	URIFormat   bool
+}
+
+// URLFromMetadata constructs a bare SSH URL or an SSH URI from metadata
+func URLFromMetadata(meta SSHMetadata) string {
+	userHostAndPort := meta.UserAndHost
+	port := meta.Port
+	if port != "" {
+		userHostAndPort = fmt.Sprintf("%s:%s", userHostAndPort, port)
+	}
+
+	var url string
+	if meta.URIFormat {
+		url = fmt.Sprintf("ssh://%s%s", userHostAndPort, meta.Path)
+	} else {
+		if port != "" {
+			userHostAndPort = fmt.Sprintf("[%s]", userHostAndPort)
+		}
+		url = fmt.Sprintf("%s:%s", userHostAndPort, meta.Path)
+	}
+	return url
 }
 
 func FormatArgs(cmd string, args []string, needShell bool) (string, []string) {

--- a/t/t-env.sh
+++ b/t/t-env.sh
@@ -718,11 +718,23 @@ begin_test "env with multiple ssh remotes"
   git init
   git remote add origin git@git-server.com:user/repo.git
   git remote add other git@other-git-server.com:user/repo.git
+  git remote add port [git@git-server.com:1337]:user/repo.git
+  git remote add port-anon [git-server.com:1337]:user/repo.git
+  git remote add port-abspath [git@git-server.com:1337]:/user/repo.git
+  git remote add anon-abspath git-server.com:/user/repo.git
 
   expected='Endpoint=https://git-server.com/user/repo.git/info/lfs (auth=none)
   SSH=git@git-server.com:user/repo.git
 Endpoint (other)=https://other-git-server.com/user/repo.git/info/lfs (auth=none)
   SSH=git@other-git-server.com:user/repo.git
+Endpoint (port)=https://git-server.com/user/repo.git/info/lfs (auth=none)
+  SSH=[git@git-server.com:1337]:user/repo.git
+Endpoint (port-anon)=https://git-server.com/user/repo.git/info/lfs (auth=none)
+  SSH=[git-server.com:1337]:user/repo.git
+Endpoint (port-abspath)=https://git-server.com/user/repo.git/info/lfs (auth=none)
+  SSH=[git@git-server.com:1337]:/user/repo.git
+Endpoint (anon-abspath)=https://git-server.com/user/repo.git/info/lfs (auth=none)
+  SSH=git-server.com:/user/repo.git
 GIT_SSH=lfs-ssh-echo'
 
   contains_same_elements "$expected" "$(git lfs env \


### PR DESCRIPTION
## Work in Progress

#### TODO: improve parsing of bare [...:port] format
#### check on terminology
#### check on relative paths in bare format

Git LFS supports both "bare" SSH URLs, of the form `user@host:path`, and SSH URIs of the form `ssh://user@host/path`, when parsing its configuration fields.  However, we do not at present retain any record of this difference, and so we are not able to reconstruct the original input when reporting SSH endpoints in the `git lfs env` command.

We also do not report a non-default SSH port, if one was configured, in the output from that command, leading to confusion when the input configuration was a URI like `ssh://example.com:1337/path` and we report it as `example.com:/path`, which looks like we have dropped the port entirely.

We therefore add a `URIFormat` member to our `SSHMetadata` structure and set this true only when parsing an SSH URI with a `ssh://` scheme.  We also add a `URLFromMetadata()` helper function in our `ssh` package which the `git lfs env` command can now use to format SSH metadata to match its original input format, including any non-default port number.

As well, we revise one change which was introduced in commit a0190a60205bc6223d1d9028c34585583721c of PR #4446, whereby the `lfshttp.EndpointFromBareSshUrl()` function always strips off the leading path separator.  The code actually only performs this action if the path returned by `EndpointFromSshUrl()` begins with a slash character, but since that function expects an SSH URI and we construct one as its argument, it will always return an absolute path with a leading separator, and so we always strip that off.

Instead, we now detect whether the configured path in the bare SSH URL is an absolute or relative one before we generate a temporary URI to pass to `EndpointFromSshUrl()`.  We can then remove the leading slash always returned by that function if the original input had a relative path and not otherwise.

We also expand an existing test in the `t/t-env.sh` file so as to confirm that our changes work as expected with a variety of bare SSH URLs.

