### PR TITLE
Install msgfmt on Windows in CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,11 @@ jobs:
       shell: bash
     - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" go install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@latest
       shell: bash
+    - uses: git-for-windows/setup-git-for-windows-sdk@v1
+      with:
+        flavor: minimal
+      # We install the SDK so as to have access to the msgfmt.exe binary
+      # from the GNU gettext package.
     - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" env -u TMPDIR script/cibuild
       shell: bash
       # We clear the TMPDIR set for Ruby so mktemp and Go use the same

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,11 @@ jobs:
     - run: choco install -y jq
     - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" go install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@latest
       shell: bash
+    - uses: git-for-windows/setup-git-for-windows-sdk@v1
+      with:
+        flavor: minimal
+      # We install the SDK so as to have access to the msgfmt.exe binary
+      # from the GNU gettext package.
     - run: mkdir -p bin/releases
       shell: bash
       # We clear the TMPDIR set for Ruby so mktemp and Go use the same


### PR DESCRIPTION
As of Git for Windows v2.44, the `msgfmt.exe` binary is no longer installed by default and is therefore not available in the GitHub Actions runners we use for our CI and release jobs.  We instead use the `git-for-windows/setup-git-for-windows-sdk` Action to install the SDK for Git for Windows, which includes `msgfmt.exe`.

This should resolve one of the problems noted in https://github.com/git-lfs/git-lfs/pull/5660#issuecomment-1969919567.

h/t @dscho for the advice to use the SDK!