### PR TITLE
Simplify and deduplicate installation instructions

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -1,23 +1,20 @@
 # Installing on Linux using packagecloud
 
-[packagecloud](https://packagecloud.io) hosts [`git-lfs` packages](https://packagecloud.io/github/git-lfs) for popular Linux distributions with Apt/deb and Yum/rpm based package-managers.  Installing from packagecloud is reasonably straightforward and involves:
+[packagecloud](https://packagecloud.io) hosts [`git-lfs` packages](https://packagecloud.io/github/git-lfs) for popular Linux distributions with apt/deb and yum/rpm based package-managers.  Installing from packagecloud is reasonably straightforward and involves two steps:
 
-* Adding the packagecloud repo that best matches your Linux distribution and version, then
-* Running your package-manager's install command
-
-## Adding the packagecloud repository
+## 1. Adding the packagecloud repository
 
 packagecloud provides scripts to automate the process of configuring the package repository on your system, importing signing-keys etc.  These scripts must be run sudo root, and you should review them first.  The scripts are:
 
-* Apt/deb repositories: https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh
-* Yum/rpm repositories: https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh
+* apt/deb repositories: https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh
+* yum/rpm repositories: https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh
 
 The scripts check your Linux distribution and version, and use those parameters to create the best repository URL.  If you are running one of the distributions listed for the latest version of Git LFS listed at [packagecloud](https://packagecloud.io/github/git-lfs) e.g `debian/jessie`, `el/7`, you can run the script without parameters:
 
-Apt/deb repos:
+apt/deb repos:
 `curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash`
 
-Yum/rpm repos:
+yum/rpm repos:
 `curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh | sudo bash`
 
 If you are running a distribution which does not match exactly a repository uploaded for Git LFS, but for which there is a repository for a compatible upstream distribution, you can either run the script with some additional parameters, or run it and then manually-correct the resulting repository URLs.  See [#1074](https://github.com/git-lfs/git-lfs/issues/1074) for details.
@@ -35,12 +32,12 @@ curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.s
 sudo env os=ubuntu dist="${DISTRIB_CODENAME}" bash)
 ```
 
-## Installing packages
+## 2. Installing packages
 
 With the packagecloud repository configured for your system, you can install Git LFS:
 
-* Apt/deb: `sudo apt-get install git-lfs`
-* Yum/rpm: `sudo yum install git-lfs`
+* apt/deb: `sudo apt-get install git-lfs`
+* yum/rpm: `sudo yum install git-lfs`
 
 ## A note about proxies
 

--- a/README.md
+++ b/README.md
@@ -14,54 +14,42 @@ for an overview of features.
 
 ## Getting Started
 
-### Downloading
-
-You can install the Git LFS client in several different ways, depending on your
-setup and preferences.
-
-* **Linux users**. Debian and RPM packages are available from
-  [PackageCloud](https://packagecloud.io/github/git-lfs/install).
-* **macOS users**. [Homebrew](https://brew.sh) bottles are distributed, and can
-  be installed via `brew install git-lfs`.
-* **Windows users**. Git LFS is included in the distribution of
-  [Git for Windows](https://gitforwindows.org/). Alternatively, you can
-  install a recent version of Git LFS from the [Chocolatey](https://chocolatey.org/) package manager.
-* **Binary packages**. In addition, [binary packages](https://github.com/git-lfs/git-lfs/releases) are
-available for Linux, macOS, Windows, and FreeBSD.
-* **Building from source**. [This repository](https://github.com/git-lfs/git-lfs.git) can also be
-built from source using the latest version of [Go](https://golang.org), and the
-available instructions in our
-[Wiki](https://github.com/git-lfs/git-lfs/wiki/Installation#source).
-
-Note that Debian and RPM packages are built for all OSes for amd64 and i386.
-For arm64, only Debian packages for the latest Debian release are built due to the cost of building in emulation.
-
 ### Installing
+
+#### On Linux
+
+Debian and RPM packages are available from packagecloud, see [installation instructions](INSTALLING.md).
+
+#### On macOS
+
+[Homebrew](https://brew.sh) bottles are distributed and can be installed via `brew install git-lfs`.
+
+#### On Windows
+
+Git LFS is included in the distribution of [Git for Windows](https://gitforwindows.org/).
+Alternatively, you can install a recent version of Git LFS from the [Chocolatey](https://chocolatey.org/) package manager.
 
 #### From binary
 
-The [binary packages](https://github.com/git-lfs/git-lfs/releases) include a script which will:
+[Binary packages](https://github.com/git-lfs/git-lfs/releases) are
+available for Linux, macOS, Windows, and FreeBSD.
+The binary packages include a script which will:
 
 - Install Git LFS binaries onto the system `$PATH`
-- Run `git lfs install` to
-perform required global configuration changes.
+- Run `git lfs install` to perform required global configuration changes.
 
 ```ShellSession
 $ ./install.sh
 ```
 
+Note that Debian and RPM packages are built for all OSes for amd64 and i386.
+For arm64, only Debian packages for the latest Debian release are built due to the cost of building in emulation.
+
 #### From source
 
-- Ensure you have the latest version of Go, GNU make, and a standard Unix-compatible build environment installed.
-- On Windows, install `goversioninfo` with `go install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@latest`.
-- Run `make`.
-- Place the `git-lfs` binary, which can be found in `bin`, on your system’s executable `$PATH` or equivalent.
-- Git LFS requires global configuration changes once per-machine. This can be done by
-running:
-
-```ShellSession
-$ git lfs install
-```
+[This repository](https://github.com/git-lfs/git-lfs.git) can also be built from source using the latest version
+of [Go](https://golang.org), and the available instructions
+in our [Wiki](https://github.com/git-lfs/git-lfs/wiki/Installation#source).
 
 #### Verifying releases
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ for an overview of features.
 
 #### On Linux
 
-Debian and RPM packages are available from packagecloud, see [installation instructions](INSTALLING.md).
+Debian and RPM packages are available from packagecloud, see the Linux [installation instructions](INSTALLING.md).
 
 #### On macOS
 
@@ -42,8 +42,8 @@ The binary packages include a script which will:
 $ ./install.sh
 ```
 
-Note that Debian and RPM packages are built for all OSes for amd64 and i386.
-For arm64, only Debian packages for the latest Debian release are built due to the cost of building in emulation.
+Note that Debian and RPM packages are built for multiple Linux distributions and versions for both amd64 and i386.
+For arm64, only Debian packages are built and only for recent versions due to the cost of building in emulation.
 
 #### From source
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,12 @@ For arm64, only Debian packages are built and only for recent versions due to th
 
 #### From source
 
-[This repository](https://github.com/git-lfs/git-lfs.git) can also be built from source using the latest version
-of [Go](https://golang.org), and the available instructions
-in our [Wiki](https://github.com/git-lfs/git-lfs/wiki/Installation#source).
+- Ensure you have the latest version of Go, GNU make, and a standard Unix-compatible build environment installed.
+- On Windows, install `goversioninfo` with `go install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@latest`.
+- Run `make`.
+- Place the `git-lfs` binary, which can be found in `bin`, on your system’s executable `$PATH` or equivalent.
+- Git LFS requires global configuration changes once per-machine. This can be done by
+running: `git lfs install`
 
 #### Verifying releases
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ for an overview of features.
 
 #### On Linux
 
-Debian and RPM packages are available from packagecloud, see the Linux [installation instructions](INSTALLING.md).
+Debian and RPM packages are available from packagecloud, see the [Linux installation instructions](INSTALLING.md).
 
 #### On macOS
 


### PR DESCRIPTION
Today I wanted to install Git LFS on a Linux-based system.
Unfortunately I had a hard time to find the complete installation instructions. 😩

## Reproduction steps

1. I first opened [git-lfs.com](https://git-lfs.com/) on my macOS machine and I did _not_ see any link to installation instructions for Linux: <img width="1840" alt="image" src="https://user-images.githubusercontent.com/6301/213690713-265201a9-71c6-4560-9ada-928fb5492e88.png">
2. I then went to [GitHub's documentation for installing Git LFS](https://docs.github.com/en/repositories/working-with-files/managing-large-files/installing-git-large-file-storage) which besides pointing to [git-lfs.com](https://git-lfs.com/) (where I was already unsuccessful) it also points to the [README's Getting Started](https://github.com/git-lfs/git-lfs#getting-started) section.
I was happy to find a **Linux users** mention with a link to [installation instructions on packagecloud](https://packagecloud.io/github/git-lfs/install).
3. I performed the "quick install" command: `curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash`
Unfortunately Git LFS was still not installed (I got `git: 'lfs' is not a git command. See 'git --help'.` when running `git lfs`). 😢
4. I then looked at what the "quick install" script does and noticed that it only adds the packagecloud repository to apt, but it does not install it yet.
I then ran `apt-get install git-lfs` for which I got a permission error.
5. I then ran `sudo apt-get install git-lfs` which finally installed Git LFS on my Linux system. 😅

Baffled by the unclear installation instructions I then found that there is a whole document dedicated to installing Git LFS on Linux:
https://github.com/git-lfs/git-lfs/blob/main/INSTALLING.md

This document is currently not linked to from the README (or the website at [git-lfs.com](https://git-lfs.com/)).

## Proposal ☺️

I propose to simplify and deduplicate the README's installation instructions as well as adding the missing link to [INSTALLING.md](https://github.com/git-lfs/git-lfs/blob/main/INSTALLING.md).

First I noticed that there is a **Downloading** section which starts with a "You can install ..." sentence and that there is a **Installing** section.
Both sections include information on installing from **binary** and from **source**, which seem to be redundant?

I therefore propose to consolidate the **Downloading** and **Installing** sections into one **Installing** section.
This is the main change proposal of this pull request besides adding a link to [INSTALLING.md](https://github.com/git-lfs/git-lfs/blob/main/INSTALLING.md).

I also propose to make the [INSTALLING.md](https://github.com/git-lfs/git-lfs/blob/main/INSTALLING.md) document a little bit more clear.
I removed some redundant steps information in the beginning of the document and I added "1." and "2." numbering to the sections to make it clear there are two steps.
(I also lowercased some confusing uppercase mentions of apt and yum. 😊)

_I ~may also open~ have opened a pull request for https://github.com/git-lfs/git-lfs.github.com to make these README installation instructions easier to discover: https://github.com/git-lfs/git-lfs.github.com/pull/55_