### PR TITLE
lfs: avoid unnecessary byte/string conversion

### DIFF
--- a/lfs/pointer.go
+++ b/lfs/pointer.go
@@ -219,7 +219,7 @@ func parseOid(value string) (string, error) {
 		return "", errors.New(tr.Tr.Get("Invalid OID type: %s", parts[0]))
 	}
 	oid := parts[1]
-	if !oidRE.Match([]byte(oid)) {
+	if !oidRE.MatchString(oid) {
 		return "", errors.New(tr.Tr.Get("Invalid OID: %s", oid))
 	}
 	return oid, nil
@@ -289,7 +289,7 @@ func decodeKVData(data []byte) (kvps map[string]string, exts map[string]string, 
 		}
 
 		if expected := pointerKeys[line]; key != expected {
-			if !extRE.Match([]byte(key)) {
+			if !extRE.MatchString(key) {
 				err = errors.NewBadPointerKeyError(expected, key)
 				return
 			}


### PR DESCRIPTION
We should use `(*regexp.Regexp).MatchString` instead of `(*regexp.Regexp).Match([]byte(...))` to avoid unnecessary `[]byte` conversions and reduce allocations. A one-line change for free performance gain.

Example benchmark:

```go
func BenchmarkMatch(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := oidRE.Match([]byte("2a3b6578c2de07a35b2f2d9bf1869d437aed2e5b8f1c96a0df9d9be3c05a4a8a")); !match {
			b.Fail()
		}
	}
}

func BenchmarkMatchString(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := oidRE.MatchString("2a3b6578c2de07a35b2f2d9bf1869d437aed2e5b8f1c96a0df9d9be3c05a4a8a"); !match {
			b.Fail()
		}
	}
}
```

Result:

```
goos: linux
goarch: amd64
pkg: github.com/git-lfs/git-lfs/v3/lfs
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
BenchmarkMatch-16          	 1044811	      1202 ns/op	      64 B/op	       1 allocs/op
BenchmarkMatchString-16    	 2201485	       560.9 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/git-lfs/git-lfs/v3/lfs	3.882s
```