### PR TITLE
Fix flaky test `t-credentials.sh`

### DIFF
--- a/t/t-credentials.sh
+++ b/t/t-credentials.sh
@@ -4,6 +4,9 @@
 
 ensure_git_version_isnt $VERSION_LOWER "2.3.0"
 
+export CREDSDIR="$REMOTEDIR/creds-credentials"
+setup_creds
+
 begin_test "credentials with url-specific helper skips askpass"
 (
   set -e

--- a/t/testhelpers.sh
+++ b/t/testhelpers.sh
@@ -557,6 +557,13 @@ write_creds_file() {
   fi
 }
 
+setup_creds() {
+  mkdir -p "$CREDSDIR"
+  write_creds_file "user:pass" "$CREDSDIR/127.0.0.1"
+  write_creds_file ":pass" "$CREDSDIR/--$certpath"
+  write_creds_file ":pass" "$CREDSDIR/--$keypath"
+}
+
 # setup initializes the clean, isolated environment for integration tests.
 setup() {
   cd "$ROOTDIR"
@@ -613,10 +620,7 @@ setup() {
   # setup the git credential password storage
   local certpath="$(echo "$LFS_CLIENT_CERT_FILE" | tr / -)"
   local keypath="$(echo "$LFS_CLIENT_KEY_FILE_ENCRYPTED" | tr / -)"
-  mkdir -p "$CREDSDIR"
-  write_creds_file "user:pass" "$CREDSDIR/127.0.0.1"
-  write_creds_file ":pass" "$CREDSDIR/--$certpath"
-  write_creds_file ":pass" "$CREDSDIR/--$keypath"
+  setup_creds
 
   echo "#"
   echo "# HOME: $HOME"


### PR DESCRIPTION
We've noticed that this test has become flaky sometimes and fails in CI. More recently, a distributor noticed that this test fails consistently when run with 4 jobs at a time with `prove`.  Not all of the tests fail every time, but at least one of them does.

Part of the relevant difference is that our netrc tests use `localhost` as the machine name instead of the default 127.0.0.1.  This is helpful, because it means we don't call the credential helper, when we really want to fall back to the askpass code.  That's because we use different credentials for the `netrctest` remote, so if there were credentials available for `localhost`, we'll fail since we'll provide the wrong ones.

The reason, therefore, that this test is flaky is that the clone code creates an entry for the credential helper for `localhost`, and the credential directory is shared among tests.  Thus, `t-credentials.sh` fails whenever these tests run concurrently.

The obvious solution is to simply create a per-test credentials directory so that we aren't affected by what other tests are doing. Let's do that, which makes this test pass consistently.

The initial commit here simply sets up a function so that we can call it in our test.

Fixes #5609