### PR TITLE
Add support for `wwwauth[]` to credential helpers

### DIFF
--- a/creds/creds.go
+++ b/creds/creds.go
@@ -74,7 +74,8 @@ type CredentialHelperContext struct {
 	askpassCredHelper *AskPassCredentialHelper
 	cachingCredHelper *credentialCacher
 
-	urlConfig *config.URLConfig
+	urlConfig      *config.URLConfig
+	wwwAuthHeaders []string
 }
 
 func NewCredentialHelperContext(gitEnv config.Environment, osEnv config.Environment) *CredentialHelperContext {
@@ -113,6 +114,10 @@ func NewCredentialHelperContext(gitEnv config.Environment, osEnv config.Environm
 	return c
 }
 
+func (ctxt *CredentialHelperContext) SetWWWAuthHeaders(headers []string) {
+	ctxt.wwwAuthHeaders = headers
+}
+
 // getCredentialHelper parses a 'credsConfig' from the git and OS environments,
 // returning the appropriate CredentialHelper to authenticate requests with.
 //
@@ -126,6 +131,9 @@ func (ctxt *CredentialHelperContext) GetCredentialHelper(helper CredentialHelper
 	}
 	if u.Scheme == "cert" || ctxt.urlConfig.Bool("credential", rawurl, "usehttppath", false) {
 		input["path"] = []string{strings.TrimPrefix(u.Path, "/")}
+	}
+	if len(ctxt.wwwAuthHeaders) != 0 && !ctxt.urlConfig.Bool("credential", rawurl, "skipwwwauth", false) {
+		input["wwwauth[]"] = ctxt.wwwAuthHeaders
 	}
 
 	if helper != nil {

--- a/creds/creds_test.go
+++ b/creds/creds_test.go
@@ -44,7 +44,7 @@ func TestCredHelperSetNoErrors(t *testing.T) {
 	helper1 := newTestCredHelper()
 	helper2 := newTestCredHelper()
 	helpers := NewCredentialHelpers([]CredentialHelper{cache, helper1, helper2})
-	creds := Creds{"protocol": "https", "host": "example.com"}
+	creds := Creds{"protocol": []string{"https"}, "host": []string{"example.com"}}
 
 	out, err := helpers.Fill(creds)
 	assert.Nil(t, err)
@@ -59,7 +59,12 @@ func TestCredHelperSetNoErrors(t *testing.T) {
 	assert.Equal(t, 2, len(helper1.fill))
 	assert.Equal(t, 0, len(helper2.fill))
 
-	credsWithPass := Creds{"protocol": "https", "host": "example.com", "username": "foo", "password": "bar"}
+	credsWithPass := Creds{
+		"protocol": []string{"https"},
+		"host":     []string{"example.com"},
+		"username": []string{"foo"},
+		"password": []string{"bar"},
+	}
 	assert.Nil(t, helpers.Approve(credsWithPass))
 	assert.Equal(t, 1, len(helper1.approve))
 	assert.Equal(t, 0, len(helper2.approve))
@@ -100,7 +105,7 @@ func TestCredHelperSetFillError(t *testing.T) {
 	helper1 := newTestCredHelper()
 	helper2 := newTestCredHelper()
 	helpers := NewCredentialHelpers([]CredentialHelper{cache, helper1, helper2})
-	creds := Creds{"protocol": "https", "host": "example.com"}
+	creds := Creds{"protocol": []string{"https"}, "host": []string{"example.com"}}
 
 	helper1.fillErr = errors.New("boom")
 	out, err := helpers.Fill(creds)
@@ -139,7 +144,7 @@ func TestCredHelperSetApproveError(t *testing.T) {
 	helper1 := newTestCredHelper()
 	helper2 := newTestCredHelper()
 	helpers := NewCredentialHelpers([]CredentialHelper{cache, helper1, helper2})
-	creds := Creds{"protocol": "https", "host": "example.com"}
+	creds := Creds{"protocol": []string{"https"}, "host": []string{"example.com"}}
 
 	approveErr := errors.New("boom")
 	helper1.approveErr = approveErr
@@ -170,7 +175,7 @@ func TestCredHelperSetFillAndApproveError(t *testing.T) {
 	helper1 := newTestCredHelper()
 	helper2 := newTestCredHelper()
 	helpers := NewCredentialHelpers([]CredentialHelper{cache, helper1, helper2})
-	creds := Creds{"protocol": "https", "host": "example.com"}
+	creds := Creds{"protocol": []string{"https"}, "host": []string{"example.com"}}
 
 	credErr := errors.New("boom")
 	helper1.fillErr = credErr
@@ -200,7 +205,7 @@ func TestCredHelperSetRejectError(t *testing.T) {
 	helper1 := newTestCredHelper()
 	helper2 := newTestCredHelper()
 	helpers := NewCredentialHelpers([]CredentialHelper{cache, helper1, helper2})
-	creds := Creds{"protocol": "https", "host": "example.com"}
+	creds := Creds{"protocol": []string{"https"}, "host": []string{"example.com"}}
 
 	rejectErr := errors.New("boom")
 	helper1.rejectErr = rejectErr
@@ -238,7 +243,7 @@ func TestCredHelperSetAllFillErrors(t *testing.T) {
 	helper1 := newTestCredHelper()
 	helper2 := newTestCredHelper()
 	helpers := NewCredentialHelpers([]CredentialHelper{cache, helper1, helper2})
-	creds := Creds{"protocol": "https", "host": "example.com"}
+	creds := Creds{"protocol": []string{"https"}, "host": []string{"example.com"}}
 
 	helper1.fillErr = errors.New("boom 1")
 	helper2.fillErr = errors.New("boom 2")

--- a/creds/netrc_test.go
+++ b/creds/netrc_test.go
@@ -12,21 +12,21 @@ func TestNetrcWithHostAndPort(t *testing.T) {
 	netrcHelper.netrcFinder = &fakeNetrc{}
 
 	what := make(Creds)
-	what["protocol"] = "http"
-	what["host"] = "netrc-host:123"
-	what["path"] = "/foo/bar"
+	what["protocol"] = []string{"http"}
+	what["host"] = []string{"netrc-host:123"}
+	what["path"] = []string{"/foo/bar"}
 
 	creds, err := netrcHelper.Fill(what)
 	if err != nil {
 		t.Fatalf("error retrieving netrc credentials: %s", err)
 	}
 
-	username := creds["username"]
+	username := creds["username"][0]
 	if username != "abc" {
 		t.Fatalf("bad username: %s", username)
 	}
 
-	password := creds["password"]
+	password := creds["password"][0]
 	if password != "def" {
 		t.Fatalf("bad password: %s", password)
 	}
@@ -37,21 +37,21 @@ func TestNetrcWithHost(t *testing.T) {
 	netrcHelper.netrcFinder = &fakeNetrc{}
 
 	what := make(Creds)
-	what["protocol"] = "http"
-	what["host"] = "netrc-host"
-	what["path"] = "/foo/bar"
+	what["protocol"] = []string{"http"}
+	what["host"] = []string{"netrc-host"}
+	what["path"] = []string{"/foo/bar"}
 
 	creds, err := netrcHelper.Fill(what)
 	if err != nil {
 		t.Fatalf("error retrieving netrc credentials: %s", err)
 	}
 
-	username := creds["username"]
+	username := creds["username"][0]
 	if username != "abc" {
 		t.Fatalf("bad username: %s", username)
 	}
 
-	password := creds["password"]
+	password := creds["password"][0]
 	if password != "def" {
 		t.Fatalf("bad password: %s", password)
 	}
@@ -62,9 +62,9 @@ func TestNetrcWithBadHost(t *testing.T) {
 	netrcHelper.netrcFinder = &fakeNetrc{}
 
 	what := make(Creds)
-	what["protocol"] = "http"
-	what["host"] = "other-host"
-	what["path"] = "/foo/bar"
+	what["protocol"] = []string{"http"}
+	what["host"] = []string{"other-host"}
+	what["path"] = []string{"/foo/bar"}
 
 	_, err := netrcHelper.Fill(what)
 	if err != credHelperNoOp {

--- a/lfsapi/auth.go
+++ b/lfsapi/auth.go
@@ -161,7 +161,7 @@ func (c *Client) getCreds(remote string, access creds.Access, req *http.Request)
 		err = credWrapper.FillCreds()
 		if err == nil {
 			tracerx.Printf("Filled credentials for %s", credsURL)
-			setRequestAuth(req, credWrapper.Creds["username"], credWrapper.Creds["password"])
+			setRequestAuth(req, credWrapper.Creds["username"][0], credWrapper.Creds["password"][0])
 		}
 		return credWrapper, err
 	}

--- a/lfshttp/certs.go
+++ b/lfshttp/certs.go
@@ -45,14 +45,14 @@ func decryptPEMBlock(c *Client, block *pem.Block, path string, key []byte) ([]by
 	}
 	credWrapper := c.credHelperContext.GetCredentialHelper(nil, url)
 
-	credWrapper.Input["username"] = ""
+	credWrapper.Input["username"] = []string{""}
 
 	creds, err := credWrapper.CredentialHelper.Fill(credWrapper.Input)
 	if err != nil {
 		tracerx.Printf("Error filling credentials for %q: %v", fileurl, err)
 		return nil, err
 	}
-	pass := creds["password"]
+	pass := creds["password"][0]
 	decrypted, err := x509.DecryptPEMBlock(block, []byte(pass))
 	if err != nil {
 		credWrapper.CredentialHelper.Reject(creds)

--- a/t/cmd/lfstest-gitserver.go
+++ b/t/cmd/lfstest-gitserver.go
@@ -1589,6 +1589,7 @@ func skipIfNoCookie(w http.ResponseWriter, r *http.Request, id string) bool {
 func skipIfBadAuth(w http.ResponseWriter, r *http.Request, id string) bool {
 	auth := r.Header.Get("Authorization")
 	if auth == "" {
+		w.Header().Add("Lfs-Authenticate", "Basic realm=\"testsuite\"")
 		w.WriteHeader(401)
 		return true
 	}


### PR DESCRIPTION
Git recently added a new field to the credential helper, `wwwauth[]`, which may be repeated and includes all of the `WWW-Authenticate` headers so that the credential helper may choose an appropriate set of credentials and extract any sort of necessary data from the field (such as challenge).

In Git LFS, we also want to do this with the `LFS-Authenticate` headers as well, since those are often used for the same purpose, so include both these headers in that field when passing them to `git credential fill`.

Note that `git credential fill` only honours this value and passes it to the credential helper in Git 2.41 and newer (including the latest `HEAD`).  However, just to be safe, let's add an undocumented and experimental option (`credential.*.skipwwwauth`) that users can use to control this, which we can remove in a few releases if it turns out it's not needed.  Similarly, skip our new tests if we have an older version of Git where this doesn't work, since they'll otherwise fail.

In addition, perform some preparatory work to allow multiple values for a key, which we'll use in the second commit.

Fixes: #5222