### PR TITLE
checkout: gracefully handle files deleted from the index

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -258,6 +258,23 @@ func DiffIndex(ref string, cached bool, refresh bool, workingDir string) (*bufio
 	return bufio.NewScanner(cmd.Stdout), nil
 }
 
+func DiffIndexWithPaths(ref string, cached bool, paths []string) (string, error) {
+	args := []string{"diff-index"}
+	if cached {
+		args = append(args, "--cached")
+	}
+	args = append(args, ref)
+	args = append(args, "--")
+	args = append(args, paths...)
+
+	output, err := gitSimple(args...)
+	if err != nil {
+		return "", err
+	}
+
+	return output, nil
+}
+
 func HashObject(r io.Reader) (string, error) {
 	cmd, err := gitNoLFS("hash-object", "--stdin")
 	if err != nil {

--- a/t/t-checkout.sh
+++ b/t/t-checkout.sh
@@ -51,6 +51,14 @@ begin_test "checkout"
   grep 'accepting "file1.dat"' checkout.log
   grep 'rejecting "file1.dat"' checkout.log && exit 1
 
+  git rm file1.dat
+
+  echo "checkout should skip replacing files deleted in index"
+  git lfs checkout
+  [ ! -f file1.dat ]
+
+  git reset --hard
+
   # Remove the working directory
   rm -rf file1.dat file2.dat file3.dat folder1/nested.dat folder2/nested.dat
 


### PR DESCRIPTION
Right now, when someone deletes a pointer from the index with `git rm` and then runs `git lfs checkout`, the operation fails with a message of "Could not update the index" because our invocation of `git update-index` is missing the `--add` flag.

Obviously, the user does not expect an error in this case, and `git checkout` simply ignores files staged for deletation, so let's do the same thing.  If a file on disk is deleted, check the index with `git diff-index` to see if it's deleted from `HEAD`.  If so, ignore the file, just like Git does. Note that we use `git diff-index` specifically because it doesn't refresh the index and is therefore much cheaper than alternatives, such as `git status`, which might do that.

Fixes #5669