### PR TITLE
Fix multiple http authorization

### DIFF
--- a/lfshttp/client.go
+++ b/lfshttp/client.go
@@ -251,6 +251,14 @@ func (c *Client) ExtraHeadersFor(req *http.Request) http.Header {
 			copy[k] = append(copy[k], v)
 		}
 	}
+
+	// There must only be a single Authorization HTTP header.
+	// We keep the first specified header, which should be the one explicitly set by git-lfs.
+	vals, ok := copy["Authorization"]
+	if ok && len(vals) > 1 {
+		copy["Authorization"] = []string{ vals[0] }
+	}
+
 	return copy
 }
 


### PR DESCRIPTION
TLDR Problem:
If the `Authorization` HTTP header is already configured via the (local) Git config for the domain where the LFS files are pulled from, Git LFS will send two `Authorization` HTTP headers, which constitutes and invalid HTTP request and is answered with a 400 Bad Request response by most HTTP servers.

TLDR Solution:
Make sure that there is always at most one `Authorization` header, when in doubt, Git LFS should override the local Git config.

I have a problem checking out Git LFS files in Gitea Actions using the `actions/checkout@v4` action on my own server.
The Action configures the `Authorization` HTTP header for the base URL from where the repository is cloned.
The LFS files are served from the very same base URL.
When I run `git lfs pull`, git-lfs sets the `Authorization` header on its own, but then copies the extra HTTP headers from the Git config.

The Gitea server itself accepts these malformed HTTP requests.
However I am running the Gitea server behind an NGINX reverse proxy, which rejects these requests and does not forward them.

On Github the same error can be forced by cloning a private repository, and having the `Authorization` header configured for `https://lfs.github.com`, but why would anyone do this?
