### PR TITLE
Filter --above by path and by type

### DIFF
--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -38,6 +38,8 @@ var (
 	// above the provided size.
 	migrateImportAboveFmt string
 
+	migrateImportAboveOnlyBinary bool
+
 	// migrateEverything indicates the presence of the --everything flag,
 	// and instructs 'git lfs migrate' to migrate all local references.
 	migrateEverything bool
@@ -396,6 +398,7 @@ func init() {
 
 	importCmd := NewCommand("import", migrateImportCommand)
 	importCmd.Flags().StringVar(&migrateImportAboveFmt, "above", "", "--above=<n>")
+	importCmd.Flags().BoolVar(&migrateImportAboveOnlyBinary, "above-only-binary", false, "--above only applies to binary files")
 	importCmd.Flags().BoolVar(&migrateVerbose, "verbose", false, "Verbose logging")
 	importCmd.Flags().StringVar(&objectMapFilePath, "object-map", "", "Object map file")
 	importCmd.Flags().BoolVar(&migrateNoRewrite, "no-rewrite", false, "Add new history without rewriting previous")

--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -38,7 +38,24 @@ var (
 	// above the provided size.
 	migrateImportAboveFmt string
 
-	migrateImportAboveOnlyBinary bool
+	// migrateImportAboveNotByTypeFmt indicates the presence of the
+	// --above-not-by-type=<regexes> flag and modifies --above=<size> to
+	// ignore files where the 'file' utility's analysis matches the
+	// given regex chain. Example, ASCII|Unicode;postscript will match
+	// ASCII or Unicode files, unless they are also postscript.
+	migrateImportAboveNotByTypeFmt string
+
+	// migrateImportAboveNotByPathFmt indicates the presence of the
+	// --above-not-by-path=<regexes> flag and skips the expensive analysis
+	// of --above-not-by-type where the path is reliable enough.
+	// Example: .(c|h|cxx|hxx|java|kt|kts|go|rb|py)$ skips by extension.
+	migrateImportAboveNotByPathFmt string
+
+	// migrateImportAboveAndByPathFmt indicates the presence of the
+	// --above-and-by-path=<regex> flag and skips the expensive analysis
+	// of --above-not-by-type where the path is reliable enough.
+	// Example, .(png|gif|jpg|jpeg|png|exe|lib|so)$ tracks by extension.
+	migrateImportAboveAndByPathFmt string
 
 	// migrateEverything indicates the presence of the --everything flag,
 	// and instructs 'git lfs migrate' to migrate all local references.
@@ -398,7 +415,9 @@ func init() {
 
 	importCmd := NewCommand("import", migrateImportCommand)
 	importCmd.Flags().StringVar(&migrateImportAboveFmt, "above", "", "--above=<n>")
-	importCmd.Flags().BoolVar(&migrateImportAboveOnlyBinary, "above-only-binary", false, "--above only applies to binary files")
+	importCmd.Flags().StringVar(&migrateImportAboveAndByPathFmt, "above-and-by-path", "", "--above-and-by-path=<regex><!<regex>>* matching paths are tracked by above without examining type")
+	importCmd.Flags().StringVar(&migrateImportAboveNotByPathFmt, "above-not-by-path", "", "--above-not-by-path=<regex><!<regex>>* matching paths are skipped by above without examining type")
+	importCmd.Flags().StringVar(&migrateImportAboveNotByTypeFmt, "above-not-by-type", "", "--above-not-by-type=<regex><!<regex>>* skipped by above if '/bin/file file' output matches, second RE countermands, etc.")
 	importCmd.Flags().BoolVar(&migrateVerbose, "verbose", false, "Verbose logging")
 	importCmd.Flags().StringVar(&objectMapFilePath, "object-map", "", "Object map file")
 	importCmd.Flags().BoolVar(&migrateNoRewrite, "no-rewrite", false, "Add new history without rewriting previous")

--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -38,24 +38,24 @@ var (
 	// above the provided size.
 	migrateImportAboveFmt string
 
-	// migrateImportAboveNotByTypeFmt indicates the presence of the
-	// --above-not-by-type=<regexes> flag and modifies --above=<size> to
+	// migrateImportAboveExcludeByTypeFmt indicates the presence of the
+	// --above-exclude-by-type=<regexes> flag and modifies --above=<size> to
 	// ignore files where the 'file' utility's analysis matches the
 	// given regex chain. Example, ASCII|Unicode;postscript will match
 	// ASCII or Unicode files, unless they are also postscript.
-	migrateImportAboveNotByTypeFmt string
+	migrateImportAboveExcludeByTypeFmt string
 
-	// migrateImportAboveNotByPathFmt indicates the presence of the
-	// --above-not-by-path=<regexes> flag and skips the expensive analysis
-	// of --above-not-by-type where the path is reliable enough.
+	// migrateImportAboveExcludeByPathFmt indicates the presence of the
+	// --above-exclude-by-path=<regexes> flag and skips the expensive analysis
+	// of --above-exclude-by-type where the path is reliable enough.
 	// Example: .(c|h|cxx|hxx|java|kt|kts|go|rb|py)$ skips by extension.
-	migrateImportAboveNotByPathFmt string
+	migrateImportAboveExcludeByPathFmt string
 
-	// migrateImportAboveAndByPathFmt indicates the presence of the
-	// --above-and-by-path=<regex> flag and skips the expensive analysis
-	// of --above-not-by-type where the path is reliable enough.
+	// migrateImportAboveIncludeByPathFmt indicates the presence of the
+	// --above-include-by-path=<regex> flag and skips the expensive analysis
+	// of --above-exclude-by-type where the path is reliable enough.
 	// Example, .(png|gif|jpg|jpeg|png|exe|lib|so)$ tracks by extension.
-	migrateImportAboveAndByPathFmt string
+	migrateImportAboveIncludeByPathFmt string
 
 	// migrateEverything indicates the presence of the --everything flag,
 	// and instructs 'git lfs migrate' to migrate all local references.
@@ -415,9 +415,9 @@ func init() {
 
 	importCmd := NewCommand("import", migrateImportCommand)
 	importCmd.Flags().StringVar(&migrateImportAboveFmt, "above", "", "--above=<n>")
-	importCmd.Flags().StringVar(&migrateImportAboveAndByPathFmt, "above-and-by-path", "", "--above-and-by-path=<regex><!<regex>>* matching paths are tracked by above without examining type")
-	importCmd.Flags().StringVar(&migrateImportAboveNotByPathFmt, "above-not-by-path", "", "--above-not-by-path=<regex><!<regex>>* matching paths are skipped by above without examining type")
-	importCmd.Flags().StringVar(&migrateImportAboveNotByTypeFmt, "above-not-by-type", "", "--above-not-by-type=<regex><!<regex>>* skipped by above if '/bin/file file' output matches, second RE countermands, etc.")
+	importCmd.Flags().StringVar(&migrateImportAboveIncludeByPathFmt, "above-include-by-path", "", "--above-include-by-path=<regex><!<regex>>* matching paths are tracked by above without examining type")
+	importCmd.Flags().StringVar(&migrateImportAboveExcludeByPathFmt, "above-exclude-by-path", "", "--above-exclude-by-path=<regex><!<regex>>* matching paths are skipped by above without examining type")
+	importCmd.Flags().StringVar(&migrateImportAboveExcludeByTypeFmt, "above-exclude-by-type", "", "--above-exclude-by-type=<regex><!<regex>>* skipped by above if '/bin/file file' output matches, second RE countermands, etc.")
 	importCmd.Flags().BoolVar(&migrateVerbose, "verbose", false, "Verbose logging")
 	importCmd.Flags().StringVar(&objectMapFilePath, "object-map", "", "Object map file")
 	importCmd.Flags().BoolVar(&migrateNoRewrite, "no-rewrite", false, "Add new history without rewriting previous")

--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -314,12 +313,8 @@ func skipBecauseText(
 		}
 		s := out.String()
 		if matchAntimatch(s, typeSkipRe) {
-			log.Printf("Text %s %s", path, s)
 			return blobContents, true
 		}
-		log.Printf("Binary %s %s", path, s)
-	} else {
-		log.Printf("Path binary %s", path)
 	}
 	return blobContents, false
 }

--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -157,7 +157,7 @@ func migrateImportCommand(cmd *cobra.Command, args []string) {
 		ExitWithError(errors.Errorf(tr.Tr.Get("Without --above there is no context for --above-exclude-by-type or --above-exclude-by-path or --above-include-by-path")))
 	}
 
-	if len(typeSkipRe) != 0 && len(pathTrackRe) == 0 {
+	if len(typeSkipRe) == 0 && len(pathTrackRe) != 0 {
 		ExitWithError(errors.Errorf(tr.Tr.Get("Without --above-exclude-by-type there is no context for --above-include-by-path to skip : all files that pass --above-exclude-by-path will be counted anyway")))
 	}
 

--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -149,16 +149,16 @@ func migrateImportCommand(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	typeSkipRe := compileRegexList(";", migrateImportAboveNotByTypeFmt)
-	pathSkipRe := compileRegexList(";", migrateImportAboveNotByPathFmt)
-	pathTrackRe := compileRegexList(";", migrateImportAboveAndByPathFmt)
+	typeSkipRe := compileRegexList(";", migrateImportAboveExcludeByTypeFmt)
+	pathSkipRe := compileRegexList(";", migrateImportAboveExcludeByPathFmt)
+	pathTrackRe := compileRegexList(";", migrateImportAboveIncludeByPathFmt)
 
 	if above == 0 && (len(typeSkipRe) != 0 || len(pathSkipRe) != 0 || len(pathTrackRe) != 0) {
-		ExitWithError(errors.Errorf(tr.Tr.Get("Without --above there is no context for --above-not-by-type or --above-not-by-path or --above-and-by-path")))
+		ExitWithError(errors.Errorf(tr.Tr.Get("Without --above there is no context for --above-exclude-by-type or --above-exclude-by-path or --above-include-by-path")))
 	}
 
 	if len(typeSkipRe) != 0 && len(pathTrackRe) == 0 {
-		ExitWithError(errors.Errorf(tr.Tr.Get("Without --above-not-by-type there is no context for --above-and-by-path to skip : all files that pass --above-not-by-path will be counted anyway")))
+		ExitWithError(errors.Errorf(tr.Tr.Get("Without --above-exclude-by-type there is no context for --above-include-by-path to skip : all files that pass --above-exclude-by-path will be counted anyway")))
 	}
 
 	migrate(args, rewriter, l, &githistory.RewriteOptions{

--- a/commands/command_migrate_import_test.go
+++ b/commands/command_migrate_import_test.go
@@ -1,0 +1,76 @@
+package commands
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseRegexEvenCount(t *testing.T) {
+	regexes := compileRegexList("!", "ASCII|Unicode!postscript!special")
+
+	assert.Equal(t, false, matchAntimatch("binary", regexes))
+	assert.Equal(t, true, matchAntimatch("ASCII", regexes))
+	assert.Equal(t, false, matchAntimatch("ASCII postscript", regexes))
+	assert.Equal(t, true, matchAntimatch("ASCII postscript special", regexes))
+}
+
+func TestParseRegexOddCount(t *testing.T) {
+	regexes := compileRegexList("!", "ASCII|Unicode!postscript")
+
+	assert.Equal(t, false, matchAntimatch("binary", regexes))
+	assert.Equal(t, true, matchAntimatch("ASCII", regexes))
+	assert.Equal(t, false, matchAntimatch("ASCII postscript", regexes))
+}
+
+var emptyRegexList = compileRegexList(";", "")
+
+func TestSkipBecauseByMatchingTextPath(t *testing.T) {
+	reader := strings.NewReader("data")
+	outReader, skip := skipBecauseText(reader, "path.txt", compileRegexList(";", "txt$"), emptyRegexList, emptyRegexList)
+	assert.Equal(t, reader, outReader, "reader should be unaffected")
+	assert.Equal(t, true, skip, "Text path match should skip")
+}
+
+func TestSkipBecauseByMatchingBinaryPath(t *testing.T) {
+	reader := strings.NewReader("data")
+	outReader, skip := skipBecauseText(reader, "path.bin", compileRegexList(";", "txt$"), compileRegexList(";", "bin$"), emptyRegexList)
+	assert.Equal(t, reader, outReader, "reader should be unaffected")
+	assert.Equal(t, false, skip, "Binary path match should count")
+}
+
+func TestSkipBecauseByMatchingTextData(t *testing.T) {
+	readerData := "Plain text"
+	reader := strings.NewReader(readerData)
+	outReader, skip := skipBecauseText(reader, "path/file", emptyRegexList, emptyRegexList, compileRegexList(";", "ASCII"))
+	assert.NotEqual(t, reader, outReader, "reader should be different")
+	data, err := io.ReadAll(outReader)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, readerData, bytes.NewBuffer(data).String())
+	assert.Equal(t, true, skip, "Text path match should skip")
+}
+
+func TestSkipBecauseByMatchingUnicodeData(t *testing.T) {
+	readerData := "Unicode £ text"
+	reader := strings.NewReader(readerData)
+	outReader, skip := skipBecauseText(reader, "path/file", emptyRegexList, emptyRegexList, compileRegexList(";", "Unicode"))
+	assert.NotEqual(t, reader, outReader, "reader should be different")
+	data, err := io.ReadAll(outReader)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, readerData, bytes.NewBuffer(data).String())
+	assert.Equal(t, true, skip, "Text path match should skip")
+}
+
+func TestSkipBecauseByMatchingBinaryData(t *testing.T) {
+	readerData := "\xAE\bi\n\a\ry"
+	reader := strings.NewReader(readerData)
+	outReader, skip := skipBecauseText(reader, "path/file", emptyRegexList, emptyRegexList, compileRegexList(";", "ASCII|Unicode"))
+	assert.NotEqual(t, reader, outReader, "reader should be different")
+	data, err := io.ReadAll(outReader)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, readerData, bytes.NewBuffer(data).String())
+	assert.Equal(t, false, skip, "Binary path match should count")
+}

--- a/docs/man/git-lfs-migrate.adoc
+++ b/docs/man/git-lfs-migrate.adoc
@@ -247,6 +247,24 @@ files tracked and stored with Git LFS. It supports all the core
   may be specified as a number of bytes, or a number followed by a storage unit,
   e.g., "1b", "20 MB", "3 TiB", etc. This option cannot be used with the
   `--include`, `--exclude`, and `--fixup` options.
+`--above-not-by-type=<regexes>`::
+  Do not migrate files matching the --above option, whose output through the `file` utility
+   matches <regexes>.
+  `regexes` is a `;` delimited list of regular expressions where the first matches,
+  the second countermands the first, etc. e.g., "ASCII|Unicode;postscript"
+  would match files that look like text, unless they also looked like postscript.
+`--above-not-by-path=<regexes>`::
+  Do not migrate files matching the --above option, whose paths match <regexes>.
+  In particular, this skips `--above-not-by-type` which can be expensive.
+  `regexes` is a `;` delimited list of regular expressions where the first matches,
+  the second countermands the first, etc. e.g., "\.(txt|sh|c|h|cxx|pl|go)$;/very-volatile-files/"
+  would match files with the given extension, unless they are in the `very-volatile-files` directory.
+`--above-and-by-path=<regexes>`::
+  Do migrate files matching the --above option, whose paths match <regexes>.
+  This is useful to sidestep `--above-not-by-type` which can be expensive.
+  `regexes` is a `;` delimited list of regular expressions where the first matches,
+  the second countermands the first, etc. e.g., "\.(png|exe|jpg)$;/never-changing-files/"
+  would match files with the given extension, unless they are in the `never-changing-files` directory.
 `--object-map=<path>`::
   Write to `path` a file with the mapping of each rewritten commits. The file
   format is CSV with this pattern: `OLD-SHA`,`NEW-SHA`

--- a/docs/man/git-lfs-migrate.adoc
+++ b/docs/man/git-lfs-migrate.adoc
@@ -247,21 +247,21 @@ files tracked and stored with Git LFS. It supports all the core
   may be specified as a number of bytes, or a number followed by a storage unit,
   e.g., "1b", "20 MB", "3 TiB", etc. This option cannot be used with the
   `--include`, `--exclude`, and `--fixup` options.
-`--above-not-by-type=<regexes>`::
+`--above-exclude-by-type=<regexes>`::
   Do not migrate files matching the --above option, whose output through the `file` utility
    matches <regexes>.
   `regexes` is a `;` delimited list of regular expressions where the first matches,
   the second countermands the first, etc. e.g., "ASCII|Unicode;postscript"
   would match files that look like text, unless they also looked like postscript.
-`--above-not-by-path=<regexes>`::
+`--above-exclude-by-path=<regexes>`::
   Do not migrate files matching the --above option, whose paths match <regexes>.
-  In particular, this skips `--above-not-by-type` which can be expensive.
+  In particular, this skips `--above-exclude-by-type` which can be expensive.
   `regexes` is a `;` delimited list of regular expressions where the first matches,
   the second countermands the first, etc. e.g., "\.(txt|sh|c|h|cxx|pl|go)$;/very-volatile-files/"
   would match files with the given extension, unless they are in the `very-volatile-files` directory.
-`--above-and-by-path=<regexes>`::
+`--above-include-by-path=<regexes>`::
   Do migrate files matching the --above option, whose paths match <regexes>.
-  This is useful to sidestep `--above-not-by-type` which can be expensive.
+  This is useful to sidestep `--above-exclude-by-type` which can be expensive.
   `regexes` is a `;` delimited list of regular expressions where the first matches,
   the second countermands the first, etc. e.g., "\.(png|exe|jpg)$;/never-changing-files/"
   would match files with the given extension, unless they are in the `never-changing-files` directory.

--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -32,7 +32,7 @@ type Rewriter struct {
 	// filter will cull out any unmodifiable subtrees and blobs.
 	filter *filepathfilter.Filter
 	// db is the *ObjectDatabase from which blobs, commits, and trees are
-	// loaded from.
+	// loaded.
 	db *gitobj.ObjectDatabase
 	// l is the *tasklog.Logger to which updates are written.
 	l *tasklog.Logger
@@ -581,7 +581,7 @@ func (r *Rewriter) Filter() *filepathfilter.Filter {
 	return r.filter
 }
 
-// cacheEntry caches then given "from" entry so that it is always rewritten as
+// cacheEntry caches the given "from" entry so that it is always rewritten as
 // a *TreeEntry equivalent to "to".
 func (r *Rewriter) cacheEntry(path string, from, to *gitobj.TreeEntry) *gitobj.TreeEntry {
 	r.mu.Lock()


### PR DESCRIPTION
This augments --above, so it can be given:
* `--above-exclude-by-path=a regex of paths to ignore`
* `--above-exclude-by-type=a regex of types to ignore` where type is determined by running them through the unix 'file' utility
Since the latter can be an expensive operation, it can also be given:
* `--above-include-by-path=a regex of paths to include` which skips the 'file' check.

The rationale for using the 'file' utility is that under Unix, executables are not given an extension like '.exe' and so cannot be usefully matched by trivial globs/regexes.

Note that these 'regex' expressions are actually a ';' separated list of regexes, where the first regex is used to match, the second to countermand the result if the first matches, etc, so - for example - '.*ASCII.*;.*postscript.*' would match strings that contained `ASCII` but not `postscript`.