### PR TITLE
Distro updates for v3.5

### DIFF
--- a/script/lib/distro.rb
+++ b/script/lib/distro.rb
@@ -34,10 +34,11 @@ class DistroMap
           "scientific/7", # EOL June 2024
           # opensuse https://en.opensuse.org/Lifetime
           # or https://en.wikipedia.org/wiki/OpenSUSE_version_history
-          "opensuse/15.4", # EOL November 2023
+          "opensuse/15.5", # EOL December 2024
+          "opensuse/15.6", # EOL December 2025
           # SLES EOL https://www.suse.com/lifecycle/
           "sles/12.5", # EOL October 2024 (LTSS October 2027)
-          "sles/15.4", # Current
+          "sles/15.5", # Current
         ],
       },
       "centos/8" => {
@@ -58,8 +59,9 @@ class DistroMap
         package_tag: "-1.el9",
         equivalent: [
           "el/9",
-          "fedora/37", # EOL November 2023
           "fedora/38", # EOL May 2024
+          "fedora/39", # EOL Dec 2024
+          "fedora/40", # Current
         ],
       },
       # Debian EOL https://wiki.debian.org/LTS/
@@ -87,12 +89,13 @@ class DistroMap
         package_type: "deb",
         package_tag: "",
         equivalent: [
-          "debian/bullseye",  # EOL June 2026
-          "ubuntu/jammy",     # EOL April 2027
-          "ubuntu/kinetic",   # EOL July 2023
-          "ubuntu/lunar",     # EOL January 2024
-          "linuxmint/vanessa",# EOL April 2027
-          "linuxmint/vera",   # EOL April 2027
+          "debian/bullseye",    # EOL June 2026
+          "ubuntu/jammy",       # EOL April 2027
+          "ubuntu/mantic",      # EOL July 2024
+          "linuxmint/vanessa",  # EOL April 2027
+          "linuxmint/vera",     # EOL April 2027
+          "linuxmint/victoria", # EOL April 2027
+          "linuxmint/virginia", # EOL April 2027
         ],
       },
       "debian/12" => {
@@ -104,6 +107,7 @@ class DistroMap
         equivalent: [
           "debian/bookworm",  # Current stable
           "debian/trixie",    # Current testing
+          "ubuntu/noble",     # EOL June 2029
         ]
       },
     }

--- a/script/lib/distro.rb
+++ b/script/lib/distro.rb
@@ -23,6 +23,9 @@ class DistroMap
   def self.builtin_map
     {
       # RHEL EOL https://access.redhat.com/support/policy/updates/errata
+      # SLES EOL https://www.suse.com/lifecycle/
+      # opensuse https://en.opensuse.org/Lifetime
+      # or https://en.wikipedia.org/wiki/OpenSUSE_version_history
       "centos/7" => {
         name: "RPM RHEL 7/CentOS 7",
         component: "el/7",
@@ -32,13 +35,7 @@ class DistroMap
         equivalent: [
           "el/7",         # EOL June 2024
           "scientific/7", # EOL June 2024
-          # opensuse https://en.opensuse.org/Lifetime
-          # or https://en.wikipedia.org/wiki/OpenSUSE_version_history
-          "opensuse/15.5", # EOL December 2024
-          "opensuse/15.6", # EOL December 2025
-          # SLES EOL https://www.suse.com/lifecycle/
-          "sles/12.5", # EOL October 2024 (LTSS October 2027)
-          "sles/15.5", # Current
+          "sles/12.5",    # EOL October 2024 (LTSS October 2027)
         ],
       },
       "centos/8" => {
@@ -49,6 +46,9 @@ class DistroMap
         package_tag: "-1.el8",
         equivalent: [
           "el/8",
+          "opensuse/15.5", # EOL December 2024
+          "opensuse/15.6", # EOL December 2025
+          "sles/15.5",     # Current
         ],
       },
       "rocky/9" => {


### PR DESCRIPTION
Update our distros to remove old, EOL versions and add new versions.

As part of this work, move our SLES and OpenSUSE 15 RPMs to use the Rocky 8 versions in preparation for a future CentOS 7 EOL.

/cc #5627