### PR TITLE
fix: pure SSH list lock command name

### DIFF
--- a/locking/ssh.go
+++ b/locking/ssh.go
@@ -228,7 +228,7 @@ func (c *sshLockClient) SearchVerifiable(remote string, vreq *lockVerifiableRequ
 	conn := c.connection()
 	conn.Lock()
 	defer conn.Unlock()
-	err := conn.SendMessage("list-locks", args)
+	err := conn.SendMessage("list-lock", args)
 	if err != nil {
 		return nil, 0, err
 	}


### PR DESCRIPTION
Fix typo in the command name.

Fixes: c07c98a755c9 ("locking: provide a pure SSH transport")
Signed-off-by: Ayman Bagabas <ayman.bagabas@gmail.com>

CC/ @bk2204