### PR TITLE
Improve HTML formatting of git-lfs-push.adoc

### DIFF
--- a/docs/man/git-lfs-push.adoc
+++ b/docs/man/git-lfs-push.adoc
@@ -28,8 +28,8 @@ by the local clone of the remote.
   all local refs are pushed. Note that this behavior differs from that of
   git-lfs-fetch(1) when its `--all` option is used; in that case, all refs are
   fetched, including refs other than those under `refs/heads` and `refs/tags`.
-  If you are migrating a repository with these commands, make sure to run `git
-  lfs push` for any additional remote refs that contain Git LFS objects not
+  If you are migrating a repository with these commands, make sure to run
+  `git lfs push` for any additional remote refs that contain Git LFS objects not
   reachable from your local refs.
 `--object-id`::
   This pushes only the object OIDs listed at the end of the command, separated


### PR DESCRIPTION
Avoid a line break between backticks because that produces a hardcoded line break in HTML.