### PR TITLE
Limit CopyCallbackFile to print every 200 ms

### DIFF
--- a/lfs/util.go
+++ b/lfs/util.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/git-lfs/git-lfs/v3/config"
 	"github.com/git-lfs/git-lfs/v3/errors"
@@ -51,12 +52,14 @@ func (f *GitFilter) CopyCallbackFile(event, filename string, index, totalFiles i
 	}
 
 	var prevWritten int64
-
+	deadline := time.Now().Add(time.Millisecond * 250)
 	cb := tools.CopyCallback(func(total int64, written int64, current int) error {
-		if written != prevWritten {
-			_, err := file.Write([]byte(fmt.Sprintf("%s %d/%d %d/%d %s\n", event, index, totalFiles, written, total, filename)))
+		now := time.Now()
+		if written != prevWritten && (!now.Before(deadline) || written == total) {
+			_, err := fmt.Fprintf(file, "%s %d/%d %d/%d %s\n", event, index, totalFiles, written, total, filename)
 			file.Sync()
 			prevWritten = written
+			deadline = now.Add(time.Millisecond * 250)
 			return wrapProgressError(err, event, logPath)
 		}
 

--- a/lfs/util.go
+++ b/lfs/util.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/git-lfs/git-lfs/v3/config"
 	"github.com/git-lfs/git-lfs/v3/errors"
+	"github.com/git-lfs/git-lfs/v3/tasklog"
 	"github.com/git-lfs/git-lfs/v3/tools"
 	"github.com/git-lfs/git-lfs/v3/tr"
 )
@@ -52,14 +53,14 @@ func (f *GitFilter) CopyCallbackFile(event, filename string, index, totalFiles i
 	}
 
 	var prevWritten int64
-	deadline := time.Now().Add(time.Millisecond * 250)
+	deadline := time.Now().Add(tasklog.DefaultLoggingThrottle)
 	cb := tools.CopyCallback(func(total int64, written int64, current int) error {
 		now := time.Now()
-		if written != prevWritten && (!now.Before(deadline) || written == total) {
+		if written != prevWritten && (!now.Before(deadline) || written >= total) {
 			_, err := fmt.Fprintf(file, "%s %d/%d %d/%d %s\n", event, index, totalFiles, written, total, filename)
 			file.Sync()
 			prevWritten = written
-			deadline = now.Add(time.Millisecond * 250)
+			deadline = now.Add(tasklog.DefaultLoggingThrottle)
 			return wrapProgressError(err, event, logPath)
 		}
 


### PR DESCRIPTION
Prior to this commit, the callback would print every single iteration of io.Copy. This results in a print every 32kb and
can slow clean operations by several orders of magnitude when GIT_LFS_PROGRESS is set.
By limiting the print to every quarter second in this PR, most of negative impact is mitigated.