### PR TITLE
Support multistage authentication with a Git credential helper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,4 +44,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.17
+go 1.21

--- a/lfsapi/auth_test.go
+++ b/lfsapi/auth_test.go
@@ -39,7 +39,7 @@ func TestAuthenticateHeaderAccess(t *testing.T) {
 			res := &http.Response{Header: make(http.Header)}
 			res.Header.Set(key, value)
 			t.Logf("%s: %s", key, value)
-			result, _, _ := getAuthAccess(res, creds.NoneAccess, creds.AllAccessModes())
+			result, _, _ := getAuthAccess(res, creds.NoneAccess, creds.AllAccessModes(), false)
 			assert.Equal(t, expected, result)
 		}
 	}
@@ -48,11 +48,11 @@ func TestAuthenticateHeaderAccess(t *testing.T) {
 func TestDualAccessModes(t *testing.T) {
 	res := &http.Response{Header: make(http.Header)}
 	res.Header["Www-Authenticate"] = []string{"Negotiate 123", "Basic 456"}
-	access, next, _ := getAuthAccess(res, creds.NoneAccess, creds.AllAccessModes())
+	access, next, _ := getAuthAccess(res, creds.NoneAccess, creds.AllAccessModes(), false)
 	assert.Equal(t, creds.NegotiateAccess, access)
-	access, next, _ = getAuthAccess(res, access, next)
+	access, next, _ = getAuthAccess(res, access, next, false)
 	assert.Equal(t, creds.BasicAccess, access)
-	access, _, _ = getAuthAccess(res, access, next)
+	access, _, _ = getAuthAccess(res, access, next, false)
 	assert.Equal(t, creds.BasicAccess, access)
 }
 

--- a/t/cmd/git-credential-lfstest.go
+++ b/t/cmd/git-credential-lfstest.go
@@ -189,7 +189,7 @@ func credsForHostAndPath(host, path string) (credential, error) {
 	return credsFromFilename(hostFilename)
 }
 
-func credsFromFilename(file string) (credential, error) {
+func parseOneCredential(s, file string) (credential, error) {
 	// Each line in a file is of the following form:
 	//
 	// skip::
@@ -204,13 +204,9 @@ func credsFromFilename(file string) (credential, error) {
 	//	If MULTISTAGE is set to "true", then the multistage flag is set.
 	// :USERNAME:PASSWORD
 	//	This is a normal username and password.
-	fileContents, err := os.ReadFile(file)
-	if err != nil {
-		return credential{}, fmt.Errorf("Error opening %q: %s", file, err)
-	}
-	credsPieces := strings.SplitN(strings.TrimSpace(string(fileContents)), ":", 3)
+	credsPieces := strings.SplitN(strings.TrimSpace(s), ":", 3)
 	if len(credsPieces) != 3 && len(credsPieces) != 6 {
-		return credential{}, fmt.Errorf("Invalid data %q while reading %q", string(fileContents), file)
+		return credential{}, fmt.Errorf("Invalid data %q while reading %q", string(s), file)
 	}
 	if credsPieces[0] == "skip" {
 		return credential{skip: true}, nil
@@ -227,6 +223,14 @@ func credsFromFilename(file string) (credential, error) {
 			multistage: credsPieces[5] == "true",
 		}, nil
 	}
+}
+
+func credsFromFilename(file string) (credential, error) {
+	fileContents, err := os.ReadFile(file)
+	if err != nil {
+		return credential{}, fmt.Errorf("Error opening %q: %s", file, err)
+	}
+	return parseOneCredential(string(fileContents), file)
 }
 
 func log() {

--- a/t/t-credentials.sh
+++ b/t/t-credentials.sh
@@ -320,6 +320,35 @@ begin_test "credentials can authenticate with Bearer auth"
 )
 end_test
 
+begin_test "credentials can authenticate with multistage auth"
+(
+  set -e
+  [ $(git credential capability </dev/null | grep -E "capability (authtype|state)" | wc -l) -eq 2 ] || exit 0
+
+  reponame="auth-multistage-token"
+  setup_remote_repo "$reponame"
+
+  printf 'Multistage::cred2:state1:state2:\nMultistage::cred1::state1:true' > "$CREDSDIR/127.0.0.1--$reponame"
+
+  clone_repo "$reponame" "$reponame"
+  git checkout -b new-branch
+
+  git lfs track "*.dat" 2>&1 | tee track.log
+  grep "Tracking \"\*.dat\"" track.log
+
+  contents="b"
+
+  printf "%s" "$contents" > b.dat
+  git add b.dat
+  git add .gitattributes
+  git commit -m "add b.dat"
+
+  GIT_TERMINAL_PROMPT=0 GIT_TRACE=1 GIT_TRANSFER_TRACE=1 GIT_CURL_VERBOSE=1 git push origin new-branch 2>&1 | tee push.log
+  grep "Uploading LFS objects: 100% (1/1), 1 B" push.log
+  [ "1" -eq "$(cat push.log | grep "creds: git credential approve" | wc -l)" ]
+  [ "2" -eq "$(cat push.log | grep "creds: git credential fill" | wc -l)" ]
+)
+end_test
 
 begin_test "git credential"
 (


### PR DESCRIPTION
In 2.46, Git will support multistage authentication from credential helpers.  This will allow Git and Git LFS to implement functionality like NTLM and Kerberos in the credential helper, which lets this functionality to work even if Git LFS doesn't support it natively.

This requires two separate pieces of data.  First, it involves a `state[]` field, which each credential helper can add to keep track of state.  Second, it allows the usage of a boolean `continue` field, which indicates that the response is multistage and this is not the final stage.

In order to make this work, we adjust a few things.  First, we advertise the `state` capability.  Additionally, we save and pass back the `state[]` fields that the credential helper may send to us.  We also don't change the authentication scheme if the helper told us that this was a multistage response.  Finally, we add a check to avoid a credential helper getting stuck in an infinite loop if it keeps handing back the same credentials.

There are also a variety of preparatory steps which are necessary and are present in their own commits for easy review.