### PR TITLE
Add installation note about restarting shells on Windows for PATH changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Alternatively, you can install a recent version of Git LFS from the [Chocolatey]
 available for Linux, macOS, Windows, and FreeBSD.
 The binary packages include a script which will:
 
-- Install Git LFS binaries onto the system `$PATH`
+- Install Git LFS binaries onto the system `$PATH`.  On Windows in particular, you may need to restart your command shell so any change to `$PATH` will take effect and Git can locate the Git LFS binary.
 - Run `git lfs install` to perform required global configuration changes.
 
 ```ShellSession


### PR DESCRIPTION
As discussed in #5498, Windows users in particular may need to restart their command shell after installing a Git LFS binary in order for any changes to `$PATH` to take effect, so we add a note to our installation instructions on this point.

/cc @zpostfacto as reporter.