### PR TITLE
Supports downloading each file using multi-threading for basicDownloa…

### DIFF
--- a/tools/iotools.go
+++ b/tools/iotools.go
@@ -19,6 +19,20 @@ const (
 	memoryBufferLimit = 1024
 )
 
+func CopyNWithCallBack(w io.Writer, r io.Reader, totalSize, startByte, endByte int64, cb CopyCallback) (int64, error) {
+	if cb == nil {
+		return io.CopyN(w, r, endByte-startByte+1)
+	}
+
+	cbReader := &CallbackReader{
+		C:         cb,
+		TotalSize: totalSize,
+		Reader:    r,
+	}
+
+	return io.CopyN(w, cbReader, endByte-startByte+1)
+}
+
 // CopyWithCallback copies reader to writer while performing a progress callback
 func CopyWithCallback(writer io.Writer, reader io.Reader, totalSize int64, cb CopyCallback) (int64, error) {
 	if success, _ := CloneFile(writer, reader); success {


### PR DESCRIPTION
git-lfs downloads multiple lfs files at the same time, but only uses one thread to download each file

Multi-threaded downloading is very useful, I hope to add this feature to basicDownloadAdapter

Control the number of threads through the newly added configuration `lfs.downloadthreads`, default 8, maximum 64

There are some additional tests. If it does not pass, it will return to the original single-threaded download:
1. File smaller than 100MB
2. An error occurred in the HEAD request, or the server did not respond to the ‘Accept-Ranges’ header