### PR TITLE
Display correct status information when `git lfs ls-files` run in subdirectory

### DIFF
--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/git-lfs/git-lfs/v3/errors"
@@ -181,7 +182,7 @@ func lsFilesCommand(cmd *cobra.Command, args []string) {
 // Returns true if a pointer appears to be properly smudge on checkout
 func fileExistsOfSize(p *lfs.WrappedPointer) bool {
 	path := cfg.Filesystem().DecodePathname(p.Name)
-	info, err := os.Stat(path)
+	info, err := os.Stat(filepath.Join(cfg.LocalWorkingDir(), path))
 	return err == nil && info.Size() == p.Size
 }
 

--- a/t/t-ls-files.sh
+++ b/t/t-ls-files.sh
@@ -84,6 +84,56 @@ EOF)
 )
 end_test
 
+begin_test "ls-files: run within subdirectory"
+(
+  set -e
+
+  reponame="ls-files-in-subdir"
+  git init "$reponame"
+  cd "$reponame"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  mkdir subdir
+  contents1="a"
+  oid1="$(calc_oid "$contents1")"
+  printf "%s" "$contents1" > a.dat
+  contents2="b"
+  oid2="$(calc_oid "$contents2")"
+  printf "%s" "$contents2" > subdir/b.dat
+
+  cd subdir
+
+  [ "" = "$(git lfs ls-files)" ]
+
+  git add ../a.dat b.dat
+
+  expected="${oid1:0:10} * a.dat
+${oid2:0:10} * subdir/b.dat"
+
+  [ "$expected" = "$(git lfs ls-files)" ]
+
+  diff -u <(git lfs ls-files --debug) <(cat <<-EOF
+filepath: a.dat
+    size: 1
+checkout: true
+download: true
+     oid: sha256 $oid1
+ version: https://git-lfs.github.com/spec/v1
+
+filepath: subdir/b.dat
+    size: 1
+checkout: true
+download: true
+     oid: sha256 $oid2
+ version: https://git-lfs.github.com/spec/v1
+
+EOF)
+)
+end_test
+
 begin_test "ls-files: checkout and download status"
 (
   set -e
@@ -131,6 +181,86 @@ filepath: b.dat
 checkout: false
 download: false
      oid: sha256 $oid2
+ version: https://git-lfs.github.com/spec/v1
+
+EOF)
+)
+end_test
+
+begin_test "ls-files: checkout and download status (run within subdirectory)"
+(
+  set -e
+
+  reponame="ls-files-status-in-subdir"
+  git init "$reponame"
+  cd "$reponame"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  contents1="a"
+  oid1="$(calc_oid "$contents1")"
+  printf "%s" "$contents1" > a.dat
+  contents2="b"
+  oid2="$(calc_oid "$contents2")"
+  printf "%s" "$contents2" > b.dat
+
+  mkdir subdir
+  cd subdir
+
+  contents3="c"
+  oid3="$(calc_oid "$contents3")"
+  printf "%s" "$contents3" > c.dat
+  contents4="d"
+  oid4="$(calc_oid "$contents4")"
+  printf "%s" "$contents4" > d.dat
+
+  [ "" = "$(git lfs ls-files)" ]
+
+  # Note that if we don't remove b.dat and d.dat from the working tree as
+  # well as the Git LFS object cache, Git calls (as invoked by Git LFS) may
+  # restore the cache copies from the working tree copies by re-invoking
+  # Git LFS in "clean" filter mode.
+  git add ../a.dat ../b.dat c.dat d.dat
+  rm ../a.dat ../b.dat c.dat d.dat
+  rm "../.git/lfs/objects/${oid2:0:2}/${oid2:2:2}/$oid2"
+  rm "../.git/lfs/objects/${oid4:0:2}/${oid4:2:2}/$oid4"
+
+  expected="${oid1:0:10} - a.dat
+${oid2:0:10} - b.dat
+${oid3:0:10} - subdir/c.dat
+${oid4:0:10} - subdir/d.dat"
+
+  [ "$expected" = "$(git lfs ls-files)" ]
+
+  diff -u <(git lfs ls-files --debug) <(cat <<-EOF
+filepath: a.dat
+    size: 1
+checkout: false
+download: true
+     oid: sha256 $oid1
+ version: https://git-lfs.github.com/spec/v1
+
+filepath: b.dat
+    size: 1
+checkout: false
+download: false
+     oid: sha256 $oid2
+ version: https://git-lfs.github.com/spec/v1
+
+filepath: subdir/c.dat
+    size: 1
+checkout: false
+download: true
+     oid: sha256 $oid3
+ version: https://git-lfs.github.com/spec/v1
+
+filepath: subdir/d.dat
+    size: 1
+checkout: false
+download: false
+     oid: sha256 $oid4
  version: https://git-lfs.github.com/spec/v1
 
 EOF)
@@ -721,6 +851,57 @@ EOF)
 )
 end_test
 
