### PR TITLE
Update Windows signing certificate hash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ TAR_XFORM_CMD ?= $(shell $(TAR) --version | grep -q 'GNU tar' && echo 's')
 
 # CERT_SHA1 is the SHA-1 hash of the Windows code-signing cert to use.  The
 # actual signature is made with SHA-256.
-CERT_SHA1 ?= 27ea8f81ce920bccd2174e3b272f2ba247605be6
+CERT_SHA1 ?= 30a531ed3a246d3d07a4273adaef31552bf6473a
 
 # CERT_FILE is the PKCS#12 file holding the certificate.
 CERT_FILE ?=


### PR DESCRIPTION
The Git LFS signing certificate for Windows binaries has changed, so we update the default signing certificate SHA-1 hash in the Makefile.

(The last update was in commit 16eec1724ef916ef1e9eb4be585c2dc27b7a7270 of PR #4946 in 2022.)

The commands used to generate this hash were:

```
$ openssl pkcs12 -info -in codesign.pfx -out codesign.pem
$ openssl x509 -text -in codesign.pem -fingerprint | \
  grep Fingerprint | sed 's/^SHA1 Fingerprint=//' | \
  sed 's/://g' | tr [:upper:] [:lower:]
```