### PR TITLE
Report invalid ref in `git lfs push` command

### DIFF
--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -157,6 +157,9 @@ func lfsPushRefs(refnames []string, pushAll bool) ([]*git.RefUpdate, error) {
 			refs[i] = git.NewRefUpdate(cfg.Git, cfg.PushRemote(), ref, nil)
 		} else {
 			ref := &git.Ref{Name: name, Type: git.RefTypeOther, Sha: name}
+			if _, err := git.ResolveRef(name); err != nil {
+				return nil, errors.New(tr.Tr.Get("Invalid ref argument: %v", name))
+			}
 			refs[i] = git.NewRefUpdate(cfg.Git, cfg.PushRemote(), ref, nil)
 		}
 	}

--- a/t/t-fetch.sh
+++ b/t/t-fetch.sh
@@ -628,6 +628,16 @@ begin_test "fetch raw remote url"
 )
 end_test
 
+begin_test "fetch with invalid ref"
+(
+  set -e
+  cd repo
+
+  git lfs fetch origin jibberish >fetch.log 2>&1 && exit 1
+  grep "Invalid ref argument" fetch.log
+)
+end_test
+
 begin_test "fetch with invalid remote"
 (
   set -e

--- a/t/t-fsck.sh
+++ b/t/t-fsck.sh
@@ -511,3 +511,15 @@ begin_test "fsck operates on specified refs"
   true
 )
 end_test
+
+begin_test "fsck detects invalid ref"
+(
+  set -e
+  reponame="fsck-default"
+  git init $reponame
+  cd $reponame
+
+  git lfs fsck jibberish >fsck.log 2>&1 && exit 1
+  grep "can't resolve ref" fsck.log
+)
+end_test

--- a/t/t-migrate-export.sh
+++ b/t/t-migrate-export.sh
@@ -367,6 +367,17 @@ begin_test "migrate export (include/exclude ref)"
 )
 end_test
 
+begin_test "migrate export (invalid ref)"
+(
+  set -e
+  remove_and_create_local_repo "migrate-export-invalid-ref"
+  git commit --allow-empty -m "initial commit"
+
+  git lfs migrate export --yes --include="*" jibberish >migrate.log 2>&1 && exit 1
+  grep "can't resolve ref" migrate.log
+)
+end_test
+
 begin_test "migrate export (.gitattributes with different permissions)"
 (
   set -e

--- a/t/t-migrate-import.sh
+++ b/t/t-migrate-import.sh
@@ -409,6 +409,17 @@ begin_test "migrate import (include/exclude ref with filter)"
 )
 end_test
 
+begin_test "migrate import (invalid ref)"
+(
+  set -e
+  remove_and_create_local_repo "migrate-import-invalid-ref"
+  git commit --allow-empty -m "initial commit"
+
+  git lfs migrate import --yes jibberish >migrate.log 2>&1 && exit 1
+  grep "can't resolve ref" migrate.log
+)
+end_test
+
 begin_test "migrate import (above)"
 (
   set -e

--- a/t/t-migrate-info.sh
+++ b/t/t-migrate-info.sh
@@ -240,6 +240,17 @@ begin_test "migrate info (include/exclude ref with filter)"
 )
 end_test
 
+begin_test "migrate info (invalid ref)"
+(
+  set -e
+  remove_and_create_local_repo "migrate-info-invalid-ref"
+  git commit --allow-empty -m "initial commit"
+
+  git lfs migrate info jibberish >migrate.log 2>&1 && exit 1
+  grep "can't resolve ref" migrate.log
+)
+end_test
+
 begin_test "migrate info (nested sub-trees, no filter)"
 (
   set -e

--- a/t/t-push.sh
+++ b/t/t-push.sh
@@ -38,6 +38,16 @@ begin_test "push with tracked ref"
 )
 end_test
 
+begin_test "push with invalid ref"
+(
+  set -e
+  push_repo_setup "push-invalid-branch-required"
+
+  git lfs push origin jibberish >push.log 2>&1 && exit 1
+  grep "Invalid ref argument" push.log
+)
+end_test
+
 begin_test "push with bad ref"
 (
   set -e


### PR DESCRIPTION
As @philip-peterson described in PR #5295, the `git lfs push` command does not currently report an error when given an invalid ref, unlike a number of our other commands, so we update the command to output an error message in this situation, and we add a test to confirm the new behaviour works as expected.

The `git lfs fetch`, `git lfs fsck`, and `git lfs migrate` commands, in contrast, do detect invalid refs provided as command-line arguments and report them as errors, but since we do not have tests for this behaviour, we add some now.

Note that this PR's changes should suffice to meet the intent of PR #5295, and incorporates work from that PR.

/cc @philip-peterson as reporter and author of PR #5295