### PR TITLE
.github/workflows: use actions/setup-go everywhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,9 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+    - uses: actions/setup-go@v5
+      with:
+        go-version: '1.22.x'
     - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
       if: ${{ github.ref_type == 'tag' }}
     - run: git clone -b master https://github.com/git/git.git "$HOME/git"
@@ -150,6 +153,9 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+    - uses: actions/setup-go@v5
+      with:
+        go-version: '1.22.x'
     - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
       if: ${{ github.ref_type == 'tag' }}
     - run: git clone -b v2.0.0 https://github.com/git/git.git "$HOME/git"


### PR DESCRIPTION
When we're building with the earliest or latest Git, it's not guaranteed that Go is installed.  Notably, in the latest version of the macos-latest runners, Go is not installed by default.  Fix this by explicitly setting up Go before running further commands.