### PR TITLE
Drop pre-1.13 Go compatibility code

### DIFF
--- a/tools/robustio_windows.go
+++ b/tools/robustio_windows.go
@@ -4,31 +4,16 @@
 package tools
 
 import (
+	"errors"
 	"os"
 
 	"github.com/avast/retry-go"
 	"golang.org/x/sys/windows"
 )
 
-func underlyingError(err error) error {
-	switch err := err.(type) {
-	case *os.PathError:
-		return err.Err
-	case *os.LinkError:
-		return err.Err
-	case *os.SyscallError:
-		return err.Err
-	}
-	return err
-}
-
 // isEphemeralError returns true if err may be resolved by waiting.
 func isEphemeralError(err error) bool {
-	// TODO: Use this instead for Go >= 1.13
-	// return errors.Is(err, windows.ERROR_SHARING_VIOLATION)
-
-	err = underlyingError(err)
-	return err == windows.ERROR_SHARING_VIOLATION
+	return errors.Is(err, windows.ERROR_SHARING_VIOLATION)
 }
 
 func RobustRename(oldpath, newpath string) error {


### PR DESCRIPTION
I failed to find which Go version git-lfs declares as oldest supported. CI runs against 1.19 and 1.20. But anyway, 1.12 became EOL back in 2020.