### PR TITLE
attribute: warn if config exists after uninstalling

### DIFF
--- a/lfs/attribute.go
+++ b/lfs/attribute.go
@@ -2,6 +2,7 @@ package lfs
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/git-lfs/git-lfs/v3/git"
@@ -46,7 +47,17 @@ func (o *FilterOptions) Install() error {
 }
 
 func (o *FilterOptions) Uninstall() error {
-	return filterAttribute().Uninstall(o)
+	attrs := filterAttribute()
+	if err := attrs.Uninstall(o); err != nil {
+		return err
+	}
+	for k := range attrs.Properties {
+		name := fmt.Sprintf("%s.%s", attrs.Section, k)
+		if len(o.GitConfig.Find(name)) > 0 {
+			return errors.New(tr.Tr.Get("some filter configuration was not removed (found %s)", name))
+		}
+	}
+	return nil
 }
 
 func filterAttribute() *Attribute {


### PR DESCRIPTION
If someone has a system configuration set up for Git LFS, such as with their package manager, `git lfs uninstall` will not be effective unless the user has specified that file and has privileges to edit it.  In such a case, let's warn the user so that they know that their attempt at uninstalling might not have been effective.

Fixes #5588