### PR TITLE
Fix git-scm.com links

### DIFF
--- a/config/url_config.go
+++ b/config/url_config.go
@@ -22,7 +22,7 @@ func NewURLConfig(git Environment) *URLConfig {
 }
 
 // Get retrieves a `http.{url}.{key}` for the given key and urls, following the
-// rules in https://git-scm.com/docs/git-config#git-config-httplturlgt.
+// rules in https://git-scm.com/docs/git-config#Documentation/git-config.txt-httplturlgt.
 // The value for `http.{key}` is returned as a fallback if no config keys are
 // set for the given urls.
 func (c *URLConfig) Get(prefix, rawurl, key string) (string, bool) {

--- a/docs/man/git-lfs-config.adoc
+++ b/docs/man/git-lfs-config.adoc
@@ -315,7 +315,7 @@ hook. You should set this if you're not using File Locking, or your Git
 server verifies locked files on pushes automatically.
 +
 Supports URL config lookup as described in:
-https://git-scm.com/docs/git-config#git-config-httplturlgt. To set this
+https://git-scm.com/docs/git-config#Documentation/git-config.txt-httplturlgt. To set this
 value per-host:
 `git config --global lfs.https://github.com/.locksverify [true|false]`.
 * `lfs.sshtransfer` / `lfs.<url>.sshtransfer`


### PR DESCRIPTION
The anchors in [git-config](https://git-scm.com/docs/git-config) have changed.