### PR TITLE
Mock time in copy callback log file test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/jcmturner/goidentity/v6 v6.0.1 // indirect
 	github.com/jcmturner/gokrb5/v8 v8.4.2 // indirect
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
+	github.com/jmhodges/clock v1.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/jcmturner/gokrb5/v8 v8.4.2 h1:6ZIM6b/JJN0X8UM43ZOM6Z4SJzla+a/u7scXFJz
 github.com/jcmturner/gokrb5/v8 v8.4.2/go.mod h1:sb+Xq/fTY5yktf/VxLsE3wlfPqQjp0aWNYyvBVK62bc=
 github.com/jcmturner/rpc/v2 v2.0.3 h1:7FXXj8Ti1IaVFpSAziCZWNzbNuZmnvw/i6CqLNdWfZY=
 github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJki3ELg/Hc=
+github.com/jmhodges/clock v1.2.0 h1:eq4kys+NI0PLngzaHEe7AmPT90XMGIEySD1JfV1PDIs=
+github.com/jmhodges/clock v1.2.0/go.mod h1:qKjhA7x7u/lQpPB1XAqX1b1lCI/w3/fNuYpI/ZjLynI=
 github.com/leonelquinteros/gotext v1.5.0 h1:ODY7LzLpZWWSJdAHnzhreOr6cwLXTAmc914FOauSkBM=
 github.com/leonelquinteros/gotext v1.5.0/go.mod h1:OCiUVHuhP9LGFBQ1oAmdtNCHJCiHiQA8lf4nAifHkr0=
 github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs=

--- a/lfs/gitfilter.go
+++ b/lfs/gitfilter.go
@@ -4,17 +4,19 @@ import (
 	"github.com/git-lfs/git-lfs/v3/config"
 	"github.com/git-lfs/git-lfs/v3/fs"
 	"github.com/git-lfs/git-lfs/v3/git"
+	"github.com/jmhodges/clock"
 )
 
 // GitFilter provides clean and smudge capabilities
 type GitFilter struct {
 	cfg *config.Configuration
 	fs  *fs.Filesystem
+	clk clock.Clock
 }
 
 // NewGitFilter initializes a new *GitFilter
 func NewGitFilter(cfg *config.Configuration) *GitFilter {
-	return &GitFilter{cfg: cfg, fs: cfg.Filesystem()}
+	return &GitFilter{cfg: cfg, fs: cfg.Filesystem(), clk: clock.New()}
 }
 
 func (f *GitFilter) ObjectPath(oid string) (string, error) {

--- a/lfs/util.go
+++ b/lfs/util.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"time"
 
 	"github.com/git-lfs/git-lfs/v3/config"
 	"github.com/git-lfs/git-lfs/v3/errors"
@@ -53,9 +52,9 @@ func (f *GitFilter) CopyCallbackFile(event, filename string, index, totalFiles i
 	}
 
 	var prevWritten int64
-	deadline := time.Now().Add(tasklog.DefaultLoggingThrottle)
+	deadline := f.clk.Now().Add(tasklog.DefaultLoggingThrottle)
 	cb := tools.CopyCallback(func(total int64, written int64, current int) error {
-		now := time.Now()
+		now := f.clk.Now()
 		if written != prevWritten && (!now.Before(deadline) || written >= total) {
 			_, err := fmt.Fprintf(file, "%s %d/%d %d/%d %s\n", event, index, totalFiles, written, total, filename)
 			file.Sync()


### PR DESCRIPTION
In commit 00f1e9521ab5d39aab393796745189d39c27b9a0 of PR #5504 we added the `TestCopyCallbackFileThrottle()` [test function](https://github.com/git-lfs/git-lfs/blob/cb27449f5c44aeda48af90962ee80832c5c42064/lfs/util_test.go#L72-L110) to confirm that the `CopyCallbackFile()` [method](https://github.com/git-lfs/git-lfs/blob/cb27449f5c44aeda48af90962ee80832c5c42064/lfs/util.go#L35-L71) of `GitFilter` structure in the `lfs` package now throttled its output of progress messages into a log file so that, in general, no more than one message was written during the interval defined by the `tasklog.DefaultLoggingThrottle` [value](https://github.com/git-lfs/git-lfs/blob/cb27449f5c44aeda48af90962ee80832c5c42064/tasklog/log.go#L18).  This new throttling behaviour was added in commit 5bfa9009dafce59789b88b1a0854691b596f6e76 in the same PR.

The `TestCopyCallbackFileThrottle()` function attempts to validate the throttling action by reading a test buffer in segments and waiting or not waiting between each read, expecting the log messages to be written or not written, as appropriate.  However, because our CI test suite may experience slow execution times as a result of running in virtualized environments, reads may occur at times more than the `tasklog.DefaultLoggingThrottle` interval apart even without the artifical waits injected by the test function, causing the test to fail when it sees more log messages than it expects.

An example of this type of CI job [failure](https://github.com/git-lfs/git-lfs/actions/runs/6331530124/job/17196268207) is shown below:
```
--- FAIL: TestCopyCallbackFileThrottle (2.16s)
    util_test.go:109: 
        	Error Trace:	util_test.go:109
        	Error:      	Not equal: 
        	            	expected: "clean 1/1 65536/131072 test_copy\nclean 1/1 131072/131072 test_copy\n"
        	            	actual  : "clean 1/1 65536/131072 test_copy\nclean 1/1 98304/131072 test_copy\nclean 1/1 131072/131072 test_copy\n"
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,2 +1,3 @@
        	            	 clean 1/1 65536/131072 test_copy
        	            	+clean 1/1 98304/131072 test_copy
        	            	 clean 1/1 131072/131072 test_copy
        	Test:       	TestCopyCallbackFileThrottle
```

We can avoid this problem by making the wait intervals in the test deterministic using a mocked value for the current time.  We use the `github.com/jmhodges/clock` package for this purpose, adding an object of its `Clock` interface type to the `GitFilter` structure.  In all non-test code this object is simply a wrapper for the `time` package's functions, but in our test we can use a variant which allows us to control the time values returned to the `CopyCallbackFile()` method, either stepping forward or not, as we desire.

/cc @cmaves