### PR TITLE
Fix Windows CI with Go 1.20

### DIFF
--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -74,7 +74,7 @@ func trackCommand(cmd *cobra.Command, args []string) {
 	var writeablePatterns []string
 ArgsLoop:
 	for _, unsanitizedPattern := range args {
-		pattern := trimCurrentPrefix(cleanRootPath(unsanitizedPattern))
+		pattern := tools.TrimCurrentPrefix(cleanRootPath(unsanitizedPattern))
 
 		// Generate the new / changed attrib line for merging
 		var encodedArg string

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -87,7 +88,7 @@ ArgsLoop:
 
 		if !trackNoModifyAttrsFlag {
 			for _, known := range knownPatterns {
-				if unescapeAttrPattern(known.Path) == filepath.Join(relpath, pattern) &&
+				if unescapeAttrPattern(known.Path) == path.Join(relpath, pattern) &&
 					((trackLockableFlag && known.Lockable) || // enabling lockable & already lockable (no change)
 						(trackNotLockableFlag && !known.Lockable) || // disabling lockable & not lockable (no change)
 						(!trackLockableFlag && !trackNotLockableFlag)) { // leave lockable as-is in all cases

--- a/commands/command_untrack.go
+++ b/commands/command_untrack.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/git-lfs/git-lfs/v3/tools"
 	"github.com/git-lfs/git-lfs/v3/tr"
 	"github.com/spf13/cobra"
 )
@@ -57,9 +58,9 @@ func untrackCommand(cmd *cobra.Command, args []string) {
 }
 
 func removePath(path string, args []string) bool {
-	withoutCurrentDir := trimCurrentPrefix(path)
+	withoutCurrentDir := tools.TrimCurrentPrefix(path)
 	for _, t := range args {
-		if withoutCurrentDir == escapeAttrPattern(trimCurrentPrefix(t)) {
+		if withoutCurrentDir == escapeAttrPattern(tools.TrimCurrentPrefix(t)) {
 			return true
 		}
 	}

--- a/commands/path.go
+++ b/commands/path.go
@@ -12,24 +12,6 @@ func gitLineEnding(git env) string {
 	}
 }
 
-const (
-	windowsPrefix = `.\`
-	nixPrefix     = `./`
-)
-
-// trimCurrentPrefix removes a leading prefix of "./" or ".\" (referring to the
-// current directory in a platform independent manner).
-//
-// It is useful for callers such as "git lfs track" and "git lfs untrack", that
-// wish to compare filepaths and/or attributes patterns without cleaning across
-// multiple platforms.
-func trimCurrentPrefix(p string) string {
-	if strings.HasPrefix(p, windowsPrefix) {
-		return strings.TrimPrefix(p, windowsPrefix)
-	}
-	return strings.TrimPrefix(p, nixPrefix)
-}
-
 type env interface {
 	Get(string) (string, bool)
 }

--- a/git/attribs.go
+++ b/git/attribs.go
@@ -105,7 +105,13 @@ func AttrPathsFromReader(mp *gitattr.MacroProcessor, path, workingDir string, rd
 	var paths []AttributePath
 
 	relfile, _ := filepath.Rel(workingDir, path)
-	reldir := filepath.Dir(relfile)
+	// Go 1.20 now always returns ".\foo" instead of "foo" in filepath.Rel,
+	// but only on Windows.  Strip the extra dot here so our paths are
+	// always fully relative with no "." or ".." components.
+	reldir := tools.TrimCurrentPrefix(filepath.Dir(relfile))
+	if reldir == "." {
+		reldir = ""
+	}
 	source := &AttributeSource{Path: relfile}
 
 	lines, eol, err := gitattr.ParseLines(rdr)

--- a/git/attribs.go
+++ b/git/attribs.go
@@ -3,6 +3,7 @@ package git
 import (
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 
@@ -101,14 +102,14 @@ func attrPathsFromFile(mp *gitattr.MacroProcessor, path, workingDir string, read
 	return AttrPathsFromReader(mp, path, workingDir, attributes, readMacros)
 }
 
-func AttrPathsFromReader(mp *gitattr.MacroProcessor, path, workingDir string, rdr io.Reader, readMacros bool) []AttributePath {
+func AttrPathsFromReader(mp *gitattr.MacroProcessor, fpath, workingDir string, rdr io.Reader, readMacros bool) []AttributePath {
 	var paths []AttributePath
 
-	relfile, _ := filepath.Rel(workingDir, path)
+	relfile, _ := filepath.Rel(workingDir, fpath)
 	// Go 1.20 now always returns ".\foo" instead of "foo" in filepath.Rel,
 	// but only on Windows.  Strip the extra dot here so our paths are
 	// always fully relative with no "." or ".." components.
-	reldir := tools.TrimCurrentPrefix(filepath.Dir(relfile))
+	reldir := filepath.ToSlash(tools.TrimCurrentPrefix(filepath.Dir(relfile)))
 	if reldir == "." {
 		reldir = ""
 	}
@@ -141,7 +142,7 @@ func AttrPathsFromReader(mp *gitattr.MacroProcessor, path, workingDir string, rd
 
 		pattern := line.Pattern.String()
 		if len(reldir) > 0 {
-			pattern = filepath.Join(reldir, pattern)
+			pattern = path.Join(reldir, pattern)
 		}
 
 		paths = append(paths, AttributePath{

--- a/t/t-track.sh
+++ b/t/t-track.sh
@@ -653,6 +653,9 @@ begin_test "track: escaped pattern in .gitattributes"
     echo >&2 "changing flag for an existing tracked file shouldn't add another line"
     exit 1
   fi
+
+  [ "Tracking \"foo/bar/$filename\"" = "$(git lfs track "foo/bar/$filename")" ]
+  [ "\"foo/bar/$filename\" already supported" = "$(git lfs track "foo/bar/$filename")" ]
 )
 end_test
 

--- a/tools/filetools.go
+++ b/tools/filetools.go
@@ -503,3 +503,21 @@ func CanonicalizePath(path string, missingOk bool) (string, error) {
 	}
 	return "", nil
 }
+
+const (
+	windowsPrefix = `.\`
+	nixPrefix     = `./`
+)
+
+// TrimCurrentPrefix removes a leading prefix of "./" or ".\" (referring to the
+// current directory in a platform independent manner).
+//
+// It is useful for callers such as "git lfs track" and "git lfs untrack", that
+// wish to compare filepaths and/or attributes patterns without cleaning across
+// multiple platforms.
+func TrimCurrentPrefix(p string) string {
+	if strings.HasPrefix(p, windowsPrefix) {
+		return strings.TrimPrefix(p, windowsPrefix)
+	}
+	return strings.TrimPrefix(p, nixPrefix)
+}


### PR DESCRIPTION
As some have recently noticed, our Windows CI has been broken due to the `t/t-track.sh` test failing, which has been caused by a change to our CI in Go 1.20 wherein it always “helpfully” includes a dot component for relative paths with no other directory.  This is not very helpful in our case, and patch 2 here fixes that problem.

Patch 3 also fixes a problem that had gone unnoticed by our testsuite but that is related.

As usual, these commits all have their own reasonable commit messages and explain independently why they're valuable.