### PR TITLE
Use lower-case file extensions in Windows installer path checks

### DIFF
--- a/script/windows-installer/inno-setup-git-lfs-installer.iss
+++ b/script/windows-installer/inno-setup-git-lfs-installer.iss
@@ -179,7 +179,7 @@ begin
     Path := Copy(PathEnv, 1, i-1) + '\git';
     PathEnv := Copy(PathEnv, i+1, Length(PathEnv)-i);
 
-    PathExt := GetEnv('PATHEXT') + ';';
+    PathExt := AnsiLowercase(GetEnv('PATHEXT')) + ';';
     repeat
       j := Pos(';', PathExt);
       Ext := Copy(PathExt, 1, j-1);


### PR DESCRIPTION
In commit a5b751f541abb52e30b60aebe530f9dbd72838df of PR #4925 we introduced an advisory check into the Windows installer for Git LFS which notifies the administrator if a `git.exe` file is found outside of the `C:\Program Files` directory and would, according to the order of elements in the `PATH` and `PATHEXT` environment variables, be found and run by Git LFS during the installation process.

Git LFS [searches](https://github.com/git-lfs/git-lfs/blob/add64b8f91827db7922c8a4f6574b019b7cedfb8/subprocess/path.go#L39-L70) for executables using logic imported and modified from the Go standard libraries into our `subprocess` package, because until Go v1.19, the `os/exec` package would search first in the current working directory, which allowed was a security vulnerability.  Hence Git LFS explicitly excludes the current working directory when searching for executables.

In the Windows version of our `subprocess` package, where we implement this file search, we use an internal `findPathExtensions()` [function](https://github.com/git-lfs/git-lfs/blob/add64b8f91827db7922c8a4f6574b019b7cedfb8/subprocess/path_windows.go#L75-L92) which mirrors part of the `LookPath()` [function](https://github.com/golang/go/blob/7bb721b9384bdd196befeaed593b185f7f2a5589/src/os/exec/lp_windows.go#L54-L94) in the Windows version of the `os/exec` package circa 2020, including the fact that our implementation [converts](https://github.com/git-lfs/git-lfs/blob/add64b8f91827db7922c8a4f6574b019b7cedfb8/subprocess/path_windows.go#L79) the contents of the `PATHEXT` environment variable to lower-case in the same [manner](https://github.com/golang/go/blob/7bb721b9384bdd196befeaed593b185f7f2a5589/src/os/exec/lp_windows.go#L64) the older Go implementation.  The current `os/exec` implementation also [performs](https://github.com/golang/go/blob/4c2b1e0feb3d3112da94fa4cd11ebe995003fa89/src/os/exec/lp_windows.go#L119) this conversion.

So long as Windows directories are case-insensitive, this conversion has no particular consequences.  However, modern versions of Windows allow for some directories to be made case-sensitive in their handling of filenames, not just case-preserving.  In such a directory, Git LFS will only locate a file to execute if it has an all-lowercase extension such as `.exe`.

However, in the advisory [check](https://github.com/git-lfs/git-lfs/blob/add64b8f91827db7922c8a4f6574b019b7cedfb8/script/windows-installer/inno-setup-git-lfs-installer.iss#L154-L215) we [perform](https://github.com/git-lfs/git-lfs/blob/add64b8f91827db7922c8a4f6574b019b7cedfb8/script/windows-installer/inno-setup-git-lfs-installer.iss#L233-L237) in our Windows installer, we [utilize](https://github.com/git-lfs/git-lfs/blob/add64b8f91827db7922c8a4f6574b019b7cedfb8/script/windows-installer/inno-setup-git-lfs-installer.iss#L182) the file extensions as they are found in the PATH environment variable, which by default contains a list of all-uppercase extensions, e.g., `.COM;.EXE;.BAT;...`.  Thus if a case-sensitive directory precedes any `C:\Program Files` directory in the `PATH` environment variable and also contains a file named `git.exe`, Git LFS will find and run that file, but the Windows installer will not advise that such a file exists outside of `C:\Program Files`.

To bring the installer into closer alignment with the behaviour of Git LFS, we therefore want to convert the contents of the `PATHEXT` environment variable to all-lowercase before we use them to search for a potential Git executable.

To reiterate the points we made in PR #4925 when we introduced the advisory check into the Windows installer, it is not intended to provide a guarantee of system safety.  As we wrote at the time:

> [W]hen installing Git LFS as an administrator with elevated privileges, final responsibility lies with the administrator to ensure there are no compromised executables in their system `PATH`.
>
> [I]f a Windows administrator runs the `git-lfs.exe install` command manually, the checks we are adding to the Inno Setup script will not be performed, and the situation then is no different than a macOS or Linux user running `sudo git-lfs install` without confidence that the system PATH and installed Git binary are already secure.