### PR TITLE
Use --sparse parameter for ls-files for performance optimization

### DIFF
--- a/git/ls_files.go
+++ b/git/ls_files.go
@@ -29,6 +29,10 @@ func NewLsFiles(workingDir string, standardExclude bool, untracked bool) (*LsFil
 		"--cached",
 	}
 
+	if IsGitVersionAtLeast("2.35.0") {
+		args = append(args, "--sparse")
+	}
+
 	if standardExclude {
 		args = append(args, "--exclude-standard")
 	}


### PR DESCRIPTION
When lfs is used with a huge mono repository with sparse-checkout, the lfs post-commit command took a long time. Per default git ls-files, which excute during the post-commit, retrieves all file paths, irrespectevly of the sparse set. When sparse-index is used ls-files respects the --sparse parameter, which omits the irrelevant files that are not in the sparse set, resulting in a performance improvement.