### PR TITLE
enhance git-lfs-migrate(1) man page

### DIFF
--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -311,6 +311,9 @@ argument to specify which files to export. Files matching the `--include`
 patterns will be removed from Git LFS, while files matching the `--exclude`
 patterns will retain their Git LFS status. The export command will modify the
 `.gitattributes` to set/unset any filepath patterns as given by those flags.
+The `export` mode also requires at least one or more references (specified by
+``--include-ref` or `--everything`) to be given. Otherwise, the export won't do
+anything. The given references will be rewritten during the export.
 
 ## INCLUDE AND EXCLUDE
 

--- a/docs/man/git-lfs-migrate.1.ronn
+++ b/docs/man/git-lfs-migrate.1.ronn
@@ -312,8 +312,8 @@ patterns will be removed from Git LFS, while files matching the `--exclude`
 patterns will retain their Git LFS status. The export command will modify the
 `.gitattributes` to set/unset any filepath patterns as given by those flags.
 The `export` mode also requires at least one or more references (specified by
-``--include-ref` or `--everything`) to be given. Otherwise, the export won't do
-anything. The given references will be rewritten during the export.
+`--include-ref` or `--everything`) to be given. The given references will be
+rewritten during the export.
 
 ## INCLUDE AND EXCLUDE
 


### PR DESCRIPTION
Add a hint that a reference must be provided at the command line or export will not perform any changes.

Fixes: #3484