### PR TITLE
tools: don't match MINGW as Cygwin

### DIFF
--- a/t/t-multiple-remotes.sh
+++ b/t/t-multiple-remotes.sh
@@ -15,8 +15,8 @@ prepare_consumer() {
   mkdir "$consumer"
   cd "$consumer"
   git init
-  git remote add mr file://"$REMOTEDIR"/"$smain".git
-  git remote add fr file://"$REMOTEDIR"/"$sfork".git
+  git remote add mr "file://$(urlify "$REMOTEDIR/$smain.git")"
+  git remote add fr "file://$(urlify "$REMOTEDIR/$sfork.git")"
   git fetch mr
   git fetch fr
 }

--- a/t/testhelpers.sh
+++ b/t/testhelpers.sh
@@ -843,7 +843,12 @@ add_symlink() {
 urlify() {
   if [ "$IS_WINDOWS" -eq 1 ]
   then
-    echo "$1" | sed -e 's,\\,/,g' -e 's,:,%3a,g' -e 's, ,%20,g'
+    local prefix="" path="$(canonical_path "$1")"
+    if echo "$path" | grep -qsv "^/"
+    then
+      prefix="/"
+    fi
+    echo "$prefix$path" | sed -e 's,\\,/,g' -e 's,:,%3a,g' -e 's, ,%20,g'
   else
     echo "$1"
   fi

--- a/tools/cygwin_windows.go
+++ b/tools/cygwin_windows.go
@@ -47,7 +47,7 @@ func isCygwin() bool {
 		return false
 	}
 
-	if bytes.Contains(out, []byte("CYGWIN")) || bytes.Contains(out, []byte("MSYS")) || bytes.Contains(out, []byte("MINGW")) {
+	if bytes.Contains(out, []byte("CYGWIN")) || bytes.Contains(out, []byte("MSYS")) {
 		cygwinState = cygwinStateEnabled
 	} else {
 		cygwinState = cygwinStateDisabled


### PR DESCRIPTION
The cygpath binary from Git for Windows has a bug: when the path contains braces, apostrophes, or certain other special characters, it strips them out when called from Go, but not from the command line.

This results in us having broken behaviour with those characters in the current working directory.  To address this, no longer consider MINGW to be a Cygwin-like environment.

Fixes #5105
Fixes #4829