### PR TITLE
Ensure all logging tasks are closed and simplify log task dispatching

### DIFF
--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -154,18 +154,16 @@ func fetchRef(ref string, filter *filepathfilter.Filter) bool {
 
 func pointersToFetchForRefs(refs []string) ([]*lfs.WrappedPointer, error) {
 	// This could be a long process so use the chan version & report progress
-	task := tasklog.NewSimpleTask()
-	defer task.Complete()
-
 	logger := tasklog.NewLogger(OutputWriter,
 		tasklog.ForceProgress(cfg.ForceProgress()),
 	)
-	logger.Enqueue(task)
-	var numObjs int64
+	task := logger.Simple()
+	defer task.Complete()
 
 	// use temp gitscanner to collect pointers
 	var pointers []*lfs.WrappedPointer
 	var multiErr error
+	var numObjs int64
 	tempgitscanner := lfs.NewGitScanner(cfg, func(p *lfs.WrappedPointer, err error) {
 		if err != nil {
 			if multiErr != nil {
@@ -293,18 +291,16 @@ func fetchAll() bool {
 
 func scanAll() []*lfs.WrappedPointer {
 	// This could be a long process so use the chan version & report progress
-	task := tasklog.NewSimpleTask()
-	defer task.Complete()
-
 	logger := tasklog.NewLogger(OutputWriter,
 		tasklog.ForceProgress(cfg.ForceProgress()),
 	)
-	logger.Enqueue(task)
-	var numObjs int64
+	task := logger.Simple()
+	defer task.Complete()
 
 	// use temp gitscanner to collect pointers
 	var pointers []*lfs.WrappedPointer
 	var multiErr error
+	var numObjs int64
 	tempgitscanner := lfs.NewGitScanner(cfg, func(p *lfs.WrappedPointer, err error) {
 		if err != nil {
 			if multiErr != nil {

--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -266,11 +266,9 @@ func getRemoteRefs(l *tasklog.Logger) (map[string][]*git.Ref, error) {
 	}
 
 	if !migrateSkipFetch {
-		w := l.Waiter(fmt.Sprintf("migrate: %s", tr.Tr.Get("Fetching remote refs")))
-		if err := git.Fetch(remotes...); err != nil {
+		if err := fetchRemoteRefs(l, remotes); err != nil {
 			return nil, err
 		}
-		w.Complete()
 	}
 
 	for _, remote := range remotes {
@@ -289,6 +287,13 @@ func getRemoteRefs(l *tasklog.Logger) (map[string][]*git.Ref, error) {
 	}
 
 	return refs, nil
+}
+
+func fetchRemoteRefs(l *tasklog.Logger, remotes []string) error {
+	w := l.Waiter(fmt.Sprintf("migrate: %s", tr.Tr.Get("Fetching remote refs")))
+	defer w.Complete()
+
+	return git.Fetch(remotes...)
 }
 
 // formatRefName returns the fully-qualified name for the given Git reference

--- a/commands/command_migrate_export.go
+++ b/commands/command_migrate_export.go
@@ -158,11 +158,7 @@ func migrateExportCommand(cmd *cobra.Command, args []string) {
 
 	// Only perform `git-checkout(1) -f` if the repository is non-bare.
 	if bare, _ := git.IsBare(); !bare {
-		t := l.Waiter(fmt.Sprintf("migrate: %s", tr.Tr.Get("checkout")))
-		err := git.Checkout("", nil, true)
-		t.Complete()
-
-		if err != nil {
+		if err := performForceCheckout(l); err != nil {
 			ExitWithError(err)
 		}
 	}
@@ -177,6 +173,13 @@ func migrateExportCommand(cmd *cobra.Command, args []string) {
 
 	// Prune our cache
 	prune(fetchPruneCfg, false, false, true)
+}
+
+func performForceCheckout(l *tasklog.Logger) error {
+	t := l.Waiter(fmt.Sprintf("migrate: %s", tr.Tr.Get("checkout")))
+	defer t.Complete()
+
+	return git.Checkout("", nil, true)
 }
 
 // trackedFromExportFilter returns an ordered set of strings where each entry

--- a/commands/command_prune.go
+++ b/commands/command_prune.go
@@ -303,6 +303,7 @@ func pruneTaskCollectErrors(outtaskErrors *[]error, errorChan chan error, errorw
 
 func pruneDeleteFiles(prunableObjects []string, logger *tasklog.Logger) {
 	task := logger.Percentage(fmt.Sprintf("prune: %s", tr.Tr.Get("Deleting objects")), uint64(len(prunableObjects)))
+	defer task.Complete()
 
 	var problems bytes.Buffer
 	// In case we fail to delete some

--- a/commands/command_prune.go
+++ b/commands/command_prune.go
@@ -197,25 +197,31 @@ func prune(fetchPruneConfig lfs.FetchPruneConfig, verifyRemote, dryRun, verbose 
 		return
 	}
 
+	logVerboseOutput(logger, verboseOutput, len(prunableObjects), totalSize, dryRun)
+
+	if !dryRun {
+		pruneDeleteFiles(prunableObjects, logger)
+	}
+}
+
+func logVerboseOutput(logger *tasklog.Logger, verboseOutput []string, numPrunableObjects int, totalSize int64, dryRun bool) {
 	info := logger.Simple()
+	defer info.Complete()
+
 	if dryRun {
 		info.Logf("prune: %s", tr.Tr.GetN(
 			"%d file would be pruned (%s)",
 			"%d files would be pruned (%s)",
-			len(prunableObjects),
-			len(prunableObjects),
+			numPrunableObjects,
+			numPrunableObjects,
 			humanize.FormatBytes(uint64(totalSize))))
 		for _, item := range verboseOutput {
 			info.Logf("\n * %s", item)
 		}
-		info.Complete()
 	} else {
 		for _, item := range verboseOutput {
 			info.Logf("\n%s", item)
 		}
-		info.Complete()
-
-		pruneDeleteFiles(prunableObjects, logger)
 	}
 }
 

--- a/commands/command_prune.go
+++ b/commands/command_prune.go
@@ -197,8 +197,7 @@ func prune(fetchPruneConfig lfs.FetchPruneConfig, verifyRemote, dryRun, verbose 
 		return
 	}
 
-	info := tasklog.NewSimpleTask()
-	logger.Enqueue(info)
+	info := logger.Simple()
 	if dryRun {
 		info.Logf("prune: %s", tr.Tr.GetN(
 			"%d file would be pruned (%s)",
@@ -255,10 +254,8 @@ func pruneCheckErrors(taskErrors []error) {
 func pruneTaskDisplayProgress(progressChan PruneProgressChan, waitg *sync.WaitGroup, logger *tasklog.Logger) {
 	defer waitg.Done()
 
-	task := tasklog.NewSimpleTask()
+	task := logger.Simple()
 	defer task.Complete()
-
-	logger.Enqueue(task)
 
 	localCount := 0
 	retainCount := 0

--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -3,7 +3,6 @@ package githistory
 import (
 	"encoding/hex"
 	"fmt"
-	"io"
 	"os"
 	"strings"
 	"sync"
@@ -156,14 +155,6 @@ var (
 		return func(r *Rewriter) {
 			r.filter = filter
 		}
-	}
-
-	// WithLoggerTo logs updates caused by the *git/githistory.Rewriter to
-	// the given io.Writer "sink".
-	WithLoggerTo = func(sink io.Writer, forceProgress bool) rewriterOption {
-		return WithLogger(tasklog.NewLogger(sink,
-			tasklog.ForceProgress(forceProgress),
-		))
 	}
 
 	// WithLogger logs updates caused by the *git/githistory.Rewriter to the

--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -208,6 +208,7 @@ func (r *Rewriter) Rewrite(opt *RewriteOptions) ([]byte, error) {
 	} else {
 		perc = r.l.Percentage(fmt.Sprintf("migrate: %s", tr.Tr.Get("Examining commits")), uint64(len(commits)))
 	}
+	defer perc.Complete()
 
 	var vPerc *tasklog.PercentageTask
 	if opt.Verbose {

--- a/tasklog/log.go
+++ b/tasklog/log.go
@@ -115,7 +115,7 @@ func (l *Logger) Close() {
 	l.wg.Wait()
 }
 
-// Waitier creates and enqueues a new *WaitingTask.
+// Waiter creates and enqueues a new *WaitingTask.
 func (l *Logger) Waiter(msg string) *WaitingTask {
 	t := NewWaitingTask(msg)
 	l.Enqueue(t)
@@ -139,7 +139,7 @@ func (l *Logger) List(msg string) *ListTask {
 	return t
 }
 
-// List creates and enqueues a new *SimpleTask.
+// Simple creates and enqueues a new *SimpleTask.
 func (l *Logger) Simple() *SimpleTask {
 	t := NewSimpleTask()
 	l.Enqueue(t)

--- a/tasklog/log.go
+++ b/tasklog/log.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/git-lfs/git-lfs/v3/tools"
 	isatty "github.com/mattn/go-isatty"
 	"github.com/olekukonko/ts"
 )
@@ -285,7 +286,7 @@ func (l *Logger) logTask(task Task) {
 // It returns the number of bytes "n" written to the sink and the error "err",
 // if one was encountered.
 func (l *Logger) logLine(str string) (n int, err error) {
-	padding := strings.Repeat(" ", maxInt(0, l.widthFn()-len(str)))
+	padding := strings.Repeat(" ", tools.MaxInt(0, l.widthFn()-len(str)))
 
 	return l.log(str + padding + "\r")
 }
@@ -296,11 +297,4 @@ func (l *Logger) logLine(str string) (n int, err error) {
 // if one was encountered.
 func (l *Logger) log(str string) (n int, err error) {
 	return fmt.Fprint(l.sink, str)
-}
-
-func maxInt(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
 }

--- a/tasklog/percentage_task.go
+++ b/tasklog/percentage_task.go
@@ -78,6 +78,15 @@ func (c *PercentageTask) Entry(update string) {
 	}
 }
 
+// Complete notes that the task is completed by setting the number of
+// completed elements to the total number of elements, and if necessary
+// closing the Updates channel, which yields the logger to the next Task.
+func (c *PercentageTask) Complete() {
+	if count := atomic.SwapUint64(&c.n, c.total); count < c.total {
+		close(c.ch)
+	}
+}
+
 // Updates implements Task.Updates and returns a channel which is written to
 // when the state of this task changes, and closed when the task is completed.
 func (c *PercentageTask) Updates() <-chan *Update {

--- a/tasklog/percentage_task.go
+++ b/tasklog/percentage_task.go
@@ -70,8 +70,8 @@ func (c *PercentageTask) Count(n uint64) (new uint64) {
 }
 
 // Entry logs a line-delimited task entry.
-func (t *PercentageTask) Entry(update string) {
-	t.ch <- &Update{
+func (c *PercentageTask) Entry(update string) {
+	c.ch <- &Update{
 		S:     fmt.Sprintf("%s\n", update),
 		At:    time.Now(),
 		Force: true,
@@ -80,7 +80,6 @@ func (t *PercentageTask) Entry(update string) {
 
 // Updates implements Task.Updates and returns a channel which is written to
 // when the state of this task changes, and closed when the task is completed.
-// has been completed.
 func (c *PercentageTask) Updates() <-chan *Update {
 	return c.ch
 }

--- a/tasklog/waiting_task.go
+++ b/tasklog/waiting_task.go
@@ -28,8 +28,8 @@ func (w *WaitingTask) Complete() {
 	close(w.ch)
 }
 
-// Done implements Task.Done and returns a channel which is closed when
-// Complete() is called.
+// Updates implements the Task.Updates function and returns a channel of updates
+// to log to the sink.
 func (w *WaitingTask) Updates() <-chan *Update {
 	return w.ch
 }


### PR DESCRIPTION
This PR revises our handling of structures that implement the `Task` [interface](https://github.com/git-lfs/git-lfs/blob/1efc16b424ea1f88bfbcfe81a667bcfb2cdba3d5/tasklog/task.go#L5-L17) of the `tasklog` package so that in all cases we always immediately register a deferred call to their `Complete()` method after allocating and initializing a new structure.  This ensures that the channels created for the structures are always closed, which prevents `Logger` instances waiting on those channels from hanging indefinitely following a panic or other exceptional error condition.

As well, we simplify some instances of the construction of these types of structures, and clean up some details in the implementation of the `tasklog` package.

---

In the case of the `PercentageTask` [structure](https://github.com/git-lfs/git-lfs/blob/1efc16b424ea1f88bfbcfe81a667bcfb2cdba3d5/tasklog/percentage_task.go), we first add a new `Complete()` method, which does not currently exist (although it was discussed in https://github.com/git-lfs/git-lfs/pull/2757#discussion_r154760580, in relation to the `git-lfs-prune(1)` command).  We can then register a call to our new `*PercentageTask.Complete()` method with `defer` following the creation of a `PercentageTask` structure, such as [occurs](https://github.com/git-lfs/git-lfs/blob/1efc16b424ea1f88bfbcfe81a667bcfb2cdba3d5/git/githistory/rewriter.go#L214-L219) in the `Rewrite()` method of the `Rewrite` structure in the `git/githistory` package.

This particular use case resolves one of the problems reported in #5332, where after a panic occurs (due to an unrelated bug while processing Git macro attributes) in the Git history rewriting phase of a `git lfs migrate import --fixup` command, the command hangs because the deferred `*Logger.Close()` [call](https://github.com/git-lfs/git-lfs/blob/1efc16b424ea1f88bfbcfe81a667bcfb2cdba3d5/commands/command_migrate_import.go#L32) of the "main" goroutine is stuck [waiting](https://github.com/git-lfs/git-lfs/blob/1efc16b424ea1f88bfbcfe81a667bcfb2cdba3d5/tasklog/log.go#L115) on a semaphore which will never decrement to zero.  Under normal circumstances the `*Rewriter.Rewrite()` method would iterate through all the commits selected for rewriting, and so the final [call](https://github.com/git-lfs/git-lfs/blob/1efc16b424ea1f88bfbcfe81a667bcfb2cdba3d5/git/githistory/rewriter.go#L312) to the `*PercentageTask.Count()` would cause the task's channel to be [closed](https://github.com/git-lfs/git-lfs/blob/1efc16b424ea1f88bfbcfe81a667bcfb2cdba3d5/tasklog/percentage_task.go#L65-L67), thus notifying the [anonymous function](https://github.com/git-lfs/git-lfs/blob/1efc16b424ea1f88bfbcfe81a667bcfb2cdba3d5/tasklog/log.go#L181-L187) that is [waiting](https://github.com/git-lfs/git-lfs/blob/1efc16b424ea1f88bfbcfe81a667bcfb2cdba3d5/tasklog/log.go#L254) on the channel that is should cease waiting and begin to exit.  But if the `*Rewriter.Rewrite()` method panics during its processing of commits, it never closes the channel of the `PercentageTask`.  By adding an explicitly deferred call to our new `Complete()` method for that task, though, we can guarantee that the channel will always be closed by the time the `*Rewriter.Rewrite()` method returns.

(The macro attribute processing bug from #5332, and the discrepancy between how the `import` and `info` subcommands of the `git-lfs-migrate(1)` command manage the cleanup of their `*Logger` structures, will be dealt with in subsequent PRs.)

Also, as in the case of the `SimpleTask` structure [used](https://github.com/git-lfs/git-lfs/blob/1efc16b424ea1f88bfbcfe81a667bcfb2cdba3d5/commands/command_prune.go#L200) by the `git-lfs-prune(1)` command's `prune()` function, we refactor our code so as to introduce small utility functions which encapsulate the initialization and cleanup of structures implementing the `Task` interface.  This allows us to always establish a deferred call to the structure's `Cleanup()` method immediately after initializing and enqueuing the structure, so the return from the utility function guarantees the structure's channel is closed in all instances.

This pattern was discussed in https://github.com/git-lfs/git-lfs/pull/2757#discussion_r154774369 as a desirable one to follow for all resource allocation and deallocation, and corresponds to the resource management approach used elsewhere, such as in the `UpdateRefs()` method of the `refUpdater` structure in the `git/githistory` package, where a `ListTask` is [created](https://github.com/git-lfs/git-lfs/blob/1efc16b424ea1f88bfbcfe81a667bcfb2cdba3d5/git/githistory/ref_updater.go#L43) and a matching deferred call to its `Complete()` method is then [defined](https://github.com/git-lfs/git-lfs/blob/1efc16b424ea1f88bfbcfe81a667bcfb2cdba3d5/git/githistory/ref_updater.go#L44), and in the `scanAll()` and `pointersToFetchForRefs()` functions of the `git-lfs-fetch(1)` command, where `SimpleTask` structures are [created](https://github.com/git-lfs/git-lfs/blob/1efc16b424ea1f88bfbcfe81a667bcfb2cdba3d5/commands/command_fetch.go#L296-L297) and a deferred call to their `Complete()` method is immediately [established](https://github.com/git-lfs/git-lfs/blob/1efc16b424ea1f88bfbcfe81a667bcfb2cdba3d5/commands/command_fetch.go#L157-L158).  (Note, though, that we refine these functions by making use of the `*Logger.Simple()` [method](https://github.com/git-lfs/git-lfs/blob/1efc16b424ea1f88bfbcfe81a667bcfb2cdba3d5/tasklog/log.go#L143-L148), which was introduced in commit 0cad488c23350ff35f969980753bf9798071942e of PR #2767 but is not used anywhere at present.)

---

This PR also fixes some minor issues relating to the `tasklog` package, removing unused or unnecessary code and correcting code comments, and simplifying the initialization of some `SimpleTask` structures with the `*Logger.Simple()` method, as mentioned above.

One notable change is the removal of the `pending` and `next` variables and the code to [populate](https://github.com/git-lfs/git-lfs/blob/1efc16b424ea1f88bfbcfe81a667bcfb2cdba3d5/tasklog/log.go#L194-L199) and [process](https://github.com/git-lfs/git-lfs/blob/1efc16b424ea1f88bfbcfe81a667bcfb2cdba3d5/tasklog/log.go#L216-L233) them from the `*Logger.consume()` method of the `tasklog` package.  This method was introduced in the initial form of the `tasklog` package in commit e90d54dabb45fd61c0c98803e009961800422010 of PR #2329, and included the internal `pending` slice and the logic to push and pop tasks from it in much the same form as that code still exists today.

However, that logic which manages the `pending` slice is never exercised because tasks are only [appended](https://github.com/git-lfs/git-lfs/blob/1efc16b424ea1f88bfbcfe81a667bcfb2cdba3d5/tasklog/log.go#L228) in a conditional [block](https://github.com/git-lfs/git-lfs/blob/1efc16b424ea1f88bfbcfe81a667bcfb2cdba3d5/tasklog/log.go#L215-L234) which executes if the `next` variable is non-`nil`, but that variable is [initialized](https://github.com/git-lfs/git-lfs/blob/1efc16b424ea1f88bfbcfe81a667bcfb2cdba3d5/tasklog/log.go#L196) as `nil` and can only be [set](https://github.com/git-lfs/git-lfs/blob/1efc16b424ea1f88bfbcfe81a667bcfb2cdba3d5/tasklog/log.go#L197-L199) to another value if the `pending` slice is non-empty.  As a result, neither condition is ever true, and so only the in the conditional [block](https://github.com/git-lfs/git-lfs/blob/1efc16b424ea1f88bfbcfe81a667bcfb2cdba3d5/tasklog/log.go#L201-L214) for when the `next` variable is `nil` ever executes, and we can remove the rest.

---

It may be easiest to review this PR commit-by-commit, as each commit has a detailed description and should be logically independent and bisectable, but it should also be possible to review this PR as a single diff.

/cc #5332 where the `git lfs migrate import --fixup` hang behaviour was reported.
/cc @ttaylorr for insight on the design of the `tasklog` and its buffering logic.