### PR TITLE
Update to Go version 1.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        go: ['1.19.x']
+        go: ['1.20.x']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -45,7 +45,7 @@ jobs:
     name: Build with specific Go
     strategy:
       matrix:
-        go: ['1.18.x']
+        go: ['1.19.x']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -74,7 +74,7 @@ jobs:
       # which does not honour the PATH we set to our built git-lfs binary.
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.19.x'
+        go-version: '1.20.x'
     - run: mkdir -p "$HOME/go/bin"
       shell: bash
     - run: set GOPATH=%HOME%\go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        go: ['1.19.x']
+        go: ['1.20.x']
     steps:
     - uses: actions/checkout@v3
       with:
@@ -73,7 +73,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        go: ['1.19.x']
+        go: ['1.20.x']
     steps:
     - uses: actions/checkout@v3
       with:
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.19.x']
+        go: ['1.20.x']
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
As our official policy is to support the latest version of Go, we upgrade our CI and release workflows to version 1.20, which was recently released.

We also drop support for versions older than 1.19 as they are not supported by upstream Go.

Note that several older required CI jobs will not run for this PR, and the newer jobs should be marked as required after this PR is merged.