### PR TITLE
Unlock by ID with JSON Flag returns empty array

### DIFF
--- a/commands/command_unlock.go
+++ b/commands/command_unlock.go
@@ -109,6 +109,11 @@ func unlockCommand(cmd *cobra.Command, args []string) {
 			success = false
 		} else if !locksCmdFlags.JSON {
 			Print(tr.Tr.Get("Unlocked Lock %s", unlockCmdFlags.Id))
+		} else {
+			locks = append(locks, unlockResponse{
+				Id:     unlockCmdFlags.Id,
+				Unlocked: true,
+			})
 		}
 	} else {
 		Exit(tr.Tr.Get("Exactly one of --id or a set of paths must be provided"))

--- a/commands/command_unlock.go
+++ b/commands/command_unlock.go
@@ -111,7 +111,7 @@ func unlockCommand(cmd *cobra.Command, args []string) {
 			Print(tr.Tr.Get("Unlocked Lock %s", unlockCmdFlags.Id))
 		} else {
 			locks = append(locks, unlockResponse{
-				Id:     unlockCmdFlags.Id,
+				Id:       unlockCmdFlags.Id,
 				Unlocked: true,
 			})
 		}

--- a/t/t-unlock.sh
+++ b/t/t-unlock.sh
@@ -308,6 +308,25 @@ begin_test "unlocking a lock by id"
 )
 end_test
 
+begin_test "unlocking a lock by id (--json)"
+(
+  set -e
+
+  reponame="unlock_by_id_json"
+  setup_repo "$reponame" "c_json.dat"
+
+  git lfs lock --json "c_json.dat" | tee lock.log
+
+  id=$(assert_lock lock.log c_json.dat)
+  assert_server_lock "$reponame" "$id"
+
+  git lfs unlock --json --id="$id" 2>&1 | tee unlock.log
+  grep "\"unlocked\":true" unlock.log
+
+  refute_server_lock "$reponame" "$id"
+)
+end_test
+
 begin_test "unlocking a lock without sufficient info"
 (
   set -e


### PR DESCRIPTION
When unlock is called with the JSON flag and ID, the response is empty.

The current behavior:
git lfs lock --json <SOME_PATH>
[{"id":"103","path":"<SOME_PATH>","owner":{"name":"<Author>"},"locked_at":"2023-06-06T10:44:37Z"}]

git lfs unlock --json --id=103 
[]

The expected behavior:
git lfs lock --json <SOME_PATH>
[{"id":"103","path":"<SOME_PATH>","owner":{"name":"<Author>"},"locked_at":"2023-06-06T10:44:37Z"}]

git lfs unlock --json --id=103 
[{"id":"103","unlocked":true}]