### PR TITLE
script/packagecloud: instantiate distro map properly

### DIFF
--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -26,7 +26,7 @@ $client = Packagecloud::Client.new(credentials)
 
 # matches package directories built by docker to one or more packagecloud distros
 # https://packagecloud.io/docs#os_distro_version
-$distro_name_map = DistroMap.distro_name_map
+$distro_name_map = DistroMap.new.distro_name_map
 
 # caches distro id lookups
 $distro_id_map = {}


### PR DESCRIPTION
We need an instance to call `distro_name_map`, so make sure we properly instantiate one by calling `new`.