### PR TITLE
Remove test references to old CI

### DIFF
--- a/t/t-askpass.sh
+++ b/t/t-askpass.sh
@@ -34,14 +34,6 @@ begin_test "askpass: push with core.askPass"
 (
   set -e
 
-  if [ ! -z "$TRAVIS" ] ; then
-    # This test is known to be broken on Travis, so we skip it if the $TRAVIS
-    # environment variable is set.
-    #
-    # See: https://github.com/git-lfs/git-lfs/pull/2500 for more.
-    exit 0
-  fi
-
   reponame="askpass-with-config"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"
@@ -70,14 +62,6 @@ end_test
 begin_test "askpass: push with SSH_ASKPASS"
 (
   set -e
-
-  if [ ! -z "$TRAVIS" ] ; then
-    # This test is known to be broken on Travis, so we skip it if the $TRAVIS
-    # environment variable is set.
-    #
-    # See: https://github.com/git-lfs/git-lfs/pull/2500 for more.
-    exit 0
-  fi
 
   reponame="askpass-with-ssh-environ"
   setup_remote_repo "$reponame"

--- a/t/t-clone.sh
+++ b/t/t-clone.sh
@@ -89,10 +89,6 @@ end_test
 begin_test "cloneSSL"
 (
   set -e
-  if $TRAVIS; then
-    echo "Skipping SSL tests, Travis has weird behaviour in validating custom certs, test locally only"
-    exit 0
-  fi
 
   reponame="test-cloneSSL"
   setup_remote_repo "$reponame"
@@ -123,9 +119,8 @@ begin_test "cloneSSL"
 
   newclonedir="testcloneSSL1"
   git lfs clone "$SSLGITSERVER/$reponame" "$newclonedir" 2>&1 | tee lfsclone.log
-  assert_clean_status
+  (cd "$newclonedir" && assert_clean_status)
   grep "Cloning into" lfsclone.log
-  grep "Git LFS:" lfsclone.log
   # should be no filter errors
   [ ! $(grep "filter" lfsclone.log) ]
   [ ! $(grep "error" lfsclone.log) ]

--- a/t/t-clone.sh
+++ b/t/t-clone.sh
@@ -145,10 +145,6 @@ end_test
 begin_test "clone ClientCert"
 (
   set -e
-  if $TRAVIS; then
-    echo "Skipping SSL tests, Travis has weird behaviour in validating custom certs, test locally only"
-    exit 0
-  fi
 
   reponame="test-cloneClientCert"
   setup_remote_repo "$reponame"

--- a/t/testenv.sh
+++ b/t/testenv.sh
@@ -146,7 +146,6 @@ GIT_CONFIG_NOSYSTEM=1
 GIT_TERMINAL_PROMPT=0
 GIT_SSH=lfs-ssh-echo
 GIT_TEMPLATE_DIR="$(native_path "$ROOTDIR/t/fixtures/templates")"
-APPVEYOR_REPO_COMMIT_MESSAGE="test: env test should look for GIT_SSH too"
 LC_ALL=C
 
 export CREDSDIR
@@ -154,7 +153,6 @@ export GIT_LFS_FORCE_PROGRESS
 export GIT_CONFIG_NOSYSTEM
 export GIT_SSH
 export GIT_TEMPLATE_DIR
-export APPVEYOR_REPO_COMMIT_MESSAGE
 export LC_ALL
 
 # Don't fail if run under git rebase -x.


### PR DESCRIPTION
We no longer use Appveyor or TravisCI, so let's remove references to them in the testsuite.