### PR TITLE
Allow configuring the SSH protocol

### DIFF
--- a/docs/man/git-lfs-config.adoc
+++ b/docs/man/git-lfs-config.adoc
@@ -318,6 +318,13 @@ Supports URL config lookup as described in:
 https://git-scm.com/docs/git-config#git-config-httplturlgt. To set this
 value per-host:
 `git config --global lfs.https://github.com/.locksverify [true|false]`.
+* `lfs.sshtransfer` / `lfs.<url>.sshtransfer`
++
+Configures whether SSH transfers (the pure SSH protocol) are used.
+By default (or if the value is set to `negotiate`), the pure SSH protocol is
+tried first, and then the older hybrid protocol.  If `always` is used, then
+only the pure SSH protocol is tried.  Similarly, if `never` is used, then only
+the hybrid protocol is attempted.
 * `lfs.<url>.contenttype`
 +
 Determines whether Git LFS should attempt to detect an appropriate HTTP

--- a/lfsapi/endpoint_finder_test.go
+++ b/lfsapi/endpoint_finder_test.go
@@ -564,7 +564,8 @@ func TestEndpointParsing(t *testing.T) {
 					Path:        "git-lfs/git-lfs.git",
 					Port:        "",
 				},
-				Operation: "",
+				Operation:   "",
+				OriginalUrl: "ssh://git@github.com/git-lfs/git-lfs.git",
 			},
 		},
 		"port bare ssh": {
@@ -576,7 +577,8 @@ func TestEndpointParsing(t *testing.T) {
 					Path:        "git-lfs/git-lfs.git",
 					Port:        "443",
 				},
-				Operation: "",
+				Operation:   "",
+				OriginalUrl: "ssh://git@lfshttp.github.com:443/git-lfs/git-lfs.git",
 			},
 		},
 		"no user bare ssh": {
@@ -588,7 +590,8 @@ func TestEndpointParsing(t *testing.T) {
 					Path:        "git-lfs/git-lfs.git",
 					Port:        "",
 				},
-				Operation: "",
+				Operation:   "",
+				OriginalUrl: "ssh://github.com/git-lfs/git-lfs.git",
 			},
 		},
 		"bare word bare ssh": {
@@ -600,7 +603,8 @@ func TestEndpointParsing(t *testing.T) {
 					Path:        "git-lfs/git-lfs.git",
 					Port:        "",
 				},
-				Operation: "",
+				Operation:   "",
+				OriginalUrl: "ssh://github/git-lfs/git-lfs.git",
 			},
 		},
 		"insteadof alias": {
@@ -612,7 +616,8 @@ func TestEndpointParsing(t *testing.T) {
 					Path:        "",
 					Port:        "",
 				},
-				Operation: "",
+				Operation:   "",
+				OriginalUrl: "https://github.com/git-lfs/git-lfs.git",
 			},
 		},
 		"remote helper": {
@@ -663,7 +668,8 @@ func TestInsteadOf(t *testing.T) {
 					Path:        "",
 					Port:        "",
 				},
-				Operation: "download",
+				Operation:   "download",
+				OriginalUrl: "https://example.com/git-lfs/git-lfs.git",
 			},
 		},
 		"pushinsteadof alias (upload)": {
@@ -676,7 +682,8 @@ func TestInsteadOf(t *testing.T) {
 					Path:        "/git-lfs/git-lfs.git",
 					Port:        "",
 				},
-				Operation: "upload",
+				Operation:   "upload",
+				OriginalUrl: "ssh://example.com/git-lfs/git-lfs.git",
 			},
 		},
 		"exp alias (download)": {
@@ -689,7 +696,8 @@ func TestInsteadOf(t *testing.T) {
 					Path:        "/git-lfs/git-lfs.git",
 					Port:        "",
 				},
-				Operation: "download",
+				Operation:   "download",
+				OriginalUrl: "ssh://example.com/git-lfs/git-lfs.git",
 			},
 		},
 		"exp alias (upload)": {
@@ -702,7 +710,8 @@ func TestInsteadOf(t *testing.T) {
 					Path:        "/git-lfs/git-lfs.git",
 					Port:        "",
 				},
-				Operation: "upload",
+				Operation:   "upload",
+				OriginalUrl: "ssh://example.com/git-lfs/git-lfs.git",
 			},
 		},
 	} {

--- a/lfsapi/lfsapi.go
+++ b/lfsapi/lfsapi.go
@@ -1,6 +1,7 @@
 package lfsapi
 
 import (
+	"github.com/git-lfs/git-lfs/v3/config"
 	"github.com/git-lfs/git-lfs/v3/creds"
 	"github.com/git-lfs/git-lfs/v3/errors"
 	"github.com/git-lfs/git-lfs/v3/lfshttp"
@@ -57,6 +58,11 @@ func (c *Client) SSHTransfer(operation, remote string) *ssh.SSHTransfer {
 	}
 	endpoint := c.Endpoints.Endpoint(operation, remote)
 	if len(endpoint.SSHMetadata.UserAndHost) == 0 {
+		return nil
+	}
+	uc := config.NewURLConfig(c.context.GitEnv())
+	if val, ok := uc.Get("lfs", endpoint.OriginalUrl, "sshtransfer"); ok && val != "negotiate" && val != "always" {
+		tracerx.Printf("skipping pure SSH protocol connection by request")
 		return nil
 	}
 	ctx := c.Context()

--- a/lfshttp/client.go
+++ b/lfshttp/client.go
@@ -209,6 +209,12 @@ func (c *Client) sshResolveWithRetries(e Endpoint, method string) (*sshAuthRespo
 	var sshRes sshAuthResponse
 	var err error
 
+	uc := config.NewURLConfig(c.gitEnv)
+	if val, ok := uc.Get("lfs", e.OriginalUrl, "sshtransfer"); ok && val != "negotiate" && val != "never" {
+		tracerx.Printf("skipping SSH-HTTPS hybrid protocol connection by request")
+		return nil, errors.New("git-lfs-authenticate has been disabled by request")
+	}
+
 	requests := tools.MaxInt(0, c.sshTries) + 1
 	for i := 0; i < requests; i++ {
 		sshRes, err = c.SSH.Resolve(e, method)

--- a/lfshttp/endpoint.go
+++ b/lfshttp/endpoint.go
@@ -17,6 +17,7 @@ type Endpoint struct {
 	Url         string
 	SSHMetadata ssh.SSHMetadata
 	Operation   string
+	OriginalUrl string
 }
 
 func endpointOperation(e Endpoint, method string) string {
@@ -42,6 +43,8 @@ func EndpointFromSshUrl(u *url.URL) Endpoint {
 		endpoint.Url = UrlUnknown
 		return endpoint
 	}
+
+	endpoint.OriginalUrl = u.String()
 
 	host := match[1]
 	if u.User != nil && u.User.Username() != "" {
@@ -100,15 +103,16 @@ func EndpointFromBareSshUrl(rawurl string) Endpoint {
 // Construct a new endpoint from a HTTP URL
 func EndpointFromHttpUrl(u *url.URL) Endpoint {
 	// just pass this straight through
-	return Endpoint{Url: u.String()}
+	return Endpoint{Url: u.String(), OriginalUrl: u.String()}
 }
 
 func EndpointFromLocalPath(path string) Endpoint {
-	return Endpoint{Url: git.RewriteLocalPathAsURL(path)}
+	url := git.RewriteLocalPathAsURL(path)
+	return Endpoint{Url: url, OriginalUrl: url}
 }
 
 // Construct a new endpoint from a file URL
 func EndpointFromFileUrl(u *url.URL) Endpoint {
 	// just pass this straight through
-	return Endpoint{Url: u.String()}
+	return Endpoint{Url: u.String(), OriginalUrl: u.String()}
 }

--- a/t/t-locks.sh
+++ b/t/t-locks.sh
@@ -72,6 +72,16 @@ begin_test "list a single lock (SSH; git-lfs-authenticate)"
   grep "f.dat" locks.log
   grep "Git LFS Tests" locks.log
   grep "lfs-ssh-echo.*git-lfs-authenticate /$reponame download" trace.log
+
+  GIT_TRACE=1 git -c lfs."$sshurl".sshtransfer=never lfs locks --path "f.dat" 2>trace.log | tee locks.log
+  [ $(wc -l < locks.log) -eq 1 ]
+  grep "f.dat" locks.log
+  grep "Git LFS Tests" locks.log
+  grep "lfs-ssh-echo.*git-lfs-authenticate /$reponame download" trace.log
+  grep "skipping pure SSH protocol" trace.log
+
+  GIT_TRACE=1 git -c lfs."$sshurl".sshtransfer=always lfs locks --path "f.dat" 2>trace.log && exit 1
+  grep "git-lfs-authenticate has been disabled by request" trace.log
 )
 end_test
 
@@ -95,6 +105,16 @@ begin_test "list a single lock (SSH; git-lfs-transfer)"
 
   GIT_TRACE=1 git lfs locks --path "f.dat" 2>trace.log | tee locks.log
   cat trace.log
+  [ $(wc -l < locks.log) -eq 1 ]
+  grep "f.dat" locks.log
+  grep "lfs-ssh-echo.*git-lfs-transfer .*$reponame.git download" trace.log
+
+  GIT_TRACE=1 git -c lfs."$sshurl".sshtransfer=always lfs locks --path "f.dat" 2>trace.log | tee locks.log
+  [ $(wc -l < locks.log) -eq 1 ]
+  grep "f.dat" locks.log
+  grep "lfs-ssh-echo.*git-lfs-transfer .*$reponame.git download" trace.log
+
+  GIT_TRACE=1 git -c lfs."$sshurl".sshtransfer=negotiate lfs locks --path "f.dat" 2>trace.log | tee locks.log
   [ $(wc -l < locks.log) -eq 1 ]
   grep "f.dat" locks.log
   grep "lfs-ssh-echo.*git-lfs-transfer .*$reponame.git download" trace.log


### PR DESCRIPTION
Some people have very slow SSH round trips and the extra time to attempt a failed git-lfs-transfer operation is bothersome.  Let's add an option to allow users to use either the pure SSH protocol or the older hybrid protocol based on the URL in question to let them choose the right value if they know what it should be.