### PR TITLE
workflow: use `choco install`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,8 +78,8 @@ jobs:
     - run: mkdir -p "$HOME/go/bin"
       shell: bash
     - run: set GOPATH=%HOME%\go
-    - run: cinst InnoSetup -y
-    - run: cinst strawberryperl -y
+    - run: choco install -y InnoSetup
+    - run: choco install -y strawberryperl
     - run: refreshenv
     - run: make man
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,10 @@ jobs:
     - run: mkdir -p "$HOME/go/bin"
       shell: bash
     - run: set GOPATH=%HOME%\go
-    - run: cinst InnoSetup -y
-    - run: cinst strawberryperl -y
-    - run: cinst zip -y
-    - run: cinst jq -y
+    - run: choco install -y InnoSetup
+    - run: choco install -y strawberryperl
+    - run: choco install -y zip
+    - run: choco install -y jq
     - run: refreshenv
     - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" go install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@latest
       shell: bash


### PR DESCRIPTION
`cinst` is deprecated in favour of `choco install`.  Convert our CI system and release process to the new form and move the `-y` to its proper place before the package name for better compatibility.

Fixes #5272