### PR TITLE
Update release documentation and changelog summary script for patch releases

### DIFF
--- a/docs/howto/release-git-lfs.md
+++ b/docs/howto/release-git-lfs.md
@@ -101,8 +101,8 @@ to zero, we are releasing a PATCH version.
        MINOR release number in that series.  For a MINOR release, use
        `script/changelog vM.(N-1).0...HEAD`, where `(N-1)` is the previous
        MINOR release number, and for a PATCH release, use
-       `script/changelog vM.N.(P-1)...HEAD`, where `(P-1)` is the previous
-       PATCH release number.
+       `script/changelog --patch vM.N.(P-1)...HEAD`, where `(P-1)` is the
+       previous PATCH release number.
 
        * Optionally write 1-2 paragraphs summarizing the release and calling
          out community contributions.
@@ -117,10 +117,16 @@ to zero, we are releasing a PATCH version.
          `release-M.(N-1)`.)
 
      * Run `script/update-version vM.N.P` to update the version number in all
-       of the relevant files.
+       of the relevant files.  Note that this script requires a version of
+       `sed(1)` compatible with the GNU implementation.
 
      * Adjust the date in the `debian/changelog` entry to reflect the
        expected release date rather than the current date.
+
+     * Commit all the files changed in the steps above in a single new commit:
+       ```ShellSession
+       $ git commit -m 'release: vM.N.P'
+       ```
 
   2. Then, push the `release-next` branch and create a pull request with your
      changes from the branch.  If you're building a MAJOR or MINOR release,
@@ -131,9 +137,13 @@ to zero, we are releasing a PATCH version.
 
      * In the PR description, consider uploading builds for implementers to
        use in testing.  These can be generated from a local tag, which
-       does not need to be signed (but must be annotated).  The build
-       artifacts will be placed in the `bin/releases` directory and may
-       be uploaded from there:
+       does not need to be signed (but must be annotated).  Check that the
+       local version of Go is equivalent to the most recent one used by the
+       GitHub Actions workflows for the release branch, which may be different
+       from that used on the `main` branch.  For a patch release in particular
+       you may need to downgrade your local Go version.  The build artifacts
+       will be placed in the `bin/releases` directory and may be uploaded
+       into the PR from there:
 
        ```ShellSession
        $ git tag -m vM.N.P-pre vM.N.P-pre
@@ -152,7 +162,7 @@ to zero, we are releasing a PATCH version.
        which will trigger a run of the release workflow that does not upload
        artifacts to Packagecloud.  Alternatively, in a private clone of
        the repository, create such a tag from the `release-next` branch plus
-       one commit to change to the repository name in `script/upload`, and
+       one commit to change the repository name in `script/upload`, and
        push the tag so Actions will run the release workflow.  Ensure that
        the workflow succeeds (excepting the Packagecloud upload step, which
        will be skipped).
@@ -238,6 +248,7 @@ to zero, we are releasing a PATCH version.
      release's source files which is available at the given URL:
 
      ```
+     $ brew tap homebrew/core
      $ brew bump-formula-pr \
          --url https://github.com/git-lfs/git-lfs/releases/download/vM.N.P/git-lfs-vM.N.P.tar.gz \
          --sha256 <SHA-256> \

--- a/script/changelog
+++ b/script/changelog
@@ -3,7 +3,7 @@
 # Interactively generates a changelog over a range of commits:
 
 commit_summary() {
-  local hash=$1
+  local hash="$1"
 
   pr=$(git show $hash | grep -o "#\([0-9]*\)" | cut -c 2-)
   prjson="$(curl -n https://api.github.com/repos/git-lfs/git-lfs/pulls/$pr 2>/dev/null)"
@@ -21,7 +21,11 @@ commit_summary() {
 }
 
 revisions_in () {
-  git rev-list --merges --first-parent $1
+  if [ "$patch" -eq 1 ]; then
+    git rev-list --first-parent "$1"
+  else
+    git rev-list --merges --first-parent "$1"
+  fi
 }
 
 noninteractive () {
@@ -46,7 +50,14 @@ if [ "$1" = "--noninteractive" ]; then
   shift
 fi
 
-range=$1
+if [ "$1" = "--patch" ]; then
+  patch=1
+  shift
+else
+  patch=0
+fi
+
+range="$1"
 
 if [ "$range" = "" ]; then
   echo "Usage: $0 [options] base..next"
@@ -64,7 +75,7 @@ bugs=""
 misc=""
 
 for rev in $(revisions_in "$range"); do
-  git show $rev
+  git show -s $rev
 
   processed=0
   while [ $processed -eq 0 ]; do


### PR DESCRIPTION
When we prepare a patch release of Git LFS, we cherry-pick specific merged changes from the `main` branch onto a `release-next` branch using the `git cherry-pick` command with the `-m1` option, which flattens all the commits unique to the merge on the `main` branch into a single non-merge commit on the release branch.

As a result, when we run our `script/changelog` script to generate a summary of the changes for the patch release, the `git rev-list` command it [executes](https://github.com/git-lfs/git-lfs/blob/7832469836703657c55b85e9cba1b2f7809dfc12/script/changelog#L24) returns nothing because it uses the `--merges` option, and the flattened commits on the release branch are not actual merge commits.

We therefore add a `--patch` option (as suggested by @bk2204) to our script which runs `git rev-list` without the `--merges` option, and note its use in the appropriate step in the how-to documentation of our Git LFS release process.

We also add the `-s` option to the `git show` command the script [runs](https://github.com/git-lfs/git-lfs/blob/7832469836703657c55b85e9cba1b2f7809dfc12/script/changelog#L67) so as to avoid cluttering the output with the patch diff for each commit it presents for categorization by the user.  When run for a non-patch Git LFS release, this is not important because the commits found by `git rev-list` are all merges and generally have no blob changes directly associated with them, so the `git show` output is relatively succinct.  But with the commits on the release branch for a Git LFS patch release, which are not merges, the `git show` output without the `-s` option is potentially quite verbose.

We also expand our documentation's description of several of our release steps with additional notes, and fix one typo.