### PR TITLE
t: set init.defaultBranch

### DIFF
--- a/t/testhelpers.sh
+++ b/t/testhelpers.sh
@@ -607,6 +607,7 @@ setup() {
     git config --global http.$LFS_CLIENT_CERT_URL/.sslKey "$LFS_CLIENT_KEY_FILE"
     git config --global http.$LFS_CLIENT_CERT_URL/.sslCert "$LFS_CLIENT_CERT_FILE"
     git config --global http.$LFS_CLIENT_CERT_URL/.sslVerify "false"
+    git config --global init.defaultBranch main
   fi | sed -e 's/^/# /g'
 
   # setup the git credential password storage


### PR DESCRIPTION
Previously, we used a template to set the default HEAD ref to "main" so that our branch would be correct.  It appears that Git has changed things so that that no longer works, so set init.defaultBranch as well to make sure we initialize new repositories properly.
