### PR TITLE
release: v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,140 @@
 # Git LFS Changelog
 
+## 3.2.0 (25 May 2022)
+
+This release is a feature release which includes support for machine-readable
+formats for a couple more commands, plus the ability to automatically merge
+LFS-based text files from the command-line.  It's likely that the merge driver
+will see future improvements, but if you have feedback on the design, please use
+the discussions feature.
+
+Note that our binary release archives no longer unpack into the current
+directory, and now contain a top-level directory just like the source archives
+do.
+
+We would like to extend a special thanks to the following open-source
+contributors:
+
+* @bbodenmiller for fixing the formatting in our manual pages
+* @breyed for fixing a typo in our manual pages
+* @btoll for improving our README
+* @rcoup for fixing our Accept header syntax
+* @vtbassmatt for documenting our deprecation of NTLM
+
+### Features
+
+* ls-files: add a --json option #5007 (@bk2204)
+* Add --json output for git lfs track #5006 (@bk2204)
+* Add a merge driver #4970 (@bk2204)
+* lfs: don't write hooks when they haven't changed #4935 (@bk2204)
+* Tarballs, not tarbombs #4980 (@bk2204)
+
+### Bugs
+
+* Apply several Makefile fixes for Windows #5016 (@bk2204)
+* git: don't panic on pkt-line without equals #4982 (@bk2204)
+* lfshttp: fix invalid Accept header syntax #4996 (@rcoup)
+* Grammar fix #4981 (@breyed)
+* Use `gitignore`-style path matching for additional commands #4951 (@chrisd8088)
+* Avoid pruning when identical files both match and do not match `lfs.fetchexclude` #4973 (@chrisd8088)
+* Apply `lfs.fetchexclude` filter to previous commits when pruning #4968 (@chrisd8088)
+* Update and correct several error message strings #4943 (@chrisd8088)
+* script/upload: correct RHEL 8 package repo #4936 (@bk2204)
+* lfs: add old hook content to the list of old hooks #4878 (@bk2204)
+* .github/workflows: install packagecloud gem #4873 (@bk2204)
+
+### Misc
+
+* Update distros for packagecloud.io #5010 (@bk2204)
+* lfshttp: log the Negotiate error on failure #5000 (@bk2204)
+* Build CI on Windows 2022 #4997 (@chrisd8088)
+* workflows: use ronn-ng #4992 (@bk2204)
+* Multiple hash support #4971 (@bk2204)
+* note deprecation of NTLM #4987 (@vtbassmatt)
+* Update to Go 1.18, drop older Go version support, and update modules and dependencies #4963 (@chrisd8088)
+* Update tests to check `prune` command excludes `lfs.fetchexclude` paths #4964 (@chrisd8088)
+* Add test to check `prune` command retains tagged unpushed objects #4962 (@chrisd8088)
+* Adjust test helpers and tests related to path filtering #4960 (@chrisd8088)
+* Include shell path in restricted `PATH` in credential helper path test #4959 (@chrisd8088)
+* Build test helper commands with `.exe` file extension on Windows #4954 (@chrisd8088)
+* Update Windows signing certificate SHA hash in `Makefile` #4946 (@chrisd8088)
+* remove unused `Pipe[Media]Command()` functions #4942 (@chrisd8088)
+* Makefile: remove legacy trimpath code #4938 (@bk2204)
+* add Inno Setup check of Git install paths and remove old uninstaller checks #4925 (@chrisd8088)
+* note `git lfs push --all` only pushes local refs in man page #4898 (@chrisd8088)
+* Build man pages into per-section subdirectories #4890 (@chrisd8088)
+* Call out destructive command in README #4880 (@btoll)
+* Improve formatting #4863 (@bbodenmiller)
+* docs/howto: remind core team member to check Actions workflows #4868 (@bk2204)
+* .github: fix syntax error in release workflow #4866 (@bk2204)
+
+## 3.1.4 (19 Apr 2022)
+
+This release is a bugfix release to fix some problems during the build of
+v3.1.3.  There are otherwise no substantial changes from v3.1.3.
+
+### Misc
+
+* Use only Windows Server 2019 runners for CI in GitHub Actions #4883 (@chrisd8088)
+* remove unused `Pipe[Media]Command()` functions #4942 (@chrisd8088)
+
+## 3.1.3 (19 Apr 2022)
+
+This release introduces a security fix for Windows systems, which has been
+assigned CVE-2022-24826.
+
+On Windows, if Git LFS operates on a malicious repository with a `..exe` file as
+well as a file named `git.exe`, and `git.exe` is not found in PATH, the `..exe`
+program will be executed, permitting the attacker to execute arbitrary code.
+Similarly, if the malicious repository contains files named `..exe` and
+`cygpath.exe`, and `cygpath.exe` is not found in PATH, the `..exe` program will
+be executed when certain Git LFS commands are run.
+
+This security problem does not affect Unix systems.  This is the same issue as
+CVE-2020-27955 and CVE-2021-21237, but the fix for those issue was incomplete
+and certain options can still cause the problem to occur.
+
+This occurs because on Windows, Go includes (and prefers) the current directory
+when the name of a command run does not contain a directory separator, and it
+continues to search for programs even when the specified program name is empty.
+This has been solved by failing if the path is empty or not found.
+
+We would like to extend a special thanks to the following open-source
+contributors:
+
+* @yuske for reporting this to us responsibly
+
+### Bugs
+
+* Report errors when finding executables and revise PATH search tests (@chrisd8088)
+
+### Misc
+
+* Update Windows signing certificate SHA hash in Makefile (@chrisd8088)
+
+## 3.1.2 (16 Feb 2022)
+
+This is a bugfix release which fixes a bug in `git lfs install` and some issues
+in our CI release processes, including one that prevented arm64 packages for
+Debian 11 from being uploaded.
+
+### Bugs
+
+* lfs: add old hook content to the list of old hooks #4878 (@bk2204)
+
+### Misc
+
+* Revert "Merge pull request #4795 from bk2204/actions-checkout-v2" #4877 (@bk2204)
+* .github/workflows: install packagecloud gem #4873 (@bk2204)
+
+## 3.1.1 (14 Feb 2022)
+
+This is a bugfix release which fixes a syntax error in the release workflow.
+
+### Misc
+
+* .github: fix syntax error in release workflow #4866 (@bk2204)
+
 ## 3.1.0 (14 Feb 2022)
 
 This release is a feature release which includes support for fallback from

