### PR TITLE
Handle macro attribute references with unspecified flag

### DIFF
--- a/git/gitattr/macro.go
+++ b/git/gitattr/macro.go
@@ -38,6 +38,16 @@ func (mp *MacroProcessor) ProcessLines(lines []*Line, readMacros bool) []*Line {
 						resultLine.Attrs,
 						macros...,
 					)
+				} else if attr.Unspecified && macros != nil {
+					for _, m := range macros {
+						resultLine.Attrs = append(
+							resultLine.Attrs,
+							&Attr{
+								K:           m.K,
+								Unspecified: true,
+							},
+						)
+					}
 				}
 
 				// Git copies through aliases as well as

--- a/git/gitattr/macro_test.go
+++ b/git/gitattr/macro_test.go
@@ -61,6 +61,39 @@ func TestProcessLinesWithMacrosDisabled(t *testing.T) {
 	assert.Equal(t, lines[1].Attrs[0], &Attr{K: "text", V: "true"})
 }
 
+func TestProcessLinesWithUnspecifiedMacros(t *testing.T) {
+	lines, _, err := ParseLines(strings.NewReader(strings.Join([]string{
+		"[attr]lfs filter=lfs diff=lfs merge=lfs -text",
+		"*.dat lfs",
+		"*.dat !lfs"}, "\n")))
+
+	assert.Len(t, lines, 3)
+	assert.NoError(t, err)
+
+	mp := NewMacroProcessor()
+	lines = mp.ProcessLines(lines, true)
+
+	assert.Len(t, lines, 2)
+
+	assert.Equal(t, lines[0].Macro, "")
+	assert.Equal(t, lines[0].Pattern.String(), "*.dat")
+	assert.Len(t, lines[0].Attrs, 5)
+	assert.Equal(t, lines[0].Attrs[0], &Attr{K: "filter", V: "lfs"})
+	assert.Equal(t, lines[0].Attrs[1], &Attr{K: "diff", V: "lfs"})
+	assert.Equal(t, lines[0].Attrs[2], &Attr{K: "merge", V: "lfs"})
+	assert.Equal(t, lines[0].Attrs[3], &Attr{K: "text", V: "false"})
+	assert.Equal(t, lines[0].Attrs[4], &Attr{K: "lfs", V: "true"})
+
+	assert.Equal(t, lines[1].Macro, "")
+	assert.Equal(t, lines[1].Pattern.String(), "*.dat")
+	assert.Len(t, lines[1].Attrs, 5)
+	assert.Equal(t, lines[1].Attrs[0], &Attr{K: "filter", V: "", Unspecified: true})
+	assert.Equal(t, lines[1].Attrs[1], &Attr{K: "diff", V: "", Unspecified: true})
+	assert.Equal(t, lines[1].Attrs[2], &Attr{K: "merge", V: "", Unspecified: true})
+	assert.Equal(t, lines[1].Attrs[3], &Attr{K: "text", V: "", Unspecified: true})
+	assert.Equal(t, lines[1].Attrs[4], &Attr{K: "lfs", V: "", Unspecified: true})
+}
+
 func TestProcessLinesWithBinaryMacros(t *testing.T) {
 	lines, _, err := ParseLines(strings.NewReader(strings.Join([]string{
 		"*.dat binary",

--- a/t/t-attributes.sh
+++ b/t/t-attributes.sh
@@ -32,8 +32,9 @@ begin_test "macros"
   git lfs track '*.dat' 2>&1 | tee track.log
   grep '"*.dat" already supported' track.log
 
-  git lfs track 'dir/*.bin' 2>&1 | tee track.log
-  ! grep '"dir/*.bin" already supported' track.log
+  cd dir
+  git lfs track '*.bin' 2>&1 | tee track.log
+  ! grep '"*.bin" already supported' track.log
 )
 end_test
 

--- a/t/t-attributes.sh
+++ b/t/t-attributes.sh
@@ -35,6 +35,16 @@ begin_test "macros"
   cd dir
   git lfs track '*.bin' 2>&1 | tee track.log
   ! grep '"*.bin" already supported' track.log
+
+  # NOTE: At present we do not test that "git lfs track" reports
+  #       "already supported" when it finds a pattern in a subdirectory's
+  #       .gitattributes file which references a macro attribute in
+  #       the top-level .gitattributes file that sets "filter=lfs".
+  #       This is because, while "git check-attr" resolves macro references
+  #       from a file such as dir/.gitattributes to .gitattributess,
+  #       "git lfs track" only resolves macro references as it reads these
+  #       files in depth-first order, so unlike Git it does not expand an
+  #       "lfs" reference to "filter=lfs" if it appears in dir/.gitattributes.
 )
 end_test
 

--- a/t/t-fsck.sh
+++ b/t/t-fsck.sh
@@ -35,7 +35,6 @@ begin_test "fsck default"
     exit 1
   fi
 
-
   echo "CORRUPTION" >> .git/lfs/objects/$aOid12/$aOid34/$aOid
 
   moved=$(canonical_path "$TRASHDIR/$reponame/.git/lfs/bad")
@@ -138,6 +137,20 @@ begin_test "fsck: outside git repository"
 )
 end_test
 
+create_invalid_pointers() {
+  valid="$1"
+  ext="${2:-dat}"
+
+  git cat-file blob ":$valid" | awk '{ sub(/$/, "\r"); print }' >"crlf.$ext"
+  base64 /dev/urandom | head -c 1025 >"large.$ext"
+  git \
+    -c "filter.lfs.process=" \
+    -c "filter.lfs.clean=cat" \
+    -c "filter.lfs.required=false" \
+    add "crlf.$ext" "large.$ext"
+  git commit -m "invalid pointers"
+}
+
 setup_invalid_pointers () {
   git init $reponame
   cd $reponame
@@ -149,14 +162,7 @@ setup_invalid_pointers () {
   git add .gitattributes *.dat
   git commit -m "first commit"
 
-  git cat-file blob :a.dat | awk '{ sub(/$/, "\r"); print }' >crlf.dat
-  base64 /dev/urandom | head -c 1025 > large.dat
-  git \
-    -c "filter.lfs.process=" \
-    -c "filter.lfs.clean=cat" \
-    -c "filter.lfs.required=false" \
-    add crlf.dat large.dat
-  git commit -m "second commit"
+  create_invalid_pointers "a.dat"
 }
 
 begin_test "fsck detects invalid pointers"
@@ -177,6 +183,50 @@ begin_test "fsck detects invalid pointers"
   [ "$RET2" -eq 1 ]
   [ $(grep -c 'pointer: nonCanonicalPointer: Pointer.*was not canonical' test.log) -eq 2 ]
   [ $(grep -c 'pointer: unexpectedGitObject: "large.dat".*should have been a pointer but was not' test.log) -eq 2 ]
+)
+end_test
+
+begin_test "fsck detects invalid pointers with macro patterns"
+(
+  set -e
+
+  reponame="fsck-pointers-macros"
+  git init $reponame
+  cd $reponame
+
+  printf '[attr]lfs filter=lfs diff=lfs merge=lfs -text\n*.dat lfs\n' \
+    >.gitattributes
+  echo "test data" >a.dat
+  mkdir dir
+  printf '*.bin lfs\n' >dir/.gitattributes
+  git add .gitattributes a.dat dir
+  git commit -m "first commit"
+
+  create_invalid_pointers "a.dat"
+
+  cd dir
+  create_invalid_pointers "a.dat" "bin"
+  cd ..
+
+  # NOTE: We should also create a .dir directory with the same files as
+  #       as in the dir/ directory, and confirm those .dir/*.bin files are
+  #       reported by "git lfs fsck" as well.  However, at the moment
+  #       "git lfs fsck" will not resolve a macro attribute reference
+  #       in .dir/.gitattributes because it sorts that file before
+  #       .gitattributes and then processes them in that order.
+
+  set +e
+  git lfs fsck >test.log 2>&1
+  RET=$?
+  git lfs fsck --pointers >>test.log 2>&1
+  RET2=$?
+  set -e
+
+  [ "$RET" -eq 1 ]
+  [ "$RET2" -eq 1 ]
+  [ $(grep -c 'pointer: nonCanonicalPointer: Pointer.*was not canonical' test.log) -eq 4 ]
+  [ $(grep -c 'pointer: unexpectedGitObject: "large.dat".*should have been a pointer but was not' test.log) -eq 2 ]
+  [ $(grep -c 'pointer: unexpectedGitObject: "dir/large.bin".*should have been a pointer but was not' test.log) -eq 2 ]
 )
 end_test
 


### PR DESCRIPTION
In commit 1ff52542da97d6418689a5528112b57e37536014 of PR #3391 we introduced the `MacroProcessor` type and methods to support the use of macro attributes in `.gitattributes` files.

However, we do not currently support the case where a macro attributes is specified with a `!` prefix, which Git handles by setting all attributes defined by the macro attribute back to the unspecified state.  (Note that the `-` prefix is not supported by Git for macro attributes, only the `!` one.)

To mimic the same behaviour in Git LFS we add a check for a macro attribute with its `Unspecified` `bool` set to `true`, and when this is detected we iterate through the set of attributes defined by the macro attribute and set them all to the same unspecified state.

We also add tests to confirm this new handling works as expected, both a new Go test and two new tests in the `t/t-fsck.sh` test scrript.  In the latter file we refactor the `setup_invalid_pointers()` helper function so that we can reuse some of its code in a new, smaller function that just creates invalid pointers.

The new `"fsck does not detect invalid pointers with negated macro patterns"` test in `t/t-fsck.sh` will not succeed without the changes to the `MacroProcessor` in this PR, because without those changes any patterns that reference a macro attribute with the `!` prefix are not processed as making the macro's attributes unspecified again, and so non-pointer files matching those patterns are reported as invalid Git LFS pointers.  The `"fsck detects invalid pointers with macro patterns"` test, on the other hand, simply validates existing behaviour.

In both of the new tests in `t/t-fsck.sh` we include comments describing how the `git lfs fsck` command currently processes `.gitattributes` files in the order returned by `git ls-tree`, and so a `.gitattributes` file in a directory such as `.dir/` will be parsed before the top-level `.gitattributes` one because it sorts first.  The result is that any macro attribute references in the `.dir/.gitattributes` file will not be resolved properly, and so our tests variously either skip testing this situation or succeed but not quite for the right reasons.

We also update the `"macros"` test in `t/t-attributes.sh` so that one of its checks that validates the Git LFS is not processing macro attribute definitions in `.gitattributes` files other than the top-level one would actually fail if this were not to be the case due to some regression of the existing logic.

Finally, we add a new `"macros with unspecified flag"` test in the `t/t-attributes.sh` test script, but this test ultimately is only a placeholder as it can not actually test that the `git lfs track` command will not overwrite a pattern in a `.gitattributes` file in a subdirectory if it references a macro attribute defined in the top-level `.gitattributes` file and the reference has the `!` prefix.  This is due to the fact that the `git lfs track` command parses `.gitattributes` files in the order of the length of their full paths, from longest to shortest, and so macro attribute references can not be resolved except within the top-level `.gitattributes` file (with some caveats regarding the `.git/info/attributes` file and the global and system attributes files).  We also add comments to the `"macros"` test relating to this issue.  For now we defer resolution of both this issue and the one described regarding the order in which the `git lfs fsck` command processes `.gitattributes` files to the future.

It may be easiest to review this PR commit-by-commit, as each one has a detailed description and should be logically independent and bisectable, but it should also be possible to review this PR as a single diff.  

/cc @baffles as reporter.
Fixes #5145.