### PR TITLE
Add support for Rocky Linux 9

### DIFF
--- a/docker/run_dockers.bsh
+++ b/docker/run_dockers.bsh
@@ -59,7 +59,7 @@ done
 
 if [[ ${#IMAGES[@]} == 0 ]]; then
   # If you change this list, change script/upload as well.
-  IMAGES=(centos_7 centos_8 debian_9 debian_10 debian_11)
+  IMAGES=(centos_7 centos_8 rocky_9 debian_9 debian_10 debian_11)
 fi
 
 mkdir -p "${PACKAGE_DIR}"

--- a/rpm/SPECS/git-lfs.spec
+++ b/rpm/SPECS/git-lfs.spec
@@ -33,7 +33,7 @@ ln -s $(pwd) src/github.com/git-lfs/%{name}
 %endif
 
 pushd src/github.com/git-lfs/%{name}
-  %if %{_arch} == i386
+  %if "%{_arch}" == "i386"
     GOARCH=386 FORCE_LOCALIZE=true make
   %else
     GOARCH=amd64 FORCE_LOCALIZE=true make

--- a/rpm/SPECS/rubygem-asciidoctor.spec
+++ b/rpm/SPECS/rubygem-asciidoctor.spec
@@ -36,7 +36,7 @@ gem install -V --local --force --install-dir ./%{gemdir} --wrappers --bindir ./u
 %endif
 
 %build
-%if 0%{?el8}
+%if 0%{?el8}%{?el9}
 gem build ../%{gem_name}-%{version}.gemspec
 gem install -V --local --build-root . --force --no-document %{gem_name}-%{version}.gem
 %endif
@@ -53,7 +53,7 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
-%if 0%{?el8}
+%if 0%{?el8}%{?el9}
 %dir %{gem_instdir}
 %{gem_libdir}
 %exclude %{gem_cache}

--- a/rpm/build_rpms.bsh
+++ b/rpm/build_rpms.bsh
@@ -14,7 +14,7 @@ else #Basically Centos 5/6
 fi
 
 case "${OS_NAME}" in
-  centos*|red*|almalinux)
+  centos*|red*|almalinux|rocky*)
     RPM_DIST=".el${VERSION_ID}"
     ;;
   fedora)

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -44,6 +44,9 @@ $distro_name_map = {
     "fedora/34",
     "fedora/35",
   ],
+  "rocky/9" => [
+    "el/9",
+  ],
   # Debian EOL https://wiki.debian.org/LTS/
   # Ubuntu EOL https://wiki.ubuntu.com/Releases
   # Mint EOL https://linuxmint.com/download_all.php
@@ -120,6 +123,7 @@ package_files.each do |full_path|
   when /centos\/6/  then ["RPM RHEL 6/CentOS 6", "el/6"]
   when /centos\/7/  then ["RPM RHEL 7/CentOS 7", "el/7"]
   when /centos\/8/  then ["RPM RHEL 8/CentOS 8", "el/8"]
+  when /rocky\/9/  then ["RPM RHEL 8/Rocky 9", "el/9"]
   end
 
   next unless os

--- a/script/upload
+++ b/script/upload
@@ -195,7 +195,7 @@ finalize_body_message () {
 Up to date packages are available on [PackageCloud](https://packagecloud.io/github/git-lfs) and [Homebrew](http://brew.sh/).
 
 [RPM RHEL 7/CentOS 7](https://packagecloud.io/github/git-lfs/packages/el/7/git-lfs-VERSION-1.el7.x86_64.rpm/download)
-[RPM RHEL 8/CentOS 8](https://packagecloud.io/github/git-lfs/packages/el/8/git-lfs-VERSION-1.x86_64.rpm/download)
+[RPM RHEL 8/Rocky Linux 8](https://packagecloud.io/github/git-lfs/packages/el/8/git-lfs-VERSION-1.el8.x86_64.rpm/download)
 [Debian 9](https://packagecloud.io/github/git-lfs/packages/debian/stretch/git-lfs_VERSION_amd64.deb/download)
 [Debian 10](https://packagecloud.io/github/git-lfs/packages/debian/buster/git-lfs_VERSION_amd64.deb/download)
 [Debian 11](https://packagecloud.io/github/git-lfs/packages/debian/bullseye/git-lfs_VERSION_amd64.deb/download)

--- a/script/upload
+++ b/script/upload
@@ -196,6 +196,7 @@ Up to date packages are available on [PackageCloud](https://packagecloud.io/gith
 
 [RPM RHEL 7/CentOS 7](https://packagecloud.io/github/git-lfs/packages/el/7/git-lfs-VERSION-1.el7.x86_64.rpm/download)
 [RPM RHEL 8/Rocky Linux 8](https://packagecloud.io/github/git-lfs/packages/el/8/git-lfs-VERSION-1.el8.x86_64.rpm/download)
+[RPM RHEL 9/Rocky Linux 9](https://packagecloud.io/github/git-lfs/packages/el/9/git-lfs-VERSION-1.el9.x86_64.rpm/download)
 [Debian 9](https://packagecloud.io/github/git-lfs/packages/debian/stretch/git-lfs_VERSION_amd64.deb/download)
 [Debian 10](https://packagecloud.io/github/git-lfs/packages/debian/buster/git-lfs_VERSION_amd64.deb/download)
 [Debian 11](https://packagecloud.io/github/git-lfs/packages/debian/bullseye/git-lfs_VERSION_amd64.deb/download)


### PR DESCRIPTION
RHEL 9 recently came out.  Let's use Rocky Linux 9 to build packages for RHEL and RHEL-equivalent versions so that users have packages to work with.

Each step has its own commit and description.

Fixes #5107