### PR TITLE
Update notarization to use `notarytool`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,7 @@ jobs:
       env:
         DARWIN_DEV_USER: ${{secrets.MACOS_DEV_USER}}
         DARWIN_DEV_PASS: ${{secrets.MACOS_DEV_PASS}}
+        DARWIN_DEV_TEAM: ${{secrets.MACOS_DEV_TEAM}}
         DARWIN_CERT_ID: ${{secrets.MACOS_CERT_ID}}
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,6 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
     - run: brew install gettext
-    - run: brew install mitchellh/gon/gon
     - run: make release
       env:
           FORCE_LOCALIZE: true

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,8 @@ DARWIN_CERT_ID ?=
 # certificate is located.
 DARWIN_KEYCHAIN_ID ?= CI.keychain
 
+export DARWIN_DEV_USER DARWIN_DEV_PASS DARWIN_DEV_TEAM
+
 # SOURCES is a listing of all .go files in this and child directories, excluding
 # that in vendor.
 SOURCES = $(shell find . -type f -name '*.go' | grep -v vendor)
@@ -516,7 +518,7 @@ release-darwin: bin/releases/git-lfs-darwin-amd64-$(VERSION).zip bin/releases/gi
 			jq -e ".notarize.path = \"$$i\" | .apple_id.username = \"$(DARWIN_DEV_USER)\"" script/macos/manifest.json > "$$temp/manifest.json"; \
 			for j in 1 2 3; \
 			do \
-				$(GON) "$$temp/manifest.json" && break; \
+				script/notarize "$$i" && break; \
 			done; \
 		); \
 		status="$$?"; [ -n "$$temp" ] && $(RM) -r "$$temp"; [ "$$status" -eq 0 ] || exit "$$status"; \

--- a/Makefile
+++ b/Makefile
@@ -127,9 +127,6 @@ XGOTEXT ?= xgotext
 # CODESIGN is the macOS signing tool.
 CODESIGN ?= codesign
 
-# GON is the macOS notarizing tool.
-GON ?= gon
-
 # SIGNTOOL is the Windows signing tool.
 SIGNTOOL ?= signtool.exe
 

--- a/script/notarize
+++ b/script/notarize
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# Notarizes the file given on the command line with the Apple ID in
+# $DARWIN_DEV_USER, the password in $DARWIN_DEV_PASS, and the team ID (usually
+# ten characters) in $DARWIN_DEV_TEAM.
+#
+# This script exists to not echo these variables into the log.  Don't run this
+# on a multi-user system, only in CI.
+
+xcrun notarytool submit "$1" \
+  --apple-id "$DARWIN_DEV_USER" --password "$DARWIN_DEV_PASS" --team-id "$DARWIN_DEV_TEAM" \
+  --wait


### PR DESCRIPTION
As of November 1, 2023, Apple will no longer accept notarized apps using altool, which is used by https://github.com/mitchellh/gon, which we've been using.  Port this code to notarytool, which is Apple's preferred command-line tool.

The secrets have been placed in the regular and CI test secret stores already and this has worked successfully on a test build of the release workflow.

Fixes #5394