### PR TITLE
Fix setting commit & vendor variables via make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ GO_TEST_EXTRA_ARGS =
 # DWARF-stripping is enabled unless DWARF=YesPlease.
 BUILTIN_LD_FLAGS =
 ifneq ("$(VENDOR)","")
-BUILTIN_LD_FLAGS += -X github.com/git-lfs/git-lfs/v3/config.Vendor=$(VENDOR)
+BUILTIN_LD_FLAGS += -X 'github.com/git-lfs/git-lfs/v3/config.Vendor=$(VENDOR)'
 endif
 BUILTIN_LD_FLAGS += -X github.com/git-lfs/git-lfs/v3/config.GitCommit=$(GIT_LFS_SHA)
 ifneq ("$(DWARF)","YesPlease")

--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,9 @@ GO_TEST_EXTRA_ARGS =
 # DWARF-stripping is enabled unless DWARF=YesPlease.
 BUILTIN_LD_FLAGS =
 ifneq ("$(VENDOR)","")
-BUILTIN_LD_FLAGS += -X github.com/git-lfs/git-lfs/config.Vendor=$(VENDOR)
+BUILTIN_LD_FLAGS += -X github.com/git-lfs/git-lfs/v3/config.Vendor=$(VENDOR)
 endif
-BUILTIN_LD_FLAGS += -X github.com/git-lfs/git-lfs/config.GitCommit=$(GIT_LFS_SHA)
+BUILTIN_LD_FLAGS += -X github.com/git-lfs/git-lfs/v3/config.GitCommit=$(GIT_LFS_SHA)
 ifneq ("$(DWARF)","YesPlease")
 BUILTIN_LD_FLAGS += -s
 BUILTIN_LD_FLAGS += -w


### PR DESCRIPTION
087db1de (#4911) bumped the git-lfs Go package version to v3, but the variables being set in the Makefile for `GitCommit` & `Vendor` didn't change, which meant setting them had no effect. Fix this by updating the variable paths.

In addition, quote the `Vendor` variable so it can have spaces in it.

Before (main@ d3716c90):

```console
$ make bin/git-lfs VENDOR=WorldOfGooCorp
...
GOOS= GOARCH= go build -ldflags="-X github.com/git-lfs/git-lfs/config.Vendor=WorldofGooCorp -X github.com/git-lfs/git-lfs/config.GitCommit=d3716c90 -s -w " -gcflags=" " -trimpath -o ./bin/git-lfs ./git-lfs.go
$ bin/git-lfs version
git-lfs/3.2.0 (GitHub; darwin arm64; go 1.19.1)

$ make bin/git-lfs "VENDOR=World of Goo Corporation"
...
GOOS= GOARCH= go build -ldflags="-X github.com/git-lfs/git-lfs/config.Vendor=World of Goo Corporation -X github.com/git-lfs/git-lfs/config.GitCommit=d3716c90 -s -w " -gcflags=" " -trimpath -o ./bin/git-lfs ./git-lfs.go
# command-line-arguments
usage: link [options] main.o
...
make: *** [Makefile:318: bin/git-lfs] Error 2
```



After:
```console
$ make bin/git-lfs "VENDOR=World of Goo Corporation"
...
GOOS= GOARCH= go build -ldflags="-X 'github.com/git-lfs/git-lfs/v3/config.Vendor=World of Goo Corporation' -X github.com/git-lfs/git-lfs/v3/config.GitCommit=8d300427 -s -w " -gcflags=" " -trimpath -o ./bin/git-lfs ./git-lfs.go
$ bin/git-lfs version
git-lfs/3.2.0 (World of Goo Corporation; darwin arm64; go 1.19.1; git 8d300427)
```