### PR TITLE
Handle local paths with trailing slashes

### DIFF
--- a/lfsapi/endpoint_finder.go
+++ b/lfsapi/endpoint_finder.go
@@ -151,8 +151,8 @@ func (e *endpointGitFinder) NewEndpointFromCloneURL(operation, rawurl string) lf
 		return ep
 	}
 
-	if strings.HasSuffix(rawurl, "/") {
-		ep.Url = rawurl[0 : len(rawurl)-1]
+	if strings.HasSuffix(ep.Url, "/") {
+		ep.Url = ep.Url[0 : len(ep.Url)-1]
 	}
 
 	if strings.HasPrefix(ep.Url, "file://") {

--- a/t/t-standalone-file.sh
+++ b/t/t-standalone-file.sh
@@ -66,6 +66,7 @@ do_upload_download_test () {
 
 do_local_path_test () {
   local reponame="$1"
+  local suffix="$2"
 
   git lfs track "*.dat" 2>&1 | tee track.log
   grep "Tracking \"\*.dat\"" track.log
@@ -111,17 +112,17 @@ do_local_path_test () {
   cd "$TRASHDIR"
 
   # Check a clone using an absolute Unix-style path.
-  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git clone "$testdir" "$reponame-repo1"  2>&1 | tee clonecustom.log
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git clone "$testdir$suffix" "$reponame-repo1"  2>&1 | tee clonecustom.log
   (cd "$reponame-repo1" && git lfs fsck)
   grep "xfer: started custom adapter process" clonecustom.log
 
   # Check a clone using a relative path.
-  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git clone "$reponame-repo1" "$reponame-repo2"  2>&1 | tee clonecustom.log
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git clone "$reponame-repo1$suffix" "$reponame-repo2"  2>&1 | tee clonecustom.log
   (cd "$reponame-repo2" && git lfs fsck)
   grep "xfer: started custom adapter process" clonecustom.log
 
   # Check a clone using an absolute native-style path.
-  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git clone "$(native_path "$testdir")" "$reponame-repo3"  2>&1 | tee clonecustom.log
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git clone "$(native_path "$testdir")$suffix" "$reponame-repo3"  2>&1 | tee clonecustom.log
   (cd "$reponame-repo3" && git lfs fsck)
   grep "xfer: started custom adapter process" clonecustom.log
 
@@ -318,7 +319,22 @@ begin_test "standalone-file-local-path"
   # clone directly, not through lfstest-gitserver
   clone_repo_url "$REMOTEDIR/$reponame.git" $reponame
 
-  do_local_path_test "$reponame"
+  do_local_path_test "$reponame" ""
+)
+end_test
+
+begin_test "standalone-file-local-path-trailing-slash"
+(
+  set -e
+
+  # setup a git repo to be used as a local repo, not remote
+  reponame="standalone-file-local-path-trailing-slash"
+  setup_remote_repo "$reponame"
+
+  # clone directly, not through lfstest-gitserver
+  clone_repo_url "$REMOTEDIR/$reponame.git/" $reponame
+
+  do_local_path_test "$reponame" "$suffix"
 )
 end_test
 

--- a/t/t-standalone-file.sh
+++ b/t/t-standalone-file.sh
@@ -64,6 +64,69 @@ do_upload_download_test () {
   [ "$(echo "$objectlist" | wc -l)" -eq 12 ]
 }
 
+do_local_path_test () {
+  local reponame="$1"
+
+  git lfs track "*.dat" 2>&1 | tee track.log
+  grep "Tracking \"\*.dat\"" track.log
+  git add .gitattributes
+  git commit -m "Tracking"
+
+  git checkout -b test
+
+  # set up a decent amount of data so that there's work for multiple concurrent adapters
+  echo "[
+  {
+    \"CommitDate\":\"$(get_date -10d)\",
+    \"Files\":[
+      {\"Filename\":\"verify.dat\",\"Size\":18,\"Data\":\"send-verify-action\"},
+      {\"Filename\":\"file1.dat\",\"Size\":1024},
+      {\"Filename\":\"file2.dat\",\"Size\":750}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -7d)\",
+    \"Files\":[
+      {\"Filename\":\"file1.dat\",\"Size\":1050},
+      {\"Filename\":\"file3.dat\",\"Size\":660},
+      {\"Filename\":\"file4.dat\",\"Size\":230}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -5d)\",
+    \"Files\":[
+      {\"Filename\":\"file5.dat\",\"Size\":1200},
+      {\"Filename\":\"file6.dat\",\"Size\":300}]
+  },
+  {
+    \"CommitDate\":\"$(get_date -2d)\",
+    \"Files\":[
+      {\"Filename\":\"file3.dat\",\"Size\":120},
+      {\"Filename\":\"file5.dat\",\"Size\":450},
+      {\"Filename\":\"file7.dat\",\"Size\":520},
+      {\"Filename\":\"file8.dat\",\"Size\":2048}]
+  }
+  ]" | lfstest-testutils addcommits
+
+  testdir="$(pwd)"
+
+  cd "$TRASHDIR"
+
+  # Check a clone using an absolute Unix-style path.
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git clone "$testdir" "$reponame-repo1"  2>&1 | tee clonecustom.log
+  (cd "$reponame-repo1" && git lfs fsck)
+  grep "xfer: started custom adapter process" clonecustom.log
+
+  # Check a clone using a relative path.
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git clone "$reponame-repo1" "$reponame-repo2"  2>&1 | tee clonecustom.log
+  (cd "$reponame-repo2" && git lfs fsck)
+  grep "xfer: started custom adapter process" clonecustom.log
+
+  # Check a clone using an absolute native-style path.
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git clone "$(native_path "$testdir")" "$reponame-repo3"  2>&1 | tee clonecustom.log
+  (cd "$reponame-repo3" && git lfs fsck)
+  grep "xfer: started custom adapter process" clonecustom.log
+
+}
+
 begin_test "standalone-file-upload-download-bare"
 (
   set -e
@@ -255,64 +318,7 @@ begin_test "standalone-file-local-path"
   # clone directly, not through lfstest-gitserver
   clone_repo_url "$REMOTEDIR/$reponame.git" $reponame
 
-  git lfs track "*.dat" 2>&1 | tee track.log
-  grep "Tracking \"\*.dat\"" track.log
-  git add .gitattributes
-  git commit -m "Tracking"
-
-  git checkout -b test
-
-  # set up a decent amount of data so that there's work for multiple concurrent adapters
-  echo "[
-  {
-    \"CommitDate\":\"$(get_date -10d)\",
-    \"Files\":[
-      {\"Filename\":\"verify.dat\",\"Size\":18,\"Data\":\"send-verify-action\"},
-      {\"Filename\":\"file1.dat\",\"Size\":1024},
-      {\"Filename\":\"file2.dat\",\"Size\":750}]
-  },
-  {
-    \"CommitDate\":\"$(get_date -7d)\",
-    \"Files\":[
-      {\"Filename\":\"file1.dat\",\"Size\":1050},
-      {\"Filename\":\"file3.dat\",\"Size\":660},
-      {\"Filename\":\"file4.dat\",\"Size\":230}]
-  },
-  {
-    \"CommitDate\":\"$(get_date -5d)\",
-    \"Files\":[
-      {\"Filename\":\"file5.dat\",\"Size\":1200},
-      {\"Filename\":\"file6.dat\",\"Size\":300}]
-  },
-  {
-    \"CommitDate\":\"$(get_date -2d)\",
-    \"Files\":[
-      {\"Filename\":\"file3.dat\",\"Size\":120},
-      {\"Filename\":\"file5.dat\",\"Size\":450},
-      {\"Filename\":\"file7.dat\",\"Size\":520},
-      {\"Filename\":\"file8.dat\",\"Size\":2048}]
-  }
-  ]" | lfstest-testutils addcommits
-
-  testdir="$(pwd)"
-
-  cd "$TRASHDIR"
-
-  # Check a clone using an absolute Unix-style path.
-  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git clone "$testdir" "$reponame-repo1"  2>&1 | tee clonecustom.log
-  (cd "$reponame-repo1" && git lfs fsck)
-  grep "xfer: started custom adapter process" clonecustom.log
-
-  # Check a clone using a relative path.
-  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git clone "$reponame-repo1" "$reponame-repo2"  2>&1 | tee clonecustom.log
-  (cd "$reponame-repo2" && git lfs fsck)
-  grep "xfer: started custom adapter process" clonecustom.log
-
-  # Check a clone using an absolute native-style path.
-  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git clone "$(native_path "$testdir")" "$reponame-repo3"  2>&1 | tee clonecustom.log
-  (cd "$reponame-repo3" && git lfs fsck)
-  grep "xfer: started custom adapter process" clonecustom.log
-
+  do_local_path_test "$reponame"
 )
 end_test
 


### PR DESCRIPTION
When we want to handle a local path, we must rewrite it internally into a `file:///` URL, because we dispatch our standalone transfer agent based on the URL scheme.  However, once we've looked up an appropriate URL and formatted it as the scheme prefers, if it contains a trailing slash, we ignore the entire lookup and replace the URL with the raw one given, but without the trailing slash.

This behaviour seems a bit bizarre, and it causes us to take a local path with a trailing slash and treat it not as the `file:///` URL it needs to be, but as a raw local path, which gets refused.  Let's avoid this problem by looking at the rewritten URL, and modifying that instead if we find its trailing slash to be offensive.

Fixes #5400
/cc @ebardsley as reporter