### PR TITLE
ssh: don't leak resources when falling back to legacy protocol

### DIFF
--- a/ssh/connection.go
+++ b/ssh/connection.go
@@ -60,8 +60,15 @@ func startConnection(id int, osEnv config.Environment, gitEnv config.Environment
 	conn := &PktlineConnection{
 		cmd: cmd,
 		pl:  pl,
+		r:   r,
+		w:   w,
 	}
 	err = conn.Start()
+	if err != nil {
+		r.Close()
+		w.Close()
+		cmd.Wait()
+	}
 	return conn, err
 }
 

--- a/ssh/protocol.go
+++ b/ssh/protocol.go
@@ -12,6 +12,8 @@ import (
 )
 
 type PktlineConnection struct {
+	r   io.ReadCloser
+	w   io.WriteCloser
 	mu  sync.Mutex
 	cmd *subprocess.Cmd
 	pl  Pktline
@@ -39,6 +41,8 @@ func (conn *PktlineConnection) End() error {
 		return err
 	}
 	_, err = conn.ReadStatus()
+	conn.r.Close()
+	conn.w.Close()
 	conn.cmd.Wait()
 	return err
 }


### PR DESCRIPTION
When we attempt a connection with the pure SSH protocol but fail, we fail to close the file descriptors for the pipes or reap the process which has exited.  This can cause substantial resource consumption and run the user out of file descriptors or processes.

Since that's not very nice, let's be sure to explicitly close the pipes and wait for the process if this occurs, which it probably will quite frequently, since few people are using the new pure SSH protocol.

Fixes #5077