### PR TITLE
release: v3.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Git LFS Changelog
 
+## 3.4.1 (13 Dec 2023)
+
+This is a bugfix release which resolves a bug introduced in the
+v3.4.0 release, where Git LFS may crash if the Git credential manager
+returns credentials containing one or more empty fields.
+
+### Bugs
+
+* Fix a panic in the credential code #5490 (@bk2204)
+
 ## 3.4.0 (26 July 2023)
 
 This release is a feature release which includes support for generating

--- a/config/version.go
+++ b/config/version.go
@@ -13,7 +13,7 @@ var (
 )
 
 const (
-	Version = "3.4.0"
+	Version = "3.4.1"
 )
 
 func init() {

--- a/creds/creds.go
+++ b/creds/creds.go
@@ -184,9 +184,9 @@ const (
 // provided, i.e. through the git URL
 func (a *AskPassCredentialHelper) Fill(what Creds) (Creds, error) {
 	u := &url.URL{
-		Scheme: firstEntryForKey(what, "protocol"),
-		Host:   firstEntryForKey(what, "host"),
-		Path:   firstEntryForKey(what, "path"),
+		Scheme: FirstEntryForKey(what, "protocol"),
+		Host:   FirstEntryForKey(what, "host"),
+		Path:   FirstEntryForKey(what, "path"),
 	}
 
 	creds := make(Creds)
@@ -297,9 +297,9 @@ type commandCredentialHelper struct {
 
 func (h *commandCredentialHelper) Fill(creds Creds) (Creds, error) {
 	tracerx.Printf("creds: git credential fill (%q, %q, %q)",
-		firstEntryForKey(creds, "protocol"),
-		firstEntryForKey(creds, "host"),
-		firstEntryForKey(creds, "path"))
+		FirstEntryForKey(creds, "protocol"),
+		FirstEntryForKey(creds, "host"),
+		FirstEntryForKey(creds, "path"))
 	return h.exec("fill", creds)
 }
 
@@ -310,9 +310,9 @@ func (h *commandCredentialHelper) Reject(creds Creds) error {
 
 func (h *commandCredentialHelper) Approve(creds Creds) error {
 	tracerx.Printf("creds: git credential approve (%q, %q, %q)",
-		firstEntryForKey(creds, "protocol"),
-		firstEntryForKey(creds, "host"),
-		firstEntryForKey(creds, "path"))
+		FirstEntryForKey(creds, "protocol"),
+		FirstEntryForKey(creds, "host"),
+		FirstEntryForKey(creds, "path"))
 	_, err := h.exec("approve", creds)
 	return err
 }
@@ -345,7 +345,7 @@ func (h *commandCredentialHelper) exec(subcommand string, input Creds) (Creds, e
 	if _, ok := err.(*exec.ExitError); ok {
 		if h.SkipPrompt {
 			return nil, errors.New(tr.Tr.Get("change the GIT_TERMINAL_PROMPT env var to be prompted to enter your credentials for %s://%s",
-				firstEntryForKey(input, "protocol"), firstEntryForKey(input, "host")))
+				FirstEntryForKey(input, "protocol"), FirstEntryForKey(input, "host")))
 		}
 
 		// 'git credential' exits with 128 if the helper doesn't fill the username
@@ -386,9 +386,9 @@ func NewCredentialCacher() *credentialCacher {
 
 func credCacheKey(creds Creds) string {
 	parts := []string{
-		firstEntryForKey(creds, "protocol"),
-		firstEntryForKey(creds, "host"),
-		firstEntryForKey(creds, "path"),
+		FirstEntryForKey(creds, "protocol"),
+		FirstEntryForKey(creds, "host"),
+		FirstEntryForKey(creds, "path"),
 	}
 	return strings.Join(parts, "//")
 }
@@ -401,9 +401,9 @@ func (c *credentialCacher) Fill(what Creds) (Creds, error) {
 
 	if ok {
 		tracerx.Printf("creds: git credential cache (%q, %q, %q)",
-			firstEntryForKey(what, "protocol"),
-			firstEntryForKey(what, "host"),
-			firstEntryForKey(what, "path"))
+			FirstEntryForKey(what, "protocol"),
+			FirstEntryForKey(what, "host"),
+			FirstEntryForKey(what, "path"))
 		return cached, nil
 	}
 
@@ -572,7 +572,9 @@ func (h *nullCredentialHelper) Reject(creds Creds) error {
 	return nil
 }
 
-func firstEntryForKey(input Creds, key string) string {
+// FirstEntryForKey extracts and returns the first entry for a given key, or
+// returns the empty string if no value for that key is available.
+func FirstEntryForKey(input Creds, key string) string {
 	if val, ok := input[key]; ok && len(val) > 0 {
 		return val[0]
 	}

--- a/creds/netrc.go
+++ b/creds/netrc.go
@@ -63,7 +63,7 @@ func newNetrcCredentialHelper(osEnv config.Environment) *netrcCredentialHelper {
 }
 
 func (c *netrcCredentialHelper) Fill(what Creds) (Creds, error) {
-	host, err := getNetrcHostname(firstEntryForKey(what, "host"))
+	host, err := getNetrcHostname(FirstEntryForKey(what, "host"))
 	if err != nil {
 		return nil, credHelperNoOp
 	}
@@ -72,7 +72,7 @@ func (c *netrcCredentialHelper) Fill(what Creds) (Creds, error) {
 	if c.skip[host] {
 		return nil, credHelperNoOp
 	}
-	if machine := c.netrcFinder.FindMachine(host, firstEntryForKey(what, "username")); machine != nil {
+	if machine := c.netrcFinder.FindMachine(host, FirstEntryForKey(what, "username")); machine != nil {
 		creds := make(Creds)
 		creds["username"] = []string{machine.Login}
 		creds["password"] = []string{machine.Password}
@@ -82,9 +82,9 @@ func (c *netrcCredentialHelper) Fill(what Creds) (Creds, error) {
 		creds["path"] = what["path"]
 		creds["source"] = []string{"netrc"}
 		tracerx.Printf("netrc: git credential fill (%q, %q, %q, %q)",
-			firstEntryForKey(what, "protocol"),
-			firstEntryForKey(what, "host"), machine.Login,
-			firstEntryForKey(what, "path"))
+			FirstEntryForKey(what, "protocol"),
+			FirstEntryForKey(what, "host"), machine.Login,
+			FirstEntryForKey(what, "path"))
 		return creds, nil
 	}
 
@@ -105,15 +105,15 @@ func getNetrcHostname(hostname string) (string, error) {
 }
 
 func (c *netrcCredentialHelper) Approve(what Creds) error {
-	if firstEntryForKey(what, "source") == "netrc" {
-		host, err := getNetrcHostname(firstEntryForKey(what, "host"))
+	if FirstEntryForKey(what, "source") == "netrc" {
+		host, err := getNetrcHostname(FirstEntryForKey(what, "host"))
 		if err != nil {
 			return credHelperNoOp
 		}
 		tracerx.Printf("netrc: git credential approve (%q, %q, %q)",
-			firstEntryForKey(what, "protocol"),
-			firstEntryForKey(what, "host"),
-			firstEntryForKey(what, "path"))
+			FirstEntryForKey(what, "protocol"),
+			FirstEntryForKey(what, "host"),
+			FirstEntryForKey(what, "path"))
 		c.mu.Lock()
 		c.skip[host] = false
 		c.mu.Unlock()
@@ -123,7 +123,7 @@ func (c *netrcCredentialHelper) Approve(what Creds) error {
 }
 
 func (c *netrcCredentialHelper) Reject(what Creds) error {
-	if firstEntryForKey(what, "source") == "netrc" {
+	if FirstEntryForKey(what, "source") == "netrc" {
 		host, err := getNetrcHostname(what["host"][0])
 		if err != nil {
 			return credHelperNoOp

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+git-lfs (3.4.1) stable; urgency=low
+
+  * New upstream version
+
+ -- Chris Darroch <chrisd8088@github.com>  Wed, 13 Dec 2023 14:29:00 -0000
+
 git-lfs (3.4.0) stable; urgency=low
 
   * New upstream version

--- a/lfsapi/auth.go
+++ b/lfsapi/auth.go
@@ -162,7 +162,7 @@ func (c *Client) getCreds(remote string, access creds.Access, req *http.Request)
 		err = credWrapper.FillCreds()
 		if err == nil {
 			tracerx.Printf("Filled credentials for %s", credsURL)
-			setRequestAuth(req, credWrapper.Creds["username"][0], credWrapper.Creds["password"][0])
+			setRequestAuth(req, creds.FirstEntryForKey(credWrapper.Creds, "username"), creds.FirstEntryForKey(credWrapper.Creds, "password"))
 		}
 		return credWrapper, err
 	}

--- a/rpm/SPECS/git-lfs.spec
+++ b/rpm/SPECS/git-lfs.spec
@@ -1,5 +1,5 @@
 Name:           git-lfs
-Version:        3.4.0
+Version:        3.4.1
 Release:        1%{?dist}
 Summary:        Git extension for versioning large files
 

--- a/versioninfo.json
+++ b/versioninfo.json
@@ -4,7 +4,7 @@
 		"FileVersion": {
 			"Major": 3,
 			"Minor": 4,
-			"Patch": 0,
+			"Patch": 1,
 			"Build": 0
 		}
 	},
@@ -13,7 +13,7 @@
 		"FileDescription": "Git LFS",
 		"LegalCopyright": "GitHub, Inc. and Git LFS contributors",
 		"ProductName": "Git Large File Storage (LFS)",
-		"ProductVersion": "3.4.0"
+		"ProductVersion": "3.4.1"
 	},
 	"IconPath": "script/windows-installer/git-lfs-logo.ico"
 }


### PR DESCRIPTION
This is an in-progress look at the next release of Git LFS, v3.4.1, which is scheduled for Wednesday, December 13, 2023.

Note that this release will be made by a different member of the core team than the person who performed many of the past releases, and thus this release will be signed with a different OpenPGP key.  Please follow [the steps in the README to download all of the keys for the core team](https://github.com/git-lfs/git-lfs#verifying-releases) to verify this release.

I've attached some builds below for people to use for testing:

[git-lfs-darwin-amd64-v3.4.1-pre.zip](https://github.com/git-lfs/git-lfs/files/13642027/git-lfs-darwin-amd64-v3.4.1-pre.zip)
[git-lfs-darwin-arm64-v3.4.1-pre.zip](https://github.com/git-lfs/git-lfs/files/13642028/git-lfs-darwin-arm64-v3.4.1-pre.zip)
[git-lfs-freebsd-386-v3.4.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/13642029/git-lfs-freebsd-386-v3.4.1-pre.tar.gz)
[git-lfs-freebsd-amd64-v3.4.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/13642031/git-lfs-freebsd-amd64-v3.4.1-pre.tar.gz)
[git-lfs-linux-386-v3.4.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/13642032/git-lfs-linux-386-v3.4.1-pre.tar.gz)
[git-lfs-linux-amd64-v3.4.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/13642033/git-lfs-linux-amd64-v3.4.1-pre.tar.gz)
[git-lfs-linux-arm-v3.4.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/13642034/git-lfs-linux-arm-v3.4.1-pre.tar.gz)
[git-lfs-linux-arm64-v3.4.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/13642035/git-lfs-linux-arm64-v3.4.1-pre.tar.gz)
[git-lfs-linux-ppc64le-v3.4.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/13642036/git-lfs-linux-ppc64le-v3.4.1-pre.tar.gz)
[git-lfs-linux-s390x-v3.4.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/13642037/git-lfs-linux-s390x-v3.4.1-pre.tar.gz)
[git-lfs-v3.4.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/13642038/git-lfs-v3.4.1-pre.tar.gz)
[git-lfs-windows-386-v3.4.1-pre.zip](https://github.com/git-lfs/git-lfs/files/13642039/git-lfs-windows-386-v3.4.1-pre.zip)
[git-lfs-windows-amd64-v3.4.1-pre.zip](https://github.com/git-lfs/git-lfs/files/13642040/git-lfs-windows-amd64-v3.4.1-pre.zip)
[git-lfs-windows-arm64-v3.4.1-pre.zip](https://github.com/git-lfs/git-lfs/files/13642041/git-lfs-windows-arm64-v3.4.1-pre.zip)

In addition, the CI system will produce artifacts for Windows, Linux, and macOS if you prefer to use those; they should be equivalent.

/cc @git-lfs/core
/cc @git-lfs/implementers
/cc @git-lfs/releases