### PR TITLE
Use expected version of Git on macOS in CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,12 @@ jobs:
     - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
       if: ${{ github.ref_type == 'tag' }}
     - run: git clone -b master https://github.com/git/git.git "$HOME/git"
+    - run: |
+        echo "GIT_INSTALL_DIR=$HOME/git" >> "$GITHUB_ENV"
+        echo "$HOME/git/bin" >> "$GITHUB_PATH"
+      if: ${{ matrix.os == 'macos-latest' }}
+      # We install our custom Git version into a PATH location ahead of
+      # that of the Git installed by Homebrew.
     - run: script/build-git "$HOME/git"
     - run: GIT_DEFAULT_HASH=sha256 script/cibuild
   build-earliest:
@@ -159,6 +165,12 @@ jobs:
     - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
       if: ${{ github.ref_type == 'tag' }}
     - run: git clone -b v2.0.0 https://github.com/git/git.git "$HOME/git"
+    - run: |
+        echo "GIT_INSTALL_DIR=$HOME/git" >> "$GITHUB_ENV"
+        echo "$HOME/git/bin" >> "$GITHUB_PATH"
+      if: ${{ matrix.os == 'macos-latest' }}
+      # We install our custom Git version into a PATH location ahead of
+      # that of the Git installed by Homebrew.
     - run: script/build-git "$HOME/git"
     - run: script/cibuild
   build-docker:

--- a/script/build-git
+++ b/script/build-git
@@ -14,11 +14,13 @@ case $(uname -s) in
     sudo apt-get -y build-dep git;;
 esac
 
+GIT_INSTALL_PATH="${GIT_INSTALL_DIR:-"/usr/local"}"
+
 cd "$DIR"
 printf "%s\n" \
   "NO_GETTEXT=YesPlease" \
   "NO_OPENSSL=YesPlease" \
-  "prefix=/usr/local" \
+  "prefix=$GIT_INSTALL_PATH" \
   > config.mak
 make -j2
 sudo make install


### PR DESCRIPTION
Possibly since we first switched to the use of GitHub Actions for our CI jobs, in PR #3808, the version of Git we've used on macOS in our `build-earliest` and `build-latest` [jobs](https://github.com/git-lfs/git-lfs/blob/8e36a03d85bf05bbca004dd7e8b55b147809b3e0/.github/workflows/ci.yml#L128-L163) has actually been the one installed by Homebrew rather than the one we've custom-built for the purpose.

This is due to the fact that, by default, the `PATH` environment variable supplied in GitHub Actions runners on macOS has the `/opt/homebrew/bin` location listed ahead of the `/usr/local/bin` location where we install our custom version of Git.

We can address this by ensuring that our `build-git` [script](https://github.com/git-lfs/git-lfs/blob/8e36a03d85bf05bbca004dd7e8b55b147809b3e0/script/build-git) installs the custom version of Git into a unique location, when running on macOS, and then placing this location ahead of all others in the `PATH` environment variable.

(We could consider using `$HOME/.local/bin` instead of `$HOME/git/bin`, which has the advantage that at present it is already listed ahead of `/opt/homebrew/bin` in `PATH` on the macOS runners, so we wouldn't need to modify `PATH` at all.  However, that order is likely not guaranteed, and if it changed in the future we could see another silent regression in the version of Git used in our macOS CI jobs.  Using `$HOME/git/bin` and explicitly placing it at the start of `PATH` should avoid this problem, and it is also aligned with the `$HOME/go/bin` location used by Go.)

On Linux we can just continue to install our version of Git into `/usr/local/bin`, as that takes precedence over any other installed version of Git on the GitHub Actions Linux runners.

Fixes #5790.
/cc @bk2204 as reporter.