### PR TITLE
docs/api: note API clients may send `charset` parameter in `Content-Type` header

### DIFF
--- a/docs/api/basic-transfers.md
+++ b/docs/api/basic-transfers.md
@@ -141,4 +141,7 @@ Git LFS clients send:
 < HTTP/1.1 200 OK
 ```
 
+The client may also include a `charset=utf-8` parameter in the
+`Content-Type` header, which servers should be prepared to accept.
+
 A 200 response means that the object exists on the server.

--- a/docs/api/batch.md
+++ b/docs/api/batch.md
@@ -19,6 +19,9 @@ headers. The request and response bodies are JSON.
     Accept: application/vnd.git-lfs+json
     Content-Type: application/vnd.git-lfs+json
 
+The client may also include a `charset=utf-8` parameter in the
+`Content-Type` header, which servers should be prepared to accept.
+
 See the [Authentication doc](./authentication.md) for more info on how LFS
 gets authorizes Batch API requests.
 

--- a/docs/api/locking.md
+++ b/docs/api/locking.md
@@ -18,6 +18,9 @@ All File Locking requests require the following HTTP headers:
     Accept: application/vnd.git-lfs+json
     Content-Type: application/vnd.git-lfs+json
 
+The client may also include a `charset=utf-8` parameter in the
+`Content-Type` header, which servers should be prepared to accept.
+
 See the [Authentication doc](./authentication.md) for more info on how LFS
 gets authorizes Batch API requests.
 


### PR DESCRIPTION
Since at least commit 099adaaa5e59be83ee9f3079398c4398fd282e50 in 2013 the Git LFS client has included a `charset=utf-8` parameter in some or all of the `Content-Type` headers it sends to server API endpoints.

As noted in #5775, we do not at present mention this parameter in our API documentation, and the `charset` parameter is not required by any IETF RFCs for MIME types other than `text/*` types, so we update our documentation to mention that servers should be prepared to accept this header parameter but that it is not required.

Thanks to @KalleOlaviNiemitalo for the suggestion!