### PR TITLE
lfshttp: fix invalid Accept header syntax

### DIFF
--- a/lfshttp/client.go
+++ b/lfshttp/client.go
@@ -27,7 +27,8 @@ import (
 	"golang.org/x/net/http2"
 )
 
-const MediaType = "application/vnd.git-lfs+json; charset=utf-8"
+const MediaType = "application/vnd.git-lfs+json"
+const RequestContentType = MediaType + "; charset=utf-8"
 
 var (
 	UserAgent = "git-lfs"
@@ -148,7 +149,7 @@ hint: without the API server" in custom-transfers.md for details.`), "\n")
 		if merr := MarshalToRequest(req, body); merr != nil {
 			return req, merr
 		}
-		req.Header.Set("Content-Type", MediaType)
+		req.Header.Set("Content-Type", RequestContentType)
 	}
 
 	return req, err

--- a/locking/api_test.go
+++ b/locking/api_test.go
@@ -30,7 +30,7 @@ func TestAPILock(t *testing.T) {
 
 		assert.Equal(t, "POST", r.Method)
 		assert.Equal(t, lfshttp.MediaType, r.Header.Get("Accept"))
-		assert.Equal(t, lfshttp.MediaType, r.Header.Get("Content-Type"))
+		assert.Equal(t, lfshttp.RequestContentType, r.Header.Get("Content-Type"))
 		assert.Equal(t, "53", r.Header.Get("Content-Length"))
 
 		reqLoader, body := gojsonschema.NewReaderLoader(r.Body)
@@ -80,7 +80,7 @@ func TestAPIUnlock(t *testing.T) {
 
 		assert.Equal(t, "POST", r.Method)
 		assert.Equal(t, lfshttp.MediaType, r.Header.Get("Accept"))
-		assert.Equal(t, lfshttp.MediaType, r.Header.Get("Content-Type"))
+		assert.Equal(t, lfshttp.RequestContentType, r.Header.Get("Content-Type"))
 
 		reqLoader, body := gojsonschema.NewReaderLoader(r.Body)
 		unlockReq := &unlockRequest{}
@@ -182,7 +182,7 @@ func TestAPISearchVerifiable(t *testing.T) {
 
 		assert.Equal(t, "POST", r.Method)
 		assert.Equal(t, lfshttp.MediaType, r.Header.Get("Accept"))
-		assert.Equal(t, lfshttp.MediaType, r.Header.Get("Content-Type"))
+		assert.Equal(t, lfshttp.RequestContentType, r.Header.Get("Content-Type"))
 
 		body := lockVerifiableRequest{}
 		if assert.Nil(t, json.NewDecoder(r.Body).Decode(&body)) {


### PR DESCRIPTION
git-lfs uses the same constant value for the `Content-Type` and `Accept` request HTTP headers:

```
POST /objects/batch/
Accept: application/vnd.git-lfs+json; charset=utf-8
Content-Type: application/vnd.git-lfs+json; charset=utf-8
...
```

But `charset` [isn't valid syntax for `Accept`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept). This change splits out the constant to fix this:

```
POST /objects/batch/
Accept: application/vnd.git-lfs+json
Content-Type: application/vnd.git-lfs+json; charset=utf-8
...
```