### PR TITLE
Add a FAQ entry on Jenkins problems

### DIFF
--- a/docs/man/git-lfs-faq.adoc
+++ b/docs/man/git-lfs-faq.adoc
@@ -137,6 +137,23 @@ patterns are possible: run `git help gitattributes` for more information on
 valid patterns.  Note that if you're specifying directories, using slashes is
 mandatory: backslashes are not allowed as path separators.
 
+I'm using Jenkins and `git lfs install` fails due to an invalid hook path.  What do I do?::
+  Recent versions of Jenkins have set `core.hooksPath` to various values,
+  notably `NUL:` on Windows, with the goal of disabling hooks.  This is not a
+  valid path on Windows, nor a valid value for this configuration option, so
+  when `git lfs install` runs and Git LFS attempts to install hooks, the
+  operation fails.
++
+The easiest way to solve this problem is by using the `--skip-repo` option to
+`git lfs install`, which skips the installation of the hooks.  Despite the name,
+it can be successfully combined with `--local` if you need that option.
++
+Note that this prevents things like `git push` from pushing LFS objects and
+locked files from being read only, since those are implemented by hooks.  If you
+need that functionality, you should review the Jenkins documentation about how
+to properly configure the environment in such a situation so that hooks can be
+used.
+
 == SEE ALSO
 
 git-config(1), git-lfs-install(1), gitattributes(5), gitignore(5).

--- a/docs/man/git-lfs-install.adoc
+++ b/docs/man/git-lfs-install.adoc
@@ -50,8 +50,9 @@ and clean filters if they are not already set.
   manual "git lfs pull" every time a new commit is checked out on your
   repository.
 `--skip-repo`::
-  Skips setup of the local repo; use if you want to install the global lfs
-  filters but not make changes to the current repo.
+  Skips installation of hooks into the local repository; use if you want to
+  install the LFS filters but not make changes to the hooks.  It is valid to use
+  `--local`, `--global`, or `--system` in conjunction with this option.
 
 == SEE ALSO
 


### PR DESCRIPTION
We've recently some some problems where Jenkins sets `core.hooksPath` to an invalid value (on Windows, notably this is `NUL:`).  Let's address this with a FAQ entry to explain how to work around that if necessary.

Also, in the course of writing this, it's been noted that the `--skip-repo` option is confusing with regards to `--local`.  These options are orthogonal and can be used together, so indicate that and update the documentation to better describe what the `--skip-repo` option does and how it can be used.

Fixes #5171