### PR TITLE
t: pipe random data to `base64(1)` to be compatible with macOS

### DIFF
--- a/t/t-clean.sh
+++ b/t/t-clean.sh
@@ -67,8 +67,8 @@ begin_test "clean stdin"
   git init "$reponame"
   cd "$reponame"
 
-  base64 /dev/urandom | head -c 1024 > small.dat
-  base64 /dev/urandom | head -c 2048 > large.dat
+  base64 < /dev/urandom | head -c 1024 > small.dat
+  base64 < /dev/urandom | head -c 2048 > large.dat
 
   expected_small="$(calc_oid_file "small.dat")"
   expected_large="$(calc_oid_file "large.dat")"

--- a/t/t-fsck.sh
+++ b/t/t-fsck.sh
@@ -142,7 +142,7 @@ create_invalid_pointers() {
   ext="${2:-dat}"
 
   git cat-file blob ":$valid" | awk '{ sub(/$/, "\r"); print }' >"crlf.$ext"
-  base64 /dev/urandom | head -c 1025 >"large.$ext"
+  base64 < /dev/urandom | head -c 1025 >"large.$ext"
   git \
     -c "filter.lfs.process=" \
     -c "filter.lfs.clean=cat" \

--- a/t/t-malformed-pointers.sh
+++ b/t/t-malformed-pointers.sh
@@ -14,10 +14,10 @@ begin_test "malformed pointers"
   git add .gitattributes
   git commit -m "initial commit"
 
-  base64 /dev/urandom | head -c 1023 > malformed_small.dat
-  base64 /dev/urandom | head -c 1024 > malformed_exact.dat
-  base64 /dev/urandom | head -c 1025 > malformed_large.dat
-  base64 /dev/urandom | head -c 1048576 > malformed_xxl.dat
+  base64 < /dev/urandom | head -c 1023 > malformed_small.dat
+  base64 < /dev/urandom | head -c 1024 > malformed_exact.dat
+  base64 < /dev/urandom | head -c 1025 > malformed_large.dat
+  base64 < /dev/urandom | head -c 1048576 > malformed_xxl.dat
 
   git \
     -c "filter.lfs.process=" \


### PR DESCRIPTION
The `base64(1)` binary provided with macOS does not accept a bare input file name, unlike any of the GNU coreutils implementations of `base64(1)` or either the older Fourmilab or newer `bintrans(1)` BSD implementations.  Instead, it appears to be a version unique to OS X which requires an `-i` option before a file name to be used for input.

(See, for reference, the manual pages for the OS X [version](https://www.unix.com/man-page/osx/1/base64/), the GNU coreutils [version](https://man7.org/linux/man-pages/man1/base64.1.html), the Fourmilab BSD [version](https://www.fourmilab.ch/webtools/base64/), and the `bintrans(1)` BSD [version](https://man.freebsd.org/cgi/man.cgi?query=base64&manpath=FreeBSD+15.0-CURRENT).)

With the Xcode developer tools for macOS installed, along with Go, Git, etc., our test suite mostly succeeds, but several tests fail because they expect to call `base64(1)` and pass the bare `/dev/urandom` file name.

We can resolve this inconvenience for developers by adjusting those tests to use the technique we already use in the `t/t-migrate-*.sh` test suites where we [redirect](https://github.com/git-lfs/git-lfs/blob/ad64c6cf4e40688ba64e2026e5eb21b845a288b1/t/t-migrate-export.sh#L13) `/dev/urandom` into `base64` as its standard input.  This allows the test suites to function on both macOS as well as Linux systems which use one of the other `base64(1)` implementations.