### PR TITLE
Update more stale comments relating to object scanning

### DIFF
--- a/git/object_scanner.go
+++ b/git/object_scanner.go
@@ -36,10 +36,10 @@ type ObjectScanner struct {
 }
 
 // NewObjectScanner constructs a new instance of the `*ObjectScanner` type and
-// returns it. It backs the ObjectScanner with an invocation of the `git
-// cat-file --batch` command. If any errors were encountered while starting that
-// command, they will be returned immediately.
-//
+// returns it. It backs the ObjectScanner with an ObjectDatabase from the
+// github.com/git-lfs/gitobj/v2 package.
+// If any errors are encountered while creating the ObjectDatabase,
+// they will be returned immediately.
 // Otherwise, an `*ObjectScanner` is returned with no error.
 func NewObjectScanner(gitEnv, osEnv Environment) (*ObjectScanner, error) {
 	gitdir, err := GitCommonDir()

--- a/lfs/gitscanner_tree.go
+++ b/lfs/gitscanner_tree.go
@@ -38,10 +38,13 @@ func runScanTree(cb GitScannerFoundPointer, ref string, filter *filepathfilter.F
 	return nil
 }
 
-// catFileBatchTree uses git cat-file --batch to get the object contents
-// of a git object, given its sha1. The contents will be decoded into
-// a Git LFS pointer. treeblobs is a channel over which blob entries
-// will be sent. It returns a channel from which point.Pointers can be read.
+// catFileBatchTree() uses an ObjectDatabase from the
+// github.com/git-lfs/gitobj/v2 package to get the contents of Git
+// blob objects, given their SHA1s from git.TreeBlob structs, similar
+// to the behaviour of 'git cat-file --batch'.
+// Input git.TreeBlob structs should be sent over the treeblobs channel.
+// The blob contents will be decoded as Git LFS pointers and any valid
+// pointers will be returned as pointer.Pointer structs in a new channel.
 func catFileBatchTree(treeblobs *TreeBlobChannelWrapper, gitEnv, osEnv config.Environment) (*PointerChannelWrapper, error) {
 	scanner, err := NewPointerScanner(gitEnv, osEnv)
 	if err != nil {


### PR DESCRIPTION
This PR updates several stale comments that relate to scanning Git blob objects to find valid Git LFS pointers.

In commit 201b8ba5c6677f99f5a0fa23188e6316f54f6206 of PR #5163 we updated several comments relating to the change from the use of the `git cat-file --batch` command to an internal `ObjectDatabase` provided by the `github.com/git-lfs/gitobj` package.  This change was originally made in e3fcde746a04c26f33ac866f39d54b7cbcf2d933 of PR #3236, but various comments were not updated at the same time.

In PR #5163 we missed two of those comments, for the `NewObjectScanner()` and `catFileBatchTree()` functions, so we update those now as well.