### PR TITLE
git: don't panic on pkt-line without equals

### DIFF
--- a/git/filter_process_scanner.go
+++ b/git/filter_process_scanner.go
@@ -185,7 +185,9 @@ func (o *FilterProcessScanner) readRequest() (*Request, error) {
 
 	for _, pair := range requestList {
 		v := strings.SplitN(pair, "=", 2)
-		req.Header[v[0]] = v[1]
+		if len(v) > 1 {
+			req.Header[v[0]] = v[1]
+		}
 	}
 
 	return req, nil


### PR DESCRIPTION
In some cases, we can end up with a version of Git that contain a filter-process pkt-line without an equals.  (What exactly these contents are is not known.)  This causes us to panic when we split, since `v[1]` doesn't exist in the array.  Let's fix this by simply ignoring the header if it doesn't contain an equals since we wouldn't care about its value anyway.

Fixes #4974