### PR TITLE
release: v3.5.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,11 @@ jobs:
       shell: bash
     - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" go install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@latest
       shell: bash
+    - uses: git-for-windows/setup-git-for-windows-sdk@v1
+      with:
+        flavor: minimal
+      # We install the SDK so as to have access to the msgfmt.exe binary
+      # from the GNU gettext package.
     - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" env -u TMPDIR script/cibuild
       shell: bash
       # We clear the TMPDIR set for Ruby so mktemp and Go use the same

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        go: ['1.22.x']
+        go: ['1.21.x']
     steps:
     - uses: actions/checkout@v4
       with:
@@ -104,7 +104,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        go: ['1.22.x']
+        go: ['1.21.x']
     steps:
     - uses: actions/checkout@v4
       with:
@@ -143,7 +143,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.22.x']
+        go: ['1.21.x']
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,11 @@ jobs:
     - run: choco install -y jq
     - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" go install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@latest
       shell: bash
+    - uses: git-for-windows/setup-git-for-windows-sdk@v1
+      with:
+        flavor: minimal
+      # We install the SDK so as to have access to the msgfmt.exe binary
+      # from the GNU gettext package.
     - run: mkdir -p bin/releases
       shell: bash
       # We clear the TMPDIR set for Ruby so mktemp and Go use the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Git LFS Changelog
 
+## 3.5.1 (7 March 2024)
+
+This release is a patch release which includes some fixes to the release
+process to properly build assets.  It should have no user-visible changes from
+v3.5.0.
+
+### Misc
+
+* Build release assets with Go 1.21 #5668 (@bk2204)
+* script/packagecloud: instantiate distro map properly #5662 (@bk2204)
+* Install msgfmt on Windows in CI and release workflows #5666 (@chrisd8088)
+
 ## 3.5.0 (28 February 2024)
 
 This release is a feature release which includes support for LoongArch and

--- a/config/version.go
+++ b/config/version.go
@@ -13,7 +13,7 @@ var (
 )
 
 const (
-	Version = "3.5.0"
+	Version = "3.5.1"
 )
 
 func init() {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+git-lfs (3.5.1) stable; urgency=low
+
+  * New upstream version
+
+ -- brian m. carlson <bk2204@github.com>  Thu, 07 Mar 2024 14:29:00 -0000
+
 git-lfs (3.5.0) stable; urgency=low
 
   * New upstream version

--- a/rpm/SPECS/git-lfs.spec
+++ b/rpm/SPECS/git-lfs.spec
@@ -1,5 +1,5 @@
 Name:           git-lfs
-Version:        3.5.0
+Version:        3.5.1
 Release:        1%{?dist}
 Summary:        Git extension for versioning large files
 

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -26,7 +26,7 @@ $client = Packagecloud::Client.new(credentials)
 
 # matches package directories built by docker to one or more packagecloud distros
 # https://packagecloud.io/docs#os_distro_version
-$distro_name_map = DistroMap.distro_name_map
+$distro_name_map = DistroMap.new.distro_name_map
 
 # caches distro id lookups
 $distro_id_map = {}

--- a/versioninfo.json
+++ b/versioninfo.json
@@ -4,7 +4,7 @@
 		"FileVersion": {
 			"Major": 3,
 			"Minor": 5,
-			"Patch": 0,
+			"Patch": 1,
 			"Build": 0
 		}
 	},
@@ -13,7 +13,7 @@
 		"FileDescription": "Git LFS",
 		"LegalCopyright": "GitHub, Inc. and Git LFS contributors",
 		"ProductName": "Git Large File Storage (LFS)",
-		"ProductVersion": "3.5.0"
+		"ProductVersion": "3.5.1"
 	},
 	"IconPath": "script/windows-installer/git-lfs-logo.ico"
 }


### PR DESCRIPTION
This is an in-progress look at the next release of Git LFS, v3.5.0, which is scheduled for Thursday, March 7, 2024.

I've attached some builds below for people to use for testing:

[git-lfs-darwin-amd64-v3.5.1-pre.zip](https://github.com/git-lfs/git-lfs/files/14512973/git-lfs-darwin-amd64-v3.5.1-pre.zip)
[git-lfs-darwin-arm64-v3.5.1-pre.zip](https://github.com/git-lfs/git-lfs/files/14512975/git-lfs-darwin-arm64-v3.5.1-pre.zip)
[git-lfs-freebsd-386-v3.5.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/14512976/git-lfs-freebsd-386-v3.5.1-pre.tar.gz)
[git-lfs-freebsd-amd64-v3.5.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/14512977/git-lfs-freebsd-amd64-v3.5.1-pre.tar.gz)
[git-lfs-linux-386-v3.5.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/14512978/git-lfs-linux-386-v3.5.1-pre.tar.gz)
[git-lfs-linux-amd64-v3.5.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/14512979/git-lfs-linux-amd64-v3.5.1-pre.tar.gz)
[git-lfs-linux-arm64-v3.5.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/14512980/git-lfs-linux-arm64-v3.5.1-pre.tar.gz)
[git-lfs-linux-arm-v3.5.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/14512981/git-lfs-linux-arm-v3.5.1-pre.tar.gz)
[git-lfs-linux-loong64-v3.5.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/14512982/git-lfs-linux-loong64-v3.5.1-pre.tar.gz)
[git-lfs-linux-ppc64le-v3.5.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/14512983/git-lfs-linux-ppc64le-v3.5.1-pre.tar.gz)
[git-lfs-linux-riscv64-v3.5.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/14512984/git-lfs-linux-riscv64-v3.5.1-pre.tar.gz)
[git-lfs-linux-s390x-v3.5.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/14512985/git-lfs-linux-s390x-v3.5.1-pre.tar.gz)
[git-lfs-v3.5.1-pre.tar.gz](https://github.com/git-lfs/git-lfs/files/14512986/git-lfs-v3.5.1-pre.tar.gz)
[git-lfs-windows-386-v3.5.1-pre.zip](https://github.com/git-lfs/git-lfs/files/14512987/git-lfs-windows-386-v3.5.1-pre.zip)
[git-lfs-windows-amd64-v3.5.1-pre.zip](https://github.com/git-lfs/git-lfs/files/14512988/git-lfs-windows-amd64-v3.5.1-pre.zip)
[git-lfs-windows-arm64-v3.5.1-pre.zip](https://github.com/git-lfs/git-lfs/files/14512989/git-lfs-windows-arm64-v3.5.1-pre.zip)

In addition, the CI system will produce artifacts for Windows, Linux, and macOS if you prefer to use those; they should be equivalent.

/cc @git-lfs/core
/cc @git-lfs/implementers
/cc @git-lfs/releases