### PR TITLE
script/cibuild: exclude icons from whitespace check

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -42,7 +42,7 @@ popd >/dev/null
 
 echo "Looking for trailing whitespace..."
 if git grep -lE '[[:space:]]+$' | \
-   grep -vE '(^vendor/|\.git/(objects/|index)|\.bat$)'
+  grep -vE '(^vendor/|\.git/(objects/|index)|\.(bat|ico|bmp)$)'
 then
   exit 1
 fi


### PR DESCRIPTION
On macOS, we can match our Windows BMP and ICO icons as having trailing whitespace.  Since we don't really care about the whitespace content of binary files, exclude them from the list of files we want to consider.