### PR TITLE
Allow alternative remotes to be handled by LFS

### DIFF
--- a/commands/command_filter_process.go
+++ b/commands/command_filter_process.go
@@ -95,6 +95,14 @@ func filterCommand(cmd *cobra.Command, args []string) {
 				closeOnce = new(sync.Once)
 				available = make(chan *tq.Transfer)
 
+				if cfg.AutoDetectRemoteEnabled() {
+					// update current remote with information gained by treeish
+					newRemote := git.FirstRemoteForTreeish(req.Header["treeish"])
+					if newRemote != "" {
+						cfg.SetRemote(newRemote)
+					}
+				}
+
 				q = tq.NewTransferQueue(
 					tq.Download,
 					getTransferManifestOperationRemote("download", cfg.Remote()),

--- a/config/config.go
+++ b/config/config.go
@@ -220,6 +220,10 @@ func (c *Configuration) IsDefaultRemote() bool {
 	return c.Remote() == defaultRemote
 }
 
+func (c *Configuration) AutoDetectRemoteEnabled() bool {
+	return c.Git.Bool("lfs.remote.autodetect", false)
+}
+
 // Remote returns the default remote based on:
 // 1. The currently tracked remote branch, if present
 // 2. The value of remote.lfsdefault.

--- a/config/config.go
+++ b/config/config.go
@@ -224,6 +224,10 @@ func (c *Configuration) AutoDetectRemoteEnabled() bool {
 	return c.Git.Bool("lfs.remote.autodetect", false)
 }
 
+func (c *Configuration) SearchAllRemotesEnabled() bool {
+	return c.Git.Bool("lfs.remote.searchall", false)
+}
+
 // Remote returns the default remote based on:
 // 1. The currently tracked remote branch, if present
 // 2. The value of remote.lfsdefault.

--- a/docs/man/git-lfs-config.adoc
+++ b/docs/man/git-lfs-config.adoc
@@ -56,6 +56,19 @@ and `branch.*.pushremote` for the current branch override this setting.
 If this setting is not set, `remote.pushdefault` is used, or if that is
 not set, the order of selection is used as specified in the
 `remote.lfsdefault` above.
+* `lfs.remote.autodetect`
++
+This boolean option enables the remote autodetect feaure within Git LFS.
+LFS tries to derive the corresponding remote from the commit information
+and, in case of success, ignores the settings defined by
+`remote.lfsdefault` and `remote.<remote>.lfsurl`.
+* `lfs.remote.searchall`
++
+This boolean option enables Git LFS to search all registered remotes to
+find LFS data. This is a fallback mechanism executed only if the LFS
+data could not be found via the ordinary heuristics as described in
+`remote.lfsdefault`, `remote.<remote>.lfsurl` and, if enabled,
+`lfs.remote.autodetect`.
 * `lfs.dialtimeout`
 +
 Sets the maximum time, in seconds, that the HTTP client will wait to

--- a/t/t-multiple-remotes.sh
+++ b/t/t-multiple-remotes.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# Test lfs capability to download data when blobs are stored in different
+# endpoints
+
+. "$(dirname "$0")/testlib.sh"
+
+# This feature depends on the treeish parameter that is provided as metadata
+# in git versions higher or equal than 2.27
+ensure_git_version_isnt $VERSION_LOWER "2.27.0"
+
+reponame="$(basename "$0" ".sh")"
+
+prepare_consumer() {
+  local consumer="$1"
+  mkdir "$consumer"
+  cd "$consumer"
+  git init
+  git remote add mr file://"$REMOTEDIR"/"$smain".git
+  git remote add fr file://"$REMOTEDIR"/"$sfork".git
+  git fetch mr
+  git fetch fr
+}
+
+prepare_forks () {
+  local testcase="$1"
+  smain="$reponame"-"$testcase"-main-remote
+  sfork="$reponame"-"$testcase"-fork-remote
+  cmain="$HOME"/"$reponame"-"$testcase"-main-repo
+  cfork="$HOME"/"$reponame"-"$testcase"-fork-repo
+  setup_remote_repo "$smain"
+  setup_remote_repo "$sfork"
+  prepare_consumer "$cmain"
+  git checkout -b main
+  git lfs track '*.bin'
+  git add --all
+  git commit -m "Initial commit"
+  git push -u mr main
+  git push -u fr main
+  #Add a .bin in main repo
+  touch a.bin
+  printf "1234" > a.bin
+  git add --all
+  git commit -m "Add Bin file"
+  git push mr main
+  prepare_consumer "$cfork"
+}
+
+exec_fail_git(){
+  set +e
+  git "$@"
+  res=$?
+  set -e
+  if [ "$res" = "0" ]; then
+    exit 1
+  fi
+}
+
+begin_test "accept reset to different remote"
+(
+  set -e
+  prepare_forks "a-reset"
+  git checkout fr/main
+  git config lfs.remote.searchall false
+  git config lfs.remote.autodetect true
+  git reset --hard mr/main
+)
+end_test
+
+begin_test "accept pull from different remote"
+(
+  set -e
+  prepare_forks "a-pull"
+  git checkout fr/main
+  git config lfs.remote.searchall false
+  git config lfs.remote.autodetect true
+  git pull mr main
+)
+end_test
+
+begin_test "accept checkout different remote"
+(
+  set -e
+  prepare_forks "a-checkout"
+  git checkout fr/main
+  git config lfs.remote.searchall false
+  git config lfs.remote.autodetect true
+  git checkout mr/main
+)
+end_test
+
+begin_test "accept rebase different remote"
+(
+  set -e
+  prepare_forks "a-rebase"
+  git checkout fr/main
+  git config lfs.remote.searchall false
+  git config lfs.remote.autodetect true
+  git rebase mr/main
+)
+end_test
+
+begin_test "accept add bin file with sparsecheckout"
+(
+  set -e
+  prepare_forks "a-sparsecheckout"
+  git sparse-checkout init --no-cone
+  git sparse-checkout set /.gitignore
+  git checkout mr/main
+  git config lfs.remote.searchall false
+  git config lfs.remote.autodetect true
+  git sparse-checkout add a.bin
+)
+end_test
+
+begin_test "accept cherry-pick head different remote"
+(
+  set -e
+  prepare_forks "a-cherrypick"
+  git checkout -b main --track fr/main
+  git config lfs.remote.searchall true
+  git config lfs.remote.autodetect false
+  git cherry-pick mr/main
+)
+end_test
+
+begin_test "reject reset to different remote"
+(
+  set -e
+  prepare_forks "r-reset"
+  git checkout fr/main
+  git config lfs.remote.searchall false
+  git config lfs.remote.autodetect false
+  exec_fail_git reset --hard mr/main
+)
+end_test
+
+begin_test "reject pull from different remote"
+(
+  set -e
+  prepare_forks "r-pull"
+  git checkout fr/main
+  git config lfs.remote.searchall false
+  git config lfs.remote.autodetect false
+  exec_fail_git pull mr main
+)
+end_test
+
+begin_test "reject checkout different remote"
+(
+  set -e
+  prepare_forks "r-checkout"
+  git checkout fr/main
+  git config lfs.remote.searchall false
+  git config lfs.remote.autodetect false
+  exec_fail_git checkout mr/main
+)
+end_test
+
+begin_test "reject rebase different remote"
+(
+  set -e
+  prepare_forks "r-rebase"
+  git checkout fr/main
+  git config lfs.remote.searchall false
+  git config lfs.remote.autodetect false
+  exec_fail_git rebase mr/main
+)
+end_test
+
+begin_test "reject add bin file with sparsecheckout"
+(
+  set -e
+  prepare_forks "r-sparsecheckout"
+  git sparse-checkout init --no-cone
+  git sparse-checkout set /.gitignore
+  git checkout mr/main
+  git config lfs.remote.searchall false
+  git config lfs.remote.autodetect false
+  exec_fail_git sparse-checkout add a.bin
+)
+end_test
+
+begin_test "reject cherry-pick head different remote"
+(
+  set -e
+  prepare_forks "r-cherrypick"
+  git checkout -b main --track fr/main
+  git config lfs.remote.searchall false
+  git config lfs.remote.autodetect false
+  exec_fail_git cherry-pick mr/main
+)
+end_test


### PR DESCRIPTION
This fixes issue #3835. LFS could not derive the right remote endpoint under certain circumstances. For example, in a detached state, a simple heuristic was used to derive the remote (i.e. branch.*.remote, remote.lfsdefault, any other single remote, origin). This fails if there are multiple remotes in play. This patch derives the corresponding remote from the commit hash / treeish.

Thanks to @stanhu for providing the first version which this PR is based on.