### PR TITLE
Change git-lfs migrate import --everything to migrate everything except for special git refs

### DIFF
--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -128,6 +128,13 @@ func rewriteOptions(args []string, opts *githistory.RewriteOptions, l *tasklog.L
 // isSpecialGitRef checks if a ref spec is a special git ref to exclude from
 // --everything
 func isSpecialGitRef(refspec string) bool {
+	// Special refspecs.
+	switch refspec {
+	case "refs/stash":
+		return true
+	}
+
+	// Special refspecs from namespaces.
 	parts := strings.SplitN(refspec, "/", 3)
 	if len(parts) < 3 {
 		return false

--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -125,6 +125,21 @@ func rewriteOptions(args []string, opts *githistory.RewriteOptions, l *tasklog.L
 	}, nil
 }
 
+// isSpecialGitRef checks if a ref spec is a special git ref to exclude from
+// --everything
+func isSpecialGitRef(refspec string) bool {
+	parts := strings.SplitN(refspec, "/", 3)
+	if len(parts) < 3 {
+		return false
+	}
+	prefix := strings.Join(parts[:2], "/")
+	switch prefix {
+	case "refs/notes", "refs/bisect", "refs/replace":
+		return true
+	}
+	return false
+}
+
 // includeExcludeRefs returns fully-qualified sets of references to include, and
 // exclude, or an error if those could not be determined.
 //
@@ -198,18 +213,10 @@ func includeExcludeRefs(l *tasklog.Logger, args []string) (include, exclude []st
 
 				include = append(include, ref.Refspec())
 			case git.RefTypeOther:
-				parts := strings.SplitN(ref.Refspec(), "/", 3)
-				if len(parts) < 2 {
+				if isSpecialGitRef(ref.Refspec()) {
 					continue
 				}
-
-				switch parts[1] {
-				// The following are GitLab-, GitHub-, VSTS-,
-				// and BitBucket-specific reference naming
-				// conventions.
-				case "merge-requests", "pull", "pull-requests":
-					include = append(include, ref.Refspec())
-				}
+				include = append(include, ref.Refspec())
 			}
 		}
 	} else {

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -47,3 +47,11 @@ func TestDetermineIncludeExcludePathsReturnsNothingWhenAbsent(t *testing.T) {
 	assert.Empty(t, i)
 	assert.Empty(t, e)
 }
+
+func TestSpecialGitRefsExclusion(t *testing.T) {
+	assert.True(t, isSpecialGitRef("refs/notes/commits"))
+	assert.True(t, isSpecialGitRef("refs/bisect/bad"))
+	assert.True(t, isSpecialGitRef("refs/replace/abcdef90"))
+	assert.True(t, isSpecialGitRef("refs/stash"))
+	assert.False(t, isSpecialGitRef("refs/commits/abcdef90"))
+}


### PR DESCRIPTION
This PR implements @bk2204 's suggestion in #4810 to only exclude special git refs.