### PR TITLE
Add a single source of truth for distro info

### DIFF
--- a/docker/run_dockers.bsh
+++ b/docker/run_dockers.bsh
@@ -39,7 +39,7 @@ function split_image_name()
 }
 
 # Parse Arguments
-IMAGES=()
+IMAGES=
 PRUNE=
 ARCH=amd64
 while [[ $# -gt 0 ]]; do
@@ -52,19 +52,18 @@ while [[ $# -gt 0 ]]; do
     DOCKER_CMD="${@}"
     break
   else
-    IMAGES+=("$1")
+    IMAGES="$IMAGES $1"
   fi
   shift
 done
 
-if [[ ${#IMAGES[@]} == 0 ]]; then
-  # If you change this list, change script/upload and script/packagecloud.rb as well.
-  IMAGES=(centos_7 centos_8 rocky_9 debian_10 debian_11 debian_12)
+if [[ -z "$IMAGES" ]]; then
+  IMAGES="$(script/distro-tool --image-names)"
 fi
 
 mkdir -p "${PACKAGE_DIR}"
 #Run docker to build packages
-for IMAGE_NAME in "${IMAGES[@]}"; do
+for IMAGE_NAME in $IMAGES; do
   split_image_name "${IMAGE_NAME}" #set IMAGE_NAME and IMAGE_INFO
 
   #It CAN'T be empty () with set -u... So I put some defaults in here

--- a/script/distro-tool
+++ b/script/distro-tool
@@ -1,0 +1,1 @@
+lib/distro.rb

--- a/script/lib/distro.rb
+++ b/script/lib/distro.rb
@@ -1,0 +1,176 @@
+#!/usr/bin/env ruby
+
+require 'optionparser'
+
+class DistroMap
+  attr_reader :entries
+
+  def initialize(map = nil)
+    @entries = map || self.class.builtin_map
+  end
+  # Returns the map for our distros.
+  #
+  # The key in each case is a string containing a lowercase OS name, a slash,
+  # and a version number.  The value is a map containing the following fields:
+  #
+  # name:: a human-readable name for this distro.
+  # component:: a component suitable for a packagecloud.io URL.
+  # image:: a Docker image name from build_dockers without any extension.
+  # equivalent:: packagecloud.io components for which we can upload the same
+  # package.
+  # package_type:: the extension for the package format on this OS.
+  # package_tag:: the trailing component after the version number on this OS.
+  def self.builtin_map
+    {
+      # RHEL EOL https://access.redhat.com/support/policy/updates/errata
+      "centos/7" => {
+        name: "RPM RHEL 7/CentOS 7",
+        component: "el/7",
+        image: "centos_7",
+        package_type: "rpm",
+        package_tag: "-1.el7",
+        equivalent: [
+          "el/7",         # EOL June 2024
+          "scientific/7", # EOL June 2024
+          # opensuse https://en.opensuse.org/Lifetime
+          # or https://en.wikipedia.org/wiki/OpenSUSE_version_history
+          "opensuse/15.4", # EOL November 2023
+          # SLES EOL https://www.suse.com/lifecycle/
+          "sles/12.5", # EOL October 2024 (LTSS October 2027)
+          "sles/15.4", # Current
+        ],
+      },
+      "centos/8" => {
+        name: "RPM RHEL 8/Rocky Linux 8",
+        component: "el/8",
+        image: "centos_8",
+        package_type: "rpm",
+        package_tag: "-1.el8",
+        equivalent: [
+          "el/8",
+        ],
+      },
+      "rocky/9" => {
+        name: "RPM RHEL 9/Rocky Linux 9",
+        component: "el/9",
+        image: "rocky_9",
+        package_type: "rpm",
+        package_tag: "-1.el9",
+        equivalent: [
+          "el/9",
+          "fedora/37", # EOL November 2023
+          "fedora/38", # EOL May 2024
+        ],
+      },
+      # Debian EOL https://wiki.debian.org/LTS/
+      # Ubuntu EOL https://wiki.ubuntu.com/Releases
+      # Mint EOL https://linuxmint.com/download_all.php
+      "debian/10" => {
+        name: "Debian 10",
+        component: "debian/buster",
+        image: "debian_10",
+        package_type: "deb",
+        package_tag: "",
+        equivalent: [
+          "debian/buster",    # EOL June 2024
+          "linuxmint/ulyana", # EOL April 2025
+          "linuxmint/ulyssa", # EOL April 2025
+          "linuxmint/uma",    # EOL April 2025
+          "linuxmint/una",    # EOL April 2025
+          "ubuntu/focal",     # EOL April 2025
+        ],
+      },
+      "debian/11" => {
+        name: "Debian 11",
+        component: "debian/bullseye",
+        image: "debian_11",
+        package_type: "deb",
+        package_tag: "",
+        equivalent: [
+          "debian/bullseye",  # EOL June 2026
+          "ubuntu/jammy",     # EOL April 2027
+          "ubuntu/kinetic",   # EOL July 2023
+          "ubuntu/lunar",     # EOL January 2024
+          "linuxmint/vanessa",# EOL April 2027
+          "linuxmint/vera",   # EOL April 2027
+        ],
+      },
+      "debian/12" => {
+        name: "Debian 12",
+        component: "debian/bookworm",
+        image: "debian_12",
+        package_type: "deb",
+        package_tag: "",
+        equivalent: [
+          "debian/bookworm",  # Current stable
+          "debian/trixie",    # Current testing
+        ]
+      },
+    }
+  end
+
+  def distro_name_map
+    entries.map { |k, v| [k, v[:equivalent]] }.to_h
+  end
+
+  def image_names
+    entries.values.map { |v| v[:image] }.to_a
+  end
+end
+
+class DistroMapProgram
+  def initialize(stdout, stderr, dmap = nil)
+    @dmap = DistroMap.new(dmap)
+    @stdout = stdout
+    @stderr = stderr
+  end
+
+  def image_names
+    @stdout.puts @dmap.image_names.join(" ")
+  end
+
+  def distro_markdown
+    arch = {
+      "rpm" => ".x86_64",
+      "deb" => "_amd64",
+    }
+    separator = {
+      "rpm" => "-",
+      "deb" => "_",
+    }
+    result = @dmap.entries.map do |_k, v|
+      type = v[:package_type]
+      "[#{v[:name]}](https://packagecloud.io/github/git-lfs/packages/#{v[:component]}/git-lfs#{separator[type]}VERSION#{v[:package_tag]}#{arch[type]}.#{type}/download)\n"
+    end.join
+    @stdout.puts result
+  end
+
+  def run(args)
+    options = {}
+    OptionParser.new do |parser|
+      parser.on("--image-names", "Print the names of all images") do
+        options[:mode] = :image_names
+      end
+
+      parser.on("--distro-markdown", "Print links to packages for all distros") do
+        options[:mode] = :distro_markdown
+      end
+    end.parse!(args)
+
+    case options[:mode]
+    when nil
+      @stderr.puts "A mode option is required"
+      2
+    when :image_names
+      image_names
+      0
+    when :distro_markdown
+      distro_markdown
+      0
+    end
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  exit DistroMapProgram.new($stdout, $stderr).run(ARGV)
+end

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -8,6 +8,7 @@ packagecloud_token = ENV["PACKAGECLOUD_TOKEN"] || begin
 end
 
 require "json"
+require_relative 'lib/distro'
 
 packagecloud_ruby_minimum_version = "1.0.4"
 begin
@@ -25,53 +26,7 @@ $client = Packagecloud::Client.new(credentials)
 
 # matches package directories built by docker to one or more packagecloud distros
 # https://packagecloud.io/docs#os_distro_version
-#
-# If you change the keys of this list, change the values below, as well as
-# script/upload and docker/run_dockers.bsh.
-$distro_name_map = {
-  # RHEL EOL https://access.redhat.com/support/policy/updates/errata
-  "centos/7" => [
-    "el/7",         # EOL June 2024
-    "scientific/7", # EOL June 2024
-    # opensuse https://en.opensuse.org/Lifetime
-    # or https://en.wikipedia.org/wiki/OpenSUSE_version_history
-    "opensuse/15.4", # EOL November 2023
-    # SLES EOL https://www.suse.com/lifecycle/
-    "sles/12.5", # EOL October 2024 (LTSS October 2027)
-    "sles/15.4", # Current
-  ],
-  "centos/8" => [
-    "el/8",
-  ],
-  "rocky/9" => [
-    "el/9",
-    "fedora/37", # EOL November 2023
-    "fedora/38", # EOL May 2024
-  ],
-  # Debian EOL https://wiki.debian.org/LTS/
-  # Ubuntu EOL https://wiki.ubuntu.com/Releases
-  # Mint EOL https://linuxmint.com/download_all.php
-  "debian/10" => [
-    "debian/buster",    # EOL June 2024
-    "linuxmint/ulyana", # EOL April 2025
-    "linuxmint/ulyssa", # EOL April 2025
-    "linuxmint/uma",    # EOL April 2025
-    "linuxmint/una",    # EOL April 2025
-    "ubuntu/focal",     # EOL April 2025
-  ],
-  "debian/11" => [
-    "debian/bullseye",  # EOL June 2026
-    "ubuntu/jammy",     # EOL April 2027
-    "ubuntu/kinetic",   # EOL July 2023
-    "ubuntu/lunar",     # EOL January 2024
-    "linuxmint/vanessa",# EOL April 2027
-    "linuxmint/vera",   # EOL April 2027
-  ],
-  "debian/12" => [
-    "debian/bookworm",  # Current stable
-    "debian/trixie",    # Current testing
-  ]
-}
+$distro_name_map = DistroMap.distro_name_map
 
 # caches distro id lookups
 $distro_id_map = {}

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -108,22 +108,3 @@ package_files.each do |full_path|
     end
   end
 end
-
-package_files.each do |full_path|
-  next if full_path.include?("SRPM") || full_path.include?("i386") || full_path.include?("i686")
-  next unless full_path =~ /\/git-lfs[-|_]\d/
-  # If you change the entries below, change the keys above, as well as
-  # script/upload and docker/run_dockers.bsh.
-  os, distro = case full_path
-  when /debian\/10/ then ["Debian 10", "debian/buster"]
-  when /debian\/11/ then ["Debian 11", "debian/bullseye"]
-  when /debian\/12/ then ["Debian 12", "debian/bookworm"]
-  when /centos\/7/  then ["RPM RHEL 7/CentOS 7", "el/7"]
-  when /centos\/8/  then ["RPM RHEL 8/CentOS 8", "el/8"]
-  when /rocky\/9/  then ["RPM RHEL 9/Rocky Linux 9", "el/9"]
-  end
-
-  next unless os
-
-  puts "[#{os}](https://packagecloud.io/#{packagecloud_user}/git-lfs/packages/#{distro}/#{File.basename(full_path)}/download)"
-end

--- a/script/spec/distro_spec.rb
+++ b/script/spec/distro_spec.rb
@@ -1,0 +1,98 @@
+require_relative "../lib/distro"
+
+def test_map
+  {
+    "centos/7" => {
+      name: "RPM RHEL 7/CentOS 7",
+      component: "el/7",
+      image: "centos_7",
+      package_type: "rpm",
+      package_tag: "-1.el7",
+      equivalent: [
+        "el/7",
+        "scientific/7",
+        "opensuse/15.4",
+        "sles/12.5",
+        "sles/15.4",
+      ],
+    },
+    "centos/8" => {
+      name: "RPM RHEL 8/Rocky Linux 8",
+      component: "el/8",
+      image: "centos_8",
+      package_type: "rpm",
+      package_tag: "-1.el8",
+      equivalent: [
+        "el/8",
+      ],
+    },
+    "debian/12" => {
+      name: "Debian 12",
+      component: "debian/bookworm",
+      image: "debian_12",
+      package_type: "deb",
+      package_tag: "",
+      equivalent: [
+        "debian/bookworm",
+        "debian/trixie",
+      ]
+    },
+  }
+end
+
+context DistroMapProgram do
+  it "should print image names" do
+    stdout = StringIO.new
+    stderr = StringIO.new
+    expect(DistroMapProgram.new(stdout, stderr, test_map).run(["--image-names"])).to eq 0
+    expect(stderr.string).to be_empty
+    expect(stdout.string).to eq "centos_7 centos_8 debian_12\n"
+  end
+
+  it "should print distro markdown" do
+    stdout = StringIO.new
+    stderr = StringIO.new
+    expect(DistroMapProgram.new(stdout, stderr, test_map).run(["--distro-markdown"])).to eq 0
+    expect(stderr.string).to be_empty
+    expected = <<~EOM
+    [RPM RHEL 7/CentOS 7](https://packagecloud.io/github/git-lfs/packages/el/7/git-lfs-VERSION-1.el7.x86_64.rpm/download)
+    [RPM RHEL 8/Rocky Linux 8](https://packagecloud.io/github/git-lfs/packages/el/8/git-lfs-VERSION-1.el8.x86_64.rpm/download)
+    [Debian 12](https://packagecloud.io/github/git-lfs/packages/debian/bookworm/git-lfs_VERSION_amd64.deb/download)
+    EOM
+    expect(stdout.string).to eq expected
+  end
+
+  it "should whine when no options were given" do
+    stdout = StringIO.new
+    stderr = StringIO.new
+    expect(DistroMapProgram.new(stdout, stderr, test_map).run([])).to eq 2
+    expect(stdout.string).to be_empty
+    expect(stderr.string).to eq "A mode option is required\n"
+  end
+end
+
+context DistroMap do
+  it "should produce the correct distro names" do
+    map = {
+      "centos/7" => [
+        "el/7",
+        "scientific/7",
+        "opensuse/15.4",
+        "sles/12.5",
+        "sles/15.4",
+      ],
+      "centos/8" => [
+        "el/8",
+      ],
+      "debian/12" => [
+        "debian/bookworm",
+        "debian/trixie",
+      ],
+    }
+    expect(DistroMap.new(test_map).distro_name_map).to eq map
+  end
+
+  it "should produce the correct image names" do
+    expect(DistroMap.new(test_map).image_names).to eq %w[centos_7 centos_8 debian_12]
+  end
+end

--- a/script/upload
+++ b/script/upload
@@ -186,20 +186,13 @@ finalize_body_message () {
 
   version=$(echo "$version" | sed -e 's/^v//')
 
-  # If you change the list of distributions here, change docker/run_dockers.bsh
-  # and script/packagecloud.rb as well.
   cat "$changelog" > "$WORKDIR/body-template"
   cat <<EOM >> "$WORKDIR/body-template"
 ## Packages
 
 Up to date packages are available on [PackageCloud](https://packagecloud.io/github/git-lfs) and [Homebrew](http://brew.sh/).
 
-[RPM RHEL 7/CentOS 7](https://packagecloud.io/github/git-lfs/packages/el/7/git-lfs-VERSION-1.el7.x86_64.rpm/download)
-[RPM RHEL 8/Rocky Linux 8](https://packagecloud.io/github/git-lfs/packages/el/8/git-lfs-VERSION-1.el8.x86_64.rpm/download)
-[RPM RHEL 9/Rocky Linux 9](https://packagecloud.io/github/git-lfs/packages/el/9/git-lfs-VERSION-1.el9.x86_64.rpm/download)
-[Debian 10](https://packagecloud.io/github/git-lfs/packages/debian/buster/git-lfs_VERSION_amd64.deb/download)
-[Debian 11](https://packagecloud.io/github/git-lfs/packages/debian/bullseye/git-lfs_VERSION_amd64.deb/download)
-[Debian 12](https://packagecloud.io/github/git-lfs/packages/debian/bookworm/git-lfs_VERSION_amd64.deb/download)
+$(script/distro-tool --distro-markdown)
 
 ## SHA-256 hashes:
 EOM


### PR DESCRIPTION
Right now, we have multiple different locations for our distro information.  This is suboptimal in many ways because it requires developers to keep multiple sources of information in sync.

To solve this, let's write a Ruby script that contains our single source of truth.  It contains all of the existing data we have now in an easily processable format.  It uses a style which is called a _modulino_ in the Perl community, which is essentially a script which can also be required as a library for testing purposes.

Since we can require any file which ends in `.rb`, create the script as a library with this trailing suffix and require it in the RSpec tests we're adding so that we can test it produces the expected results. These tests can be run with a simple `rspec script/spec` using a standard distro Ruby and RSpec.

For our script itself, symlink it into the `script` directory without a trailing suffix.  Various authorities, including Debian, recommend not using a trailing suffix on programs so that the implementation language can change easily if need be.  We follow this advice here.

The symlink itself should not pose a problem because this is only run on Unix by CI or core team members, and our CI system should have developer mode enabled on Windows, allowing symlinks without elevated permissions. Hapless end users cloning this repository on Windows without developer mode enabled will receive a plain text file in place of the symlink, which should not pose a practical problem since they won't be using this script.

