### PR TITLE
Include reference specifier in unlock requests

### DIFF
--- a/locking/locks.go
+++ b/locking/locks.go
@@ -402,6 +402,7 @@ func (c *Client) lockIdFromPath(path string) (string, error) {
 		Filters: []lockFilter{
 			{Property: "path", Value: path},
 		},
+		Refspec: c.RemoteRef.Refspec(),
 	})
 
 	if err != nil {


### PR DESCRIPTION
This PR cherry-picks the key change from PR #5376, authored by @bogomolets-owl, which revises the internal `lockIdFromPath()` [method](https://github.com/git-lfs/git-lfs/blob/6fc7893e4205b5bfcdbfd7065b269df15fc0f6d0/locking/locks.go#L391-L419) of the `Client` structure in the `locking` package so that the current refspec is always sent to the Git LFS File Locking API when querying for a lock ID corresponding to a given file path, and adds and expands our test suite to confirm this change is effective when the API service tracks locks using refspecs and causes no problems when the API service does not do so.

The `lockIdFromPath()` method is only [called](https://github.com/git-lfs/git-lfs/blob/6fc7893e4205b5bfcdbfd7065b269df15fc0f6d0/locking/locks.go#L157) by the `UnlockFile()` method, and only when querying to retrieve the lock ID, if any, corresponding to a single file path.  This code path is used when the `git lfs unlock` command is used without the `--id` option.

As noted in PR #5376, the fact that this method does not send the current refspec to the Git LFS File Locking API service means that the unlock-by-file-path operation is the one exception that prevents an implementation of the API service from tracking locks by both file path and refspec.  (Not all implementations of the Git LFS File Locking API have to track locks by refspec, though.)

This inconsistency stems from a small oversight in PR #2773, when the option to include a refspec in File Locking API requests was added.  That PR included changes to the `lfstest-gitserver.go` test server used in our test suite so it could mimic production services whose APIs did not expect or check the `refspec` query parameter, but also emulate those services which chose to fully implement the new API feature and only list locks matching the given `refspec`.  The tests can vary the test server's behaviour in this regard by naming their temporary repository with the `branch-required` suffix, which the test server [checks](https://github.com/git-lfs/git-lfs/blob/6fc7893e4205b5bfcdbfd7065b269df15fc0f6d0/t/cmd/lfstest-gitserver.go#L1231-L1241) for and uses as a signal as to whether or not to read and use the `refspec` query parameter.

Four tests of the `git lfs unlock` command were added or changed in PR #2773 in order to check the command's behaviour.  In commit 257df970f07900bd1a6b79619ee553afce674b33, the `unlocking a lock by path` test was revised into the `unlocking a lock by path with good ref` [test](https://github.com/git-lfs/git-lfs/blob/6fc7893e4205b5bfcdbfd7065b269df15fc0f6d0/t/t-unlock.sh#L13-L28), and the `unlocking a lock by path with tracked ref`, `unlocking a lock by path with bad ref`, and `unlocking a lock by id with bad ref` [tests](https://github.com/git-lfs/git-lfs/blob/6fc7893e4205b5bfcdbfd7065b269df15fc0f6d0/t/t-unlock.sh#L30-L120) were added.  All of these tests used test repository names with the `branch-required` suffix so as to cause the test API service to require a `refspec` query parameter in client `GET` requests, and check that its value matched the branch name extracted from the test repository name as the word which preceded the suffix (e.g., `main` in the test repository [name](https://github.com/git-lfs/git-lfs/blob/6fc7893e4205b5bfcdbfd7065b269df15fc0f6d0/t/t-unlock.sh#L17) `unlock-by-path-main-branch-required`).

But then in commit 9027b941e8ec9e053324a73a14d1bc362009f9b8 of the same PR #2773, the three `unlocking a lock by path*` tests were all [changed](https://github.com/git-lfs/git-lfs/blob/6fc7893e4205b5bfcdbfd7065b269df15fc0f6d0/t/t-unlock.sh#L25) to [actually](https://github.com/git-lfs/git-lfs/blob/6fc7893e4205b5bfcdbfd7065b269df15fc0f6d0/t/t-unlock.sh#L53) [provide](https://github.com/git-lfs/git-lfs/blob/6fc7893e4205b5bfcdbfd7065b269df15fc0f6d0/t/t-unlock.sh#L79) a lock ID with the `--id` argument to the `git lfs unlock` command.  The test names and test repository names were not updated, though.  This change meant that the `unlocking a lock by path with bad ref` test was identical to the `unlocking a lock by id with bad ref` test, except for its names; it also meant that no tests validated the command's behaviour when only a file path was provided on the command line, not a lock ID, and the API service was configured to require a `refspec`.

The consequence of this omission was that no tests detected the fact that the `git lfs unlock` command did not send a `refspec` argument to the API service even when attempting to look up a lock by file path.

The change to the `lockIdFromPath()` method in this PR resolves the problem, so we also revise and and expand our test suite to validate the new behaviour and confirm that it does not affect legacy API services which do not recognize the `refspec` query argument.

First, we change the `unlocking a lock by path with good ref` and `unlocking a lock by path with tracked ref` tests to actually use a file path rather than an ID in their `git lfs unlock` commands, while also replicating them as `unlocking a lock by id*` tests which continue to use the `--id` option.  As well, we alter the `unlocking a lock by path with bad ref` test to actually use a file path as well.  With these changes we now have a set of tests which confirm that the `git lfs unlock` command, when supplied with a file path and not a lock ID, sends a `refspec` query parameter in its lock listing request, and either succeeds or fails depending on whether the `refspec` matches that of the lock recorded by the API service.

Note that without the fix to the `lockIdFromPath()` method, our new `unlocking a lock by path with good ref`, `unlocking a lock by path with tracked ref`, and `unlocking a lock by path with bad ref` tests all now fail, whereas previously they would pass because the used the `git lfs unlock --id` option and so did not exercise the incorrect implementation of the file path option.

Next, because no tests were added in PR #2773 which explicitly test the `git lfs unlock` command against an API service that did not require the `refspec` query parameter when searching for matching locks, we add a pair of tests that do this.  Some tests, such as the `unlocking a lock (--json)` [test](https://github.com/git-lfs/git-lfs/blob/6fc7893e4205b5bfcdbfd7065b269df15fc0f6d0/t/t-unlock.sh#L274-L291), do so implicitly, but none check all aspects of the expected behaviour in this case.

The first new test we add simply performs a `git lfs unlock` command using a file path argument and confirms it succeeds when the test server emulates an older API service that does not check the `refspec` query argument in lock listing requests.  This test is akin to others, like the `unlocking a lock (--json)` test, but explicitly named `unlocking a lock by path without a ref required` to make its intent clear.

The second new test we add checks that a `git lfs unlock` command which uses a file path argument succeeds and removes a lock even if it passes a `refspec` query parameter to the server that does not match the ref name sent in the original lock request, so long as the test server is emulating an older API service and does not recognize or check the `refspec` argument in lock listing requests.  Note that this new `unlocking a lock by path with bad ref without a ref required` test is similar to the `unlocking a lock by path with bad ref` test, but because it configures the test server to behave like an older API service, it succeeds in removing the lock, whereas the `unlocking a lock by path with bad ref` test expects to not remove the lock due to the mismatched refs in its lock and unlock requests.

This PR replaces PR #5376.

/cc @bogomolets-owl as reporter and contributor.