### PR TITLE
t: avoid incorrect negated commands

### DIFF
--- a/t/t-attributes.sh
+++ b/t/t-attributes.sh
@@ -34,7 +34,8 @@ begin_test "macros"
 
   cd dir
   git lfs track '*.bin' 2>&1 | tee track.log
-  ! grep '"*.bin" already supported' track.log
+  grep '"*.bin" already supported' track.log && exit 1
+  true
 
   # NOTE: At present we do not test that "git lfs track" reports
   #       "already supported" when it finds a pattern in a subdirectory's

--- a/t/t-checkout.sh
+++ b/t/t-checkout.sh
@@ -49,7 +49,7 @@ begin_test "checkout"
   [ "$contents" = "$(cat folder2/nested.dat)" ]
   grep "Checking out LFS objects: 100% (5/5), 95 B" checkout.log
   grep 'accepting "file1.dat"' checkout.log
-  ! grep 'rejecting "file1.dat"' checkout.log
+  grep 'rejecting "file1.dat"' checkout.log && exit 1
 
   # Remove the working directory
   rm -rf file1.dat file2.dat file3.dat folder1/nested.dat folder2/nested.dat
@@ -231,7 +231,7 @@ begin_test "checkout: conflicts"
     git commit -m "second"
 
     # This will cause a conflict.
-    ! git merge first
+    git merge first && exit 1
 
     git lfs checkout --to base.txt --base file1.dat
     git lfs checkout --to ours.txt --ours file1.dat

--- a/t/t-fetch.sh
+++ b/t/t-fetch.sh
@@ -95,7 +95,7 @@ begin_test "fetch (shared repository)"
   rm -rf .git/lfs/objects
 
   git lfs fetch 2>&1 | tee fetch.log
-  ! grep "Could not scan" fetch.log
+  grep "Could not scan" fetch.log && exit 1
   assert_local_object "$contents_oid" 1
 
   git lfs fsck 2>&1 | tee fsck.log

--- a/t/t-migrate-import.sh
+++ b/t/t-migrate-import.sh
@@ -846,7 +846,7 @@ begin_test "migrate import (--everything with tag pointing to tag)"
   assert_pointer "refs/heads/my-feature" "a.md" "$md_feature_oid" "30"
 
   git tag --points-at refs/tags/abc | grep -q def
-  ! git tag --points-at refs/tags/def | grep -q abc
+  git tag --points-at refs/tags/def | grep -q abc && exit 1
 
   assert_local_object "$md_main_oid" "140"
   assert_local_object "$md_feature_oid" "30"

--- a/t/t-post-commit.sh
+++ b/t/t-post-commit.sh
@@ -101,6 +101,7 @@ begin_test "post-commit does not enter submodules"
 
   git add *.dat
   GIT_TRACE=1 git commit -m "Committed large files" 2>&1 | tee output
-  ! grep -E 'filepathfilter:.*submodule/foo' output
+  grep -E 'filepathfilter:.*submodule/foo' output && exit 1
+  true
 )
 end_test

--- a/t/t-pre-push.sh
+++ b/t/t-pre-push.sh
@@ -1216,7 +1216,8 @@ begin_test "pre-push with pushDefault and explicit remote"
   GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git push origin main 2>&1 | tee push.log
 
   assert_server_object "$reponame" 98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4 "refs/heads/main"
-  ! grep wrong-url push.log
+  grep wrong-url push.log && exit 1
+  true
 )
 end_test
 
@@ -1280,7 +1281,8 @@ begin_test "pre-push does not traverse Git objects server has"
   # Verify that we haven't tried to push or query for the object we already
   # pushed before; i.e., we didn't see it because we ignored its Git object
   # during traversal.
-  ! grep $contents_oid push.log
+  grep $contents_oid push.log && exit 1
+  true
 )
 end_test
 

--- a/t/t-standalone-file.sh
+++ b/t/t-standalone-file.sh
@@ -455,7 +455,7 @@ begin_test "standalone-file-lfs.url http URL"
   [ ${PIPESTATUS[0]} = "0" ]
 
   # We should not use the custom adapter process here.
-  ! grep "xfer: started custom adapter process" push.log
+  grep "xfer: started custom adapter process" push.log && exit 1
   grep -F "$GITSERVER/$reponame" push.log
 
   # Make sure we didn't write to the wrong repo.
@@ -465,7 +465,7 @@ begin_test "standalone-file-lfs.url http URL"
   rm -fr .git/lfs/objects
 
   GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git lfs fetch --all 2>&1 | tee fetch.log
-  ! grep "xfer: started custom adapter process" fetch.log
+  grep "xfer: started custom adapter process" fetch.log && exit 1
   grep -F "$GITSERVER/$reponame" fetch.log
 
   git lfs fsck

--- a/t/t-track.sh
+++ b/t/t-track.sh
@@ -74,7 +74,8 @@ begin_test "track --no-excluded"
   echo "*.mov -filter=lfs -text" >> a/b/.gitattributes
 
   git lfs track --no-excluded | tee track.log
-  ! grep "Listing excluded patterns" track.log
+  grep "Listing excluded patterns" track.log && exit 1
+  true
 )
 end_test
 


### PR DESCRIPTION
When `set -e` is enabled, not all commands trigger an error exit if they return false.  For example, it's clear that commands in an `if` or `while` statement don't cause an error if they are false.

What is less obvious, however, is that negated commands and negated pipelines also have no effect on `set -e`.  From POSIX 1003.1-2017 (on `sh -e`):

    When this option is on, if a simple command fails for any of the
    reasons listed in Consequences of Shell Errors or returns an exit
    status value >0, and is not part of the compound list following a
    while, until, or if keyword, and is not a part of an AND or OR list,
    and is not a pipeline preceded by the ! reserved word, then the
    shell shall immediately exit.

As such, writing something like `! grep` will never fail.  Fortunately, we can append `&& exit 1` instead of the `!` and that will work correctly.

To make this work, run the following command to make the code properly check the exit status of our commands:

```
git grep -l '! [a-z]' t | \
  xargs ruby -pi -e '$_.gsub!(/^(\s+)! ([a-z].*)$/, "\\1\\2 && exit 1")'
```

Fixes #5183