### PR TITLE
Error out for invalid ref name

### DIFF
--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -159,11 +159,12 @@ func lfsPushRefs(refnames []string, pushAll bool) ([]*git.RefUpdate, error) {
 	}
 
 	for _, suspiciousRef := range suspiciousRefs {
-		isValid, err := git.IsValidRef(suspiciousRef)
+		resolvedRef, err := git.ResolveRef(suspiciousRef)
+
 		if err != nil {
 			return nil, errors.New(tr.Tr.Get("Unable to determine ref validity of %v. Error: %v", suspiciousRef, err))
 		}
-		if !isValid {
+		if resolvedRef == nil {
 			return nil, errors.New(tr.Tr.Get("Invalid ref: %v", suspiciousRef))
 		}
 	}

--- a/git/git.go
+++ b/git/git.go
@@ -14,6 +14,7 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -1166,6 +1167,24 @@ func CachedRemoteRefs(remoteName string) ([]*Ref, error) {
 		}
 	}
 	return ret, cmd.Wait()
+}
+
+// Indicates whether a ref can be resolved via `git show-ref“
+func IsValidRef(refName string) (bool, error) {
+	cmd, err := gitNoLFS("show-ref", refName)
+	if err != nil {
+		return false, errors.New(tr.Tr.Get("failed to find `git show-ref`: %v", err))
+	}
+
+	cmd.Start()
+	err = cmd.Wait()
+	if err != nil {
+		if _, ok := err.(*exec.ExitError); ok {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 func parseShowRefLine(refPrefix, line string) (sha, name string, ok bool) {

--- a/git/git.go
+++ b/git/git.go
@@ -14,7 +14,6 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -1167,24 +1166,6 @@ func CachedRemoteRefs(remoteName string) ([]*Ref, error) {
 		}
 	}
 	return ret, cmd.Wait()
-}
-
-// Indicates whether a ref can be resolved via `git show-ref“
-func IsValidRef(refName string) (bool, error) {
-	cmd, err := gitNoLFS("show-ref", refName)
-	if err != nil {
-		return false, errors.New(tr.Tr.Get("failed to find `git show-ref`: %v", err))
-	}
-
-	cmd.Start()
-	err = cmd.Wait()
-	if err != nil {
-		if _, ok := err.(*exec.ExitError); ok {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
 }
 
 func parseShowRefLine(refPrefix, line string) (sha, name string, ok bool) {

--- a/t/t-fetch.sh
+++ b/t/t-fetch.sh
@@ -57,6 +57,21 @@ begin_test "init for fetch tests"
 )
 end_test
 
+begin_test "fetch (invalid ref)"
+(
+  set -e
+  cd clone
+  rm -rf .git/lfs/objects
+
+  # should return non-zero
+  set +e
+  git lfs fetch origin jibberish
+  fetch_exit=$?
+  set -e
+  [ "$fetch_exit" != "0" ]
+)
+end_test
+
 begin_test "fetch"
 (
   set -e

--- a/t/t-push.sh
+++ b/t/t-push.sh
@@ -26,6 +26,20 @@ begin_test "push with good ref"
 )
 end_test
 
+begin_test "push with invalid ref"
+(
+  set -e
+  push_repo_setup "push-invalid-branch-required"
+
+  # should return non-zero
+  set +e
+  git lfs push origin jibberish
+  push_exit=$?
+  set -e
+  [ "$push_exit" != "0" ]
+)
+end_test
+
 begin_test "push with tracked ref"
 (
   set -e


### PR DESCRIPTION
I noticed that `git lfs push origin jibberishnamehere` returns `0` regardless of whether `jibberishnamehere` is a valid ref. This PR adds a check to see if all the refs you provided are valid, and if they aren't, errors out early.