### PR TITLE
Fix logScanner fails to parse pointer file containing unicode chars

### DIFF
--- a/lfs/gitscanner_log.go
+++ b/lfs/gitscanner_log.go
@@ -216,7 +216,7 @@ func newLogScanner(dir LogDiffDirection, r io.Reader) *logScanner {
 		// no need to compile these regexes on every `git-lfs` call, just ones that
 		// use the scanner.
 		commitHeaderRegex:    regexp.MustCompile(fmt.Sprintf(`^lfs-commit-sha: (%s)(?: (%s))*`, git.ObjectIDRegex, git.ObjectIDRegex)),
-		fileHeaderRegex:      regexp.MustCompile(`^diff --git a\/(.+?)\s+b\/(.+)`),
+		fileHeaderRegex:      regexp.MustCompile(`^diff --git "?a\/(.+?)\s+"?b\/(.+)`),
 		fileMergeHeaderRegex: regexp.MustCompile(`^diff --cc (.+)`),
 		pointerDataRegex:     regexp.MustCompile(`^([\+\- ])(version https://git-lfs|oid sha256|size|ext-).*$`),
 	}
@@ -341,6 +341,11 @@ func (s *logScanner) scan() (*WrappedPointer, bool) {
 }
 
 func (s *logScanner) setFilename(name string) {
+	// Trim last character if it's a quote
+	if len(name) > 0 && name[len(name)-1] == '"' {
+		name = name[:len(name)-1]
+	}
+
 	s.currentFilename = name
 	s.currentFileIncluded = s.Filter.Allows(name)
 }

--- a/lfs/scanner_test.go
+++ b/lfs/scanner_test.go
@@ -82,11 +82,11 @@ index 0000000..8519883
 +size 125873
 lfs-commit-sha: 64b3372e108daaa593412d5e1d9df8169a9547ea e99c9cac7ff3f3cf1b2e670a64a5a381c44ffceb
 
-diff --git a/hobbit_5armies_2.mov b/hobbit_5armies_2.mov
+diff --git "a/hobbit_5armies_2.mov" "b/hobbit_5armies_2.mov"
 new file mode 100644
 index 0000000..92a88f8
 --- /dev/null
-+++ b/hobbit_5armies_2.mov
++++ "b/hobbit_5armies_2.mov"
 @@ -0,0 +1,3 @@
 +version https://git-lfs.github.com/spec/v1
 +ext-0-foo sha256:b37197ac149950d057521bcb7e00806f0528e19352bd72767165bc390d4f055e


### PR DESCRIPTION
Git will quote paths using Unicode characters in git log, but the fileHeaderRegex does not account for optional quotes in the log.

This change fixes the regex to account for quotes due to Unicode characters and improves the tests. 
Due to this bug, git lfs prune might accidentally prune recent files that contain unicode characters.

One might see a git log looking like this, for example (note the quotation marks):


```
lfs-commit-sha: cde89bbb531b285170c0119c34e656141dca269a fba0486e7940971a64f87d8ef8e65fb1be44b2ad

diff --git a/Source Assets/Audio/01 - Am Flughafen - Ankunftsbereich.mp3 b/Source Assets/Audio/01 - Am Flughafen - Ankunftsbereich.mp3
new file mode 100644
index 0000000..8bf5d61
--- /dev/null
+++ b/Source Assets/Audio/01 - Am Flughafen - Ankunftsbereich.mp3       
@@ -0,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b21b27eb6f510ef4da2ef3b35c3e394e42e735913fdd2c9bd3dbfde3be19b7b
+size 1535686
diff --git "a/Source Assets/Audio/Alltagsger\303\244usche - Kamera - Blitzlicht.mp3" "b/Source Assets/Audio/Alltagsger\303\244usche - Kamera - Blitzlicht.mp3"
new file mode 100755
index 0000000..63a83b8
--- /dev/null
+++ "b/Source Assets/Audio/Alltagsger\303\244usche - Kamera - Blitzlicht.mp3"   
@@ -0,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b265c0416fe1332300bdb08e3d59326b92e948f9a3cab4d4401b11e22100d5b
+size 251836

```