### PR TITLE
docs/man: clarify Git LFS setup instructions

### DIFF
--- a/docs/man/git-lfs.adoc
+++ b/docs/man/git-lfs.adoc
@@ -107,8 +107,8 @@ git-lfs-standalone-file(1)::
 
 To get started with Git LFS, the following commands can be used.
 
-. Setup Git LFS on your system. You only have to do this once per
-repository per machine:
+. Setup Git LFS on your system. You only have to do this once per user
+account:
 +
 ....
 git lfs install


### PR DESCRIPTION
The command `git lfs install` will install Git LFS in the Git user scope by default. However, our help files indicate that the setup is repository scoped.

Adjust the setup instructions to match what the command is doing.

The `git lfs install` command has flags to install Git LFS repository scoped (`--local`) and machine scoped (`--system`). However, I think we should not clutter the setup instructions with these details.

---

Fixes #5041 