### PR TITLE
Update and expand documentation of the Git LFS release process

### DIFF
--- a/docs/howto/release-git-lfs.md
+++ b/docs/howto/release-git-lfs.md
@@ -56,7 +56,7 @@ tests at all times. New features are added via the feature-branch workflow, or
 
 This is done so that `main` can progress and grow new features, while
 historical releases, such as `vM.N.0` can receive bug fixes as they are applied
-to main, eventually culminating in a `vM.N.1` (and so on) release.
+to `main`, eventually culminating in a `vM.N.1` (and so on) release.
 
 ## Building a release
 
@@ -190,7 +190,7 @@ vM.(N-1).0...main` at the time of release.
 ### Building `vM.N.P` (PATCH versions)
 
 When building a PATCH release, follow the same process as above, with the
-additional caveat that we must cherry-pick merges from main to the release
+additional caveat that we must cherry-pick merges from `main` to the release
 branch.
 
   1. To begin, checkout the branch `release-M.N`, and ensure that you have the

--- a/docs/howto/release-git-lfs.md
+++ b/docs/howto/release-git-lfs.md
@@ -200,6 +200,11 @@ to zero, we are releasing a PATCH version.
      $ script/upload --finalize vM.N.P
      ```
 
+     Note that this script requires GnuPG as well as Ruby (with the OpenSSL
+     gem) and several other tools.  You will need to provide your GitHub
+     credentials in your `~/.netrc` file or via a `GITHUB_TOKEN` environment
+     variable.
+
      If you want to inspect the data before approving it, pass the `--inspect`
      option, which will drop you to a shell and let you look at things.  If the
      shell exits successfully, the build will be signed; otherwise, the process

--- a/docs/howto/release-git-lfs.md
+++ b/docs/howto/release-git-lfs.md
@@ -109,18 +109,25 @@ equal to 0, we say that we are releasing a MINOR version of Git LFS, in the
      `vM.N.P`:
 
      ```ShellSession
-     $ git show -q HEAD
-     commit 9377560199b9d7cd2d3c38524a2a7f61aedc89db
-     Merge: 3f3faa90 a55b7fd9
-     Author: Taylor Blau <ttaylorr@github.com>
-     Date:   Thu Jul 26 14:48:39 2018 -0500
+     $ git show -q --pretty=%s%n%b HEAD
+     Merge pull request #xxxx from git-lfs/release-next
+     release: vM.N.P
 
-         Merge pull request #3150 from git-lfs/release-next
+     $ git tag -s vM.N.P -m vM.N.P
 
-             release: vM.N.0
-     $ git tag -s vM.N.P
      $ git describe HEAD
      vM.N.P
+
+     $ git show -q --pretty=%s%d%n%b vM.N.P
+     tag vM.N.P
+     Tagger: ...
+
+     vM.N.P
+     -----BEGIN PGP SIGNATURE-----
+     ...
+     -----END PGP SIGNATURE-----
+     Merge pull request #xxxx from git-lfs/release-next (tag: vM.N.P)
+     release: vM.N.P
      ```
 
   4. Push the tag, via:
