### PR TITLE
Fix missing parameter in `git lfs logs` manual page

### DIFF
--- a/docs/man/git-lfs-logs.adoc
+++ b/docs/man/git-lfs-logs.adoc
@@ -27,7 +27,7 @@ details are saved to ".git/lfs/logs".
 
 Without any options, `git lfs logs` simply shows the list of error logs.
 
-* : Shows the specified error log. Use "last" to show the most recent
+* `<file>`: Shows the specified error log. Use "last" to show the most recent
 error.
 
 == SEE ALSO


### PR DESCRIPTION
In PR #5054 we converted our manual pages to the AsciiDoc format, and in doing so, one entry in the manual page for the `git-lfs-logs(1)` command lost the relevant `<file>` option parameter from the ronn [version](https://github.com/git-lfs/git-lfs/blob/370b8d8f1932d47bca1f84a82c1d79bed84ec893/docs/man/git-lfs-logs.1.ronn?plain=1#L28), so we restore it now.