### PR TITLE
Upgrade workflows to latest Ubuntu and Actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     name: Build with default Git
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest]
+        os: [ubuntu-latest, macos-latest]
         go: ['1.19.x']
     runs-on: ${{ matrix.os }}
     steps:
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         go: ['1.18.x']
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-go@v2
@@ -107,7 +107,7 @@ jobs:
     name: Build with latest Git
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1
@@ -118,7 +118,7 @@ jobs:
     name: Build with earliest Git
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1
@@ -127,7 +127,7 @@ jobs:
     - run: script/cibuild
   build-docker:
     name: Build Linux packages
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - uses: ruby/setup-ruby@v1
@@ -136,7 +136,7 @@ jobs:
     - run: ./docker/run_dockers.bsh --prune
   build-docker-cross:
     name: Build Cross Linux packages
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         arch: [arm64]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,17 @@ jobs:
         go: ['1.19.x']
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
+      if: ${{ github.ref_type == 'tag' }}
+      # We update the current tag as the checkout step turns annotated tags
+      # into lightweight ones by accident, breaking "git describe".
+      # See https://github.com/actions/checkout/issues/882 for details.
     - uses: ruby/setup-ruby@v1
     - run: gem install asciidoctor
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go }}
     - run: brew install gettext
@@ -30,7 +37,7 @@ jobs:
           FORCE_LOCALIZE: true
     - run: mkdir -p bin/assets
     - run: find bin/releases -name "*$(uname -s | tr A-Z a-z)*" | xargs -I{} cp {} bin/assets
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.os }}
         path: bin/assets
@@ -41,8 +48,12 @@ jobs:
         go: ['1.18.x']
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-go@v2
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
+      if: ${{ github.ref_type == 'tag' }}
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go }}
     - run: script/cibuild
@@ -50,13 +61,18 @@ jobs:
     name: Build on Windows
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
+      if: ${{ github.ref_type == 'tag' }}
+      shell: bash
     - uses: ruby/setup-ruby@v1
     - run: gem install asciidoctor
     - run: Rename-Item -Path C:\msys64 -NewName msys64-tmp -Force
       # We move the MSYS2 installed for Ruby aside to prevent use of its Git,
       # which does not honour the PATH we set to our built git-lfs binary.
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: '1.19.x'
     - run: mkdir -p "$HOME/go/bin"
@@ -99,7 +115,7 @@ jobs:
       shell: bash
     - run: mv *.exe bin/assets
       shell: bash
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v3
       with:
         name: windows-latest
         path: bin/assets
@@ -110,7 +126,11 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
+      if: ${{ github.ref_type == 'tag' }}
     - run: git clone -b master https://github.com/git/git.git "$HOME/git"
     - run: script/build-git "$HOME/git"
     - run: GIT_DEFAULT_HASH=sha256 script/cibuild
@@ -121,7 +141,11 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
+      if: ${{ github.ref_type == 'tag' }}
     - run: git clone -b v2.0.0 https://github.com/git/git.git "$HOME/git"
     - run: script/build-git "$HOME/git"
     - run: script/cibuild
@@ -129,7 +153,11 @@ jobs:
     name: Build Linux packages
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
+      if: ${{ github.ref_type == 'tag' }}
     - uses: ruby/setup-ruby@v1
     - run: git clone https://github.com/git-lfs/build-dockers.git "$HOME/build-dockers"
     - run: (cd "$HOME/build-dockers" && ./build_dockers.bsh)
@@ -142,13 +170,17 @@ jobs:
         arch: [arm64]
         container: [debian_11]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
+      if: ${{ github.ref_type == 'tag' }}
     - uses: ruby/setup-ruby@v1
     - run: |
         echo '{"experimental": true}' | sudo tee /etc/docker/daemon.json
         sudo systemctl restart docker.service
         docker version -f '{{.Server.Experimental}}'
-    - uses: docker/setup-qemu-action@v1
+    - uses: docker/setup-qemu-action@v2
     - run: git clone https://github.com/git-lfs/build-dockers.git "$HOME/build-dockers"
     - run: (cd "$HOME/build-dockers" && ./build_dockers.bsh --arch=$ARCH $CONTAINER)
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,13 +11,20 @@ jobs:
       matrix:
         go: ['1.19.x']
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
+      shell: bash
+      # We update the current tag as the checkout step turns annotated tags
+      # into lightweight ones by accident, breaking "git describe".
+      # See https://github.com/actions/checkout/issues/882 for details.
     - uses: ruby/setup-ruby@v1
     - run: gem install asciidoctor
     - run: Rename-Item -Path C:\msys64 -NewName msys64-tmp -Force
       # We move the MSYS2 installed for Ruby aside to prevent use of its Git,
       # which does not honour the PATH we set to our built git-lfs binary.
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go }}
     - run: mkdir -p "$HOME/go/bin"
