### PR TITLE
Avoid modifying the mtime of empty files

### DIFF
--- a/lfs/gitfilter_smudge.go
+++ b/lfs/gitfilter_smudge.go
@@ -18,15 +18,21 @@ import (
 func (f *GitFilter) SmudgeToFile(filename string, ptr *Pointer, download bool, manifest tq.Manifest, cb tools.CopyCallback) error {
 	tools.MkdirAll(filepath.Dir(filename), f.cfg)
 
-	if stat, _ := os.Stat(filename); stat != nil && stat.Mode()&0200 == 0 {
-		if err := os.Chmod(filename, stat.Mode()|0200); err != nil {
-			return errors.Wrap(err,
-				tr.Tr.Get("Could not restore write permission"))
+	if stat, _ := os.Stat(filename); stat != nil {
+		if ptr.Size == 0 && stat.Size() == 0 {
+			return nil
 		}
 
-		// When we're done, return the file back to its normal
-		// permission bits.
-		defer os.Chmod(filename, stat.Mode())
+		if stat.Mode()&0200 == 0 {
+			if err := os.Chmod(filename, stat.Mode()|0200); err != nil {
+				return errors.Wrap(err,
+					tr.Tr.Get("Could not restore write permission"))
+			}
+
+			// When we're done, return the file back to its normal
+			// permission bits.
+			defer os.Chmod(filename, stat.Mode())
+		}
 	}
 
 	abs, err := filepath.Abs(filename)

--- a/t/Makefile
+++ b/t/Makefile
@@ -22,6 +22,7 @@ TEST_CMDS += ../bin/lfstest-badpathcheck$X
 TEST_CMDS += ../bin/lfstest-count-tests$X
 TEST_CMDS += ../bin/lfstest-customadapter$X
 TEST_CMDS += ../bin/lfstest-gitserver$X
+TEST_CMDS += ../bin/lfstest-nanomtime$X
 TEST_CMDS += ../bin/lfstest-realpath$X
 TEST_CMDS += ../bin/lfstest-standalonecustomadapter$X
 TEST_CMDS += ../bin/lfstest-testutils$X

--- a/t/cmd/lfstest-nanomtime.go
+++ b/t/cmd/lfstest-nanomtime.go
@@ -1,0 +1,23 @@
+//go:build testtools
+// +build testtools
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Need an argument")
+		os.Exit(2)
+	}
+	st, err := os.Stat(os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to stat %q: %s", os.Args[1], err)
+		os.Exit(3)
+	}
+	mtime := st.ModTime()
+	fmt.Printf("%d.%09d", mtime.Unix(), mtime.Nanosecond())
+}

--- a/t/t-pull.sh
+++ b/t/t-pull.sh
@@ -365,3 +365,30 @@ begin_test "pull: outside git repository"
   grep "Not in a Git repository" pull.log
 )
 end_test
+
+begin_test "pull with empty file doesn't modify mtime"
+(
+  set -e
+  git init pull-empty-file
+  cd pull-empty-file
+
+  git lfs track "*.bin"
+  git add .
+  git commit -m 'gitattributes'
+  printf abc > abc.bin
+  git add .
+  git commit -m 'abc'
+
+  touch foo.bin
+  lfstest-nanomtime foo.bin >foo.mtime
+
+  # This isn't necessary, but it takes a few cycles to make sure that our
+  # timestamp changes.
+  git add foo.bin
+  git commit -m 'foo'
+
+  git lfs pull
+  lfstest-nanomtime foo.bin >foo.mtime2
+  diff -u foo.mtime foo.mtime2
+)
+end_test


### PR DESCRIPTION
When a user performs a `git lfs pull`, we update all of the files in the working tree that are pointers (and aren't excluded) to have their correct content.  However, if the files are empty, they don't need a change, and some users find the fact that we update the mtime of the file to be undesirable.

Let's avoid this by explicitly checking to see if the file is empty and if it's supposed to be and not updating it.

Fixes #5113