### PR TITLE
Update distributions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
     strategy:
       matrix:
         arch: [arm64]
-        container: [debian_11]
+        container: [debian_12]
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,7 +163,7 @@ jobs:
     strategy:
       matrix:
         arch: [arm64]
-        container: [debian_11]
+        container: [debian_12]
     steps:
     - uses: actions/checkout@v3
       with:

--- a/docker/run_dockers.bsh
+++ b/docker/run_dockers.bsh
@@ -59,7 +59,7 @@ done
 
 if [[ ${#IMAGES[@]} == 0 ]]; then
   # If you change this list, change script/upload and script/packagecloud.rb as well.
-  IMAGES=(centos_7 centos_8 rocky_9 debian_10 debian_11)
+  IMAGES=(centos_7 centos_8 rocky_9 debian_10 debian_11 debian_12)
 fi
 
 mkdir -p "${PACKAGE_DIR}"

--- a/docker/run_dockers.bsh
+++ b/docker/run_dockers.bsh
@@ -58,7 +58,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ ${#IMAGES[@]} == 0 ]]; then
-  # If you change this list, change script/upload as well.
+  # If you change this list, change script/upload and script/packagecloud.rb as well.
   IMAGES=(centos_7 centos_8 rocky_9 debian_10 debian_11)
 fi
 

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -60,12 +60,15 @@ $distro_name_map = {
     "ubuntu/focal",     # EOL April 2025
   ],
   "debian/11" => [
-    "debian/bullseye",  # Current stable
-    "debian/bookworm",  # Current testing
+    "debian/bullseye",  # EOL June 2026
     "ubuntu/jammy",     # EOL April 2027
     "ubuntu/kinetic",   # EOL July 2023
     "linuxmint/vanessa",# EOL April 2027
     "linuxmint/vera",   # EOL April 2027
+  ],
+  "debian/12" => [
+    "debian/bookworm",  # Current stable
+    "debian/trixie",    # Current testing
   ]
 }
 
@@ -113,6 +116,7 @@ package_files.each do |full_path|
   os, distro = case full_path
   when /debian\/10/ then ["Debian 10", "debian/buster"]
   when /debian\/11/ then ["Debian 11", "debian/bullseye"]
+  when /debian\/12/ then ["Debian 12", "debian/bookworm"]
   when /centos\/7/  then ["RPM RHEL 7/CentOS 7", "el/7"]
   when /centos\/8/  then ["RPM RHEL 8/CentOS 8", "el/8"]
   when /rocky\/9/  then ["RPM RHEL 9/Rocky Linux 9", "el/9"]

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -25,6 +25,9 @@ $client = Packagecloud::Client.new(credentials)
 
 # matches package directories built by docker to one or more packagecloud distros
 # https://packagecloud.io/docs#os_distro_version
+#
+# If you change the keys of this list, change the values below, as well as
+# script/upload and docker/run_dockers.bsh.
 $distro_name_map = {
   # RHEL EOL https://access.redhat.com/support/policy/updates/errata
   "centos/7" => [
@@ -105,6 +108,8 @@ end
 package_files.each do |full_path|
   next if full_path.include?("SRPM") || full_path.include?("i386") || full_path.include?("i686")
   next unless full_path =~ /\/git-lfs[-|_]\d/
+  # If you change the entries below, change the keys above, as well as
+  # script/upload and docker/run_dockers.bsh.
   os, distro = case full_path
   when /debian\/10/ then ["Debian 10", "debian/buster"]
   when /debian\/11/ then ["Debian 11", "debian/bullseye"]

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -45,8 +45,8 @@ $distro_name_map = {
   ],
   "rocky/9" => [
     "el/9",
-    "fedora/36", # EOL May 2023
     "fedora/37", # EOL November 2023
+    "fedora/38", # EOL May 2024
   ],
   # Debian EOL https://wiki.debian.org/LTS/
   # Ubuntu EOL https://wiki.ubuntu.com/Releases
@@ -63,6 +63,7 @@ $distro_name_map = {
     "debian/bullseye",  # EOL June 2026
     "ubuntu/jammy",     # EOL April 2027
     "ubuntu/kinetic",   # EOL July 2023
+    "ubuntu/lunar",     # EOL January 2024
     "linuxmint/vanessa",# EOL April 2027
     "linuxmint/vera",   # EOL April 2027
   ],

--- a/script/upload
+++ b/script/upload
@@ -199,6 +199,7 @@ Up to date packages are available on [PackageCloud](https://packagecloud.io/gith
 [RPM RHEL 9/Rocky Linux 9](https://packagecloud.io/github/git-lfs/packages/el/9/git-lfs-VERSION-1.el9.x86_64.rpm/download)
 [Debian 10](https://packagecloud.io/github/git-lfs/packages/debian/buster/git-lfs_VERSION_amd64.deb/download)
 [Debian 11](https://packagecloud.io/github/git-lfs/packages/debian/bullseye/git-lfs_VERSION_amd64.deb/download)
+[Debian 12](https://packagecloud.io/github/git-lfs/packages/debian/bookworm/git-lfs_VERSION_amd64.deb/download)
 
 ## SHA-256 hashes:
 EOM

--- a/script/upload
+++ b/script/upload
@@ -187,7 +187,7 @@ finalize_body_message () {
   version=$(echo "$version" | sed -e 's/^v//')
 
   # If you change the list of distributions here, change docker/run_dockers.bsh
-  # as well.
+  # and script/packagecloud.rb as well.
   cat "$changelog" > "$WORKDIR/body-template"
   cat <<EOM >> "$WORKDIR/body-template"
 ## Packages


### PR DESCRIPTION
This PR contains four commits.  The first does some tidying up of the various locations we have for base distros (that is, those for which we build packages).  The next two update the code for Debian 12.  Finally, we update the remaining distributions for v3.4.0.

This PR contains independent, logical, bisectable commits each with their own commit message, and as such is best reviewed commit by commit.

Fixes #5227
