### PR TITLE
Make hooks refer to `core.hookspath`

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -150,10 +150,12 @@ func getHookInstallSteps() string {
 		ExitWithError(err)
 	}
 	hooks := lfs.LoadHooks(hookDir, cfg)
+	hookDir = filepath.ToSlash(hookDir)
+	workingDir := filepath.ToSlash(fmt.Sprintf("%s%c", cfg.LocalWorkingDir(), os.PathSeparator))
 	steps := make([]string, 0, len(hooks))
 	for _, h := range hooks {
 		steps = append(steps, fmt.Sprintf("%s\n\n%s",
-			tr.Tr.Get("Add the following to '.git/hooks/%s':", h.Type),
+			tr.Tr.Get("Add the following to '%s/%s':", strings.TrimPrefix(hookDir, workingDir), h.Type),
 			tools.Indent(h.Contents)))
 	}
 

--- a/lfs/hook.go
+++ b/lfs/hook.go
@@ -17,8 +17,9 @@ import (
 
 var (
 	// The basic hook which just calls 'git lfs TYPE'
-	hookBaseContent = "#!/bin/sh\ncommand -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/{{Command}}'.\\n\"; exit 2; }\ngit lfs {{Command}} \"$@\""
-	hookOldContent  = "#!/bin/sh\ncommand -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/{{Command}}.\\n\"; exit 2; }\ngit lfs {{Command}} \"$@\""
+	hookBaseContent = "#!/bin/sh\ncommand -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the '{{Command}}' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks').\\n\"; exit 2; }\ngit lfs {{Command}} \"$@\""
+	hookOldContent  = "#!/bin/sh\ncommand -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/{{Command}}'.\\n\"; exit 2; }\ngit lfs {{Command}} \"$@\""
+	hookOldContent2 = "#!/bin/sh\ncommand -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/{{Command}}.\\n\"; exit 2; }\ngit lfs {{Command}} \"$@\""
 )
 
 // A Hook represents a githook as described in http://git-scm.com/docs/githooks.
@@ -41,10 +42,11 @@ func LoadHooks(hookDir string, cfg *config.Configuration) []*Hook {
 			"#!/bin/sh\ncommand -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository has been set up with Git LFS but Git LFS is not installed.\\n\"; exit 0; }\ngit lfs pre-push \"$@\"",
 			"#!/bin/sh\ncommand -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository has been set up with Git LFS but Git LFS is not installed.\\n\"; exit 2; }\ngit lfs pre-push \"$@\"",
 			hookOldContent,
+			hookOldContent2,
 		}, cfg),
-		NewStandardHook("post-checkout", hookDir, []string{hookOldContent}, cfg),
-		NewStandardHook("post-commit", hookDir, []string{hookOldContent}, cfg),
-		NewStandardHook("post-merge", hookDir, []string{hookOldContent}, cfg),
+		NewStandardHook("post-checkout", hookDir, []string{hookOldContent, hookOldContent2}, cfg),
+		NewStandardHook("post-commit", hookDir, []string{hookOldContent, hookOldContent2}, cfg),
+		NewStandardHook("post-merge", hookDir, []string{hookOldContent, hookOldContent2}, cfg),
 	}
 }
 

--- a/t/t-install.sh
+++ b/t/t-install.sh
@@ -74,19 +74,19 @@ begin_test "install updates repo hooks"
   git init
 
   pre_push_hook="#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/pre-push'.\\n\"; exit 2; }
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'pre-push' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks').\\n\"; exit 2; }
 git lfs pre-push \"\$@\""
 
   post_checkout_hook="#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/post-checkout'.\\n\"; exit 2; }
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-checkout' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks').\\n\"; exit 2; }
 git lfs post-checkout \"\$@\""
 
   post_commit_hook="#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/post-commit'.\\n\"; exit 2; }
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-commit' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks').\\n\"; exit 2; }
 git lfs post-commit \"\$@\""
 
   post_merge_hook="#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/post-merge'.\\n\"; exit 2; }
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-merge' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks').\\n\"; exit 2; }
 git lfs post-merge \"\$@\""
 
   [ "Updated Git hooks.

--- a/t/t-update.sh
+++ b/t/t-update.sh
@@ -7,19 +7,19 @@ begin_test "update"
   set -e
 
   pre_push_hook="#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/pre-push'.\\n\"; exit 2; }
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'pre-push' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks').\\n\"; exit 2; }
 git lfs pre-push \"\$@\""
 
   post_checkout_hook="#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/post-checkout'.\\n\"; exit 2; }
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-checkout' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks').\\n\"; exit 2; }
 git lfs post-checkout \"\$@\""
 
   post_commit_hook="#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/post-commit'.\\n\"; exit 2; }
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-commit' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks').\\n\"; exit 2; }
 git lfs post-commit \"\$@\""
 
   post_merge_hook="#!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/post-merge'.\\n\"; exit 2; }
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-merge' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks').\\n\"; exit 2; }
 git lfs post-merge \"\$@\""
 
   mkdir without-pre-push
@@ -80,6 +80,13 @@ git lfs pre-push \"\$@\"" > .git/hooks/pre-push
 command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository has been set up with Git LFS but Git LFS is not installed.\\n\"; exit 2; }
 git lfs pre-push \"\$@\"" > .git/hooks/pre-push
   [ "Updated Git hooks." = "$(git lfs update)" ]
