### PR TITLE
Build release assets with 1.22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        go: ['1.21.x']
+        go: ['1.22.x']
     steps:
     - uses: actions/checkout@v4
       with:
@@ -104,7 +104,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        go: ['1.21.x']
+        go: ['1.22.x']
     steps:
     - uses: actions/checkout@v4
       with:
@@ -143,7 +143,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.21.x']
+        go: ['1.22.x']
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Now that Go 1.22.1 is out with a backport to fix https://github.com/golang/go/issues/65705, revert the change that forced us to build with Go 1.21 to avoid the problem.