### PR TITLE
push: add ability to read refs/oids from stdin

### DIFF
--- a/docs/man/git-lfs-push.adoc
+++ b/docs/man/git-lfs-push.adoc
@@ -8,7 +8,9 @@ git-lfs-push - Push queued large files to the Git LFS endpoint
 
 `git lfs push` [options] <remote> [<ref>...] +
 `git lfs push` <remote> [<ref>...] +
+`git lfs push` [options] <remote> --stdin
 `git lfs push` --object-id <remote> [<oid>...]
+`git lfs push` --object-id <remote> --stdin
 
 == DESCRIPTION
 
@@ -32,6 +34,9 @@ by the local clone of the remote.
 `--object-id`::
   This pushes only the object OIDs listed at the end of the command, separated
   by spaces.
+`--stdin`::
+  Read a list of newline-delimited refs (or object IDs when using `--object-id`)
+  from standard input instead of the command line.
 
 == SEE ALSO
 


### PR DESCRIPTION
Add the ability to provide refs or object ids to `git lfs push` via standard input. This can make life simpler when plumbing together commands or working with large numbers of OIDs/refs. Particularly on Windows where the maximum command line length is much shorter.

Read refs from stdin:
```sh
echo "mybranch" | git lfs push origin --stdin
```

Read object IDs from stdin:
```sh
printf "4c48d2a6991c9895bcddcf027e1e4907280bcf21975492b1afbade396d6a3340\n82be50ad35070a4ef3467a0a650c52d5b637035e7ad02c36652e59d01ba282b7\n\n" \
  | git lfs push origin --object-id --stdin
```

Values read from stdin are newline-delimited, and blank lines are ignored. If `--stdin` is used, any values passed via the command line arguments ~are ignored~ raise an error.