### PR TITLE
workflows: remove refreshenv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,6 @@ jobs:
     - run: set GOPATH=%HOME%\go
     - run: choco install -y InnoSetup
     - run: choco install -y strawberryperl
-    - run: refreshenv
     - run: make man
       shell: bash
     - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" go install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,6 @@ jobs:
     - run: choco install -y strawberryperl
     - run: choco install -y zip
     - run: choco install -y jq
-    - run: refreshenv
     - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" go install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@latest
       shell: bash
     - run: mkdir -p bin/releases


### PR DESCRIPTION
Running `refreshenv` in CI produces this message:

```
RefreshEnv.cmd does not work when run from this process. If you're in PowerShell, please 'Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1' and try again.
```

Since it's not really working in this case, let's just remove it.