### PR TITLE
Retrieve endpoint URL only once when checking standalone transfer adapter configurations

### DIFF
--- a/tq/manifest.go
+++ b/tq/manifest.go
@@ -274,11 +274,10 @@ func findStandaloneTransfer(client *lfsapi.Client, operation, remote string) str
 	}
 
 	ep := client.Endpoints.Endpoint(operation, remote)
-	aep := client.Endpoints.Endpoint(operation, remote)
 	uc := config.NewURLConfig(client.GitEnv())
 	v, ok := uc.Get("lfs", ep.Url, "standalonetransferagent")
 	if !ok {
-		return findDefaultStandaloneTransfer(aep.Url)
+		return findDefaultStandaloneTransfer(ep.Url)
 	}
 
 	return v


### PR DESCRIPTION
The `findStandaloneTransfer()` function of the `tq` package was updated in commit 28f9b73d2f2bc529ce4385d372ab900e3763b854 of PR #3905 to determine whether to use the built-in file standalone transfer adapter based on the actual endpoint URL, taking into account settings like `lfs.url` which override the endpoint URL we would otherwise construct from the current remote's URL.  However, the code still checked the `lfs.<url>.standaloneTransferAgent` setting using the URL constructed from the remote's URL, and so [called](https://github.com/git-lfs/git-lfs/blob/28f9b73d2f2bc529ce4385d372ab900e3763b854/tq/manifest.go#L120-L121) both the `Endpoint()` and `RemoteEndpoint()` methods of the `EndpointFinder` interface.

Then in commit 594f8e386cce3441e06c9094ab5e251f0e07ca1f of PR #4446, when the pure SSH transfer protocol was introduced, the call to the `RemoteEndpoint()` method was replaced with `Endpoint()`, which was done with the intent that it would honour `lfs.url` settings as well.  From that commit's description:

> We prefer the `Endpoint` function to the `RemoteEndpoint` function because the former handles `lfs.url` and the latter does not.

However, this resulted in [duplicate calls](https://github.com/git-lfs/git-lfs/blob/1d581ebdd9b4d0c410909d1a4e50313bf78aec01/tq/manifest.go#L276-L277) to `Endpoint()`, so we can remove one of them now.

Note that the change in commit 594f8e386cce3441e06c9094ab5e251f0e07ca1f of PR #4446 implies that the URL used when looking for `lfs.<url>.standaloneTransferAgent` settings is the URL as fully determined by settings such as `lfs.url` that override what would be otherwise constructed based on the remote's URL.  We expect to add documentation to this effect in a subsequent PR.