### PR TITLE
Add support for homedir expansion in SSL key and cert paths

### DIFF
--- a/lfshttp/certs.go
+++ b/lfshttp/certs.go
@@ -74,6 +74,16 @@ func getClientCertForHost(c *Client, host string) (*tls.Certificate, error) {
 	hostSslKey, _ := c.uc.Get("http", fmt.Sprintf("https://%v/", host), "sslKey")
 	hostSslCert, _ := c.uc.Get("http", fmt.Sprintf("https://%v/", host), "sslCert")
 
+	hostSslKey, err := tools.ExpandPath(hostSslKey, false)
+	if err != nil {
+		return nil, errors.Wrapf(err, tr.Tr.Get("Error resolving key path %q", hostSslKey))
+	}
+
+	hostSslCert, err = tools.ExpandPath(hostSslCert, false)
+	if err != nil {
+		return nil, errors.Wrapf(err, tr.Tr.Get("Error resolving cert path %q", hostSslCert))
+	}
+
 	cert, err := os.ReadFile(hostSslCert)
 	if err != nil {
 		tracerx.Printf("Error reading client cert file %q: %v", hostSslCert, err)

--- a/lfshttp/certs.go
+++ b/lfshttp/certs.go
@@ -86,6 +86,9 @@ func getClientCertForHost(c *Client, host string) (*tls.Certificate, error) {
 	}
 
 	block, _ := pem.Decode(key)
+	if block == nil {
+		return nil, errors.New(tr.Tr.Get("Error decoding PEM block from %q", hostSslKey))
+	}
 	if x509.IsEncryptedPEMBlock(block) {
 		key, err = decryptPEMBlock(c, block, hostSslKey, key)
 		if err != nil {

--- a/lfshttp/client.go
+++ b/lfshttp/client.go
@@ -470,7 +470,10 @@ func (c *Client) Transport(u *url.URL, access creds.AccessMode) (http.RoundTripp
 
 	if isClientCertEnabledForHost(c, host) {
 		tracerx.Printf("http: client cert for %s", host)
-		cert := getClientCertForHost(c, host)
+		cert, err := getClientCertForHost(c, host)
+		if err != nil {
+			return nil, err
+		}
 		if cert != nil {
 			tr.TLSClientConfig.Certificates = []tls.Certificate{*cert}
 			tr.TLSClientConfig.BuildNameToCertificate()

--- a/t/t-fetch.sh
+++ b/t/t-fetch.sh
@@ -298,6 +298,20 @@ begin_test "fetch with missing object"
 )
 end_test
 
+begin_test "fetch does not crash on empty key files"
+(
+  set -e
+  cd clone
+  rm -rf .git/lfs/objects
+
+  git config --local http.sslKey /dev/null
+  git config --local http.sslCert /dev/null
+
+  git lfs fetch origin main 2>&1 | tee fetch.log
+  grep "Error decoding PEM block" fetch.log
+)
+end_test
+
 begin_test "fetch-all"
 (
   set -e

--- a/t/testhelpers.sh
+++ b/t/testhelpers.sh
@@ -562,6 +562,8 @@ setup_creds() {
   write_creds_file "user:pass" "$CREDSDIR/127.0.0.1"
   write_creds_file ":pass" "$CREDSDIR/--$certpath"
   write_creds_file ":pass" "$CREDSDIR/--$keypath"
+  write_creds_file ":pass" "$CREDSDIR/--$homecertpath"
+  write_creds_file ":pass" "$CREDSDIR/--$homekeypath"
 }
 
 # setup initializes the clean, isolated environment for integration tests.
@@ -620,6 +622,8 @@ setup() {
   # setup the git credential password storage
   local certpath="$(echo "$LFS_CLIENT_CERT_FILE" | tr / -)"
   local keypath="$(echo "$LFS_CLIENT_KEY_FILE_ENCRYPTED" | tr / -)"
+  local homecertpath="$(echo "$TRASHDIR/home/lfs-client-cert-file" | tr / -)"
+  local homekeypath="$(echo "$TRASHDIR/home/lfs-client-key-file" | tr / -)"
   setup_creds
 
   echo "#"


### PR DESCRIPTION
Git accepts paths for SSL keys and certs starting with a tilde to expand to the user's home directory.  This is very useful for configuration which must be shared across systems.  Let's add support for the same thing here and add a test to make sure it works.

In addition, avoid crashing on invalid data by verifying our PEM block before attempting to decode it.

Fixes #5652