### PR TITLE
release: v3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,81 @@
 # Git LFS Changelog
 
+## 3.3.0 (30 November 2022)
+
+This release is a feature release which includes package support for Red Hat
+Enterprise Linux 9 and compatible OSes, experimental support for multiple
+remotes, and some command-line helpers for `git lfs push`.
+
+In this release, we no longer include vendored versions of our dependencies in
+the repository or the tarballs.  These were a source of noise and bloat, and
+users can easily download the required dependencies with Go itself.  Users who
+need to continue to vendor the dependencies can use the `make vendor` target.
+
+In addition, we've also switched the documentation to AsciiDoc from
+ronn-flavoured Markdown and included the FAQ in the repository.  This means that
+the manual pages now render properly in the GitHub web interface and it's also
+much easier to create additional formats, such as PDF, by leveraging the ability
+of Asciidoctor to convert to DocBook.
+
+It should also be noted that `git lfs migrate import --everything` now processes
+all refs that aren't special to Git instead of just branches and tags.  This is
+what it was documented to do, but didn't, so we've fixed it.
+
+Finally, please note that future releases may be done by a different member of
+the core team than many of the past releases, and thus may be signed by a
+different OpenPGP key.  Please follow [the steps in the README to download all
+of the keys for the core
+team](https://github.com/git-lfs/git-lfs#verifying-releases) to verify releases
+successfully in the future.
+
+We would like to extend a special thanks to the following open-source
+contributors:
+
+* @dhiwakarK for fixing a broken link
+* @dscho for improving our installer
+* @Leo1690 for speeding things up with sparse checkout
+* @pratap043 for proposing an extension to locking
+* @rcoup for fixing our Makefile and adding scripting features to `git lfs push`
+* @srohmen for adding support for alternative remotes
+* @WhatTheFuzz for improving our error messages
+* @wuhaochen for fixing a long-standing bug with `git lfs migrate import`
+
+### Features
+
+* Add the FAQ in the repository #5167 (@bk2204)
+* Add support for Rocky Linux 9 #5144 (@bk2204)
+* push: add ability to read refs/oids from stdin #5086 (@rcoup)
+* Allow alternative remotes to be handled by LFS #5066 (@srohmen)
+* Switch documentation to AsciiDoc #5054 (@bk2204)
+
+### Bugs
+
+* Handle macro attribute references with unspecified flag #5168 (@chrisd8088)
+* Fixed broken link for git-lfs-migrate #5153 (@dhiwakarK)
+* ssh: disable concurrent transfers if no multiplexing #5136 (@bk2204)
+* Fix setting commit & vendor variables via make #5141 (@rcoup)
+* ssh: don't leak resources when falling back to legacy protocol #5137 (@bk2204)
+* Bump gitobj to v2.1.1 #5130 (@bk2204)
+* tools: don't match MINGW as Cygwin #5106 (@bk2204)
+* installer: handle `BashOnly` Git for Windows gracefully #5048 (@dscho)
+* Change git-lfs migrate import --everything to migrate everything except for special git refs #5045 (@wuhaochen)
+
+### Misc
+
+* Use --sparse parameter for ls-files for performance optimization #5187 (@Leo1690)
+* Add information to ambiguous error message. #5172 (@WhatTheFuzz)
+* Distro update for v3.3.0 #5169 (@bk2204)
+* docs/man: clarify Git LFS setup instructions #5166 (@larsxschneider)
+* Update more stale comments relating to object scanning #5164 (@chrisd8088)
+* Update stale comments relating to object scanning and uploading #5163 (@chrisd8088)
+* script/cibuild: exclude icons from whitespace check #5142 (@bk2204)
+* Update to Go version 1.19 #5126 (@chrisd8088)
+* Drop vendoring #4903 (@bk2204)
+* Adding locking_notes.md #5079 (@pratap043)
+* t: set init.defaultBranch #5082 (@bk2204)
+* go.mod: require gopkg.in/yaml.v3 v3.0.1 #5033 (@bk2204)
+* script/upload: improve readability of asset verification #5032 (@bk2204)
+
 ## 3.2.0 (25 May 2022)
 
 This release is a feature release which includes support for machine-readable

--- a/config/version.go
+++ b/config/version.go
@@ -13,7 +13,7 @@ var (
 )
 
 const (
-	Version = "3.2.0"
+	Version = "3.3.0"
 )
 
 func init() {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+git-lfs (3.3.0) stable; urgency=low
+
+  * New upstream version
+
+ -- brian m. carlson <bk2204@github.com>  Wed, 30 Nov 2022 14:29:00 -0000
+
 git-lfs (3.2.0) stable; urgency=low
 
   * New upstream version

--- a/rpm/SPECS/git-lfs.spec
+++ b/rpm/SPECS/git-lfs.spec
@@ -1,5 +1,5 @@
 Name:           git-lfs
-Version:        3.2.0
+Version:        3.3.0
 Release:        1%{?dist}
 Summary:        Git extension for versioning large files
 

--- a/versioninfo.json
+++ b/versioninfo.json
@@ -3,7 +3,7 @@
 	{
 		"FileVersion": {
 			"Major": 3,
-			"Minor": 2,
+			"Minor": 3,
 			"Patch": 0,
 			"Build": 0
 		}
@@ -13,7 +13,7 @@
 		"FileDescription": "Git LFS",
 		"LegalCopyright": "GitHub, Inc. and Git LFS contributors",
 		"ProductName": "Git Large File Storage (LFS)",
-		"ProductVersion": "3.2.0"
+		"ProductVersion": "3.3.0"
 	},
 	"IconPath": "script/windows-installer/git-lfs-logo.ico"
 }


### PR DESCRIPTION
This is an in-progress look at the next release of Git LFS, v3.3.0, which is scheduled for Wednesday, November 30, 2022.

I've attached some builds below for people to use for testing:

[git-lfs-windows-arm64-v3.3.0-pre.zip](https://github.com/git-lfs/git-lfs/files/10107793/git-lfs-windows-arm64-v3.3.0-pre.zip)
[git-lfs-windows-amd64-v3.3.0-pre.zip](https://github.com/git-lfs/git-lfs/files/10107794/git-lfs-windows-amd64-v3.3.0-pre.zip)
[git-lfs-windows-386-v3.3.0-pre.zip](https://github.com/git-lfs/git-lfs/files/10107795/git-lfs-windows-386-v3.3.0-pre.zip)
[git-lfs-v3.3.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/10107796/git-lfs-v3.3.0-pre.tar.gz)
[git-lfs-linux-s390x-v3.3.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/10107797/git-lfs-linux-s390x-v3.3.0-pre.tar.gz)
[git-lfs-linux-ppc64le-v3.3.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/10107798/git-lfs-linux-ppc64le-v3.3.0-pre.tar.gz)
[git-lfs-linux-arm-v3.3.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/10107800/git-lfs-linux-arm-v3.3.0-pre.tar.gz)
[git-lfs-linux-arm64-v3.3.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/10107801/git-lfs-linux-arm64-v3.3.0-pre.tar.gz)
[git-lfs-linux-amd64-v3.3.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/10107802/git-lfs-linux-amd64-v3.3.0-pre.tar.gz)
[git-lfs-linux-386-v3.3.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/10107803/git-lfs-linux-386-v3.3.0-pre.tar.gz)
[git-lfs-freebsd-amd64-v3.3.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/10107804/git-lfs-freebsd-amd64-v3.3.0-pre.tar.gz)
[git-lfs-freebsd-386-v3.3.0-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/10107805/git-lfs-freebsd-386-v3.3.0-pre.tar.gz)
[git-lfs-darwin-arm64-v3.3.0-pre.zip](https://github.com/git-lfs/git-lfs/files/10107807/git-lfs-darwin-arm64-v3.3.0-pre.zip)
[git-lfs-darwin-amd64-v3.3.0-pre.zip](https://github.com/git-lfs/git-lfs/files/10107808/git-lfs-darwin-amd64-v3.3.0-pre.zip)

In addition, the CI system will produce artifacts for Windows, Linux, and macOS if you prefer to use those; they should be equivalent.

/cc @git-lfs/core 
/cc @git-lfs/implementers
/cc @git-lfs/releases