### PR TITLE
ssh: disable concurrent transfers if no multiplexing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -566,7 +566,7 @@ test-race : GO_TEST_EXTRA_ARGS=-race
 # And so on.
 test : fmt $(.DEFAULT_GOAL)
 	( \
-		unset GIT_DIR; unset GIT_WORK_TREE; unset XDG_CONFIG_HOME; \
+		unset GIT_DIR; unset GIT_WORK_TREE; unset XDG_CONFIG_HOME; unset XDG_RUNTIME_DIR; \
 		tempdir="$$(mktemp -d)"; \
 		export HOME="$$tempdir"; \
 		export GIT_CONFIG_NOSYSTEM=1; \

--- a/lfshttp/ssh.go
+++ b/lfshttp/ssh.go
@@ -79,7 +79,7 @@ func (c *sshAuthClient) Resolve(e Endpoint, method string) (sshAuthResponse, err
 		return res, nil
 	}
 
-	exe, args := ssh.GetLFSExeAndArgs(c.os, c.git, &e.SSHMetadata, "git-lfs-authenticate", endpointOperation(e, method), false)
+	exe, args, _ := ssh.GetLFSExeAndArgs(c.os, c.git, &e.SSHMetadata, "git-lfs-authenticate", endpointOperation(e, method), false)
 	cmd, err := subprocess.ExecCommand(exe, args...)
 	if err != nil {
 		return res, err

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -30,7 +30,7 @@ type SSHMetadata struct {
 	Path        string
 }
 
-func FormatArgs(cmd string, args []string, needShell bool) (string, []string) {
+func FormatArgs(cmd string, args []string, needShell bool, multiplex bool) (string, []string) {
 	if !needShell {
 		return cmd, args
 	}
@@ -38,12 +38,12 @@ func FormatArgs(cmd string, args []string, needShell bool) (string, []string) {
 	return subprocess.FormatForShellQuotedArgs(cmd, args)
 }
 
-func GetLFSExeAndArgs(osEnv config.Environment, gitEnv config.Environment, meta *SSHMetadata, command, operation string, multiplexDesired bool) (string, []string) {
-	exe, args, needShell := GetExeAndArgs(osEnv, gitEnv, meta, multiplexDesired)
+func GetLFSExeAndArgs(osEnv config.Environment, gitEnv config.Environment, meta *SSHMetadata, command, operation string, multiplexDesired bool) (string, []string, bool) {
+	exe, args, needShell, multiplexing := GetExeAndArgs(osEnv, gitEnv, meta, multiplexDesired)
 	args = append(args, fmt.Sprintf("%s %s %s", command, meta.Path, operation))
-	exe, args = FormatArgs(exe, args, needShell)
+	exe, args = FormatArgs(exe, args, needShell, multiplexing)
 	tracerx.Printf("run_command: %s %s", exe, strings.Join(args, " "))
-	return exe, args
+	return exe, args, multiplexing
 }
 
 // Parse command, and if it looks like a valid command, return the ssh binary
@@ -129,7 +129,7 @@ func getControlDir(osEnv config.Environment) (string, error) {
 
 // Return the executable name for ssh on this machine and the base args
 // Base args includes port settings, user/host, everything pre the command to execute
-func GetExeAndArgs(osEnv config.Environment, gitEnv config.Environment, meta *SSHMetadata, multiplexDesired bool) (exe string, baseargs []string, needShell bool) {
+func GetExeAndArgs(osEnv config.Environment, gitEnv config.Environment, meta *SSHMetadata, multiplexDesired bool) (exe string, baseargs []string, needShell bool, multiplexing bool) {
 	var cmd string
 
 	ssh, _ := osEnv.Get("GIT_SSH")
@@ -155,10 +155,12 @@ func GetExeAndArgs(osEnv config.Environment, gitEnv config.Environment, meta *SS
 		args = append(args, "-batch")
 	}
 
+	multiplexing = false
 	multiplexEnabled := gitEnv.Bool("lfs.ssh.automultiplex", true)
 	if variant == variantSSH && multiplexDesired && multiplexEnabled {
 		controlPath, err := getControlDir(osEnv)
 		if err == nil {
+			multiplexing = true
 			controlPath = filepath.Join(controlPath, "sock-%C")
 			args = append(args, "-oControlMaster=auto", fmt.Sprintf("-oControlPath=%s", controlPath))
 		}
@@ -191,7 +193,7 @@ func GetExeAndArgs(osEnv config.Environment, gitEnv config.Environment, meta *SS
 		args = append(args, meta.UserAndHost)
 	}
 
-	return cmd, args, needShell
+	return cmd, args, needShell, multiplexing
 }
 
 const defaultSSHCmd = "ssh"

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -158,7 +158,7 @@ func GetExeAndArgs(osEnv config.Environment, gitEnv config.Environment, meta *SS
 	multiplexEnabled := gitEnv.Bool("lfs.ssh.automultiplex", true)
 	if variant == variantSSH && multiplexDesired && multiplexEnabled {
 		controlPath, err := getControlDir(osEnv)
-		if err != nil {
+		if err == nil {
 			controlPath = filepath.Join(controlPath, "sock-%C")
 			args = append(args, "-oControlMaster=auto", fmt.Sprintf("-oControlPath=%s", controlPath))
 		}

--- a/t/cmd/lfs-ssh-echo.go
+++ b/t/cmd/lfs-ssh-echo.go
@@ -60,6 +60,11 @@ func main() {
 	offset := 1
 
 	checkSufficientArgs(offset)
+	if os.Args[offset] == "-oControlMaster=auto" {
+		offset += 2
+	}
+
+	checkSufficientArgs(offset)
 	if os.Args[offset] == "-p" {
 		offset += 2
 	}

--- a/tq/manifest.go
+++ b/tq/manifest.go
@@ -74,6 +74,10 @@ func NewManifest(f *fs.Filesystem, apiClient *lfsapi.Client, operation, remote s
 	}
 
 	sshTransfer := apiClient.SSHTransfer(operation, remote)
+	useSSHMultiplexing := false
+	if sshTransfer != nil {
+		useSSHMultiplexing = sshTransfer.IsMultiplexingEnabled()
+	}
 
 	m := &Manifest{
 		fs:                   f,
@@ -115,6 +119,10 @@ func NewManifest(f *fs.Filesystem, apiClient *lfsapi.Client, operation, remote s
 	}
 
 	if sshTransfer != nil {
+		if !useSSHMultiplexing {
+			m.concurrentTransfers = 1
+		}
+
 		// Multiple concurrent transfers are not yet supported.
 		m.batchClientAdapter = &SSHBatchClient{
 			maxRetries: m.maxRetries,


### PR DESCRIPTION
Right now, we try to spawn multiple SSH connections using ControlMaster when making multiple requests.  However, if multiplexing is not enabled, we can spawn multiple actual connections, which can be expensive and require lots of authentication requests.

Instead, let's make sure we don't enable multiple connections if multiplexing is not enabled, since this may cause the user to be prompted for multiple SSH key connection attempts (say, if they're using a security key) and is substantially more heavyweight than simply spawning a new process over the same connection.

Fixes #5064