### PR TITLE
Improve locking performance

### DIFF
--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -23,6 +23,11 @@ func lockCommand(cmd *cobra.Command, args []string) {
 		cfg.SetRemote(lockRemote)
 	}
 
+	lockData, err := computeLockData()
+	if err != nil {
+		ExitWithError(err)
+	}
+
 	refUpdate := git.NewRefUpdate(cfg.Git, cfg.PushRemote(), cfg.CurrentRef(), nil)
 	lockClient := newLockClient()
 	lockClient.RemoteRef = refUpdate.RemoteRef()
@@ -31,7 +36,7 @@ func lockCommand(cmd *cobra.Command, args []string) {
 	success := true
 	locks := make([]locking.Lock, 0, len(args))
 	for _, path := range args {
-		path, err := lockPath(path)
+		path, err := lockPath(lockData, path)
 		if err != nil {
 			Error(err.Error())
 			success = false
@@ -67,6 +72,28 @@ func lockCommand(cmd *cobra.Command, args []string) {
 	}
 }
 
+type lockData struct {
+	rootDir    string
+	workingDir string
+}
+
+// computeLockData computes data about the given repository and working
+// directory to use in lockPath.
+func computeLockData() (*lockData, error) {
+	wd, err := tools.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	wd, err = tools.CanonicalizeSystemPath(wd)
+	if err != nil {
+		return nil, err
+	}
+	return &lockData{
+		rootDir:    cfg.LocalWorkingDir(),
+		workingDir: wd,
+	}, nil
+}
+
 // lockPaths relativizes the given filepath such that it is relative to the root
 // path of the repository it is contained within, taking into account the
 // working directory of the caller.
@@ -74,42 +101,28 @@ func lockCommand(cmd *cobra.Command, args []string) {
 // lockPaths also respects different filesystem directory separators, so that a
 // Windows path of "\foo\bar" will be normalized to "foo/bar".
 //
-// If the root directory, working directory, or file cannot be
-// determined, an error will be returned. If the file in question is
-// actually a directory, an error will be returned. Otherwise, the cleaned path
-// will be returned.
+// If the file path cannot be determined, an error will be returned. If the file
+// in question is actually a directory, an error will be returned. Otherwise,
+// the cleaned path will be returned.
 //
 // For example:
 //   - Working directory: /code/foo/bar/
 //   - Repository root: /code/foo/
 //   - File to lock: ./baz
 //   - Resolved path bar/baz
-func lockPath(file string) (string, error) {
-	repo, err := git.RootDir()
-	if err != nil {
-		return "", err
-	}
-
-	wd, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-	wd, err = tools.CanonicalizeSystemPath(wd)
-	if err != nil {
-		return "", errors.Wrapf(err,
-			tr.Tr.Get("could not follow symlinks for %s", wd))
-	}
-
+func lockPath(data *lockData, file string) (string, error) {
 	var abs string
+	var err error
+
 	if filepath.IsAbs(file) {
 		abs, err = tools.CanonicalizeSystemPath(file)
 		if err != nil {
 			return "", errors.New(tr.Tr.Get("unable to canonicalize path %q: %v", file, err))
 		}
 	} else {
-		abs = filepath.Join(wd, file)
+		abs = filepath.Join(data.workingDir, file)
 	}
-	path, err := filepath.Rel(repo, abs)
+	path, err := filepath.Rel(data.rootDir, abs)
 	if err != nil {
 		return "", err
 	}

--- a/commands/command_locks.go
+++ b/commands/command_locks.go
@@ -19,7 +19,11 @@ var (
 )
 
 func locksCommand(cmd *cobra.Command, args []string) {
-	filters, err := locksCmdFlags.Filters()
+	lockData, err := computeLockData()
+	if err != nil {
+		ExitWithError(err)
+	}
+	filters, err := locksCmdFlags.Filters(lockData)
 	if err != nil {
 		Exit(tr.Tr.Get("Error building filters: %v", err))
 	}
@@ -154,11 +158,11 @@ type locksFlags struct {
 }
 
 // Filters produces a filter based on locksFlags instance.
-func (l *locksFlags) Filters() (map[string]string, error) {
+func (l *locksFlags) Filters(data *lockData) (map[string]string, error) {
 	filters := make(map[string]string)
 
 	if l.Path != "" {
-		path, err := lockPath(l.Path)
+		path, err := lockPath(data, l.Path)
 		if err != nil {
 			return nil, err
 		}

--- a/commands/command_unlock.go
+++ b/commands/command_unlock.go
@@ -58,6 +58,11 @@ func unlockCommand(cmd *cobra.Command, args []string) {
 		cfg.SetRemote(lockRemote)
 	}
 
+	lockData, err := computeLockData()
+	if err != nil {
+		ExitWithError(err)
+	}
+
 	refUpdate := git.NewRefUpdate(cfg.Git, cfg.PushRemote(), cfg.CurrentRef(), nil)
 	lockClient := newLockClient()
 	lockClient.RemoteRef = refUpdate.RemoteRef()
@@ -67,7 +72,7 @@ func unlockCommand(cmd *cobra.Command, args []string) {
 	success := true
 	if hasPath {
 		for _, pathspec := range args {
-			path, err := lockPath(pathspec)
+			path, err := lockPath(lockData, pathspec)
 			if err != nil {
 				if !unlockCmdFlags.Force {
 					locks = handleUnlockError(locks, "", path, errors.New(tr.Tr.Get("Unable to determine path: %v", err.Error())))

--- a/git/git.go
+++ b/git/git.go
@@ -531,13 +531,20 @@ func ValidateRemote(remote string) error {
 	if err != nil {
 		return err
 	}
+	return ValidateRemoteFromList(remotes, remote)
+}
+
+// ValidateRemote checks that a named remote is valid for use given a list from
+// RemoteList.  This is completely identical to ValidateRemote, except that it
+// allows caching the remote list.
+func ValidateRemoteFromList(remotes []string, remote string) error {
 	for _, r := range remotes {
 		if r == remote {
 			return nil
 		}
 	}
 
-	if err = ValidateRemoteURL(remote); err == nil {
+	if err := ValidateRemoteURL(remote); err == nil {
 		return nil
 	}
 

--- a/lfsapi/endpoint_finder.go
+++ b/lfsapi/endpoint_finder.go
@@ -41,6 +41,7 @@ type endpointGitFinder struct {
 	aliasMu     sync.Mutex
 	aliases     map[string]string
 	pushAliases map[string]string
+	remoteList  []string
 
 	accessMu  sync.Mutex
 	urlAccess map[string]creds.AccessMode
@@ -60,6 +61,9 @@ func NewEndpointFinder(ctx lfshttp.Context) EndpointFinder {
 		pushAliases: make(map[string]string),
 		urlAccess:   make(map[string]creds.AccessMode),
 	}
+
+	remotes, _ := git.RemoteList()
+	e.remoteList = remotes
 
 	e.urlConfig = config.NewURLConfig(e.gitEnv)
 	if v, ok := e.gitEnv.Get("lfs.gitprotocol"); ok {
@@ -187,7 +191,7 @@ func (e *endpointGitFinder) GitRemoteURL(remote string, forpush bool) string {
 		}
 	}
 
-	if err := git.ValidateRemote(remote); err == nil {
+	if err := git.ValidateRemoteFromList(e.remoteList, remote); err == nil {
 		return remote
 	}
 


### PR DESCRIPTION
When performing locking for multiple files, we can spend a lot of time repeating the same operations once for each file.  In most cases, we don't need to do that, and we can get better performance by doing the operation only once.  This is going to be especially noticeable on Windows, where spawning a process is more expensive.

This PR contains independent, logical, bisectable commits each with their own commit message, and as such is best reviewed commit by commit.