@@ -155,18 +162,16 @@ equal to 0, we say that we are releasing a MINOR version of Git LFS, in the
      similar to the following:
 
      ```diff
-     diff --git a/_config.yml b/_config.yml
-     index 03f23d8..6767f6f 100644
-     --- a/_config.yml
-     +++ b/_config.yml
+     --- _config.yml
+     +++ _config.yml
      @@ -1,7 +1,7 @@
       # Site settings
       title: "Git Large File Storage"
       description: "Git Large File Storage (LFS) replaces large files such as audio samples, videos, datasets, and graphics with text pointers inside Git, while storing the file contents on a remote server like GitHub.com or GitHub Enterprise."
-     -git-lfs-release: 2.5.1
-     +git-lfs-release: 2.5.2
+     -git-lfs-release: M.(N-1).0
+     +git-lfs-release: M.N.0
 
-      url: "https://git-lfs.github.com"
+      url: "https://git-lfs.com"
      ```
 
      Then update [our fork](https://github.com/git-lfs/Homebrew-core) of

--- a/docs/howto/release-git-lfs.md
+++ b/docs/howto/release-git-lfs.md
@@ -174,24 +174,6 @@ equal to 0, we say that we are releasing a MINOR version of Git LFS, in the
      [Homebrew/homebrew-core#32161](https://github.com/Homebrew/homebrew-core/pull/32161),
      then celebrate.
 
-### Building `vM.N.0` (MINOR versions)
-
-When building a MINOR release, we introduce a new `release-M.N` branch which
-will receive all new features and bug fixes since `release-M.(N-1)`. The change
-set described by `vM.(N-1).0` and `vM.N.0` is as reported by `git log
-vM.(N-1).0...main` at the time of release.
-
-  1. To introduce this new branch (after creating and merging `release-next`
-     into `main`), simply run:
-
-     ```ShellSession
-     $ git branch
-     * main
-     $ git checkout -b release-M.N
-     ```
-
-  2. Then, proceed to follow the guidelines above.
-
 ### Building `vM.N.P` (PATCH versions)
 
 When building a PATCH release, follow the same process as above, with the

--- a/docs/howto/release-git-lfs.md
+++ b/docs/howto/release-git-lfs.md
@@ -55,20 +55,20 @@ tests at all times. New features are added via the feature-branch workflow, or
 (optionally) from a contributor's fork.
 
 This is done so that `main` can progress and grow new features, while
-historical releases, such as `v2.n.0` can receive bug fixes as they are applied
-to main, eventually culminating in a `v2.n.1` (and so on) release.
+historical releases, such as `vM.N.0` can receive bug fixes as they are applied
+to main, eventually culminating in a `vM.N.1` (and so on) release.
 
 ## Building a release
 
-Let release `v2.n.m` denote the version that we are _releasing_. When `m` is
+Let release `vM.N.P` denote the version that we are _releasing_. When `N` is
 equal to 0, we say that we are releasing a MINOR version of Git LFS, in the
-`v2.n`-series. Let `v2.n-1` denote the previous release series.
+`vM.N`-series. Let `vM.(N-1)` denote the previous release series.
 
   1. First, we write the release notes and do the housekeeping required to
      indicate a new version. On a new branch, called `release-next`, do the
      following:
 
-     * Run `script/changelog v2.n-1.0...HEAD` and categorize each merge commit
+     * Run `script/changelog vM.(N-1).0...HEAD` and categorize each merge commit
        as a feature, bug-fix, miscellaneous change, or skipped. Ensure that your
        `~/.netrc` credentials are kept up-to-date in order to make requests to
        the GitHub API.
@@ -82,15 +82,15 @@ equal to 0, we say that we are releasing a MINOR version of Git LFS, in the
          community contributions.
 
        * If you are releasing a MINOR version, and not a PATCH, and if there
-         were non-zero PATCH versions released in the `v2.n-1` series, also
+         were non-zero PATCH versions released in the `vM.(N-1)` series, also
          include any changes from the latest CHANGELOG in that series, too.
 
-     * Run `script/update-version v2.n.m` to update the version number in all of
+     * Run `script/update-version vM.N.P` to update the version number in all of
        the relevant files.
 
   2. Then, create a pull request of your changes with head `release-next`. If
      you're building a MAJOR or MINOR release, set the base to `main`.
-     Otherwise, set the base to `release-2.n`.
+     Otherwise, set the base to `release-M.N`.
 
      Run Continuous Integration, and ensure that it passes.
      Notify the `@git-lfs/release` team, a collection of humans who are
@@ -101,7 +101,7 @@ equal to 0, we say that we are releasing a MINOR version of Git LFS, in the
 
   3. Once approved and verified, merge the pull request you created in the
      previous step. Locally, create a GPG-signed tag on the merge commit called
-     `v2.n.m`:
+     `vM.N.P`:
 
      ```ShellSession
      $ git show -q HEAD
@@ -112,16 +112,16 @@ equal to 0, we say that we are releasing a MINOR version of Git LFS, in the
 
          Merge pull request #3150 from git-lfs/release-next
 
-             release: v2.n.0
-     $ git tag -s v2.n.m
+             release: vM.N.0
+     $ git tag -s vM.N.P
      $ git describe HEAD
-     v2.n.m
+     vM.N.P
      ```
 
   4. Push the tag, via:
 
      ```ShellSession
-     $ git push origin v2.n.m
+     $ git push origin vM.N.P
      ```
 
      This will kick off the process of building the release artifacts.  This
@@ -132,7 +132,7 @@ equal to 0, we say that we are releasing a MINOR version of Git LFS, in the
   5. From the command line, finalize the release process by signing the release:
 
      ```ShellSession
-     $ script/upload --finalize v2.n.m
+     $ script/upload --finalize vM.N.P
      ```
 
      If you want to inspect the data before approving it, pass the `--inspect`
@@ -169,12 +169,12 @@ equal to 0, we say that we are releasing a MINOR version of Git LFS, in the
      [Homebrew/homebrew-core#32161](https://github.com/Homebrew/homebrew-core/pull/32161),
      then celebrate.
 
-### Building `v2.n.0` (MINOR versions)
+### Building `vM.N.0` (MINOR versions)
 
-When building a MINOR release, we introduce a new `release-2.n` branch which
-will receive all new features and bug fixes since `release-2.n-1`. The change
-set described by `v2.n-1.0` and `v2.n.0` is as reported by `git log
-v2.n-1.0...main` at the time of release.
+When building a MINOR release, we introduce a new `release-M.N` branch which
+will receive all new features and bug fixes since `release-M.(N-1)`. The change
+set described by `vM.(N-1).0` and `vM.N.0` is as reported by `git log
+vM.(N-1).0...main` at the time of release.
 
   1. To introduce this new branch (after creating and merging `release-next`
      into `main`), simply run:
@@ -182,25 +182,25 @@ v2.n-1.0...main` at the time of release.
      ```ShellSession
      $ git branch
      * main
-     $ git checkout -b release-2.n
+     $ git checkout -b release-M.N
      ```
 
   2. Then, proceed to follow the guidelines above.
 
-### Building `v2.n.m` (PATCH versions)
+### Building `vM.N.P` (PATCH versions)
 
 When building a PATCH release, follow the same process as above, with the
 additional caveat that we must cherry-pick merges from main to the release
 branch.
 
-  1. To begin, checkout the branch `release-2.n`, and ensure that you have the
+  1. To begin, checkout the branch `release-M.N`, and ensure that you have the
      latest changes from the remote.
 
   2. Gather a set of potential candidates to "backport" to the older release
      with:
 
      ```ShellSession
-     $ git log --merges --first-parent v2.n.m-1...main
+     $ git log --merges --first-parent vM.N.(P-1)...main
      ```
 
    3. For each merge that you want to backport, run:

--- a/docs/howto/release-git-lfs.md
+++ b/docs/howto/release-git-lfs.md
@@ -60,38 +60,67 @@ tests at all times. New features are added via the feature-branch workflow, or
 (optionally) from a contributor's fork.
 
 This is done so that `main` can progress and grow new features, while
-historical releases, such as `vM.N.0` can receive bug fixes as they are applied
+historical releases such as `vM.N.0` can receive bug fixes as they are applied
 to `main`, eventually culminating in a `vM.N.1` (and so on) release.
 
 ## Building a release
 
-Let release `vM.N.P` denote the version that we are _releasing_. When `N` is
-equal to 0, we say that we are releasing a MINOR version of Git LFS, in the
-`vM.N`-series. Let `vM.(N-1)` denote the previous release series.
+Let release `vM.N.P` denote the version that we are _releasing_.
+
+When `P` is equal to zero, we say that we are releasing a MINOR version of
+Git LFS in the `vM.N`-series, unless `N` is also equal to zero, in which
+case we are releasing a MAJOR version.  Conversely, if `P` is not equal
+to zero, we are releasing a PATCH version.
 
   1. First, we write the release notes and do the housekeeping required to
-     indicate a new version. On a new branch, called `release-next`, do the
-     following:
+     indicate a new version.  For a MAJOR or MINOR version, we start with
+     a `main` branch which is up to date with the latest changes from the
+     remote and then checkout a new `release-next` branch from that base.
 
-     * Run `script/changelog vM.(N-1).0...HEAD` and categorize each merge commit
-       as a feature, bug-fix, miscellaneous change, or skipped. Ensure that your
-       `~/.netrc` credentials are kept up-to-date in order to make requests to
-       the GitHub API.
+     If we are releasing a PATCH version, we create a `release-M.N` branch
+     with cherry-picked merges from the `main` branch, as described in
+     the [instructions](#building-patch-versions) below, and then checkout
+     the `release-next` branch from that base.
 
-       This will write a portion of the CHANGELOG to stdout, which you should
-       copy and paste into `CHANGELOG.md`, along with an H2-level heading
-       containing the version and release date (consistent with the existing
-       style in the document.)
+     We next perform the following steps to prepare the `release-next` branch:
 
-       * Optionally write 1-2 paragraphs summarizing the release, and calling out
-         community contributions.
+     * Run `script/changelog` and categorize each merge commit as a feature,
+       bug fix, miscellaneous change, or a change to be skipped and ignored.
+       Ensure that your `~/.netrc` credentials are up-to-date in order to
+       make requests to the GitHub API, or use a `GITHUB_TOKEN` environment
+       variable.
 
-       * If you are releasing a MINOR version, and not a PATCH, and if there
-         were non-zero PATCH versions released in the `vM.(N-1)` series, also
-         include any changes from the latest CHANGELOG in that series, too.
+       The `changelog` script will write a portion of the new CHANGELOG to
+       stdout, which you should copy and paste into `CHANGELOG.md`, along with
+       an H2-level heading containing the new version and the expected release
+       date.  This heading should be consistent with the exising style in the
+       document.
 
-     * Run `script/update-version vM.N.P` to update the version number in all of
-       the relevant files.
+       For a MAJOR release, use `script/changelog v(M-1).L.0...HEAD`, where
+       `(M-1)` is the previous MAJOR release number and `L` is the final
+       MINOR release number in that series.  For a MINOR release, use
+       `script/changelog vM.(N-1).0...HEAD`, where `(N-1)` is the previous
+       MINOR release number, and for a PATCH release, use
+       `script/changelog vM.N.(P-1)...HEAD`, where `(P-1)` is the previous
+       PATCH release number.
+
+       * Optionally write 1-2 paragraphs summarizing the release and calling
+         out community contributions.
+
+       * If we are releasing a MAJOR or MINOR version and not a PATCH, and
+         if the most recent non-PATCH release was followed by a series of one
+         or more PATCH releases, include any changes listed in the CHANGELOG
+         of that series' release branch in the new release's CHANGELOG.
+         (For a new MAJOR version, the prior release branch would be named
+         `release-(M-1).L`, following the terminology defined above, while
+         for a new MINOR version the prior release branch would be named
+         `release-M.(N-1)`.)
+
+     * Run `script/update-version vM.N.P` to update the version number in all
+       of the relevant files.
+
+     * Adjust the date in the `debian/changelog` entry to reflect the
+       expected release date rather than the current date.
 
   2. Then, create a pull request of your changes with head `release-next`. If
      you're building a MAJOR or MINOR release, set the base to `main`.

--- a/docs/howto/release-git-lfs.md
+++ b/docs/howto/release-git-lfs.md
@@ -232,10 +232,17 @@ to zero, we are releasing a PATCH version.
       url: "https://git-lfs.com"
      ```
 
-     Then update [our fork](https://github.com/git-lfs/Homebrew-core) of
-     `Homebrew/homebrew-core` similar to
-     [Homebrew/homebrew-core#32161](https://github.com/Homebrew/homebrew-core/pull/32161),
-     then celebrate.
+  9. Create a GitHub PR to update the Homebrew formula for Git LFS with
+     the `brew bump-formula-pr` command on a macOS system.  The SHA-256 value
+     should correspond with the packaged artifact containing the new
+     release's source files which is available at the given URL:
+
+     ```
+     $ brew bump-formula-pr \
+         --url https://github.com/git-lfs/git-lfs/releases/download/vM.N.P/git-lfs-vM.N.P.tar.gz \
+         --sha256 <SHA-256> \
+         git-lfs
+     ```
 
 ### Building PATCH versions
 

--- a/docs/howto/release-git-lfs.md
+++ b/docs/howto/release-git-lfs.md
@@ -28,12 +28,16 @@ We package several artifacts for each tagged release. They are:
 
       |     | operating system | architecture |
       | --- | ---------------- | ------------ |
-      | git-lfs-darwin-386-v@{version}.tar.gz | darwin | 386 |
       | git-lfs-darwin-amd64-v@{version}.tar.gz | darwin | amd64 |
+      | git-lfs-darwin-arm64-v@{version}.tar.gz | darwin | arm64 |
       | git-lfs-freebsd-386-v@{version}.tar.gz | freebsd | 386 |
       | git-lfs-freebsd-amd64-v@{version}.tar.gz | freebsd | amd64 |
       | git-lfs-linux-386-v@{version}.tar.gz | linux (generic) | 386 |
       | git-lfs-linux-amd64-v@{version}.tar.gz | linux (generic) | amd64 |
+      | git-lfs-linux-arm-v@{version}.tar.gz | linux (generic) | arm |
+      | git-lfs-linux-arm64-v@{version}.tar.gz | linux (generic) | arm64 |
+      | git-lfs-linux-ppc64le-v@{version}.tar.gz | linux (generic) | ppc64le |
+      | git-lfs-linux-s390x-v@{version}.tar.gz | linux (generic) | s390x |
 
   2. `git-lfs-windows-v@{release}-@{arch}.zip` for the following values:
 
@@ -41,6 +45,7 @@ We package several artifacts for each tagged release. They are:
       | --- | ---------------- | ------------ |
       | git-lfs-windows-386-v@{version}.zip | windows | 386 |
       | git-lfs-windows-amd64-v@{version}.zip | windows | amd64 |
+      | git-lfs-windows-arm64-v@{version}.zip | windows | arm64 |
 
   3. `git-lfs-windows-v@{release}.exe`, a signed Windows installer that contains
      copies of both `-x86` and `-x64` copies of Git LFS.

--- a/docs/howto/release-git-lfs.md
+++ b/docs/howto/release-git-lfs.md
@@ -122,16 +122,40 @@ to zero, we are releasing a PATCH version.
      * Adjust the date in the `debian/changelog` entry to reflect the
        expected release date rather than the current date.
 
-  2. Then, create a pull request of your changes with head `release-next`. If
-     you're building a MAJOR or MINOR release, set the base to `main`.
-     Otherwise, set the base to `release-M.N`.
+  2. Then, push the `release-next` branch and create a pull request with your
+     changes from the branch.  If you're building a MAJOR or MINOR release,
+     set the base to the `main` branch.  Otherwise, set the base to the
+     `release-M.N` branch.
 
-     Run Continuous Integration, and ensure that it passes.
-     Notify the `@git-lfs/release` team, a collection of humans who are
-     interested in Git LFS releases.
+     * Add the `release` label to the PR.
 
-     Verify that the Actions tab contains no indications of errors for the
-     workflows, especially the release workflow.
+     * In the PR description, consider uploading builds for implementers to
+       use in testing.  These can be generated from a local tag, which
+       does not need to be signed (but must be annotated).  The build
+       artifacts will be placed in the `bin/releases` directory and may
+       be uploaded from there:
+
+       ```ShellSession
+       $ git tag -m vM.N.P-pre vM.N.P-pre
+       $ make release
+       $ ls bin/releases
+       ```
+
+     * Notify the `@git-lfs/releases` and `@git-lfs/implementers` teams,
+       collections of humans who are interested in Git LFS releases.
+
+     * Ensure that the normal Continuous Integration workflow for PRs
+       that runs automatically in GitHub Actions succeeds fully.
+
+     * As the GitHub Actions release workflow will not run for PRs, consider
+       creating an annotated tag with the `-pre` suffix and pushing the tag,
+       which will trigger a run of the release workflow that does not upload
+       artifacts to Packagecloud.  Alternatively, in a private clone of
+       the repository, create such a tag from the `release-next` branch plus
+       one commit to change to the repository name in `script/upload`, and
+       push the tag so Actions will run the release workflow.  Ensure that
+       the workflow succeeds (excepting the Packagecloud upload step, which
+       will be skipped).
 
   3. Once approved and verified, merge the pull request you created in the
      previous step. Locally, create a GPG-signed tag on the merge commit called

--- a/docs/howto/release-git-lfs.md
+++ b/docs/howto/release-git-lfs.md
@@ -7,15 +7,15 @@ determining.
 
 We follow Semantic Versioning standards as follows:
 
-  * `MAJOR` releases are done on a scale of 1-2 years. These encompass breaking,
+  * `MAJOR` releases are done on a scale of 2-4 years. These encompass breaking,
     incompatible API changes, or command-line interface changes that would
     cause existing programs or use-cases scripted against Git LFS to break.
 
-  * `MINOR` releases are done on a scale of 1-2 months. These encompass new
+  * `MINOR` releases are done on a scale of 2-6 months. These encompass new
     features, bug fixes, and other "medium"-sized changes into a semi-regular
     release schedule.
 
-  * `PATCH` releases are done on the scale of 1-2 weeks. These encompass
+  * `PATCH` releases are done on the scale of weeks to months. These encompass
     critical bug fixes, but lack new features. They are amended to a `MINOR`
     release "series", or, if serious enough (e.g., security vulnerabilities,
     etc.) are backported to previous versions.

--- a/docs/howto/release-git-lfs.md
+++ b/docs/howto/release-git-lfs.md
@@ -174,17 +174,27 @@ equal to 0, we say that we are releasing a MINOR version of Git LFS, in the
      [Homebrew/homebrew-core#32161](https://github.com/Homebrew/homebrew-core/pull/32161),
      then celebrate.
 
-### Building `vM.N.P` (PATCH versions)
+### Building PATCH versions
 
-When building a PATCH release, follow the same process as above, with the
-additional caveat that we must cherry-pick merges from `main` to the release
-branch.
+When building a PATCH release, we cherry-pick merges from `main` to the
+`vM.N` release branch, creating the branch first if it does not exist,
+and then use that branch as the base for the PATCH release.
 
-  1. To begin, checkout the branch `release-M.N`, and ensure that you have the
-     latest changes from the remote.
+  1. If the `release-M.N` branch does not already exist, create it from
+     the corresponding MINOR release tag (or MAJOR release tag, if no
+     MINOR releases have been made since the last MAJOR release):
 
-  2. Gather a set of potential candidates to "backport" to the older release
-     with:
+     ```ShellSession
+     $ git checkout -b release-M.N vM.N.0
+     ```
+
+     If the release branch already exists because this is not the first
+     patch release for the given MINOR (or MAJOR) release, simply checkout
+     the `release-M.N` branch, and ensure that you have the latest changes
+     from the remote.
+
+  2. Gather a set of potential candidates to backport to the `release-M.N`
+     branch with:
 
      ```ShellSession
      $ git log --merges --first-parent vM.N.(P-1)...main
@@ -196,7 +206,9 @@ branch.
       $ git cherry-pick -m1 <SHA-1>
       ```
 
-      To cherry-pick the merge onto your release branch, adoption the first
-      parent as the mainline.
+      This will cherry-pick the merge onto your release branch, using
+      the `-m1` option to specify that the first parent of the merge
+      corresponds to the mainline.
 
-   4. Then, proceed to follow the guidelines above.
+   4. Then follow the [guidelines](#building-a-release) above, using the
+      `release-M.N` branch as the base for the new PATCH release.


### PR DESCRIPTION
This PR updates and expands the "how-to" [documentation](https://github.com/git-lfs/git-lfs/blob/cbd62023ca389f3ddc4b08293dd8cd2785d8e02d/docs/howto/release-git-lfs.md) of the steps we follow to release a new Git LFS version.

The primary changes in this PR are:
- Making our terminology more generic and consistent throughout, such as by adopting the version placeholders `vM.N.P` instead of the legacy `v2.n.m`.
- Adjusting the suggested time scales for the different types of releases to reflect the current, more attenuated development process now that the project is more mature.
- Updating the [list](https://github.com/git-lfs/git-lfs/blob/cbd62023ca389f3ddc4b08293dd8cd2785d8e02d/docs/howto/release-git-lfs.md#release-artifacts) of release artifacts to reflect the current set we publish.
- Revising the main [instructions](https://github.com/git-lfs/git-lfs/blob/cbd62023ca389f3ddc4b08293dd8cd2785d8e02d/docs/howto/release-git-lfs.md#building-a-release) to cover all types of release versions instead of just minor versions, include more detail regarding process of updating `CHANGELOG.md` and creating a PR, explain the value of testing the GitHub Actions release workflow with a "dry run" in advance of the actual release, and note the various dependencies required by the `script/upload` script.
- Simplifying the code examples in our instructions so they are more generic and focus attention on the key data elements.
- Adding a step which documents how to use `brew bump-formula-pr` to create a PR in `Homebrew/homebrew-core` that will update the `git-lfs` [formula](https://github.com/Homebrew/homebrew-core/blob/156733fc88895de25be7e10d785dfd14aa6d13f1/Formula/git-lfs.rb)'s version of Git LFS (for example, as seen in PR [Homebrew/homebrew-core#137737](https://github.com/Homebrew/homebrew-core/pull/137737)).
- Removing the [section](https://github.com/git-lfs/git-lfs/blob/cbd62023ca389f3ddc4b08293dd8cd2785d8e02d/docs/howto/release-git-lfs.md#building-v2n0-minor-versions) on building a `release-M.N` branch after each minor release, as we actually do this only when necessary because we are backporting commits from `main` to create a patch release.
- Updating the [section](https://github.com/git-lfs/git-lfs/blob/cbd62023ca389f3ddc4b08293dd8cd2785d8e02d/docs/howto/release-git-lfs.md#building-v2nm-patch-versions) on building patch releases to describe when and how to create a `release-M.N` branch.