### PR TITLE
Always close open files when cloning and spooling

### DIFF
--- a/t/t-smudge.sh
+++ b/t/t-smudge.sh
@@ -54,6 +54,10 @@ begin_test "smudge with invalid pointer"
   [ "wat" = "$(echo "wat" | git lfs smudge)" ]
   [ "not a git-lfs file" = "$(echo "not a git-lfs file" | git lfs smudge)" ]
   [ "version " = "$(echo "version " | git lfs smudge)" ]
+
+  # force use of a spool file with non-pointer input longer than max buffer
+  spool="$(base64 < /dev/urandom | head -c 2048)"
+  [ "$spool" = "$(echo "$spool" | git lfs smudge)" ]
 )
 end_test
 

--- a/tools/iotools.go
+++ b/tools/iotools.go
@@ -125,7 +125,10 @@ func Spool(to io.Writer, from io.Reader, dir string) (n int64, err error) {
 		if err != nil {
 			return 0, errors.Wrap(err, tr.Tr.Get("Unable to create temporary file for spooling"))
 		}
-		defer os.Remove(tmp.Name())
+		defer func() {
+			tmp.Close()
+			os.Remove(tmp.Name())
+		}()
 
 		if n, err = io.Copy(tmp, from); err != nil {
 			return n, errors.Wrap(err, tr.Tr.Get("unable to spool"))

--- a/tools/util_darwin.go
+++ b/tools/util_darwin.go
@@ -62,12 +62,14 @@ func CheckCloneFileSupported(dir string) (supported bool, err error) {
 		return false, err
 	}
 	defer os.Remove(src.Name())
+	src.Close()
 
 	dst, err := os.CreateTemp(dir, "dst")
 	if err != nil {
 		return false, err
 	}
 	defer os.Remove(dst.Name())
+	dst.Close()
 
 	return CloneFileByPath(dst.Name(), src.Name())
 }

--- a/tools/util_linux.go
+++ b/tools/util_linux.go
@@ -19,13 +19,19 @@ func CheckCloneFileSupported(dir string) (supported bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	defer os.Remove(src.Name())
+	defer func() {
+		src.Close()
+		os.Remove(src.Name())
+	}()
 
 	dst, err := os.CreateTemp(dir, "dst")
 	if err != nil {
 		return false, err
 	}
-	defer os.Remove(dst.Name())
+	defer func() {
+		dst.Close()
+		os.Remove(dst.Name())
+	}()
 
 	if ok, err := CloneFile(dst, src); err != nil {
 		return false, err
@@ -51,10 +57,12 @@ func CloneFileByPath(dst, src string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	defer srcFile.Close()
 	dstFile, err := os.Create(dst) //truncating, it if it already exists.
 	if err != nil {
 		return false, err
 	}
+	defer dstFile.Close()
 
 	return CloneFile(dstFile, srcFile)
 }

--- a/tools/util_windows.go
+++ b/tools/util_windows.go
@@ -43,8 +43,8 @@ func CheckCloneFileSupported(dir string) (supported bool, err error) {
 		return false, err
 	}
 	defer func() {
-		_ = src.Close()
-		_ = os.Remove(src.Name())
+		src.Close()
+		os.Remove(src.Name())
 	}()
 
 	// Make src file not empty.
@@ -59,8 +59,8 @@ func CheckCloneFileSupported(dir string) (supported bool, err error) {
 		return false, err
 	}
 	defer func() {
-		_ = dst.Close()
-		_ = os.Remove(dst.Name())
+		dst.Close()
+		os.Remove(dst.Name())
 	}()
 
 	return CloneFile(dst, src)
@@ -71,11 +71,13 @@ func CloneFileByPath(dst, src string) (success bool, err error) {
 	if err != nil {
 		return
 	}
+	defer dstFile.Close()
 
 	srcFile, err := os.Open(src)
 	if err != nil {
 		return
 	}
+	defer srcFile.Close()
 
 	return CloneFile(dstFile, srcFile)
 }


### PR DESCRIPTION
In commit e861b79a49b02996d22191ebb142feb8768358de of PR #5595 the Windows variant of our `tools.CheckCloneFileSupported()` [function](https://github.com/git-lfs/git-lfs/blob/b4a0927e399ed4acfa838b0c3c17011dce1658ae/tools/util_windows.go#L40-L67) was updated to address the problem that it could fail to remove the temporary files it creates to test whether the "file clone" operation (as used by the `git lfs dedup` command) is supported in a given directory.  This problem could occur on Windows because we did not close all of the temporary file's open descriptors, and so our deferred call to `os.Remove()` might not succeed.

Prompted by that fix, this PR makes a number of similar changes:

1. The Windows variant of our `tools.CloneFileByPath()` [function](https://github.com/git-lfs/git-lfs/blob/b4a0927e399ed4acfa838b0c3c17011dce1658ae/tools/util_windows.go#L69-L81) opens both the source and destination file paths provided for a "clone" operation but does not close the resultant file descriptors, so we now add deferred calls to ensure we always close both files.  (This minor issue dates from the introduction in commit e55bc4c5d41c227515348ef126743806d7e6a0c2 of the support for the "file clone" operation on ReFS in PR [#3790](https://github.com/git-lfs/git-lfs/pull/3790).)

2. Although non-Windows systems generally permit files to be deleted before all open descriptors for the files are closed, we can keep our implementations aligned and consistent if we also make sure to close any files we open in the Linux and macOS variants of our `tools.CheckCloneFileSupported()` and `tools.CloneFileByPath()` functions.
    
    Note that on macOS, the `CheckCloneFileSupported()` [function](https://github.com/git-lfs/git-lfs/blob/b4a0927e399ed4acfa838b0c3c17011dce1658ae/tools/util_darwin.go#L55-L73) creates two temporary files and then only [passes](https://github.com/git-lfs/git-lfs/blob/b4a0927e399ed4acfa838b0c3c17011dce1658ae/tools/util_darwin.go#L72) them by name to the `CloneFileByPath()` [function](https://github.com/git-lfs/git-lfs/blob/b4a0927e399ed4acfa838b0c3c17011dce1658ae/tools/util_darwin.go#L88-L104), so we can close them immediately after they are opened.  This is because the `tools.CloneFile()` [function](https://github.com/git-lfs/git-lfs/blob/b4a0927e399ed4acfa838b0c3c17011dce1658ae/tools/util_darwin.go#L84-L86) is not supported on macOS.  By contrast, on Linux, the `CheckCloneFileSupported()` [function](https://github.com/git-lfs/git-lfs/blob/b4a0927e399ed4acfa838b0c3c17011dce1658ae/tools/util_linux.go#L17-L35) [uses](https://github.com/git-lfs/git-lfs/blob/b4a0927e399ed4acfa838b0c3c17011dce1658ae/tools/util_linux.go#L30) `CloneFile()`, so it must defer closing the temporary files it creates rather than close them directly after opening them.  (For Linux its `CloneFileByPath()` [function](https://github.com/git-lfs/git-lfs/blob/b4a0927e399ed4acfa838b0c3c17011dce1658ae/tools/util_linux.go#L49-L60) doesn't close the files it opens, at present, so we now ensure that it does so.)

3. We update our `tools.Spool()` [function](https://github.com/git-lfs/git-lfs/blob/b4a0927e399ed4acfa838b0c3c17011dce1658ae/tools/iotools.go#L111-L145) (which is [used](https://github.com/git-lfs/git-lfs/blob/b4a0927e399ed4acfa838b0c3c17011dce1658ae/commands/command_smudge.go#L41) in the `git lfs smudge` command to handle non-pointer data) to ensure that if it creates a temporary file into which it spools data, it always closes that file before trying to remove it.  While this should have no advantage on non-Windows systems which allow for files to be deleted while there are still open file descriptors for them, on Windows this change should mean we never fail to clean up our temporary spool file, if we create one.
    
    As well, since the `tools.Spool()` function's use of a temporary file when spooling is not tested by the `t/t-smudge.sh` test suite, we add a check in the existing `smudge with invalid pointer` [test](https://github.com/git-lfs/git-lfs/blob/b4a0927e399ed4acfa838b0c3c17011dce1658ae/t/t-smudge.sh#L49-L58) which forces the use of such a file by sending more than 1024 bytes of non-pointer data, since that is the [size](https://github.com/git-lfs/git-lfs/blob/b4a0927e399ed4acfa838b0c3c17011dce1658ae/tools/iotools.go#L19) of the default internal memory buffer used by the `Spool()` function.