### PR TITLE
Update stale comments relating to object scanning and uploading

### DIFF
--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -190,8 +190,8 @@ func (c *uploadContext) prepareUpload(unfiltered ...*lfs.WrappedPointer) []*lfs.
 	// scanner
 	uniqOids := tools.NewStringSet()
 
-	// separate out objects that _should_ be uploaded, but don't exist in
-	// .git/lfs/objects. Those will skipped if the server already has them.
+	// Skip any objects which we've seen or already uploaded, as well
+	// as any which are locked by other users.
 	for _, p := range unfiltered {
 		// object already uploaded in this process, or we've already
 		// seen this OID (see above), skip!
@@ -358,6 +358,8 @@ func (c *uploadContext) uploadTransfer(p *lfs.WrappedPointer) (*tq.Transfer, err
 		return nil, errors.Wrap(err, tr.Tr.Get("Error uploading file %s (%s)", filename, oid))
 	}
 
+	// Skip the object if its corresponding file does not exist in
+	// .git/lfs/objects/.
 	if len(filename) > 0 {
 		if missing, err = c.ensureFile(filename, localMediaPath, oid); err != nil && !errors.IsCleanPointerError(err) {
 			return nil, err

--- a/lfs/gitscanner_catfilebatch.go
+++ b/lfs/gitscanner_catfilebatch.go
@@ -12,13 +12,16 @@ import (
 	"github.com/git-lfs/git-lfs/v3/tr"
 )
 
-// runCatFileBatch uses 'git cat-file --batch' to get the object contents of a
-// git object, given its sha1. The contents will be decoded into a Git LFS
-// pointer. Git Blob SHA1s are read from the sha1Ch channel and fed to STDIN.
-// Results are parsed from STDOUT, and any eligible LFS pointers are sent to
-// pointerCh. If a Git Blob is not an LFS pointer, check the lockableSet to see
-// if that blob is for a locked file. Any errors are sent to errCh. An error is
-// returned if the 'git cat-file' command fails to start.
+// runCatFileBatch() uses an ObjectDatabase from the
+// github.com/git-lfs/gitobj/v2 package to get the contents of Git
+// blob objects, given their SHA1s, similar to the behaviour of
+// 'git cat-file --batch'.
+// Git blob SHA1s are read from the revs channel and fed to an
+// ObjectScanner which looks them up in the ObjectDatabase.
+// The contents will be decoded as Git LFS pointers and any valid pointers
+// will be sent to pointerCh.
+// If a Git blob is not an LFS pointer, check the lockableSet to see
+// if that blob is for a locked file.  Any errors are sent to errCh.
 func runCatFileBatch(pointerCh chan *WrappedPointer, lockableCh chan string, lockableSet *lockableNameSet, revs *StringChannelWrapper, errCh chan error, gitEnv, osEnv config.Environment) error {
 	scanner, err := NewPointerScanner(gitEnv, osEnv)
 	if err != nil {

--- a/lfs/scanner.go
+++ b/lfs/scanner.go
@@ -45,10 +45,13 @@ func catFileBatchCheck(revs *StringChannelWrapper, lockableSet *lockableNameSet)
 	return NewStringChannelWrapper(smallRevCh, errCh), lockableCh, nil
 }
 
-// catFileBatch uses git cat-file --batch to get the object contents
-// of a git object, given its sha1. The contents will be decoded into
-// a Git LFS pointer. revs is a channel over which strings containing Git SHA1s
-// will be sent. It returns a channel from which point.Pointers can be read.
+// catFileBatch() uses an ObjectDatabase from the
+// github.com/git-lfs/gitobj/v2 package to get the contents of Git
+// blob objects, given their SHA1s, similar to the behaviour of
+// 'git cat-file --batch'.
+// Input Git blob SHA1s should be sent over the revs channel.
+// The blob contents will be decoded as Git LFS pointers and any valid
+// pointers will be returned as pointer.Pointer structs in a new channel.
 func catFileBatch(revs *StringChannelWrapper, lockableSet *lockableNameSet, gitEnv, osEnv config.Environment) (*PointerChannelWrapper, chan string, error) {
 	pointerCh := make(chan *WrappedPointer, chanBufSize)
 	lockableCh := make(chan string, chanBufSize)


### PR DESCRIPTION
This PR updates several stale comments that relate to scanning Git blob objects to find valid Git LFS pointers and to validating that objects have corresponding local file copies before uploading them.

In commit e3fcde746a04c26f33ac866f39d54b7cbcf2d933 of PR #3236 the `ObjectScanner` type was updated to use an internal `ObjectDatabase` from the `github.com/git-lfs/gitobj` package rather than invoking an external `git cat-file --batch` command.  However, the comments for the `catFileBatch()` and `runCatFileBatch()` functions were not updated at the same time and still state that they cause a `git cat-file --batch` command to run, so we update them now.

And in commit 338ab406ba35a0645bc660f8cb24dad8913f9490 of PR #1812 the `prepareUpload()` function was refactored so that it no longer checked whether an object to be pushed had a local file copy or not and skipped it if it did not.  However, the comment which stated that the function skipped any objects which did not have local file copies was not updated, so we now revise that comment and add one in the `uploadTransfer()` function.