### PR TITLE
Improve error handling for pure SSH protocol

### DIFF
--- a/tq/ssh.go
+++ b/tq/ssh.go
@@ -27,6 +27,9 @@ type SSHBatchClient struct {
 
 func (a *SSHBatchClient) batchInternal(args []string, batchLines []string) (int, []string, []string, error) {
 	conn := a.transfer.Connection(0)
+	if conn == nil {
+		return 0, nil, nil, errors.Errorf(tr.Tr.Get("could not get connection for batch request"))
+	}
 	conn.Lock()
 	defer conn.Unlock()
 	err := conn.SendMessageWithLines("batch", args, batchLines)
@@ -179,6 +182,9 @@ func (a *SSHAdapter) DoTransfer(ctx interface{}, t *Transfer, cb ProgressCallbac
 		authOkFunc()
 	}
 	conn := ctx.(*ssh.PktlineConnection)
+	if conn == nil {
+		return errors.Errorf(tr.Tr.Get("could not get connection for transfer"))
+	}
 	if a.adapterBase.direction == Upload {
 		return a.upload(t, conn, cb)
 	} else {

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -949,6 +949,7 @@ func (q *TransferQueue) Wait() {
 
 	if q.manifest.sshTransfer != nil {
 		q.manifest.sshTransfer.Shutdown()
+		q.manifest.sshTransfer = nil
 	}
 
 	if q.unsupportedContentType {


### PR DESCRIPTION
In some cases, we can end up with a panic due to a pure SSH transfer lacking any connections, but it's not clear what those cases are.  Let's add some explicit checks that our connection is functional and return an error if not, and let's also add some defensiveness to make sure that if we encounter an unexpected case that we return a better error message.