### PR TITLE
track: reject attempts to modify `.gitattributes`

### DIFF
--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -166,11 +166,6 @@ ArgsLoop:
 	// Any items left in the map, write new lines at the end of the file
 	// Note this is only new patterns, not ones which changed locking flags
 	for pattern, newline := range changedAttribLines {
-		if !trackNoModifyAttrsFlag {
-			// Newline already embedded
-			attributesFile.WriteString(newline)
-		}
-
 		// Also, for any new patterns we've added, make sure any existing git
 		// tracked files have their timestamp updated so they will now show as
 		// modified note this is relative to current dir which is how we write
@@ -203,6 +198,11 @@ ArgsLoop:
 		}
 		if matchedBlocklist {
 			continue
+		}
+
+		if !trackNoModifyAttrsFlag {
+			// Newline already embedded
+			attributesFile.WriteString(newline)
 		}
 
 		for _, f := range gittracked {

--- a/t/t-track.sh
+++ b/t/t-track.sh
@@ -377,7 +377,7 @@ begin_test "track blocklisted files by name"
   git add .gitattributes
   git commit -m 'Initial commit'
 
-  git lfs track .gitattributes 2>&1 > track.log
+  git lfs track .gitattributes 2>&1 > track.log && exit 1
   grep "Pattern '.gitattributes' matches forbidden file '.gitattributes'" track.log
   [ -z "$(git status --porcelain | grep -v '^??')" ]
 )
@@ -396,11 +396,11 @@ begin_test "track blocklisted files with glob"
   git add .gitattributes
   git commit -m 'Initial commit'
 
-  git lfs track ".git*" 2>&1 > track.log
+  git lfs track ".git*" 2>&1 > track.log && exit 1
   grep "Pattern '.git\*' matches forbidden file" track.log
   [ -z "$(git status --porcelain | grep -v '^??')" ]
 
-  git lfs track "*" 2>&1 > track.log
+  git lfs track "*" 2>&1 > track.log && exit 1
   grep "Pattern '\*' matches forbidden file" track.log
   [ -z "$(git status --porcelain | grep -v '^??')" ]
 )

--- a/t/t-track.sh
+++ b/t/t-track.sh
@@ -375,9 +375,11 @@ begin_test "track blocklisted files by name"
 
   touch .gitattributes
   git add .gitattributes
+  git commit -m 'Initial commit'
 
   git lfs track .gitattributes 2>&1 > track.log
   grep "Pattern '.gitattributes' matches forbidden file '.gitattributes'" track.log
+  [ -z "$(git status --porcelain | grep -v '^??')" ]
 )
 end_test
 
@@ -392,9 +394,15 @@ begin_test "track blocklisted files with glob"
 
   touch .gitattributes
   git add .gitattributes
+  git commit -m 'Initial commit'
 
   git lfs track ".git*" 2>&1 > track.log
   grep "Pattern '.git\*' matches forbidden file" track.log
+  [ -z "$(git status --porcelain | grep -v '^??')" ]
+
+  git lfs track "*" 2>&1 > track.log
+  grep "Pattern '\*' matches forbidden file" track.log
+  [ -z "$(git status --porcelain | grep -v '^??')" ]
 )
 end_test
 


### PR DESCRIPTION
If the user requests a pattern that matches `.gitattributes` and that's the only pattern, we currently return a zero exit status, even though we've failed.  Similarly, if an error occurs, we fail to exit nonzero. In both of these cases, switch to exiting nonzero to indicate that the operation was unsuccessful.

However, continue to return successfully if the reason we didn't process any patterns was because they're already matched, since what the user wanted is already done.

/cc #5511
/cc @RuRo as reporter