### PR TITLE
Add information to ambiguous error message.

### DIFF
--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -113,7 +113,7 @@ func pull(filter *filepathfilter.Filter) {
 	}
 
 	if singleCheckout.Skip() {
-		fmt.Println(tr.Tr.Get("Skipping object checkout, Git LFS is not installed."))
+		fmt.Println(tr.Tr.Get("Skipping object checkout, Git LFS is not installed for this repository. Consider installing it with 'git lfs install'."))
 	}
 }
 

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -113,7 +113,8 @@ func pull(filter *filepathfilter.Filter) {
 	}
 
 	if singleCheckout.Skip() {
-		fmt.Println(tr.Tr.Get("Skipping object checkout, Git LFS is not installed for this repository. Consider installing it with 'git lfs install'."))
+		fmt.Println(tr.Tr.Get("Skipping object checkout, Git LFS is not installed for this repository.\n" +
+		                      "Consider installing it with 'git lfs install'."))
 	}
 }
 

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -113,8 +113,7 @@ func pull(filter *filepathfilter.Filter) {
 	}
 
 	if singleCheckout.Skip() {
-		fmt.Println(tr.Tr.Get("Skipping object checkout, Git LFS is not installed for this repository.\n" +
-		                      "Consider installing it with 'git lfs install'."))
+		fmt.Println(tr.Tr.Get("Skipping object checkout, Git LFS is not installed for this repository.\nConsider installing it with 'git lfs install'."))
 	}
 }
 


### PR DESCRIPTION
Users could confuse the previous error message with a shell path issue, as though it could not resolve the installation of git-lfs. The proposed message in this commit offers additional insight by:

- Detailing that LFS has not been installed for this repository.
- Offering a fix (git lfs install) for the error.

Relate issue #3048. Judging by the continued addition of upvotes, even after the issue has been closed, users are still running into this problem.

Passing local test through the use of `make test`.