### PR TITLE
Refactor `GitScanner` and simplify implementation

### DIFF
--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -76,7 +76,6 @@ func checkoutCommand(cmd *cobra.Command, args []string) {
 	if err := chgitscanner.ScanTree(ref.Sha, nil); err != nil {
 		ExitWithError(err)
 	}
-	chgitscanner.Close()
 
 	meter.Start()
 	for _, p := range pointers {

--- a/commands/command_dedup.go
+++ b/commands/command_dedup.go
@@ -85,7 +85,6 @@ func dedupCommand(cmd *cobra.Command, args []string) {
 			atomic.AddInt64(&dedupStats.totalProcessedSize, p.Size)
 		}
 	})
-	defer gitScanner.Close()
 
 	if err := gitScanner.ScanTree("HEAD", nil); err != nil {
 		ExitWithError(err)

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -61,9 +61,6 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 	}
 
 	success := true
-	gitscanner := lfs.NewGitScanner(cfg, nil)
-	defer gitscanner.Close()
-
 	include, exclude := getIncludeExcludeArgs(cmd)
 	fetchPruneCfg := lfs.NewFetchPruneConfig(cfg.Git)
 

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -136,7 +136,6 @@ func pointersToFetchForRef(ref string, filter *filepathfilter.Filter) ([]*lfs.Wr
 		return nil, err
 	}
 
-	tempgitscanner.Close()
 	return pointers, multiErr
 }
 
@@ -180,7 +179,6 @@ func pointersToFetchForRefs(refs []string) ([]*lfs.WrappedPointer, error) {
 		return nil, err
 	}
 
-	tempgitscanner.Close()
 	return pointers, multiErr
 }
 
@@ -212,7 +210,6 @@ func fetchPreviousVersions(ref string, since time.Time, filter *filepathfilter.F
 		ExitWithError(err)
 	}
 
-	tempgitscanner.Close()
 	return fetchAndReportToChan(pointers, filter, nil)
 }
 
@@ -316,8 +313,6 @@ func scanAll() []*lfs.WrappedPointer {
 	if err := tempgitscanner.ScanAll(nil); err != nil {
 		Panic(err, tr.Tr.Get("Could not scan for Git LFS files"))
 	}
-
-	tempgitscanner.Close()
 
 	if multiErr != nil {
 		Panic(multiErr, tr.Tr.Get("Could not scan for Git LFS files"))

--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -162,7 +162,6 @@ func doFsckObjects(include, exclude string, useIndex bool) []string {
 		}
 	}
 
-	gitscanner.Close()
 	return corruptOids
 }
 
@@ -209,7 +208,6 @@ func doFsckPointers(include, exclude string) []corruptPointer {
 		}
 	}
 
-	gitscanner.Close()
 	return corruptPointers
 }
 

--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -134,7 +134,6 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 
 		seen[p.Name] = struct{}{}
 	})
-	defer gitscanner.Close()
 
 	includeArg, excludeArg := getIncludeExcludeArgs(cmd)
 	gitscanner.Filter = buildFilepathFilter(cfg, includeArg, excludeArg, false)

--- a/commands/command_prune.go
+++ b/commands/command_prune.go
@@ -121,8 +121,7 @@ func prune(fetchPruneConfig lfs.FetchPruneConfig, verifyRemote, dryRun, verbose 
 	progresswait.Add(1)
 	go pruneTaskDisplayProgress(progressChan, &progresswait, logger)
 
-	taskwait.Wait() // wait for subtasks
-	gitscanner.Close()
+	taskwait.Wait()   // wait for subtasks
 	close(retainChan) // triggers retain collector to end now all tasks have
 	retainwait.Wait() // make sure all retained objects added
 

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -93,7 +93,6 @@ func pull(filter *filepathfilter.Filter) {
 	}
 
 	meter.Start()
-	gitscanner.Close()
 	q.Wait()
 	wg.Wait()
 	tracerx.PerformanceSince("process queue", processQueue)

--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -245,7 +245,6 @@ func statusScanRefRange(ref *git.Ref) {
 
 		Print("\t%s (%s)", p.Name, p.Oid)
 	})
