### PR TITLE
standalone: print an error if the destination isn't a Git repository

### DIFF
--- a/lfshttp/standalone/standalone.go
+++ b/lfshttp/standalone/standalone.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -131,6 +132,9 @@ func gitDirAtPath(path string) (string, error) {
 	cmd.Cmd.Env = env
 	out, err := cmd.Output()
 	if err != nil {
+		if err, ok := err.(*exec.ExitError); ok && len(err.Stderr) > 0 {
+			return "", errors.New(tr.Tr.Get("failed to call `git rev-parse --git-dir`: %s", string(err.Stderr)))
+		}
 		return "", errors.Wrap(err, tr.Tr.Get("failed to call `git rev-parse --git-dir`"))
 	}
 


### PR DESCRIPTION
If `git rev-parse --git-dir` fails, Git doesn't think that the destination is a valid repository for whatever reason.  One of the most common reasons for that is that the repository is owned by another user.

In such a case, we want to show the error message from Git, since we really have no other indication that this is the case.  It could be just that the destination isn't a repository at all.  Regardless, the error message would be useful to the user to determine the problem, so let's return it if standard error isn't empty.

We also have an initial commit that sets up the error message processing.

Fixes #5081