### PR TITLE
Support arbitrary HTTP credential schemes for authentication

### DIFF
--- a/creds/creds.go
+++ b/creds/creds.go
@@ -56,6 +56,7 @@ type Creds map[string][]string
 func bufferCreds(c Creds) *bytes.Buffer {
 	buf := new(bytes.Buffer)
 
+	buf.Write([]byte("capability[]=authtype\n"))
 	for k, v := range c {
 		for _, item := range v {
 			buf.Write([]byte(k))

--- a/t/t-credentials.sh
+++ b/t/t-credentials.sh
@@ -39,7 +39,7 @@ begin_test "credentials without useHttpPath, with bad path password"
   reponame="no-httppath-bad-password"
   setup_remote_repo "$reponame"
 
-  printf "path:wrong" > "$CREDSDIR/127.0.0.1--$reponame"
+  printf ":path:wrong" > "$CREDSDIR/127.0.0.1--$reponame"
 
   clone_repo "$reponame" without-path
   git config credential.useHttpPath false
@@ -76,7 +76,7 @@ begin_test "credentials with url-specific useHttpPath, with bad path password"
   reponame="url-specific-httppath-bad-password"
   setup_remote_repo "$reponame"
 
-  printf "path:wrong" > "$CREDSDIR/127.0.0.1--$reponame"
+  printf ":path:wrong" > "$CREDSDIR/127.0.0.1--$reponame"
 
   clone_repo "$reponame" with-url-specific-path
   git config credential.$GITSERVER.useHttpPath false
@@ -108,7 +108,7 @@ begin_test "credentials with useHttpPath, with wrong password"
   reponame="httppath-bad-password"
   setup_remote_repo "$reponame"
 
-  printf "path:wrong" > "$CREDSDIR/127.0.0.1--$reponame"
+  printf ":path:wrong" > "$CREDSDIR/127.0.0.1--$reponame"
 
   clone_repo "$reponame" with-path-wrong-pass
   git checkout -b with-path-wrong-pass
@@ -140,7 +140,7 @@ begin_test "credentials with useHttpPath, with correct password"
   reponame="$(basename "$0" ".sh")"
   setup_remote_repo "$reponame"
 
-  printf "path:$reponame" > "$CREDSDIR/127.0.0.1--$reponame"
+  printf ":path:$reponame" > "$CREDSDIR/127.0.0.1--$reponame"
 
   clone_repo "$reponame" with-path-correct-pass
   git checkout -b with-path-correct-pass
@@ -181,7 +181,7 @@ begin_test "credentials send wwwauth[] by default"
   reponame="$(basename "$0" ".sh")-wwwauth-required"
   setup_remote_repo "$reponame"
 
-  printf "path:$reponame" > "$CREDSDIR/127.0.0.1--$reponame"
+  printf ":path:$reponame" > "$CREDSDIR/127.0.0.1--$reponame"
 
   clone_repo "$reponame" "$reponame"
   git checkout -b new-branch
@@ -222,7 +222,7 @@ begin_test "credentials sends wwwauth[] and fails with finicky helper"
   reponame="$(basename "$0" ".sh")-wwwauth-forbidden-finicky"
   setup_remote_repo "$reponame"
 
-  printf "path:$reponame" > "$CREDSDIR/127.0.0.1--$reponame"
+  printf ":path:$reponame" > "$CREDSDIR/127.0.0.1--$reponame"
 
   clone_repo "$reponame" "$reponame"
   git checkout -b new-branch
@@ -258,7 +258,7 @@ begin_test "credentials skips wwwauth[] with option"
   setup_remote_repo "$reponame"
   git config --global credential.$GITSERVER.skipwwwauth true
 
-  printf "path:$reponame" > "$CREDSDIR/127.0.0.1--$reponame"
+  printf ":path:$reponame" > "$CREDSDIR/127.0.0.1--$reponame"
 
   clone_repo "$reponame" "$reponame"
   git checkout -b new-branch
@@ -294,8 +294,8 @@ begin_test "git credential"
 (
   set -e
 
-  printf "git:server" > "$CREDSDIR/credential-test.com"
-  printf "git:path" > "$CREDSDIR/credential-test.com--some-path"
+  printf ":git:server" > "$CREDSDIR/credential-test.com"
+  printf ":git:path" > "$CREDSDIR/credential-test.com--some-path"
 
   mkdir empty
   cd empty

--- a/t/testhelpers.sh
+++ b/t/testhelpers.sh
@@ -559,11 +559,11 @@ write_creds_file() {
 
 setup_creds() {
   mkdir -p "$CREDSDIR"
-  write_creds_file "user:pass" "$CREDSDIR/127.0.0.1"
-  write_creds_file ":pass" "$CREDSDIR/--$certpath"
-  write_creds_file ":pass" "$CREDSDIR/--$keypath"
-  write_creds_file ":pass" "$CREDSDIR/--$homecertpath"
-  write_creds_file ":pass" "$CREDSDIR/--$homekeypath"
+  write_creds_file ":user:pass" "$CREDSDIR/127.0.0.1"
+  write_creds_file "::pass" "$CREDSDIR/--$certpath"
+  write_creds_file "::pass" "$CREDSDIR/--$keypath"
+  write_creds_file "::pass" "$CREDSDIR/--$homecertpath"
+  write_creds_file "::pass" "$CREDSDIR/--$homekeypath"
 }
 
 # setup initializes the clean, isolated environment for integration tests.


### PR DESCRIPTION
Git recently learned to announce capabilities for credential helpers and this functionality will be in Git 2.46.  One of the capabilities is the ability for credential helpers to specify arbitrary HTTP credential schemes and the credentials for these schemes.  This allows users with a suitable credential helper to implement support for, say, Bearer authentication where the credentials come from a credential helper.

With this capability, Git LFS will advertise the `capability[]=authtype` line, and a suitable version of Git will pass this along to the helper, which can then return something like `authtype=Bearer` and `credential=my-bearer-token` to provide a `Authorization: Bearer my-bearer-token` header.  It can also return other schemes as well, and the `credential` field can include any necessary parameters that the scheme may require.

In order to implement this in Git LFS, we first need to adjust our test credential helper and the server so that they can handle this new authentication type and return appropriate credentials.  Then, we add support in the main codebase and verify that it works as expected.

Note that Git versions which do not support this capability will exit unsuccessfully for `git credential capability` (causing our tests to be skipped) and will do nothing with the `capability[]=authtype` declaration, which means that it will not be passed to the credential helper.  At that point, the credential helper can either return the previous username/password pair, or decide to return nothing at all.

There is an additional capability to allow multi-stage authentication, such as NTLM or Kerberos, in the credential helper.  These both require two round trips for authentication to succeed, which needs additional support from the helper and Git or Git LFS.  Supporting NTLM in Git LFS via a suitable credential helper was in fact one of the goals of the upstream series, in addition to discouraging the use of the config file for storing authentication credentials (such as used to be required for Bearer auth).  However, the additional capability required for that is not implemented here, and can be implemented in an additional series in due course.