### PR TITLE
Print an error when pushing with no refs

### DIFF
--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -79,6 +79,10 @@ func pushCommand(cmd *cobra.Command, args []string) {
 		}
 		uploadsWithObjectIDs(ctx, argList)
 	} else {
+		if !useStdin && !pushAll && len(argList) < 1 {
+			Print(tr.Tr.Get("At least one ref must be supplied without --all"))
+			os.Exit(1)
+		}
 		uploadsBetweenRefAndRemote(ctx, argList)
 	}
 }

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -71,7 +71,9 @@ func pushCommand(cmd *cobra.Command, args []string) {
 	}
 
 	if pushObjectIDs {
-		if len(argList) < 1 {
+		// We allow no object IDs with `--stdin` to make scripting
+		// easier and avoid having to special-case this in scripts.
+		if !useStdin && len(argList) < 1 {
 			Print(tr.Tr.Get("At least one object ID must be supplied with --object-id"))
 			os.Exit(1)
 		}

--- a/t/t-push.sh
+++ b/t/t-push.sh
@@ -53,6 +53,16 @@ begin_test "push with bad ref"
 )
 end_test
 
+begin_test "push with nothing"
+(
+  set -e
+  push_repo_setup "push-nothing"
+
+  git lfs push origin 2>&1 | tee push.log
+  grep "At least one ref must be supplied without --all" push.log
+)
+end_test
+
 begin_test "push with given remote, configured pushRemote"
 (
   set -e

--- a/t/t-push.sh
+++ b/t/t-push.sh
@@ -432,6 +432,9 @@ begin_test "push object id(s)"
   git add .gitattributes a.dat
   git commit -m "add a.dat"
 
+  git lfs push --object-id origin --dry-run 2>&1 | tee push.log
+  grep "At least one object ID must be supplied with --object-id" push.log
+
   git lfs push --object-id origin \
     4c48d2a6991c9895bcddcf027e1e4907280bcf21975492b1afbade396d6a3340 \
     2>&1 | tee push.log
@@ -464,9 +467,8 @@ begin_test "push object id(s) via stdin"
   git add .gitattributes a.dat
   git commit -m "add a.dat"
 
-  echo "" | git lfs push --object-id origin --stdin --dry-run \
-    2>&1 | tee push.log
-  grep "At least one object ID must be supplied with --object-id" push.log
+  git lfs push --object-id origin --stdin --dry-run </dev/null 2>&1 | tee push.log
+  grep "At least one object ID must be supplied with --object-id" push.log && exit 1
 
   echo "4c48d2a6991c9895bcddcf027e1e4907280bcf21975492b1afbade396d6a3340" | \
     git lfs push --object-id origin --stdin --dry-run "c0ffee" \


### PR DESCRIPTION
Right now, a user can invoke `git lfs push` with a remote and no refs. Surprisingly for some users, this pushes nothing, since no refs were given.

To help users invoke the command in a useful way, if there are no arguments on the command line and `--all` was not specified, then complain, unless we're reading from standard input.  The reason we allow empty lists of arguments with standard input is that this makes scripting easier by not forcing scripts to specifically consider whether the input is empty.

As well, allow users to specify an empty list of object IDs in `--stdin` mode as well.

Note that it should be fine to leave this until after the v3.4.0 release.

Fixes #5430