### PR TITLE
pull: improve error message on failing checkout

### DIFF
--- a/commands/pull.go
+++ b/commands/pull.go
@@ -104,7 +104,7 @@ func (c *singleCheckout) Run(p *lfs.WrappedPointer) {
 			// acceptable error, data not local (fetch not run or include/exclude)
 			Error(tr.Tr.Get("Skipped checkout for %q, content not local. Use fetch to download.", p.Name))
 		} else {
-			FullError(errors.New(tr.Tr.Get("could not check out %q", p.Name)))
+			FullError(errors.Wrap(err, tr.Tr.Get("could not check out %q", p.Name)))
 		}
 		return
 	}


### PR DESCRIPTION
If the user is having a problem checking out a file, it would be helpful to know why.  Let's include the reason that the error is occurring so they can learn what the cause is and report it helpfully if there's a problem.