### PR TITLE
Replace deprecated `io/ioutil` functions

### DIFF
--- a/commands/command_logs.go
+++ b/commands/command_logs.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -33,7 +32,7 @@ func logsShowCommand(cmd *cobra.Command, args []string) {
 	}
 
 	name := args[0]
-	by, err := ioutil.ReadFile(filepath.Join(cfg.LocalLogDir(), name))
+	by, err := os.ReadFile(filepath.Join(cfg.LocalLogDir(), name))
 	if err != nil {
 		Exit(tr.Tr.Get("Error reading log: %s", name))
 	}
@@ -58,7 +57,7 @@ func logsBoomtownCommand(cmd *cobra.Command, args []string) {
 }
 
 func sortedLogs() []string {
-	fileinfos, err := ioutil.ReadDir(cfg.LocalLogDir())
+	fileinfos, err := os.ReadDir(cfg.LocalLogDir())
 	if err != nil {
 		return []string{}
 	}

--- a/commands/command_pointer.go
+++ b/commands/command_pointer.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/git-lfs/git-lfs/v3/git"
@@ -52,7 +51,7 @@ func pointerCommand(cmd *cobra.Command, args []string) {
 				ExitWithError(err)
 			}
 		} else if pointerStdin {
-			r = ioutil.NopCloser(os.Stdin)
+			r = io.NopCloser(os.Stdin)
 		} else {
 			ExitWithError(errors.New(tr.Tr.Get("Must specify either --file or --stdin with --compare")))
 		}

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -128,7 +127,7 @@ ArgsLoop:
 		attributesFile *os.File
 	)
 	if !trackNoModifyAttrsFlag {
-		attribContents, err = ioutil.ReadFile(".gitattributes")
+		attribContents, err = os.ReadFile(".gitattributes")
 		// it's fine for file to not exist
 		if err != nil && !os.IsNotExist(err) {
 			Print(tr.Tr.Get("Error reading '.gitattributes' file"))

--- a/commands/command_untrack.go
+++ b/commands/command_untrack.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"bufio"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -23,7 +22,7 @@ func untrackCommand(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	data, err := ioutil.ReadFile(".gitattributes")
+	data, err := os.ReadFile(".gitattributes")
 	if err != nil {
 		return
 	}

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -109,7 +108,7 @@ func newUploadContext(dryRun bool) *uploadContext {
 
 	var sink io.Writer = os.Stdout
 	if dryRun {
-		sink = ioutil.Discard
+		sink = io.Discard
 	}
 
 	ctx.logger = tasklog.NewLogger(sink,

--- a/docs/man/mangen.go
+++ b/docs/man/mangen.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -23,7 +22,7 @@ func warnf(w io.Writer, format string, a ...interface{}) {
 	fmt.Fprintf(w, format, a...)
 }
 
-func readManDir() (string, []os.FileInfo) {
+func readManDir() (string, []os.DirEntry) {
 	rootDirs := []string{
 		"..",
 		"/tmp/docker_run/git-lfs",
@@ -31,7 +30,7 @@ func readManDir() (string, []os.FileInfo) {
 
 	var err error
 	for _, rootDir := range rootDirs {
-		fs, err := ioutil.ReadDir(filepath.Join(rootDir, "docs", "man"))
+		fs, err := os.ReadDir(filepath.Join(rootDir, "docs", "man"))
 		if err == nil {
 			return rootDir, fs
 		}

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -311,7 +310,7 @@ func resolveGitStorageDir(gitDir string) string {
 }
 
 func processGitRedirectFile(file, prefix string) (string, error) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return "", err
 	}

--- a/git/filter_process_scanner_test.go
+++ b/git/filter_process_scanner_test.go
@@ -2,7 +2,7 @@ package git
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/git-lfs/pktline"
@@ -120,7 +120,7 @@ func TestFilterProcessScannerReadsRequestHeadersAndPayload(t *testing.T) {
 	assert.Equal(t, req.Header["other"], "woot")
 	assert.Equal(t, req.Header["crazy"], "'sq',\\$x=.bin")
 
-	payload, err := ioutil.ReadAll(req.Payload)
+	payload, err := io.ReadAll(req.Payload)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte("first\nsecond\n"), payload)
 }

--- a/git/git.go
+++ b/git/git.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -909,7 +908,7 @@ func GetAllWorkTreeHEADs(storageDir string) ([]*Ref, error) {
 
 // Manually parse a reference file like HEAD and return the Ref it resolves to
 func parseRefFile(filename string) (*Ref, error) {
-	bytes, err := ioutil.ReadFile(filename)
+	bytes, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -1,7 +1,6 @@
 package git_test // to avoid import cycles
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -518,7 +517,7 @@ func TestGetTrackedFiles(t *testing.T) {
 	assert.Equal(t, []string{"file1.txt", "file2.txt", "file3.txt", "file4.txt"}, tracked)
 
 	// Test includes staged but uncommitted files
-	ioutil.WriteFile("z_newfile.txt", []byte("Hello world"), 0644)
+	os.WriteFile("z_newfile.txt", []byte("Hello world"), 0644)
 	test.RunGitCommand(t, true, "add", "z_newfile.txt")
 	tracked, err = GetTrackedFiles("*.txt")
 	assert.Nil(t, err)
@@ -527,7 +526,7 @@ func TestGetTrackedFiles(t *testing.T) {
 	assert.Equal(t, fulllist, tracked)
 
 	// Test includes modified files (not staged)
-	ioutil.WriteFile("file1.txt", []byte("Modifications"), 0644)
+	os.WriteFile("file1.txt", []byte("Modifications"), 0644)
 	tracked, err = GetTrackedFiles("*.txt")
 	assert.Nil(t, err)
 	sort.Strings(tracked)

--- a/git/gitattr/tree_test.go
+++ b/git/gitattr/tree_test.go
@@ -1,8 +1,6 @@
 package gitattr
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/git-lfs/gitobj/v2"
@@ -95,9 +93,7 @@ func TestTreeAppliedInIrrelevantSubtree(t *testing.T) {
 }
 
 func TestNewDiscoversSimpleTrees(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.Remove(tmp)
+	tmp := t.TempDir()
 
 	db, err := gitobj.FromFilesystem(tmp, "")
 	require.NoError(t, err)
@@ -127,9 +123,7 @@ func TestNewDiscoversSimpleTrees(t *testing.T) {
 }
 
 func TestNewDiscoversSimpleChildrenTrees(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.Remove(tmp)
+	tmp := t.TempDir()
 
 	db, err := gitobj.FromFilesystem(tmp, "")
 	require.NoError(t, err)
@@ -170,9 +164,7 @@ func TestNewDiscoversSimpleChildrenTrees(t *testing.T) {
 }
 
 func TestNewDiscoversIndirectChildrenTrees(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.Remove(tmp)
+	tmp := t.TempDir()
 
 	db, err := gitobj.FromFilesystem(tmp, "")
 	require.NoError(t, err)
@@ -222,9 +214,7 @@ func TestNewDiscoversIndirectChildrenTrees(t *testing.T) {
 }
 
 func TestNewIgnoresChildrenAppropriately(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.Remove(tmp)
+	tmp := t.TempDir()
 
 	db, err := gitobj.FromFilesystem(tmp, "")
 	require.NoError(t, err)

--- a/git/githistory/fixtures_test.go
+++ b/git/githistory/fixtures_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -89,7 +88,7 @@ func AssertBlobContents(t *testing.T, db *gitobj.ObjectDatabase, tree, path, con
 	}
 
 	// Perform an assertion on the blob's contents.
-	got, err := ioutil.ReadAll(blob.Contents)
+	got, err := io.ReadAll(blob.Contents)
 	if err != nil {
 		t.Fatalf("gitobj: cannot read contents from blob %s: %s", path, err)
 	}
@@ -157,7 +156,7 @@ func HexDecode(t *testing.T, sha string) []byte {
 
 // copyToTmp copies the given fixture to a folder in /tmp.
 func copyToTmp(fixture string) (string, error) {
-	p, err := ioutil.TempDir("", fmt.Sprintf("git-lfs-fixture-%s", filepath.Dir(fixture)))
+	p, err := os.MkdirTemp("", fmt.Sprintf("git-lfs-fixture-%s", filepath.Dir(fixture)))
 	if err != nil {
 		return "", err
 	}
@@ -180,7 +179,7 @@ func copyDir(from, to string) error {
 		return err
 	}
 
-	entries, err := ioutil.ReadDir(from)
+	entries, err := os.ReadDir(from)
 	if err != nil {
 		return err
 	}

--- a/git/githistory/rewriter_test.go
+++ b/git/githistory/rewriter_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"io"
-	"io/ioutil"
 	"reflect"
 	"strconv"
 	"strings"
@@ -22,7 +21,7 @@ func TestRewriterRewritesHistory(t *testing.T) {
 
 	tip, err := r.Rewrite(&RewriteOptions{Include: []string{"refs/heads/master"},
 		BlobFn: func(path string, b *gitobj.Blob) (*gitobj.Blob, error) {
-			contents, err := ioutil.ReadAll(b.Contents)
+			contents, err := io.ReadAll(b.Contents)
 			if err != nil {
 				return nil, err
 			}
@@ -132,7 +131,7 @@ func TestRewriterVisitsPackedObjects(t *testing.T) {
 		BlobFn: func(path string, b *gitobj.Blob) (*gitobj.Blob, error) {
 			var err error
 
-			contents, err = ioutil.ReadAll(b.Contents)
+			contents, err = io.ReadAll(b.Contents)
 			if err != nil {
 				return nil, err
 			}

--- a/git/ls_files.go
+++ b/git/ls_files.go
@@ -2,7 +2,7 @@ package git
 
 import (
 	"bufio"
-	"io/ioutil"
+	"io"
 	"path"
 	"strings"
 
@@ -74,7 +74,7 @@ func NewLsFiles(workingDir string, standardExclude bool, untracked bool) (*LsFil
 	// the subprocess to block.
 	errorMessages := make(chan []byte)
 	go func() {
-		msg, _ := ioutil.ReadAll(stderr)
+		msg, _ := io.ReadAll(stderr)
 		errorMessages <- msg
 	}()
 

--- a/git/rev_list_scanner.go
+++ b/git/rev_list_scanner.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"regexp"
 	"strings"
 	"sync"
@@ -195,7 +194,7 @@ func NewRevListScanner(include, excluded []string, opt *ScanRefsOptions) (*RevLi
 	return &RevListScanner{
 		s: bufio.NewScanner(stdout),
 		closeFn: func() error {
-			msg, _ := ioutil.ReadAll(stderr)
+			msg, _ := io.ReadAll(stderr)
 
 			// First check if there was a non-zero exit code given
 			// when Wait()-ing on the command execution.

--- a/git/rev_list_scanner_test.go
+++ b/git/rev_list_scanner_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -35,7 +35,7 @@ func (c *ArgsTestCase) Assert(t *testing.T) {
 	assert.EqualValues(t, c.ExpectedArgs, args)
 
 	if stdin != nil {
-		b, err := ioutil.ReadAll(stdin)
+		b, err := io.ReadAll(stdin)
 		assert.Nil(t, err)
 
 		assert.Equal(t, c.ExpectedStdin, string(b))

--- a/lfs/gitscanner_catfilebatchcheck.go
+++ b/lfs/gitscanner_catfilebatchcheck.go
@@ -2,7 +2,7 @@ package lfs
 
 import (
 	"bufio"
-	"io/ioutil"
+	"io"
 	"strconv"
 	"strings"
 
@@ -47,7 +47,7 @@ func runCatFileBatchCheck(smallRevCh chan string, lockableCh chan string, lockab
 		}
 		cmd.Stdin.Close()
 
-		stderr, _ := ioutil.ReadAll(cmd.Stderr)
+		stderr, _ := io.ReadAll(cmd.Stderr)
 		err := cmd.Wait()
 		if err != nil {
 			errCh <- errors.New(tr.Tr.Get("error in `git cat-file --batch-check`: %v %v", err, string(stderr)))

--- a/lfs/gitscanner_log.go
+++ b/lfs/gitscanner_log.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"regexp"
 	"strings"
 	"time"
@@ -146,10 +145,10 @@ func parseScannerLogOutput(cb GitScannerFoundPointer, direction LogDiffDirection
 			}
 		}
 		if err := scanner.Err(); err != nil {
-			ioutil.ReadAll(cmd.Stdout)
+			io.ReadAll(cmd.Stdout)
 			ch <- gitscannerResult{Err: errors.New(tr.Tr.Get("error while scanning `git log`: %v", err))}
 		}
-		stderr, _ := ioutil.ReadAll(cmd.Stderr)
+		stderr, _ := io.ReadAll(cmd.Stderr)
 		err := cmd.Wait()
 		if err != nil {
 			ch <- gitscannerResult{Err: errors.New(tr.Tr.Get("error in `git log`: %v %v", err, string(stderr)))}

--- a/lfs/gitscanner_tree.go
+++ b/lfs/gitscanner_tree.go
@@ -1,7 +1,7 @@
 package lfs
 
 import (
-	"io/ioutil"
+	"io"
 	"path"
 	"path/filepath"
 
@@ -116,7 +116,7 @@ func lsTreeBlobs(ref string, predicate func(*git.TreeBlob) bool) (*TreeBlobChann
 			}
 		}
 
-		stderr, _ := ioutil.ReadAll(cmd.Stderr)
+		stderr, _ := io.ReadAll(cmd.Stderr)
 		err := cmd.Wait()
 		if err != nil {
 			errchan <- errors.New(tr.Tr.Get("error in `git ls-tree`: %v %v", err, string(stderr)))

--- a/lfs/hook.go
+++ b/lfs/hook.go
@@ -3,7 +3,6 @@ package lfs
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -101,7 +100,7 @@ func (h *Hook) Install(force bool) error {
 // end, and sets the mode to octal 0755. It writes to disk unconditionally, and
 // returns at any error.
 func (h *Hook) write() error {
-	return ioutil.WriteFile(h.Path(), []byte(h.Contents+"\n"), 0755)
+	return os.WriteFile(h.Path(), []byte(h.Contents+"\n"), 0755)
 }
 
 // Upgrade upgrades the (assumed to be) existing git hook to the current
@@ -150,7 +149,7 @@ func (h *Hook) matchesCurrent() (bool, bool, error) {
 		return false, false, err
 	}
 
-	by, err := ioutil.ReadAll(io.LimitReader(file, 1024))
+	by, err := io.ReadAll(io.LimitReader(file, 1024))
 	file.Close()
 	if err != nil {
 		return false, false, err

--- a/lfs/pointer_test.go
+++ b/lfs/pointer_test.go
@@ -3,7 +3,7 @@ package lfs
 import (
 	"bufio"
 	"bytes"
-	"io/ioutil"
+	"io"
 	"reflect"
 	"strings"
 	"testing"
@@ -170,7 +170,7 @@ size 12345`
 
 func TestDecodeFromEmptyReader(t *testing.T) {
 	p, buf, err := DecodeFrom(strings.NewReader(""))
-	by, _ := ioutil.ReadAll(buf)
+	by, _ := io.ReadAll(buf)
 
 	assert.Nil(t, err)
 	assert.Equal(t, p.Oid, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")

--- a/lfsapi/endpoint_finder_test.go
+++ b/lfsapi/endpoint_finder_test.go
@@ -1,7 +1,6 @@
 package lfsapi
 
 import (
-	"io/ioutil"
 	"os"
 	"regexp"
 	"runtime"
@@ -324,10 +323,8 @@ func TestLocalPathEndpointAddsDotGitForWorkingRepo(t *testing.T) {
 		return
 	}
 
-	path, err := ioutil.TempDir("", "lfsRepo")
-	assert.Nil(t, err)
-	path = path + "/local/path"
-	err = os.MkdirAll(path+"/.git", 0755)
+	path := t.TempDir() + "/local/path"
+	err := os.MkdirAll(path+"/.git", 0755)
 	assert.Nil(t, err)
 
 	finder := NewEndpointFinder(lfshttp.NewContext(nil, nil, map[string]string{
@@ -346,10 +343,8 @@ func TestLocalPathEndpointPreservesDotGitForWorkingRepo(t *testing.T) {
 		return
 	}
 
-	path, err := ioutil.TempDir("", "lfsRepo")
-	assert.Nil(t, err)
-	path = path + "/local/path/.git"
-	err = os.MkdirAll(path, 0755)
+	path := t.TempDir() + "/local/path/.git"
+	err := os.MkdirAll(path, 0755)
 	assert.Nil(t, err)
 
 	finder := NewEndpointFinder(lfshttp.NewContext(nil, nil, map[string]string{
@@ -368,10 +363,8 @@ func TestLocalPathEndpointPreservesNoDotGitForBareRepo(t *testing.T) {
 		return
 	}
 
-	path, err := ioutil.TempDir("", "lfsRepo")
-	assert.Nil(t, err)
-	path = path + "/local/path"
-	err = os.MkdirAll(path, 0755)
+	path := t.TempDir() + "/local/path"
+	err := os.MkdirAll(path, 0755)
 	assert.Nil(t, err)
 
 	finder := NewEndpointFinder(lfshttp.NewContext(nil, nil, map[string]string{
@@ -390,10 +383,8 @@ func TestLocalPathEndpointRemovesDotGitForBareRepo(t *testing.T) {
 		return
 	}
 
-	path, err := ioutil.TempDir("", "lfsRepo")
-	assert.Nil(t, err)
-	path = path + "/local/path"
-	err = os.MkdirAll(path, 0755)
+	path := t.TempDir() + "/local/path"
+	err := os.MkdirAll(path, 0755)
 	assert.Nil(t, err)
 
 	finder := NewEndpointFinder(lfshttp.NewContext(nil, nil, map[string]string{

--- a/lfshttp/certs.go
+++ b/lfshttp/certs.go
@@ -5,8 +5,8 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"path/filepath"
 
 	"github.com/git-lfs/git-lfs/v3/config"
@@ -72,12 +72,12 @@ func getClientCertForHost(c *Client, host string) *tls.Certificate {
 	hostSslKey, _ := c.uc.Get("http", fmt.Sprintf("https://%v/", host), "sslKey")
 	hostSslCert, _ := c.uc.Get("http", fmt.Sprintf("https://%v/", host), "sslCert")
 
-	cert, err := ioutil.ReadFile(hostSslCert)
+	cert, err := os.ReadFile(hostSslCert)
 	if err != nil {
 		tracerx.Printf("Error reading client cert file %q: %v", hostSslCert, err)
 		return nil
 	}
-	key, err := ioutil.ReadFile(hostSslKey)
+	key, err := os.ReadFile(hostSslKey)
 	if err != nil {
 		tracerx.Printf("Error reading client key file %q: %v", hostSslKey, err)
 		return nil
@@ -154,7 +154,7 @@ func appendCertsFromFilesInDir(pool *x509.CertPool, dir string) *x509.CertPool {
 	if errpath != nil {
 		tracerx.Printf("Error reading cert dir %q: %v", dirpath, errpath)
 	}
-	files, err := ioutil.ReadDir(dirpath)
+	files, err := os.ReadDir(dirpath)
 	if err != nil {
 		tracerx.Printf("Error reading cert dir %q: %v", dir, err)
 		return pool
@@ -170,7 +170,7 @@ func appendCertsFromFile(pool *x509.CertPool, filename string) *x509.CertPool {
 	if errfile != nil {
 		tracerx.Printf("Error reading cert dir %q: %v", filenamepath, errfile)
 	}
-	data, err := ioutil.ReadFile(filenamepath)
+	data, err := os.ReadFile(filenamepath)
 	if err != nil {
 		tracerx.Printf("Error reading cert file %q: %v", filename, err)
 		return pool

--- a/lfshttp/certs_test.go
+++ b/lfshttp/certs_test.go
@@ -2,7 +2,6 @@ package lfshttp
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -57,7 +56,7 @@ func clientForHost(c *Client, host string) *http.Client {
 }
 
 func TestCertFromSSLCAInfoConfig(t *testing.T) {
-	tempfile, err := ioutil.TempFile("", "testcert")
+	tempfile, err := os.CreateTemp("", "testcert")
 	assert.Nil(t, err, "Error creating temp cert file")
 	defer os.Remove(tempfile.Name())
 
@@ -103,7 +102,7 @@ func TestCertFromSSLCAInfoConfig(t *testing.T) {
 }
 
 func TestCertFromSSLCAInfoEnv(t *testing.T) {
-	tempfile, err := ioutil.TempFile("", "testcert")
+	tempfile, err := os.CreateTemp("", "testcert")
 	assert.Nil(t, err, "Error creating temp cert file")
 	defer os.Remove(tempfile.Name())
 
@@ -124,7 +123,7 @@ func TestCertFromSSLCAInfoEnv(t *testing.T) {
 }
 
 func TestCertFromSSLCAInfoEnvIsIgnoredForSchannelBackend(t *testing.T) {
-	tempfile, err := ioutil.TempFile("", "testcert")
+	tempfile, err := os.CreateTemp("", "testcert")
 	assert.Nil(t, err, "Error creating temp cert file")
 	defer os.Remove(tempfile.Name())
 
@@ -147,7 +146,7 @@ func TestCertFromSSLCAInfoEnvIsIgnoredForSchannelBackend(t *testing.T) {
 }
 
 func TestCertFromSSLCAInfoEnvWithSchannelBackend(t *testing.T) {
-	tempfile, err := ioutil.TempFile("", "testcert")
+	tempfile, err := os.CreateTemp("", "testcert")
 	assert.Nil(t, err, "Error creating temp cert file")
 	defer os.Remove(tempfile.Name())
 
@@ -171,11 +170,9 @@ func TestCertFromSSLCAInfoEnvWithSchannelBackend(t *testing.T) {
 }
 
 func TestCertFromSSLCAPathConfig(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "testcertdir")
-	assert.Nil(t, err, "Error creating temp cert dir")
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
-	err = ioutil.WriteFile(filepath.Join(tempdir, "cert1.pem"), []byte(testCert), 0644)
+	err := os.WriteFile(filepath.Join(tempdir, "cert1.pem"), []byte(testCert), 0644)
 	assert.Nil(t, err, "Error creating cert file")
 
 	c, err := NewClient(NewContext(nil, nil, map[string]string{
@@ -192,11 +189,9 @@ func TestCertFromSSLCAPathConfig(t *testing.T) {
 }
 
 func TestCertFromSSLCAPathEnv(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "testcertdir")
-	assert.Nil(t, err, "Error creating temp cert dir")
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
 
-	err = ioutil.WriteFile(filepath.Join(tempdir, "cert1.pem"), []byte(testCert), 0644)
+	err := os.WriteFile(filepath.Join(tempdir, "cert1.pem"), []byte(testCert), 0644)
 	assert.Nil(t, err, "Error creating cert file")
 
 	c, err := NewClient(NewContext(nil, map[string]string{

--- a/lfshttp/standalone/standalone.go
+++ b/lfshttp/standalone/standalone.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"os/exec"
@@ -191,7 +190,7 @@ func newHandler(cfg *config.Configuration, output *os.File, msg *inputMessage) (
 		return nil, err
 	}
 
-	tempdir, err := ioutil.TempDir(cfg.TempDir(), "lfs-standalone-file-*")
+	tempdir, err := os.MkdirTemp(cfg.TempDir(), "lfs-standalone-file-*")
 	if err != nil {
 		return nil, err
 	}
@@ -265,7 +264,7 @@ func (h *fileHandler) download(oid string, size int64) (string, string, error) {
 		return oid, "", err
 	}
 
-	tmp, err := ioutil.TempFile(h.tempdir, "download")
+	tmp, err := os.CreateTemp(h.tempdir, "download")
 	if err != nil {
 		return oid, "", err
 	}

--- a/lfshttp/stats_test.go
+++ b/lfshttp/stats_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -47,7 +46,7 @@ func TestStatsWithKey(t *testing.T) {
 	res, err := c.Do(req)
 	require.Nil(t, err)
 
-	io.Copy(ioutil.Discard, res.Body)
+	io.Copy(io.Discard, res.Body)
 	res.Body.Close()
 	assert.Nil(t, c.Close())
 
@@ -111,7 +110,7 @@ func TestStatsWithoutKey(t *testing.T) {
 
 	res, err := c.Do(req)
 	require.Nil(t, err)
-	io.Copy(ioutil.Discard, res.Body)
+	io.Copy(io.Discard, res.Body)
 	res.Body.Close()
 	assert.Nil(t, c.Close())
 
@@ -155,7 +154,7 @@ func TestStatsDisabled(t *testing.T) {
 	res, err := c.Do(req)
 	require.Nil(t, err)
 
-	io.Copy(ioutil.Discard, res.Body)
+	io.Copy(io.Discard, res.Body)
 	res.Body.Close()
 
 	assert.Equal(t, 200, res.StatusCode)

--- a/lfshttp/verbose_test.go
+++ b/lfshttp/verbose_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -49,7 +48,7 @@ func TestVerboseEnabled(t *testing.T) {
 
 	res, err := c.Do(req)
 	require.Nil(t, err)
-	io.Copy(ioutil.Discard, res.Body)
+	io.Copy(io.Discard, res.Body)
 	res.Body.Close()
 
 	assert.Equal(t, 200, res.StatusCode)
@@ -84,7 +83,7 @@ func TestVerboseWithBinaryBody(t *testing.T) {
 		assert.Equal(t, "POST", r.Method)
 
 		assert.Equal(t, "Basic ABC", r.Header.Get("Authorization"))
-		by, err := ioutil.ReadAll(r.Body)
+		by, err := io.ReadAll(r.Body)
 		assert.Nil(t, err)
 		assert.Equal(t, "binary-request", string(by))
 		w.Header().Set("Content-Type", "application/octet-stream")
@@ -105,7 +104,7 @@ func TestVerboseWithBinaryBody(t *testing.T) {
 
 	res, err := c.Do(req)
 	require.Nil(t, err)
-	io.Copy(ioutil.Discard, res.Body)
+	io.Copy(io.Discard, res.Body)
 	res.Body.Close()
 
 	assert.Equal(t, 200, res.StatusCode)
@@ -163,7 +162,7 @@ func TestVerboseEnabledWithDebugging(t *testing.T) {
 
 	res, err := c.Do(req)
 	require.Nil(t, err)
-	io.Copy(ioutil.Discard, res.Body)
+	io.Copy(io.Discard, res.Body)
 	res.Body.Close()
 
 	assert.Equal(t, 200, res.StatusCode)
@@ -221,7 +220,7 @@ func TestVerboseDisabled(t *testing.T) {
 
 	res, err := c.Do(req)
 	require.Nil(t, err)
-	io.Copy(ioutil.Discard, res.Body)
+	io.Copy(io.Discard, res.Body)
 	res.Body.Close()
 
 	assert.Equal(t, 200, res.StatusCode)

--- a/locking/cache_test.go
+++ b/locking/cache_test.go
@@ -1,7 +1,6 @@
 package locking
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -11,7 +10,7 @@ import (
 func TestLockCache(t *testing.T) {
 	var err error
 
-	tmpf, err := ioutil.TempFile("", "testCacheLock")
+	tmpf, err := os.CreateTemp("", "testCacheLock")
 	assert.Nil(t, err)
 	defer func() {
 		os.Remove(tmpf.Name())

--- a/locking/locks_test.go
+++ b/locking/locks_test.go
@@ -2,7 +2,6 @@ package locking
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -26,8 +25,7 @@ func (a LocksById) Less(i, j int) bool { return a[i].Id < a[j].Id }
 
 func TestRemoteLocksWithCache(t *testing.T) {
 	var err error
-	tempDir, err := ioutil.TempDir("", "testCacheLock")
-	assert.Nil(t, err)
+	tempDir := t.TempDir()
 
 	remoteQueries := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -131,8 +129,7 @@ func TestRemoteLocksWithCache(t *testing.T) {
 
 func TestRefreshCache(t *testing.T) {
 	var err error
-	tempDir, err := ioutil.TempDir("", "testCacheLock")
-	assert.Nil(t, err)
+	tempDir := t.TempDir()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "POST", r.Method)
@@ -195,8 +192,7 @@ func TestRefreshCache(t *testing.T) {
 
 func TestSearchLocksVerifiableWithCache(t *testing.T) {
 	var err error
-	tempDir, err := ioutil.TempDir("", "testCacheLock")
-	assert.Nil(t, err)
+	tempDir := t.TempDir()
 
 	remoteQueries := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/t/cmd/git-credential-lfstest.go
+++ b/t/cmd/git-credential-lfstest.go
@@ -6,7 +6,6 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -131,7 +130,7 @@ func credsForHostAndPath(host, path string) (string, string, error) {
 }
 
 func credsFromFilename(file string) (string, string, error) {
-	userPass, err := ioutil.ReadFile(file)
+	userPass, err := os.ReadFile(file)
 	if err != nil {
 		return "", "", fmt.Errorf("Error opening %q: %s", file, err)
 	}

--- a/t/cmd/lfstest-count-tests.go
+++ b/t/cmd/lfstest-count-tests.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -142,7 +141,7 @@ func main() {
 
 			// Otherwise, we need to POST to /shutdown, which will
 			// cause the lfstest-gitserver to abort itself.
-			url, err := ioutil.ReadFile(os.Getenv("LFS_URL_FILE"))
+			url, err := os.ReadFile(os.Getenv("LFS_URL_FILE"))
 			if err == nil {
 				_, err = http.Post(string(url)+"/shutdown",
 					"application/text",
@@ -225,7 +224,7 @@ func callWithCount(fn countFn) error {
 		return err
 	}
 
-	contents, err := ioutil.ReadAll(f)
+	contents, err := io.ReadAll(f)
 	if err != nil {
 		return err
 	}

--- a/t/cmd/lfstest-customadapter.go
+++ b/t/cmd/lfstest-customadapter.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strconv"
@@ -127,7 +126,7 @@ func performDownload(apiClient *lfsapi.Client, oid string, size int64, a *action
 	}
 	defer res.Body.Close()
 
-	dlFile, err := ioutil.TempFile("", "lfscustomdl")
+	dlFile, err := os.CreateTemp("", "lfscustomdl")
 	if err != nil {
 		sendTransferError(oid, 3, err.Error(), writer, errWriter)
 		return
@@ -211,7 +210,7 @@ func performUpload(apiClient *lfsapi.Client, oid string, size int64, a *action, 
 		return
 	}
 
-	io.Copy(ioutil.Discard, res.Body)
+	io.Copy(io.Discard, res.Body)
 	res.Body.Close()
 
 	// completed

--- a/t/cmd/lfstest-gitserver.go
+++ b/t/cmd/lfstest-gitserver.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"math"
 	"math/big"
@@ -389,7 +388,7 @@ func lfsBatchHandler(w http.ResponseWriter, r *http.Request, id, repo string) {
 	tee := io.TeeReader(r.Body, buf)
 	objs := &batchReq{}
 	err := json.NewDecoder(tee).Decode(objs)
-	io.Copy(ioutil.Discard, r.Body)
+	io.Copy(io.Discard, r.Body)
 	r.Body.Close()
 
 	debug(id, "REQUEST")
@@ -953,7 +952,7 @@ func validateTusHeaders(r *http.Request, id string) bool {
 
 func gitHandler(w http.ResponseWriter, r *http.Request) {
 	defer func() {
-		io.Copy(ioutil.Discard, r.Body)
+		io.Copy(io.Discard, r.Body)
 		r.Body.Close()
 	}()
 

--- a/t/cmd/lfstest-standalonecustomadapter.go
+++ b/t/cmd/lfstest-standalonecustomadapter.go
@@ -7,7 +7,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -136,7 +135,7 @@ func performCopy(oid, src, dst string, size int64, writer, errWriter *bufio.Writ
 }
 
 func performDownload(oid string, size int64, writer, errWriter *bufio.Writer) {
-	dlFile, err := ioutil.TempFile("", "lfscustomdl")
+	dlFile, err := os.CreateTemp("", "lfscustomdl")
 	if err != nil {
 		sendTransferError(oid, 1, err.Error(), writer, errWriter)
 		return

--- a/t/cmd/lfstest-testutils.go
+++ b/t/cmd/lfstest-testutils.go
@@ -6,7 +6,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -58,7 +58,7 @@ func main() {
 
 func AddCommits(repo *Repo) {
 	// Read stdin as JSON []*CommitInput
-	in, err := ioutil.ReadAll(os.Stdin)
+	in, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "addcommits: Unable to read input data: %v\n", err)
 		os.Exit(3)

--- a/t/cmd/util/testutils.go
+++ b/t/cmd/util/testutils.go
@@ -11,7 +11,6 @@ package util
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -191,7 +190,7 @@ func newRepo(callback RepoCallback, settings *RepoCreateSettings) *Repo {
 		callback: callback,
 	}
 
-	path, err := ioutil.TempDir("", "lfsRepo")
+	path, err := os.MkdirTemp("", "lfsRepo")
 	if err != nil {
 		callback.Fatalf("Can't create temp dir for git repo: %v", err)
 	}
@@ -202,7 +201,7 @@ func newRepo(callback RepoCallback, settings *RepoCreateSettings) *Repo {
 		args = append(args, "--bare")
 		ret.GitDir = ret.Path
 	case RepoTypeSeparateDir:
-		gitdir, err := ioutil.TempDir("", "lfstestgitdir")
+		gitdir, err := os.MkdirTemp("", "lfstestgitdir")
 		if err != nil {
 			ret.Cleanup()
 			callback.Fatalf("Can't create temp dir for git repo: %v", err)

--- a/tasklog/log.go
+++ b/tasklog/log.go
@@ -3,7 +3,6 @@ package tasklog
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"sync"
@@ -63,7 +62,7 @@ func ForceProgress(v bool) Option {
 // stdout is a terminal or if forceProgress is true
 func NewLogger(sink io.Writer, options ...Option) *Logger {
 	if sink == nil {
-		sink = ioutil.Discard
+		sink = io.Discard
 	}
 
 	l := &Logger{

--- a/tools/filetools.go
+++ b/tools/filetools.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -454,7 +453,7 @@ func SetFileWriteFlag(path string, writeEnabled bool) error {
 // This function is designed to handle only temporary files that will be renamed
 // into place later somewhere within the Git repository.
 func TempFile(dir, pattern string, cfg repositoryPermissionFetcher) (*os.File, error) {
-	tmp, err := ioutil.TempFile(dir, pattern)
+	tmp, err := os.CreateTemp(dir, pattern)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/filetools_test.go
+++ b/tools/filetools_test.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -189,12 +188,12 @@ func TestExpandConfigPath(t *testing.T) {
 }
 
 func TestFastWalkBasic(t *testing.T) {
-	rootDir, err := ioutil.TempDir(os.TempDir(), "GitLfsTestFastWalkBasic")
-	if err != nil {
-		assert.FailNow(t, "Unable to get temp dir: %v", err)
-	}
-	defer os.RemoveAll(rootDir)
+	wd, err := os.Getwd()
+	assert.NoError(t, err)
+
+	rootDir := t.TempDir()
 	os.Chdir(rootDir)
+	defer os.Chdir(wd)
 
 	expectedEntries := createFastWalkInputData(10, 160)
 
@@ -234,7 +233,7 @@ func createFastWalkInputData(smallFolder, largeFolder int) []string {
 		}
 		for f := 0; f < numFiles; f++ {
 			filename := join(dir, fmt.Sprintf("file%d.txt", f))
-			ioutil.WriteFile(filename, []byte("TEST"), 0644)
+			os.WriteFile(filename, []byte("TEST"), 0644)
 			expectedEntries = append(expectedEntries, filename)
 		}
 	}
@@ -285,7 +284,7 @@ func uniq(xs []string) []string {
 }
 
 func TestSetWriteFlag(t *testing.T) {
-	f, err := ioutil.TempFile("", "lfstestwriteflag")
+	f, err := os.CreateTemp("", "lfstestwriteflag")
 	assert.Nil(t, err)
 	filename := f.Name()
 	defer os.Remove(filename)

--- a/tools/iotools.go
+++ b/tools/iotools.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"hash"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/git-lfs/git-lfs/v3/errors"
@@ -122,7 +121,7 @@ func Spool(to io.Writer, from io.Reader, dir string) (n int64, err error) {
 	if err != io.EOF {
 		// If we weren't at the end of the stream, create a temporary
 		// file, and spool the remaining contents there.
-		tmp, err := ioutil.TempFile(dir, "")
+		tmp, err := os.CreateTemp(dir, "")
 		if err != nil {
 			return 0, errors.Wrap(err, tr.Tr.Get("Unable to create temporary file for spooling"))
 		}

--- a/tools/kv/keyvaluestore_test.go
+++ b/tools/kv/keyvaluestore_test.go
@@ -1,7 +1,6 @@
 package kv
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -9,7 +8,7 @@ import (
 )
 
 func TestStoreSimple(t *testing.T) {
-	tmpf, err := ioutil.TempFile("", "lfstest1")
+	tmpf, err := os.CreateTemp("", "lfstest1")
 	assert.Nil(t, err)
 	filename := tmpf.Name()
 	defer os.Remove(filename)
@@ -89,11 +88,10 @@ func TestStoreSimple(t *testing.T) {
 		assert.Fail(t, "Should be no entries")
 		return true
 	})
-
 }
 
 func TestStoreOptimisticConflict(t *testing.T) {
-	tmpf, err := ioutil.TempFile("", "lfstest2")
+	tmpf, err := os.CreateTemp("", "lfstest2")
 	assert.Nil(t, err)
 	filename := tmpf.Name()
 	defer os.Remove(filename)
@@ -138,11 +136,10 @@ func TestStoreOptimisticConflict(t *testing.T) {
 	assert.Equal(t, "value4", v) // we overwrote this so would not be merged
 	v = kvs1.Get("key5")
 	assert.Equal(t, "value5_fromkvs2", v)
-
 }
 
 func TestStoreReduceSize(t *testing.T) {
-	tmpf, err := ioutil.TempFile("", "lfstest3")
+	tmpf, err := os.CreateTemp("", "lfstest3")
 	assert.Nil(t, err)
 	filename := tmpf.Name()
 	defer os.Remove(filename)

--- a/tools/util_darwin.go
+++ b/tools/util_darwin.go
@@ -5,7 +5,6 @@ package tools
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -58,13 +57,13 @@ func CheckCloneFileSupported(dir string) (supported bool, err error) {
 		return false, errors.New(tr.Tr.Get("Unsupported OS version. 10.12.x Sierra or higher required."))
 	}
 
-	src, err := ioutil.TempFile(dir, "src")
+	src, err := os.CreateTemp(dir, "src")
 	if err != nil {
 		return false, err
 	}
 	defer os.Remove(src.Name())
 
-	dst, err := ioutil.TempFile(dir, "dst")
+	dst, err := os.CreateTemp(dir, "dst")
 	if err != nil {
 		return false, err
 	}

--- a/tools/util_darwin_test.go
+++ b/tools/util_darwin_test.go
@@ -4,7 +4,6 @@
 package tools
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -51,7 +50,7 @@ func TestCloneFileByPath(t *testing.T) {
 	as := assert.New(t)
 
 	// Precondition
-	err := ioutil.WriteFile(src, []byte("TEST"), 0666)
+	err := os.WriteFile(src, []byte("TEST"), 0666)
 	as.NoError(err)
 
 	// Do
@@ -68,7 +67,7 @@ func TestCloneFileByPath(t *testing.T) {
 	as.NoError(err)
 	as.True(ok)
 
-	dstContents, err := ioutil.ReadFile(dst)
+	dstContents, err := os.ReadFile(dst)
 	as.NoError(err)
 	as.Equal("TEST", string(dstContents))
 }

--- a/tools/util_linux.go
+++ b/tools/util_linux.go
@@ -5,7 +5,6 @@ package tools
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 
 	"golang.org/x/sys/unix"
@@ -16,13 +15,13 @@ import (
 //
 // If check failed (e.g. directory is read-only), returns err.
 func CheckCloneFileSupported(dir string) (supported bool, err error) {
-	src, err := ioutil.TempFile(dir, "src")
+	src, err := os.CreateTemp(dir, "src")
 	if err != nil {
 		return false, err
 	}
 	defer os.Remove(src.Name())
 
-	dst, err := ioutil.TempFile(dir, "dst")
+	dst, err := os.CreateTemp(dir, "dst")
 	if err != nil {
 		return false, err
 	}

--- a/tools/util_test.go
+++ b/tools/util_test.go
@@ -3,7 +3,6 @@ package tools
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -16,7 +15,7 @@ func TestCopyWithCallback(t *testing.T) {
 	called := 0
 	calledWritten := make([]int64, 0, 2)
 
-	n, err := CopyWithCallback(ioutil.Discard, buf, 5, func(total int64, written int64, current int) error {
+	n, err := CopyWithCallback(io.Discard, buf, 5, func(total int64, written int64, current int) error {
 		called += 1
 		calledWritten = append(calledWritten, written)
 		assert.Equal(t, 5, int(total))

--- a/tools/util_windows.go
+++ b/tools/util_windows.go
@@ -42,7 +42,10 @@ func CheckCloneFileSupported(dir string) (supported bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	defer os.Remove(src.Name())
+	defer func() {
+		_ = src.Close()
+		_ = os.Remove(src.Name())
+	}()
 
 	// Make src file not empty.
 	// Because `FSCTL_DUPLICATE_EXTENTS_TO_FILE` on empty file is always success even filesystem don't support it.
@@ -55,7 +58,10 @@ func CheckCloneFileSupported(dir string) (supported bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	defer os.Remove(dst.Name())
+	defer func() {
+		_ = dst.Close()
+		_ = os.Remove(dst.Name())
+	}()
 
 	return CloneFile(dst, src)
 }

--- a/tools/util_windows.go
+++ b/tools/util_windows.go
@@ -5,7 +5,6 @@ package tools
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"unsafe"
 
@@ -39,7 +38,7 @@ type duplicateExtentsData struct {
 //
 // If check failed (e.g. directory is read-only), returns err.
 func CheckCloneFileSupported(dir string) (supported bool, err error) {
-	src, err := ioutil.TempFile(dir, "src")
+	src, err := os.CreateTemp(dir, "src")
 	if err != nil {
 		return false, err
 	}
@@ -52,7 +51,7 @@ func CheckCloneFileSupported(dir string) (supported bool, err error) {
 		return false, err
 	}
 
-	dst, err := ioutil.TempFile(dir, "dst")
+	dst, err := os.CreateTemp(dir, "dst")
 	if err != nil {
 		return false, err
 	}

--- a/tools/util_windows_test.go
+++ b/tools/util_windows_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -48,9 +47,9 @@ func TestCloneFile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			as := assert.New(t)
 
-			src, err := ioutil.TempFile(testDir, tc.name+"_src")
+			src, err := os.CreateTemp(testDir, tc.name+"_src")
 			as.NoError(err)
-			dst, err := ioutil.TempFile(testDir, tc.name+"_dst")
+			dst, err := os.CreateTemp(testDir, tc.name+"_dst")
 			as.NoError(err)
 
 			srcHash, err := fillFile(src, tc.size)

--- a/tq/basic_upload.go
+++ b/tq/basic_upload.go
@@ -2,7 +2,6 @@ package tq
 
 import (
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -149,7 +148,7 @@ func (a *basicUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb Progres
 		))
 	}
 
-	io.Copy(ioutil.Discard, res.Body)
+	io.Copy(io.Discard, res.Body)
 	res.Body.Close()
 
 	return verifyUpload(a.apiClient, a.remote, t)

--- a/tq/ssh.go
+++ b/tq/ssh.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -233,7 +232,7 @@ func (a *SSHAdapter) doDownload(t *Transfer, conn *ssh.PktlineConnection, f *os.
 		buffer := &bytes.Buffer{}
 		if data != nil {
 			io.CopyN(buffer, data, 1024)
-			io.Copy(ioutil.Discard, data)
+			io.Copy(io.Discard, data)
 		}
 		return errors.NewRetriableError(errors.New(tr.Tr.Get("got status %d when fetching OID %s: %s", status, t.Oid, buffer.String())))
 	}

--- a/tq/tus_upload.go
+++ b/tq/tus_upload.go
@@ -2,7 +2,6 @@ package tq
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -150,7 +149,7 @@ func (a *tusUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb ProgressC
 		))
 	}
 
-	io.Copy(ioutil.Discard, res.Body)
+	io.Copy(io.Discard, res.Body)
 	res.Body.Close()
 
 	return verifyUpload(a.apiClient, a.remote, t)

--- a/tr/trgen/trgen.go
+++ b/tr/trgen/trgen.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -22,7 +21,7 @@ func warnf(w io.Writer, format string, a ...interface{}) {
 	fmt.Fprintf(w, format, a...)
 }
 
-func readPoDir() (string, []os.FileInfo) {
+func readPoDir() (string, []os.DirEntry) {
 	rootDirs := []string{
 		".",
 		"..",
@@ -31,7 +30,7 @@ func readPoDir() (string, []os.FileInfo) {
 
 	var err error
 	for _, rootDir := range rootDirs {
-		fs, err := ioutil.ReadDir(filepath.Join(rootDir, "po", "build"))
+		fs, err := os.ReadDir(filepath.Join(rootDir, "po", "build"))
 		if err == nil {
 			return rootDir, fs
 		}
@@ -69,7 +68,7 @@ func main() {
 		if match := fileregex.FindStringSubmatch(f.Name()); match != nil {
 			infof(os.Stderr, "%v\n", f.Name())
 			cmd := match[1]
-			content, err := ioutil.ReadFile(filepath.Join(poDir, f.Name()))
+			content, err := os.ReadFile(filepath.Join(poDir, f.Name()))
 			if err != nil {
 				warnf(os.Stderr, "Failed to open %v: %v\n", f.Name(), err)
 				os.Exit(2)


### PR DESCRIPTION
The `io/ioutil` package has been deprecated as of Go 1.16 [^1]. This commit replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

[^1]: https://golang.org/doc/go1.16#ioutil