### PR TITLE
git: match patterns, not file names, for tracked files

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -1315,8 +1315,9 @@ func GetTrackedFiles(pattern string) ([]string, error) {
 	cmd, err := gitNoLFS(
 		"-c", "core.quotepath=false", // handle special chars in filenames
 		"ls-files",
+		"--ignored",
 		"--cached", // include things which are staged but not committed right now
-		"--",       // no ambiguous patterns
+		"-x",
 		safePattern)
 	if err != nil {
 		return nil, errors.New(tr.Tr.Get("failed to find `git ls-files`: %v", err))

--- a/t/t-track.sh
+++ b/t/t-track.sh
@@ -663,14 +663,11 @@ begin_test "track: escaped glob pattern in .gitattributes"
 (
   set -e
 
-  # None of these characters are valid in the Win32 subsystem.
-  [ "$IS_WINDOWS" -eq 1 ] && exit 0
-
   reponame="track-escaped-glob"
   git init "$reponame"
   cd "$reponame"
 
-  filename='*[foo]bar?.txt'
+  filename='[foo]bar.txt'
   contents='I need escaping'
   contents_oid=$(calc_oid "$contents")
 
@@ -713,6 +710,32 @@ begin_test "track: escaped glob pattern with spaces in .gitattributes"
 
   # If Git understood our escaping, we'll have a pointer. Otherwise, we won't.
   assert_pointer "main" "$filename" "$contents_oid" 15
+)
+end_test
+
+begin_test "track: verbose logging"
+(
+  set -e
+
+  reponame="track-verbose-logging"
+  git init "$reponame"
+  cd "$reponame"
+
+  filename='[foo]bar.bin'
+  contents='I need escaping'
+  contents_oid=$(calc_oid "$contents")
+
+  printf "%s" "$contents" > "$filename"
+
+  printf 'Hello, world!\n' > a.txt
+  git add a.txt "$filename"
+  git commit -m 'some files'
+
+  git lfs track -v "*.txt" 2>&1 | tee output
+  grep "Found 1 files previously added to Git matching pattern:" output
+
+  git lfs track -v --filename "$filename" 2>&1 | tee output
+  grep "Found 1 files previously added to Git matching pattern:" output
 )
 end_test
 


### PR DESCRIPTION
Right now, when we run `git lfs track`, we warn the user if the pattern they've provided matches an existing file name.  However, when we invoke that command with `--filename` and a pattern with brackets on Windows, we get an error because the escaped pattern contains backslashes, which results in broken behaviour on Windows.

The real cause of this problem, however, is that we're ultimately asking for a file name and not a pattern.  Our invocation happens to work on Unix, but we need it to also work on Windows.  To solve this, let's instead ask for ignored cached files and specify a single pattern. Since we've asked for a pattern, this results in a different behaviour from before and avoids the error.

We would have caught this on Windows if our weird file name code had worked there, but since we included asterisks and question marks, which are not valid on Windows, the test couldn't run there.  Instead, let's leave the brackets and run the test on all platforms.  We still have the test below which does the same thing with spaces on Unix, so we're not really regressing our tests there.

In addition, since we don't have any tests for this verbose logging that prints the messages that trigger the problem, let's add some, both with more common patterns and some unusual ones as well.

Fixes #5409
/cc @zhoushaokun as reporter