### PR TITLE
Build CI on Windows 2022

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
     - run: script/cibuild
   build-windows:
     name: Build on Windows
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build-windows:
     name: Build Windows Assets
-    runs-on: windows-2019
+    runs-on: windows-latest
     strategy:
       matrix:
         go: ['1.18.x']


### PR DESCRIPTION
In commit f4ab4e7445c04fe5d663fc79ddb2ebf30a5a870f of PR #4883 we noted that the `gem install ronn` step in our Windows CI workflows currently fails on newer Windows Server 2022 GitHub Actions runners, due to possibly some missing C headers or libraries.

While this could be resolved by upgrading to the `ruby/setup-ruby@v1`  action from the deprecated `actions/setup-ruby@v1` one, that introduced a series of issues with `PATH` lookups as documented in ruby/setup-ruby#293.

We therefore chose to continue using Windows 2019 runners until a resolution or workaround was found.

Fortunately, as of commit 912b607acb162ea324d0ff00fea1a1f47657e1d4 in PR #4992 we are now using the `ronn-ng` Ruby gem instead of the unmaintained `ronn` gem, and the `gem install ronn-ng` workflow step succeeds on Windows 2022 while still using the `actions/setup-ruby@v1` action to install a Ruby build environment.  This allows us to upgrade to the latest Windows runners in GitHub Actions, although we can't yet upgrade to the `ruby/setup-ruby@v1` workflow action.

h/t to @bk2204 for finding ronn-ng!

Resolves #4995.