### PR TITLE
Avoid deadlocking on log scanning with lots of output on stderr

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -255,7 +255,7 @@ func DiffIndex(ref string, cached bool, refresh bool, workingDir string) (*bufio
 		args = append([]string{"-C", workingDir}, args...)
 	}
 
-	cmd, err := gitBuffered(args...)
+	cmd, err := gitBufferedStdout(args...)
 	if err != nil {
 		return nil, err
 	}

--- a/git/git.go
+++ b/git/git.go
@@ -212,6 +212,10 @@ func gitNoLFSBuffered(args ...string) (*subprocess.BufferedCmd, error) {
 	return subprocess.BufferedExec("git", gitConfigNoLFS(args...)...)
 }
 
+func gitNoLFSBufferedStdout(args ...string) (*subprocess.BufferedCmd, error) {
+	return subprocess.StdoutBufferedExec("git", gitConfigNoLFS(args...)...)
+}
+
 // Invoke Git with enabled LFS filters
 func git(args ...string) (*subprocess.Cmd, error) {
 	return subprocess.ExecCommand("git", args...)
@@ -223,6 +227,10 @@ func gitSimple(args ...string) (string, error) {
 
 func gitBuffered(args ...string) (*subprocess.BufferedCmd, error) {
 	return subprocess.BufferedExec("git", args...)
+}
+
+func gitBufferedStdout(args ...string) (*subprocess.BufferedCmd, error) {
+	return subprocess.StdoutBufferedExec("git", args...)
 }
 
 func CatFile() (*subprocess.BufferedCmd, error) {

--- a/subprocess/subprocess.go
+++ b/subprocess/subprocess.go
@@ -50,6 +50,36 @@ func BufferedExec(name string, args ...string) (*BufferedCmd, error) {
 	}, nil
 }
 
+// StdoutBufferedExec starts up a command and creates a stdin pipe and a
+// buffered stdout pipe, with stderr directed to /dev/null, wrapped in a
+// BufferedCmd. The stdout buffer will be of stdoutBufSize bytes.
+func StdoutBufferedExec(name string, args ...string) (*BufferedCmd, error) {
+	cmd, err := ExecCommand(name, args...)
+	if err != nil {
+		return nil, err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	return &BufferedCmd{
+		cmd,
+		stdin,
+		bufio.NewReaderSize(stdout, stdoutBufSize),
+		nil,
+	}, nil
+}
+
 // SimpleExec is a small wrapper around os/exec.Command.
 func SimpleExec(name string, args ...string) (string, error) {
 	cmd, err := ExecCommand(name, args...)


### PR DESCRIPTION
When we're running our log scanning code, we can end up with a deadlock if there is lots of output on standard error because we either don't read standard error at all or we only read it when we're done reading standard output.  To fix this, let's add and use some functions that either discard standard error if we're not using it, as well as making sure we read standard error in a separate goroutine so the child process doesn't block.

Fixes #5720