### PR TITLE
Make track handle backslashes correctly on Unix

### DIFF
--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -331,7 +332,12 @@ var (
 )
 
 func escapeGlobCharacters(s string) string {
-	var escaped string = strings.Replace(s, `\`, "/", -1)
+	var escaped string
+	if runtime.GOOS == "windows" {
+		escaped = strings.Replace(s, `\`, "/", -1)
+	} else {
+		escaped = strings.Replace(s, `\`, `\\`, -1)
+	}
 
 	for _, ch := range trackEscapeStrings {
 		escaped = strings.Replace(escaped, ch, fmt.Sprintf("\\%s", ch), -1)
@@ -343,8 +349,13 @@ func escapeGlobCharacters(s string) string {
 	return escaped
 }
 
-func escapeAttrPattern(unescaped string) string {
-	var escaped string = strings.Replace(unescaped, `\`, "/", -1)
+func escapeAttrPattern(s string) string {
+	var escaped string
+	if runtime.GOOS == "windows" {
+		escaped = strings.Replace(s, `\`, "/", -1)
+	} else {
+		escaped = strings.Replace(s, `\`, `\\`, -1)
+	}
 
 	for from, to := range trackEscapePatterns {
 		escaped = strings.Replace(escaped, from, to, -1)
@@ -358,6 +369,10 @@ func unescapeAttrPattern(escaped string) string {
 
 	for to, from := range trackEscapePatterns {
 		unescaped = strings.Replace(unescaped, from, to, -1)
+	}
+
+	if runtime.GOOS != "windows" {
+		unescaped = strings.Replace(unescaped, `\\`, `\`, -1)
 	}
 
 	return unescaped

--- a/git/git.go
+++ b/git/git.go
@@ -1313,10 +1313,10 @@ func GetTrackedFiles(pattern string) ([]string, error) {
 
 	var ret []string
 	cmd, err := gitNoLFS(
-		"-c", "core.quotepath=false", // handle special chars in filenames
 		"ls-files",
 		"--ignored",
 		"--cached", // include things which are staged but not committed right now
+		"-z",       // handle special chars in filenames
 		"-x",
 		safePattern)
 	if err != nil {
@@ -1329,6 +1329,7 @@ func GetTrackedFiles(pattern string) ([]string, error) {
 	}
 	cmd.Start()
 	scanner := bufio.NewScanner(outp)
+	scanner.Split(tools.SplitOnNul)
 	for scanner.Scan() {
 		line := scanner.Text()
 


### PR DESCRIPTION
On Windows, backslashes are path separators and we need to rewrite them into forward slashes if we want Git to honour the path provided. However, on Unix, backslashes are ordinary characters and can be used anywhere in a path.

To make `git lfs track --filename` work correctly for paths with backslashes on Unix, we must avoid converting them to forward slashes, and we need to unescape them when unescaping the paths.  Note that we must escape _before_ all other escapes and unescape _after_ all other unescaping so that we don't accidentally try to re-escape a pattern that we've just escaped (or vice-versa).

In addition, this highlights an additional subtle bug we've failed to notice so far: the `core.quotepaths` variable we've used in our invocation to `git ls-files` doesn't prevent all escaping; instead, it only prevents escaping of high bytes, which doesn't help us with sequences that contain backslashes or newlines.  To handle those gracefully, we need the `-z` option, which uses NUL-terminated filenames.

Update the tests for our new backslash behaviour on Unix and add new tests that we gracefully handle backslashes on Unix.  Check specifically for the error we would get if `git ls-files` produced unexpected output and fail if so.

Fixes #5480
/cc @nvelat as submitter