-	defer gitscanner.Close()
 
 	Print("%s\n", tr.Tr.Get("Objects to be pushed to %s:", remoteRef.Name))
 	if err := gitscanner.ScanRefRange(ref.Sha, remoteRef.Sha, nil); err != nil {

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -21,11 +21,7 @@ import (
 )
 
 func uploadForRefUpdates(ctx *uploadContext, updates []*git.RefUpdate, pushAll bool) error {
-	gitscanner, err := ctx.buildGitScanner()
-	if err != nil {
-		return err
-	}
-
+	gitscanner := ctx.buildGitScanner()
 	defer func() {
 		gitscanner.Close()
 		ctx.ReportErrors()
@@ -153,11 +149,12 @@ func (c *uploadContext) addScannerError(err error) {
 	}
 }
 
-func (c *uploadContext) buildGitScanner() (*lfs.GitScanner, error) {
+func (c *uploadContext) buildGitScanner() *lfs.GitScanner {
 	gitscanner := lfs.NewGitScanner(cfg, nil)
+	gitscanner.RemoteForPush(c.Remote)
 	gitscanner.FoundLockable = func(n string) { c.lockVerifier.LockedByThem(n) }
 	gitscanner.PotentialLockables = c.lockVerifier
-	return gitscanner, gitscanner.RemoteForPush(c.Remote)
+	return gitscanner
 }
 
 func (c *uploadContext) gitScannerCallback(tqueue *tq.TransferQueue) func(*lfs.WrappedPointer, error) {

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -22,10 +22,7 @@ import (
 
 func uploadForRefUpdates(ctx *uploadContext, updates []*git.RefUpdate, pushAll bool) error {
 	gitscanner := ctx.buildGitScanner()
-	defer func() {
-		gitscanner.Close()
-		ctx.ReportErrors()
-	}()
+	defer ctx.ReportErrors()
 
 	verifyLocksForUpdates(ctx.lockVerifier, updates)
 	exclude := make([]string, 0, len(updates))

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -147,11 +147,7 @@ func (c *uploadContext) addScannerError(err error) {
 }
 
 func (c *uploadContext) buildGitScanner() *lfs.GitScanner {
-	gitscanner := lfs.NewGitScanner(cfg, nil)
-	gitscanner.RemoteForPush(c.Remote)
-	gitscanner.FoundLockable = func(n string) { c.lockVerifier.LockedByThem(n) }
-	gitscanner.PotentialLockables = c.lockVerifier
-	return gitscanner
+	return lfs.NewGitScannerForPush(cfg, c.Remote, func(n string) { c.lockVerifier.LockedByThem(n) }, c.lockVerifier)
 }
 
 func (c *uploadContext) gitScannerCallback(tqueue *tq.TransferQueue) func(*lfs.WrappedPointer, error) {

--- a/lfs/gitscanner.go
+++ b/lfs/gitscanner.go
@@ -214,7 +214,7 @@ func (s *GitScanner) ScanStashed(cb GitScannerFoundPointer) error {
 		return err
 	}
 
-	return scanStashed(callback, s)
+	return scanStashed(callback)
 }
 
 // ScanPreviousVersions scans changes reachable from ref (commit) back to since.

--- a/lfs/gitscanner.go
+++ b/lfs/gitscanner.go
@@ -62,7 +62,7 @@ func (s *GitScanner) Close() {
 }
 
 // RemoteForPush sets up this *GitScanner to scan for objects to push to the
-// given remote. Needed for ScanRangeToRemote().
+// given remote. Needed for ScanMultiRangeToRemote().
 func (s *GitScanner) RemoteForPush(r string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -74,25 +74,6 @@ func (s *GitScanner) RemoteForPush(r string) error {
 	s.remote = r
 	s.skippedRefs = calcSkippedRefs(r)
 	return nil
-}
-
-// ScanRangeToRemote scans through all unique objects reachable from the
-// "include" ref but not reachable from the "exclude" ref and which the
-// given remote does not have. See RemoteForPush().
-func (s *GitScanner) ScanRangeToRemote(include, exclude string, cb GitScannerFoundPointer) error {
-	callback, err := firstGitScannerCallback(cb, s.FoundPointer)
-	if err != nil {
-		return err
-	}
-
-	s.mu.Lock()
-	if len(s.remote) == 0 {
-		s.mu.Unlock()
-		return errors.New(tr.Tr.Get("unable to scan starting at %q: no remote set", include))
-	}
-	s.mu.Unlock()
-
-	return scanRefsToChanSingleIncludeExclude(s, callback, include, exclude, s.cfg.GitEnv(), s.cfg.OSEnv(), s.opts(ScanRangeToRemoteMode))
 }
 
 // ScanMultiRangeToRemote scans through all unique objects reachable from the

--- a/lfs/gitscanner_catfilebatchcheck.go
+++ b/lfs/gitscanner_catfilebatchcheck.go
@@ -54,6 +54,7 @@ func runCatFileBatchCheck(smallRevCh chan string, lockableCh chan string, lockab
 		}
 		close(smallRevCh)
 		close(errCh)
+		close(lockableCh)
 	}()
 
 	return nil

--- a/lfs/gitscanner_log.go
+++ b/lfs/gitscanner_log.go
@@ -70,7 +70,7 @@ func scanUnpushed(cb GitScannerFoundPointer, remote string) error {
 	return nil
 }
 
-func scanStashed(cb GitScannerFoundPointer, s *GitScanner) error {
+func scanStashed(cb GitScannerFoundPointer) error {
 	// Stashes are actually 2-3 commits, each containing one of:
 	// 1. Working copy (WIP) modified files
 	// 2. Index changes

--- a/lfs/gitscanner_refs.go
+++ b/lfs/gitscanner_refs.go
@@ -71,13 +71,13 @@ func scanRefsToChan(scanner *GitScanner, pointerCb GitScannerFoundPointer, inclu
 		return err
 	}
 
-	lockableSet := &lockableNameSet{nameMap: nameMap, set: scanner.PotentialLockables}
+	lockableSet := &lockableNameSet{nameMap: nameMap, set: scanner.potentialLockables}
 	smallShas, batchLockableCh, err := catFileBatchCheck(revs, lockableSet)
 	if err != nil {
 		return err
 	}
 
-	lockableCb := scanner.FoundLockable
+	lockableCb := scanner.foundLockable
 	if lockableCb == nil {
 		lockableCb = noopFoundLockable
 	}

--- a/lfs/scanner_git_test.go
+++ b/lfs/scanner_git_test.go
@@ -109,7 +109,6 @@ func scanUnpushed(remoteName string) ([]*WrappedPointer, error) {
 		return nil, err
 	}
 
-	gitscanner.Close()
 	return pointers, multiErr
 }
 


### PR DESCRIPTION
The `GitScanner` [structure](https://github.com/git-lfs/git-lfs/blob/29dc7cc12772e9f89ff29ec3645cbc5274d95860/lfs/gitscanner.go#L22-L35) was originally introduced in PR #1670 and has been expanded organically over time since then.  This PR addresses a number of inconsistencies in the current design, removing unused or unnecessary logic and revising the internal implementation some of the scanning functions.

It should be easiest to review this PR commit-by-commit, as each commit has a detailed description and should be logically independent and bisectable.

---

This PR is motivated principally by the desire to remove the structure's `Close()` [method](https://github.com/git-lfs/git-lfs/blob/29dc7cc12772e9f89ff29ec3645cbc5274d95860/lfs/gitscanner.go#L50-L62), whose presence implies that it should be called to release resources opened by the `GitScanner` methods, such as I/O streams or channels.  However, upon inspection, this method simply outputs an optional performance timing tracing metric, one whose utility is undermined by the fact that various callers performs unrelated actions between the time they create a `GitScanner` structure and when the call `Close()` (if they call it at all).  And in the case of the `git lfs prune` command in particular, multiple `Scan*()` methods are called in parallel goroutines, but only the final overall timing is reported.

This PR therefore removes this method, along with the structure's internal mutex.  The mutex was introduced in commit bdbca399c46f0447f08066ce53185009b3db90ec of PR #1670, with the apparent expectation that some of the `GitScanner`'s elements might be read and written simultaneously by multiple concurrent goroutines.  However, in practice, this is never the case, so the mutex is unneeded.  As well, not all the current elements of the structure are currently protected by this mutex, as they have been introduced in subsequent PRs which ignored it.  Moreover, the two main elements which are protected, namely `remote` and `skippedRefs`, are updated exclusively by using the `RemoteForPush()` [method](https://github.com/git-lfs/git-lfs/blob/29dc7cc12772e9f89ff29ec3645cbc5274d95860/lfs/gitscanner.go#L64-L77), and the only [caller](https://github.com/git-lfs/git-lfs/blob/29dc7cc12772e9f89ff29ec3645cbc5274d95860/commands/uploader.go#L160) of this method [updates](https://github.com/git-lfs/git-lfs/blob/29dc7cc12772e9f89ff29ec3645cbc5274d95860/commands/uploader.go#L158-L159) two other elements of the structure directly, as these were added later without any mutex protection.

This sole caller of the `RemoteForPush()` method, the `(*uploadContext).buildGitScanner()` method in the `commands` package, is used only by the `git lfs pre-push` and `git lfs push` commands, as they need to scan for Git LFS objects which do not exist on a given remote.  In this context, the `FoundLockable` callback and the `PotentialLockables` `GitScannerSet` are always set as well; they are also only set in this context.  To help clarify these inter-dependencies we replace the `RemoteForPush()` method with a `NewGitScannerForPush()` function, which accepts all the necessary arguments for push operations in a single function, and avoids the need to export the `GitScannerFoundLockable` and `GitScannerSet` elements of the `GitScanner` structure.

---

We also remove the `ScanRefsOptions` [structure](https://github.com/git-lfs/git-lfs/blob/29dc7cc12772e9f89ff29ec3645cbc5274d95860/lfs/gitscanner.go#L290-L298) in the `lfs` package, as it is not needed to encapsulate multiple options when initializing a new `GitScanner` structure, unlike the similar `ScanRefsOptions` [structure](https://github.com/git-lfs/git-lfs/blob/29dc7cc12772e9f89ff29ec3645cbc5274d95860/git/rev_list_scanner.go#L73-L110) of the `git` package, which is used to consolidate the many options [passed](https://github.com/git-lfs/git-lfs/blob/29dc7cc12772e9f89ff29ec3645cbc5274d95860/git/rev_list_scanner.go#L166) to the `NewRevListScanner()` function.  This allows us to make the majority of the elements of the `GitScanner` structure private to the `lfs` package.

As part of this change to remove the `lfs.ScanRefsOptions` structure, we also create a new, dedicated and un-exported `nameMap` structure, which holds the map of Git object SHAs to their pathspecs, as populated during scan operations.  It is then utilized in the existing `lockableNameSet` [structure](https://github.com/git-lfs/git-lfs/blob/29dc7cc12772e9f89ff29ec3645cbc5274d95860/lfs/gitscanner_refs.go#L12-L15), whose `Check()` [method](https://github.com/git-lfs/git-lfs/blob/29dc7cc12772e9f89ff29ec3645cbc5274d95860/lfs/gitscanner_refs.go#L17-L32) is [called](https://github.com/git-lfs/git-lfs/blob/29dc7cc12772e9f89ff29ec3645cbc5274d95860/lfs/gitscanner_catfilebatch.go#L41) by the `runCatFileBatch()` function and also [called](https://github.com/git-lfs/git-lfs/blob/29dc7cc12772e9f89ff29ec3645cbc5274d95860/lfs/gitscanner_catfilebatchcheck.go#L35) by the `runCatFileBatchCheck()` function to collect the pathspecs of files locked by other users.

(Note that the intent to remove the `ScanRefsOptions` structure from the `lfs` package was [discussed](https://github.com/git-lfs/git-lfs/pull/1670#discussion_r88731811) in several PRs in 2016, and in particular, this commit's changes achieve some of the goals of the never-merged PR #1595, but without introducing an entirely generic `scanner` package.)

---

Finally, we add an explicit `close()` of the `lockableCh` channel at the end of the anonymous function started by `runCatFileBatchCheck()`, we can ensure the [anonymous function](https://github.com/git-lfs/git-lfs/blob/29dc7cc12772e9f89ff29ec3645cbc5274d95860/lfs/gitscanner_refs.go#L62-L66) which reads that channel will also exit as soon as possible.  This function is started by the `scanRefsToChan()` function, which then proceeds to [read directly](https://github.com/git-lfs/git-lfs/blob/29dc7cc12772e9f89ff29ec3645cbc5274d95860/lfs/gitscanner_refs.go#L83-L87) from the similar channel returned by the `runCatFileBatch()` function.  That read loop would stall indefinitely if its channel was not always [closed](https://github.com/git-lfs/git-lfs/blob/29dc7cc12772e9f89ff29ec3645cbc5274d95860/lfs/gitscanner_catfilebatch.go#L63) by `runCatFileBatch()`, whereas the anonymous function in the goroutine which handles the channel returned by `runCatFileBatchCheck()` does not exit until the program exits.