### PR TITLE
Add Refspec value to lockIdFromPath request

### DIFF
--- a/locking/locks.go
+++ b/locking/locks.go
@@ -402,6 +402,7 @@ func (c *Client) lockIdFromPath(path string) (string, error) {
 		Filters: []lockFilter{
 			{Property: "path", Value: path},
 		},
+		Refspec: c.RemoteRef.Refspec(),
 	})
 
 	if err != nil {


### PR DESCRIPTION
This PR fixes an inconsistent behaviour in git lfs client requests behaviour.
Currently all locking requests send refspec value to server except lockIdFromPath. It actually looks like the refspec value should be passed thought it dosent at the moment.

Motivation:
This inconsistency prevents custom server side locking logic that takes current user branch into account. Specificaly the unlocking request that is called with filespec param instead of lock id.
git lfs unlock "path/to/file" 

The usecase for this custom logic is a "custom lockspace" feature for ie hotfix branches, that should not interfere with main development branches locks and wont be ever merged as is back into main branch.

I work in game development where locking is used extensively due to high amount of binary assets and requires some "in place" logic tweaks for default locking logic.
Usecases include:
- hotfix branches that are made for a current product version and wont be merged into the main development branch as is;
- feature branches for "dirty" experiments that wont be merged as is and require broad project modifications with several team members;
- release branches that wont follow git flow development process, where some in place changes are applied to the current release version and backported in modified state into final product;

I dont see any directly related tests for this specific request. If they should actually be created please advice.

Best regards, Alexander Bogomolets.