--- a/config/version.go
+++ b/config/version.go
@@ -13,7 +13,7 @@ var (
 )
 
 const (
-	Version = "3.1.0"
+	Version = "3.2.0"
 )
 
 func init() {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+git-lfs (3.2.0) stable; urgency=low
+
+  * New upstream version
+
+ -- brian m. carlson <bk2204@github.com>  Wed, 25 May 2022 14:29:00 -0000
+
 git-lfs (3.1.0) stable; urgency=low
 
   * New upstream version

--- a/rpm/SPECS/git-lfs.spec
+++ b/rpm/SPECS/git-lfs.spec
@@ -1,5 +1,5 @@
 Name:           git-lfs
-Version:        3.1.0
+Version:        3.2.0
 Release:        1%{?dist}
 Summary:        Git extension for versioning large files
 

--- a/versioninfo.json
+++ b/versioninfo.json
@@ -3,7 +3,7 @@
 	{
 		"FileVersion": {
 			"Major": 3,
-			"Minor": 1,
+			"Minor": 2,
 			"Patch": 0,
 			"Build": 0
 		}
@@ -13,7 +13,7 @@
 		"FileDescription": "Git LFS",
 		"LegalCopyright": "GitHub, Inc. and Git LFS contributors",
 		"ProductName": "Git Large File Storage (LFS)",
-		"ProductVersion": "3.1.0"
+		"ProductVersion": "3.2.0"
 	},
 	"IconPath": "script/windows-installer/git-lfs-logo.ico"
 }


### PR DESCRIPTION
This is an in-progress look at the next release of Git LFS, v3.2.0, which is scheduled for tomorrow, Wednesday, May 25, 2022.

I've attached some builds below for people to use for testing:

[git-lfs-darwin-amd64-v3.2.0-pre.zip](https://github.com/git-lfs/git-lfs/files/8742455/git-lfs-darwin-amd64-v3.2.0-pre.zip)
[git-lfs-darwin-arm64-v3.2.0-pre.zip](https://github.com/git-lfs/git-lfs/files/8742456/git-lfs-darwin-arm64-v3.2.0-pre.zip)
[git-lfs-freebsd-386-v3.2.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8742457/git-lfs-freebsd-386-v3.2.0-pre.tar.gz)
[git-lfs-freebsd-amd64-v3.2.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8742458/git-lfs-freebsd-amd64-v3.2.0-pre.tar.gz)
[git-lfs-linux-386-v3.2.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8742459/git-lfs-linux-386-v3.2.0-pre.tar.gz)
[git-lfs-linux-amd64-v3.2.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8742460/git-lfs-linux-amd64-v3.2.0-pre.tar.gz)
[git-lfs-linux-arm64-v3.2.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8742461/git-lfs-linux-arm64-v3.2.0-pre.tar.gz)
[git-lfs-linux-arm-v3.2.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8742462/git-lfs-linux-arm-v3.2.0-pre.tar.gz)
[git-lfs-linux-ppc64le-v3.2.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8742463/git-lfs-linux-ppc64le-v3.2.0-pre.tar.gz)
[git-lfs-linux-s390x-v3.2.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8742464/git-lfs-linux-s390x-v3.2.0-pre.tar.gz)
[git-lfs-v3.2.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/8742465/git-lfs-v3.2.0-pre.tar.gz)
[git-lfs-windows-386-v3.2.0-pre.zip](https://github.com/git-lfs/git-lfs/files/8742466/git-lfs-windows-386-v3.2.0-pre.zip)
[git-lfs-windows-amd64-v3.2.0-pre.zip](https://github.com/git-lfs/git-lfs/files/8742467/git-lfs-windows-amd64-v3.2.0-pre.zip)
[git-lfs-windows-arm64-v3.2.0-pre.zip](https://github.com/git-lfs/git-lfs/files/8742468/git-lfs-windows-arm64-v3.2.0-pre.zip)

In addition, the CI system will produce artifacts for Windows, Linux, and macOS if you prefer to use those; they should be equivalent.

/cc @git-lfs/core
/cc @git-lfs/implementers
/cc @git-lfs/releases