### PR TITLE
Distro update for v3.3.0

### DIFF
--- a/docker/run_dockers.bsh
+++ b/docker/run_dockers.bsh
@@ -59,7 +59,7 @@ done
 
 if [[ ${#IMAGES[@]} == 0 ]]; then
   # If you change this list, change script/upload as well.
-  IMAGES=(centos_7 centos_8 rocky_9 debian_9 debian_10 debian_11)
+  IMAGES=(centos_7 centos_8 rocky_9 debian_10 debian_11)
 fi
 
 mkdir -p "${PACKAGE_DIR}"

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -33,11 +33,13 @@ $distro_name_map = {
     # opensuse https://en.opensuse.org/Lifetime
     # or https://en.wikipedia.org/wiki/OpenSUSE_version_history
     "opensuse/15.3", # EOL 2022-12
+    "opensuse/15.4",
     # SLES EOL https://www.suse.com/lifecycle/
-    "sles/12.3", # LTSS ends 30 Jun 2022
     "sles/12.4",
     "sles/12.5",
-    "sles/15.3",  # Current
+    "sles/12.5",
+    "sles/15.3",
+    "sles/15.4",  # Current
   ],
   "centos/8" => [
     "el/8",
@@ -46,6 +48,7 @@ $distro_name_map = {
   ],
   "rocky/9" => [
     "el/9",
+    "fedora/36",
   ],
   # Debian EOL https://wiki.debian.org/LTS/
   # Ubuntu EOL https://wiki.ubuntu.com/Releases
@@ -72,6 +75,7 @@ $distro_name_map = {
     "debian/bookworm",  # Current testing
     "ubuntu/impish",    # EOL July 2022
     "ubuntu/jammy",     # EOL April 2027
+    "linuxmint/vanessa",# EOL April 2027
   ]
 }
 

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -123,7 +123,7 @@ package_files.each do |full_path|
   when /centos\/6/  then ["RPM RHEL 6/CentOS 6", "el/6"]
   when /centos\/7/  then ["RPM RHEL 7/CentOS 7", "el/7"]
   when /centos\/8/  then ["RPM RHEL 8/CentOS 8", "el/8"]
-  when /rocky\/9/  then ["RPM RHEL 8/Rocky 9", "el/9"]
+  when /rocky\/9/  then ["RPM RHEL 9/Rocky Linux 9", "el/9"]
   end
 
   next unless os

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -53,15 +53,6 @@ $distro_name_map = {
   # Debian EOL https://wiki.debian.org/LTS/
   # Ubuntu EOL https://wiki.ubuntu.com/Releases
   # Mint EOL https://linuxmint.com/download_all.php
-  "debian/9" => [
-    "debian/stretch",   # EOL June 2022
-    "linuxmint/tara",   # EOL April 2023
-    "linuxmint/tessa",  # EOL April 2023
-    "linuxmint/tina",   # EOL April 2023
-    "linuxmint/tricia", # EOL April 2023
-    "ubuntu/xenial",    # ESM April 2024
-    "ubuntu/bionic",    # ESM April 2028
-  ],
   "debian/10" => [
     "debian/buster",    # EOL June 2024
     "linuxmint/ulyana", # EOL April 2025

--- a/script/upload
+++ b/script/upload
@@ -197,7 +197,6 @@ Up to date packages are available on [PackageCloud](https://packagecloud.io/gith
 [RPM RHEL 7/CentOS 7](https://packagecloud.io/github/git-lfs/packages/el/7/git-lfs-VERSION-1.el7.x86_64.rpm/download)
 [RPM RHEL 8/Rocky Linux 8](https://packagecloud.io/github/git-lfs/packages/el/8/git-lfs-VERSION-1.el8.x86_64.rpm/download)
 [RPM RHEL 9/Rocky Linux 9](https://packagecloud.io/github/git-lfs/packages/el/9/git-lfs-VERSION-1.el9.x86_64.rpm/download)
-[Debian 9](https://packagecloud.io/github/git-lfs/packages/debian/stretch/git-lfs_VERSION_amd64.deb/download)
 [Debian 10](https://packagecloud.io/github/git-lfs/packages/debian/buster/git-lfs_VERSION_amd64.deb/download)
 [Debian 11](https://packagecloud.io/github/git-lfs/packages/debian/bullseye/git-lfs_VERSION_amd64.deb/download)
 


### PR DESCRIPTION
Update our packagecloud.io script to include some new distro versions that have come out as well as fixing some minor typos here.  In addition, drop support for Debian 9, which is explained fully in the commit message.

Fixes #5108