### PR TITLE
track: don't modify `.gitattributes` with `--dry-run`

### DIFF
--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -39,6 +39,10 @@ func trackCommand(cmd *cobra.Command, args []string) {
 	requireGitVersion()
 	setupWorkingCopy()
 
+	if trackDryRunFlag {
+		trackNoModifyAttrsFlag = true
+	}
+
 	if !cfg.Os.Bool("GIT_LFS_TRACK_NO_INSTALL_HOOKS", false) {
 		installHooks(false)
 	}

--- a/t/t-track-attrs.sh
+++ b/t/t-track-attrs.sh
@@ -35,3 +35,20 @@ begin_test "track (--no-modify-attrs)"
 )
 end_test
 
+begin_test "track (--dry-run)"
+(
+  set -e
+
+  reponame="track-dry-run"
+  git init "$reponame"
+  cd "$reponame"
+
+  git lfs track --dry-run "*.dat"
+
+  echo "contents" > a.dat
+  git add a.dat
+
+  git commit -m "add a.dat"
+  refute_pointer "main" "a.dat"
+)
+end_test


### PR DESCRIPTION
In `--dry-run` mode, we're documented to not modify the disk, which means users will not expect us to be modifying `.gitattributes`.  Fix this by setting the `--no-modify-attrs` flag implicitly if `--dry-run` is set.

Fixes #5557
/cc @GTP95 as reporter