### PR TITLE
Match `PATH` case insensitively in Windows installer

### DIFF
--- a/script/windows-installer/inno-setup-git-lfs-installer.iss
+++ b/script/windows-installer/inno-setup-git-lfs-installer.iss
@@ -167,9 +167,9 @@ begin
   else
     RegisterOrDeregister := 'register';
 
-  PFiles32 := ExpandConstant('{commonpf32}\')
+  PFiles32 := AnsiLowercase(ExpandConstant('{commonpf32}\'))
   if IsWin64 then
-    PFiles64 := ExpandConstant('{commonpf64}\')
+    PFiles64 := AnsiLowercase(ExpandConstant('{commonpf64}\'))
   else
     PFiles64 := PFiles32; // `commonpf64` is not available on 32-bit Windows
 
@@ -186,7 +186,7 @@ begin
       PathExt := Copy(PathExt, j+1, Length(PathExt)-j);
 
       if FileExists(Path + Ext) then begin
-        if (Pos(PFiles32, Path) = 1) or (Pos(PFiles64, Path) = 1) then begin
+        if (Pos(PFiles32, AnsiLowercase(Path)) = 1) or (Pos(PFiles64, AnsiLowercase(Path)) = 1) then begin
           Result := True;
           Exit;
         end;


### PR DESCRIPTION
The Windows installer expands the path to the `C:\Program Files` directory using the standard casing for this.  However, our `PATH` value does not need to contain the same case, since on Windows this directory is case insensitive, and as a result, if the two differ in case, we don't correctly detect that the Git executable is in `PATH`.

Let's fix this by lowercasing both versions of the text.  Note that instead of using the `Lowercase` function, which deals only with ASCII characters, we use `AnsiLowercase`, which, despite its name, uses the current Windows locale.

This is not guaranteed to produce correct results in all cases because the file system's case folding is done in the kernel in a locale-insensitive way based on the tables created when the file system was created, but there's no way to do better than this in the general case since we don't have functionality to implement the kernel's case mapping and it is impossible to correctly fold arbitrary Unicode text in a locale-insensitive way.  We therefore adopt the least bad option available while continuing to support Windows.

Fixes #5679