+
+  # replace old hook 6
+  echo "#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/pre-push'.\\n\"; exit 2; }
+git lfs pre-push \"\$@\"" > .git/hooks/pre-push
+  [ "Updated Git hooks." = "$(git lfs update)" ]
+  [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
   # don't replace unexpected hook
@@ -114,25 +121,25 @@ To resolve this, either:
   expected="Add the following to '.git/hooks/pre-push':
 
 	#!/bin/sh
-	command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/pre-push'.\n\"; exit 2; }
+	command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'pre-push' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks').\n\"; exit 2; }
 	git lfs pre-push \"\$@\"
 
 Add the following to '.git/hooks/post-checkout':
 
 	#!/bin/sh
-	command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/post-checkout'.\n\"; exit 2; }
+	command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-checkout' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks').\n\"; exit 2; }
 	git lfs post-checkout \"\$@\"
 
 Add the following to '.git/hooks/post-commit':
 
 	#!/bin/sh
-	command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/post-commit'.\n\"; exit 2; }
+	command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-commit' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks').\n\"; exit 2; }
 	git lfs post-commit \"\$@\"
 
 Add the following to '.git/hooks/post-merge':
 
 	#!/bin/sh
-	command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting '.git/hooks/post-merge'.\n\"; exit 2; }
+	command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-merge' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks').\n\"; exit 2; }
 	git lfs post-merge \"\$@\""
 
   [ "$expected" = "$(git lfs update --manual 2>&1)" ]
@@ -147,6 +154,61 @@ Add the following to '.git/hooks/post-merge':
   [ "$post_checkout_hook" = "$(cat .git/hooks/post-checkout)" ]
   [ "$post_commit_hook" = "$(cat .git/hooks/post-commit)" ]
   [ "$post_merge_hook" = "$(cat .git/hooks/post-merge)" ]
+
+  # test manual steps with core.hookspath
+  gitversion=$(git version | cut -d" " -f3)
+  set +e
+  compare_version "$gitversion" 2.9.0
+  result=$?
+  set -e
+  if [ "$result" -ne "$VERSION_LOWER" ]
+  then
+    mkdir hooks
+    rm -fr .git/hooks
+    git config core.hookspath hooks
+    echo "test" > hooks/pre-push
+    echo "test" > hooks/post-checkout
+    echo "test" > hooks/post-commit
+    echo "test" > hooks/post-merge
+
+    expected="Add the following to 'hooks/pre-push':
+
+	#!/bin/sh
+	command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'pre-push' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks').\n\"; exit 2; }
+	git lfs pre-push \"\$@\"
+
+Add the following to 'hooks/post-checkout':
+
+	#!/bin/sh
+	command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-checkout' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks').\n\"; exit 2; }
+	git lfs post-checkout \"\$@\"
+
+Add the following to 'hooks/post-commit':
+
+	#!/bin/sh
+	command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-commit' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks').\n\"; exit 2; }
+	git lfs post-commit \"\$@\"
+
+Add the following to 'hooks/post-merge':
+
+	#!/bin/sh
+	command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-merge' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks').\n\"; exit 2; }
+	git lfs post-merge \"\$@\""
+    [ "$expected" = "$(git lfs update --manual 2>&1)" ]
+    [ "test" = "$(cat hooks/pre-push)" ]
+    [ "test" = "$(cat hooks/post-checkout)" ]
+    [ "test" = "$(cat hooks/post-commit)" ]
+    [ "test" = "$(cat hooks/post-merge)" ]
+
+    # force replace unexpected hook
+    [ "Updated Git hooks." = "$(git lfs update --force)" ]
+    [ "$pre_push_hook" = "$(cat hooks/pre-push)" ]
+    [ "$post_checkout_hook" = "$(cat hooks/post-checkout)" ]
+    [ "$post_commit_hook" = "$(cat hooks/post-commit)" ]
+    [ "$post_merge_hook" = "$(cat hooks/post-merge)" ]
+
+    test -d .git/hooks && exit 1
+  fi
 
   has_test_dir || exit 0
 

--- a/t/t-update.sh
+++ b/t/t-update.sh
@@ -71,14 +71,14 @@ git lfs pre-push \"\$@\"" > .git/hooks/pre-push
   # replace old hook 4
   echo "#!/bin/sh
 command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository has been set up with Git LFS but Git LFS is not installed.\\n\"; exit 0; }
-git lfs pre-push \"$@\""
+git lfs pre-push \"\$@\"" > .git/hooks/pre-push
   [ "Updated Git hooks." = "$(git lfs update)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 
   # replace old hook 5
   echo "#!/bin/sh
 command -v git-lfs >/dev/null 2>&1 || { echo >&2 \"\\nThis repository has been set up with Git LFS but Git LFS is not installed.\\n\"; exit 2; }
-git lfs pre-push \"$@\""
+git lfs pre-push \"\$@\"" > .git/hooks/pre-push
   [ "Updated Git hooks." = "$(git lfs update)" ]
   [ "$pre_push_hook" = "$(cat .git/hooks/pre-push)" ]
 


### PR DESCRIPTION
In some cases, users may use `core.hooksPath` to locate their hooks in a different location.  However, right now, our hook and installation instructions mention only `.git/hooks`.

We can update the instructions without a problem, but we don't want to hard-code the hook path into the hooks themselves because of things like symlinks and moved repository, plus the fact that we can't update a hook automatically unless it's identical minus some whitespace changes.  To avoid spuriously failing to update a hook, let's print the right location with the instructions, and just mention `core.hookspath` and `.git/hooks` in the message, leaving it to the user to discover.

While we're at it, fix a small portion of the test which wasn't testing what we thought it was in a preparatory commit.  The gory details are mentioned in the commit message.