### PR TITLE
Build release assets with Go 1.21

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        go: ['1.22.x']
+        go: ['1.21.x']
     steps:
     - uses: actions/checkout@v4
       with:
@@ -104,7 +104,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        go: ['1.22.x']
+        go: ['1.21.x']
     steps:
     - uses: actions/checkout@v4
       with:
@@ -143,7 +143,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.22.x']
+        go: ['1.21.x']
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Due to the issue noted in https://github.com/golang/go/issues/65705, we don't want to build our release assets with 1.22.0, since this can cause deadlock in the HTTP client.  Instead, let's keep testing with both 1.21 and 1.22 in our CI jobs, but build with 1.21 for release.

In the future, once that bug is fixed and an updated version is released, we can move back to 1.22.