@@ -57,7 +64,7 @@ jobs:
         FORCE_LOCALIZE: true
     - run: env -u TMPDIR make release-windows-rebuild
       shell: bash
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v3
       with:
         name: windows-assets
         path: bin/releases
@@ -68,10 +75,13 @@ jobs:
       matrix:
         go: ['1.19.x']
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
     - uses: ruby/setup-ruby@v1
     - run: gem install asciidoctor
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go }}
     - run: brew install gettext
@@ -90,7 +100,7 @@ jobs:
         DARWIN_DEV_USER: ${{secrets.MACOS_DEV_USER}}
         DARWIN_DEV_PASS: ${{secrets.MACOS_DEV_PASS}}
         DARWIN_CERT_ID: ${{secrets.MACOS_CERT_ID}}
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v3
       with:
         name: macos-assets
         path: bin/releases
@@ -104,21 +114,26 @@ jobs:
       matrix:
         go: ['1.19.x']
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
     - uses: ruby/setup-ruby@v1
     - run: gem install asciidoctor
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go }}
     - run: sudo apt-get update && sudo apt-get -y install gettext libarchive-tools
       env:
           DEBIAN_FRONTEND: noninteractive
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v3
       with:
         name: windows-assets
-    - uses: actions/download-artifact@v1
+        path: windows-assets
+    - uses: actions/download-artifact@v3
       with:
         name: macos-assets
