### PR TITLE
Update Linux releases in Packagecloud publication script

### DIFF
--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -110,12 +110,8 @@ package_files.each do |full_path|
   next if full_path.include?("SRPM") || full_path.include?("i386") || full_path.include?("i686")
   next unless full_path =~ /\/git-lfs[-|_]\d/
   os, distro = case full_path
-  when /debian\/8/  then ["Debian 8",  "debian/jessie"]
-  when /debian\/9/  then ["Debian 9",  "debian/stretch"]
   when /debian\/10/ then ["Debian 10", "debian/buster"]
   when /debian\/11/ then ["Debian 11", "debian/bullseye"]
-  when /centos\/5/  then ["RPM RHEL 5/CentOS 5", "el/5"]
-  when /centos\/6/  then ["RPM RHEL 6/CentOS 6", "el/6"]
   when /centos\/7/  then ["RPM RHEL 7/CentOS 7", "el/7"]
   when /centos\/8/  then ["RPM RHEL 8/CentOS 8", "el/8"]
   when /rocky\/9/  then ["RPM RHEL 9/Rocky Linux 9", "el/9"]

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -28,18 +28,17 @@ $client = Packagecloud::Client.new(credentials)
 $distro_name_map = {
   # RHEL EOL https://access.redhat.com/support/policy/updates/errata
   "centos/7" => [
-    "el/7",
-    "scientific/7",
+    "el/7",         # EOL June 2024
+    "scientific/7", # EOL June 2024
     # opensuse https://en.opensuse.org/Lifetime
     # or https://en.wikipedia.org/wiki/OpenSUSE_version_history
     "opensuse/15.3", # EOL 2022-12
-    "opensuse/15.4",
+    "opensuse/15.4", # EOL November 2023
     # SLES EOL https://www.suse.com/lifecycle/
     "sles/12.4",
-    "sles/12.5",
-    "sles/12.5",
+    "sles/12.5", # EOL October 2024 (LTSS October 2027)
     "sles/15.3",
-    "sles/15.4",  # Current
+    "sles/15.4", # Current
   ],
   "centos/8" => [
     "el/8",

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -32,22 +32,18 @@ $distro_name_map = {
     "scientific/7", # EOL June 2024
     # opensuse https://en.opensuse.org/Lifetime
     # or https://en.wikipedia.org/wiki/OpenSUSE_version_history
-    "opensuse/15.3", # EOL 2022-12
     "opensuse/15.4", # EOL November 2023
     # SLES EOL https://www.suse.com/lifecycle/
-    "sles/12.4",
     "sles/12.5", # EOL October 2024 (LTSS October 2027)
-    "sles/15.3",
     "sles/15.4", # Current
   ],
   "centos/8" => [
     "el/8",
-    "fedora/34",
-    "fedora/35",
   ],
   "rocky/9" => [
     "el/9",
-    "fedora/36",
+    "fedora/36", # EOL May 2023
+    "fedora/37", # EOL November 2023
   ],
   # Debian EOL https://wiki.debian.org/LTS/
   # Ubuntu EOL https://wiki.ubuntu.com/Releases
@@ -63,9 +59,10 @@ $distro_name_map = {
   "debian/11" => [
     "debian/bullseye",  # Current stable
     "debian/bookworm",  # Current testing
-    "ubuntu/impish",    # EOL July 2022
     "ubuntu/jammy",     # EOL April 2027
+    "ubuntu/kinetic",   # EOL July 2023
     "linuxmint/vanessa",# EOL April 2027
+    "linuxmint/vera",   # EOL April 2027
   ]
 }
 


### PR DESCRIPTION
Ubuntu Impish Indri [reached](https://wiki.ubuntu.com/Releases) its EOL in July 2022, so we remove it from the list of Debian 11 distributions for which we publish packages to Packagecloud, and we add Ubuntu Kinetic Kudu to the Debian 11 list as it was [released](https://wiki.ubuntu.com/Releases) in October 2022.

Fedora 34 [reached](https://docs.fedoraproject.org/en-US/releases/eol/) its EOL in July 2022 and Fedora 35 reached its EOL in December 2022, so we remove them from the list of CentOS 8 distributions, and we add Fedora 37 to the Rocky 9 list as it was [released](https://docs.fedoraproject.org/en-US/releases/) in November 2022.

We add Linux Mint Vera to the list of Debian 11 distributions as it was [released](https://linuxmint.com/download_all.php) in December 2022.

We remove OpenSUSE 15.3 from the list of CentOS 7 distributions as it [reached](https://en.opensuse.org/Lifetime) its EOL in December 2022.

SUSE Linux Enterprise Server 12 SP4 [reached](https://www.suse.com/lifecycle/#suse-linux-enterprise-server-12) its general EOL in June 2020, so we remove it now, and SLES 15 SP3 [reached](https://www.suse.com/lifecycle/#suse-linux-enterprise-server-15) its general EOL in December 2022, so we also remove it now.

Note that we have been somewhat inconsistent in our handling of SLES 12 and 15 Service Packs, as we have only removed SLES 12 Service Packs once they reached their LTSS (Long Term Service Pack Support) EOL, while we have removed SLES 15 SPs when they reached their general EOLs.  Thus we removed SLES 12 SP3 in commit 9ef46f8d606a05d5a51ce024c38445f1a42ecb11 of PR #5169 when that Service Pack reached its LTSS EOL, but we removed SLES 15 SP2 in commit e2465f84b50452ff746f4f389afe5f8052a5a658 PR #5010 when that Service Pack reached its general EOL but not its LTSS EOL, which is still in the future (December 2024), as is the LTSS EOL for SLES 15 SP1 (January 2024).

To be more consistent, we assume SLES users have upgraded to the latest Service Pack within the [default](https://www.suse.com/support/policy/) six-month period after its release, and we can drop support for older SPs at that point.  This is effectively how we have already treated earlier SPs for the more recent SLES 15, so applying that guideline to SLES 12 SP4 as well should be reasonable.

We also remove some older distribution names from the set of patterns we match our package filenames against in our upload script for Packagecloud when it prints Markdown output (although this feature of the script may no longer be useful), remove a duplicate entry for SLES 12 SP5, and add comments noting the EOL dates for various releases.

Fixes #5275.

/cc @dharmendrasha as reporter.