### PR TITLE
workflows: update to Go 1.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        go: ['1.21.x']
+        go: ['1.22.x']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
     name: Build with specific Go
     strategy:
       matrix:
-        go: ['1.20.x']
+        go: ['1.21.x']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -76,7 +76,7 @@ jobs:
       # which does not honour the PATH we set to our built git-lfs binary.
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.21.x'
+        go-version: '1.22.x'
     - run: mkdir -p "$HOME/go/bin"
       shell: bash
     - run: set GOPATH=%HOME%\go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        go: ['1.21.x']
+        go: ['1.22.x']
     steps:
     - uses: actions/checkout@v4
       with:
@@ -99,7 +99,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        go: ['1.21.x']
+        go: ['1.22.x']
     steps:
     - uses: actions/checkout@v4
       with:
@@ -138,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.21.x']
+        go: ['1.22.x']
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
We want to support and test the latest versions of Go.  Now that Go 1.22 is out, let's test against 1.22 and 1.21 instead of 1.21 and 1.20.