+        path: macos-assets
     - run: CGO_ENABLED=0 make release
     - run: rm -f bin/releases/*windows* bin/releases/*darwin*
     - run: 'find windows-assets -name "*windows*" -type f | xargs -I{} mv {} bin/releases'
@@ -130,7 +145,10 @@ jobs:
     name: Build Linux Packages
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
     - uses: ruby/setup-ruby@v1
     - run: gem install packagecloud-ruby
     - run: git clone https://github.com/git-lfs/build-dockers.git "$HOME/build-dockers"
@@ -148,14 +166,17 @@ jobs:
         arch: [arm64]
         container: [debian_11]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
     - uses: ruby/setup-ruby@v1
     - run: gem install packagecloud-ruby
     - run: |
         echo '{"experimental": true}' | sudo tee /etc/docker/daemon.json
         sudo systemctl restart docker.service
         docker version -f '{{.Server.Experimental}}'
-    - uses: docker/setup-qemu-action@v1
+    - uses: docker/setup-qemu-action@v2
     - run: git clone https://github.com/git-lfs/build-dockers.git "$HOME/build-dockers"
     - run: (cd "$HOME/build-dockers" && ./build_dockers.bsh --arch=$ARCH $CONTAINER)
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
     needs:
       - build-windows
       - build-macos
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         go: ['1.19.x']
@@ -128,7 +128,7 @@ jobs:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
   build-docker:
     name: Build Linux Packages
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - uses: ruby/setup-ruby@v1
@@ -142,7 +142,7 @@ jobs:
         PACKAGECLOUD_TOKEN: ${{secrets.PACKAGECLOUD_TOKEN}}
   build-docker-cross:
     name: Build Cross Linux packages
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         arch: [arm64]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,8 +121,8 @@ jobs:
         name: macos-assets
     - run: CGO_ENABLED=0 make release
     - run: rm -f bin/releases/*windows* bin/releases/*darwin*
-    - run: 'find windows-assets -name "*windows*" -type f | xargs -L1 -I{} mv {} bin/releases'
-    - run: 'find macos-assets -name "*darwin*" -type f | xargs -L1 -I{} mv {} bin/releases'
+    - run: 'find windows-assets -name "*windows*" -type f | xargs -I{} mv {} bin/releases'
+    - run: 'find macos-assets -name "*darwin*" -type f | xargs -I{} mv {} bin/releases'
     - run: script/upload --skip-verify $(git describe)
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
We upgrade our CI and release GitHub Actions workflows to use the latest Ubuntu runners, which run Ubuntu LTS 22.04 at present, and the latest available versions of all Actions steps.

As testing the `release.yml` workflow is not convenient without generating a release, it has instead been run successfully on a separate, private repository cloned from this one.

#### Ubuntu Runners

In commit d6b34fa4355bd4891294eeb69ff05bb43977f385 of PR #4437 we switched our CI and release GitHub Actions workflows to explicitly use the then-latest Ubuntu LTS version 20.04 in order to support ARM64 builds, as these required a version of Go (specifically 1.16) which was not available on the `ubuntu-latest` Actions runners at the time because they still ran Ubuntu LTS version 18.04.

However, `ubuntu-latest` Actions runners now use an even newer LTS version of Ubuntu, 22.04, than the one we have explicitly identified, so we can return to specifying `ubuntu-latest` for our CI and release builds.

#### Actions and Checkouts

In PR #5236 we upgraded our CI and release workflows to use the latest recommended `ruby/setup-ruby@v1` GitHub Actions step to install Ruby and its dependencies.

We now update our other Actions steps to their respective latest versions as well:

```
  actions/checkout:           v1 -> v3
  actions/download-artifact:  v1 -> v3
  actions/setup-go:           v2 -> v3
  actions/upload-artifact:    v1 -> v3
  docker/setup-qemu-action:   v1 -> v2
```

#### Artifact Download Paths

 As of `v2` of the `actions/download-artifact` Action, downloaded assets are not placed in a new subdirectory created with the name from the step's `name` argument, but in the current working directory instead.  We want to retain the previous behaviour so we add a `path` argument with the same name as each of the `macos-assets` and `windows-assets` download steps.

#### Fetching Full Clones

By default, the `actions/checkout Action` (as of `v2`) performs a Git fetch with a `--depth=1` option, so a shallow clone is made.  As a result, when our Makefile [calls](https://github.com/git-lfs/git-lfs/blob/4140f638e9e305605f2e8cd941355340bb71fbf0/Makefile#L8) `git describe HEAD` to set its `VERSION` variable, no tags are available and Git responds with an error message.

Many of our workflow jobs succeed despite logging that error, including the `build-docker` and `build-docker-cross` [jobs](https://github.com/git-lfs/git-lfs/blob/4140f638e9e305605f2e8cd941355340bb71fbf0/.github/workflows/ci.yml#L124-L156) in both our CI and Release workflows.  (The Docker builds create upload artifacts with the valid filenames despite the lack of any tags because they rely on the Git LFS version [strings](https://github.com/git-lfs/git-lfs/blob/4140f638e9e305605f2e8cd941355340bb71fbf0/debian/changelog#L1) in our `debian/changelog` file and in our binary; the `rpm/build_rpms.bsh` script [builds](https://github.com/git-lfs/git-lfs/blob/4140f638e9e305605f2e8cd941355340bb71fbf0/rpm/build_rpms.bsh#L144-L145) a binary just to [run](https://github.com/git-lfs/git-lfs/blob/4140f638e9e305605f2e8cd941355340bb71fbf0/rpm/build_rpms.bsh#L148) `git-lfs version` and determine the version string from its output.)

However, our workflow jobs which [run](https://github.com/git-lfs/git-lfs/blob/4140f638e9e305605f2e8cd941355340bb71fbf0/.github/workflows/ci.yml#L28-L30) the `make release` command fail outright in the absence of any Git tags, as they search for build artifacts using filenames [constructed](https://github.com/git-lfs/git-lfs/blob/4140f638e9e305605f2e8cd941355340bb71fbf0/Makefile#L414) with the empty `VERSION` variable, such as `git-lfs-windows-amd64-.zip`.  When no files are found, the `tar` [command](https://github.com/git-lfs/git-lfs/blob/4140f638e9e305605f2e8cd941355340bb71fbf0/Makefile#L422) fails, halting the job.  This affects both the `build-default` [job](https://github.com/git-lfs/git-lfs/blob/4140f638e9e305605f2e8cd941355340bb71fbf0/.github/workflows/ci.yml#L5-L36) in our CI workflow (for Linux and macOS), and all of `build-main`, `build-macos`, and `build-windows` [jobs](https://github.com/git-lfs/git-lfs/blob/4140f638e9e305605f2e8cd941355340bb71fbf0/.github/workflows/release.yml#L7-L123) in our Release workflow.

To resolve this in the case of a PR or other push to a branch, we set a `fetch-depth` value of `0` for our `actions/checkout@v3` steps, which downloads the full Git history and all tags.  This is somewhat more expensive than a shallow clone, but our project's history is not excessively large.

#### Temporary Workaround for Incorrect Tag Fetches

Due to the GitHub Actions bug documented in actions/checkout#882, though, this resolution is insufficient in the case of a push to a tag.  At present, when `fetch-depth` is `0`, the `actions/checkout@v3` incorrectly [determines](https://github.com/actions/checkout/blob/ac593985615ec2ede58e132d2e21d2b1cbd6127c/src/ref-helper.ts#L171) the SHA of an annotated tag to be the SHA of its associated commit, and then proceeds as if the tag had been updated on the server since the Action was started, and so [rewrites](https://github.com/actions/checkout/blob/ac593985615ec2ede58e132d2e21d2b1cbd6127c/src/git-source-provider.ts#L168) the tag locally to refer to the commit SHA.  This has the effect of making the local tag into a lightweight tag, which `git describe` then ignores (since we don't pass the `--tags` option to it).

As a temporary fix for this problem, we add a step after the `actions/checkout@v3` step which updates the local tag again to match the remote one.  We only run this step when the pushed reference was a tag, because on a branch push it would fail as Git would refuse to update the currently checked-out branch.  In our Release workflow, since it only runs on pushes to tags, we can run this step unconditionally.  (We could also continue to use the default `fetch-depth` of `1` for the `actions/checkout@v3` step, since we always subsequently fetch the relevant tag, but to be consistent and to avoid future issues once actions/checkout#882 is fixed upstream, we do not do so.)

/cc actions/checkout#882
/cc #5228