+begin_test "ls-files: run within subdirectory (--json)"
+(
+  set -e
+
+  reponame="ls-files-in-subdir-json"
+  git init "$reponame"
+  cd "$reponame"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  mkdir subdir
+  contents1="a"
+  oid1="$(calc_oid "$contents1")"
+  printf "%s" "$contents1" > a.dat
+  contents2="b"
+  oid2="$(calc_oid "$contents2")"
+  printf "%s" "$contents2" > subdir/b.dat
+
+  cd subdir
+
+  git add ../a.dat b.dat
+
+  diff -u <(git lfs ls-files --json) <(cat <<-EOF
+{
+ "files": [
+  {
+   "name": "a.dat",
+   "size": 1,
+   "checkout": true,
+   "downloaded": true,
+   "oid_type": "sha256",
+   "oid": "$oid1",
+   "version": "https://git-lfs.github.com/spec/v1"
+  },
+  {
+   "name": "subdir/b.dat",
+   "size": 1,
+   "checkout": true,
+   "downloaded": true,
+   "oid_type": "sha256",
+   "oid": "$oid2",
+   "version": "https://git-lfs.github.com/spec/v1"
+  }
+ ]
+}
+EOF)
+)
+end_test
+
 begin_test "ls-files: checkout and download status (--json)"
 (
   set -e
@@ -767,6 +948,89 @@ begin_test "ls-files: checkout and download status (--json)"
    "downloaded": false,
    "oid_type": "sha256",
    "oid": "$oid2",
+   "version": "https://git-lfs.github.com/spec/v1"
+  }
+ ]
+}
+EOF)
+)
+end_test
+
+begin_test "ls-files: checkout and download status (run within subdirectory) (--json)"
+(
+  set -e
+
+  reponame="ls-files-status-in-subdir-json"
+  git init "$reponame"
+  cd "$reponame"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  contents1="a"
+  oid1="$(calc_oid "$contents1")"
+  printf "%s" "$contents1" > a.dat
+  contents2="b"
+  oid2="$(calc_oid "$contents2")"
+  printf "%s" "$contents2" > b.dat
+
+  mkdir subdir
+  cd subdir
+
+  contents3="c"
+  oid3="$(calc_oid "$contents3")"
+  printf "%s" "$contents3" > c.dat
+  contents4="d"
+  oid4="$(calc_oid "$contents4")"
+  printf "%s" "$contents4" > d.dat
+
+  # Note that if we don't remove b.dat and d.dat from the working tree as
+  # well as the Git LFS object cache, Git calls (as invoked by Git LFS) may
+  # restore the cache copies from the working tree copies by re-invoking
+  # Git LFS in "clean" filter mode.
+  git add ../a.dat ../b.dat c.dat d.dat
+  rm ../a.dat ../b.dat c.dat d.dat
+  rm "../.git/lfs/objects/${oid2:0:2}/${oid2:2:2}/$oid2"
+  rm "../.git/lfs/objects/${oid4:0:2}/${oid4:2:2}/$oid4"
+
+  diff -u <(git lfs ls-files --json) <(cat <<-EOF
+{
+ "files": [
+  {
+   "name": "a.dat",
+   "size": 1,
+   "checkout": false,
+   "downloaded": true,
+   "oid_type": "sha256",
+   "oid": "$oid1",
+   "version": "https://git-lfs.github.com/spec/v1"
+  },
+  {
+   "name": "b.dat",
+   "size": 1,
+   "checkout": false,
+   "downloaded": false,
+   "oid_type": "sha256",
+   "oid": "$oid2",
+   "version": "https://git-lfs.github.com/spec/v1"
+  },
+  {
+   "name": "subdir/c.dat",
+   "size": 1,
+   "checkout": false,
+   "downloaded": true,
+   "oid_type": "sha256",
+   "oid": "$oid3",
+   "version": "https://git-lfs.github.com/spec/v1"
+  },
+  {
+   "name": "subdir/d.dat",
+   "size": 1,
+   "checkout": false,
+   "downloaded": false,
+   "oid_type": "sha256",
+   "oid": "$oid4",
    "version": "https://git-lfs.github.com/spec/v1"
   }
  ]


### PR DESCRIPTION
As reported in https://github.com/git-lfs/git-lfs/issues/1189#issuecomment-1950664657, the `git lfs ls-files` displays incorrect file status information when it is run from within a subdirectory of the Git repository's working tree rather than in the root directory.

Specifically, in the command's normal, compact output format, the `-` indicator is shown for all files, even if they exist in the working tree and should be listed with the `*` indicator.  This problem also affects the  value of the `checkout` fields in the output when the `--debug` or `--json` options are used, with the `false` value always shown for all files.

We resolve this problem by prepending the full, canonicalized path (as provided by the `cfg.LocalWorkingDir()` function) to the individual file paths before their status is [checked](https://github.com/git-lfs/git-lfs/blob/a893a720aec6e34bb0b3c51e139c83448102e28e/commands/command_ls_files.go#L184) with `os.Stat()`, as is [done](https://github.com/git-lfs/git-lfs/blob/a893a720aec6e34bb0b3c51e139c83448102e28e/commands/command_status.go#L151) [elsewhere](https://github.com/git-lfs/git-lfs/blob/a893a720aec6e34bb0b3c51e139c83448102e28e/commands/uploader.go#L374) for other commands.

We also add a variety of tests, mostly to confirm the corrected behaviour with the default output mode as well as both the `--debug` and `--json` output modes, but also to cover the common case when the command is run the root of the working tree but Git LFS files have been created in subdirectories.  We do check this latter case implicitly in [several](https://github.com/git-lfs/git-lfs/blob/a893a720aec6e34bb0b3c51e139c83448102e28e/t/t-ls-files.sh#L210-L232) [tests](https://github.com/git-lfs/git-lfs/blob/a893a720aec6e34bb0b3c51e139c83448102e28e/t/t-ls-files.sh#L389-L420) already, but without checking the full output of the command.  As we are adding tests now which pertain to the use of subdirectories, as take the opportunity to expand the test suite in this regard and more it more explicit.

/cc @rex-structorum as reporter