### PR TITLE
Fix CI by enabling Git protocol v2

### DIFF
--- a/t/cmd/lfstest-gitserver.go
+++ b/t/cmd/lfstest-gitserver.go
@@ -967,6 +967,10 @@ func gitHandler(w http.ResponseWriter, r *http.Request) {
 		fmt.Sprintf("CONTENT_TYPE=%s", r.Header.Get("Content-Type")),
 	}
 
+	if vals := r.Header.Values("Git-Protocol"); len(vals) == 1 {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("GIT_PROTOCOL=%s", vals[0]))
+	}
+
 	buffer := &bytes.Buffer{}
 	cmd.Stdin = r.Body
 	cmd.Stdout = buffer


### PR DESCRIPTION
Some time back, Git added support for protocol version 2 over HTTP. This is announced by the `Git-Protocol` header, the value of which Git expects to see as the `GIT_PROTOCOL` environment variable.  If it receives that value, then it switches into protocol v2 mode.

While this is a nice to have in general, it's presently important to fix our testsuite in CI when testing in SHA-256 mode.  In that mode, we set `GIT_DEFAULT_HASH=sha256` to specify the default hash algorithm.  In protocols v0 and v1, Git does not send a capabilities line by default (although one is accepted) in an empty repository, and if no such line is present, it's not possible to discern the hash algorithm in use.

Git recently (after 2.40) added a patch that resulted in empty repositories that are cloned not honouring `GIT_DEFAULT_HASH` in such a case, so if no refs are set, we end up with a SHA-1 repository, which makes our tests fail since they don't interoperate.  This will likely be fixed upstream by both announcing a dummy capabilities line like for pushes and by restoring the use of `GIT_DEFAULT_HASH` when no hash algorithm can be explicitly determined.

In any event, none of this matters with protocol v2, since in that case capabilities are sent as part of the initial refs request and we always know the hash algorithm.  Since this will always work for affected Git versions, let's make sure we enable protocol v2 in the test server if the client supports it.

Fixes #5352