### PR TITLE
workflows: use ronn-ng

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       if: ${{ startsWith(matrix.os, 'ubuntu-') }}
       env:
           DEBIAN_FRONTEND: noninteractive
-    - run: gem install ronn
+    - run: gem install ronn-ng
     - run: script/cibuild
       env:
           FORCE_LOCALIZE: true
@@ -61,7 +61,7 @@ jobs:
     - run: cinst InnoSetup -y
     - run: cinst strawberryperl -y
     - run: refreshenv
-    - run: gem install ronn
+    - run: gem install ronn-ng
       shell: bash
     - run: make man
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     - run: cinst strawberryperl -y
     - run: cinst zip -y
     - run: cinst jq -y
-    - run: gem install ronn
+    - run: gem install ronn-ng
     - run: refreshenv
     - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" go install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@latest
       shell: bash
@@ -70,7 +70,7 @@ jobs:
         go-version: ${{ matrix.go }}
     - run: brew install gettext
     - run: brew install mitchellh/gon/gon
-    - run: gem install ronn
+    - run: gem install ronn-ng
     - run: make release
       env:
           FORCE_LOCALIZE: true
@@ -113,7 +113,7 @@ jobs:
     - uses: actions/download-artifact@v1
       with:
         name: macos-assets
-    - run: gem install ronn
+    - run: gem install ronn-ng
     - run: CGO_ENABLED=0 make release
     - run: rm -f bin/releases/*windows* bin/releases/*darwin*
     - run: 'find windows-assets -name "*windows*" -type f | xargs -L1 -I{} mv {} bin/releases'


### PR DESCRIPTION
Recently, we changed to use the windows-2019 target because ronn fails to build on newer versions.  Unfortunately, it also fails to build on that version due to updates in GitHub Actions.

Since ronn itself is dead upstream, let's switch to ronn-ng, just like Debian has done.  This provides an identically named binary but is a supported codebase that is more likely to work now and in the future.