### PR TITLE
Remove stale video link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,10 +9,6 @@ these can also be viewed from the command line:
 $ git lfs help <command>
 $ git lfs <command> -h
 ```
-## Videos
-
-* [How to Work with Big Files](https://www.youtube.com/watch?v=uLR1RNqJ1Mw) -
-Quick intro to Git LFS.
 
 ## Developer Docs
 


### PR DESCRIPTION
In commit 2f5b120dba77dfb2e2d03422864d7462717f1347 of PR #682 a link to a YouTube video on the "GitHub Training & Guides" channel was added to the `docs/README.md` file.  The video was named "Git Large File Storage - How to Work with Big Files".

However, this YouTube channel has now been decommissioned by GitHub and the video is no longer available, so until a replacement is available, we remove the link to the old video.

For reference, the video is available from the Internet Archive's page [capture](https://web.archive.org/web/20160120103000/https://www.youtube.com/watch?v=uLR1RNqJ1Mw).

Fixes #5320.
/cc @KyrieLii as reporter.