### PR TITLE
ssh: fix connection creation "leaking" connections

### DIFF
--- a/ssh/connection.go
+++ b/ssh/connection.go
@@ -114,7 +114,11 @@ func (tr *SSHTransfer) Connection(n int) (*PktlineConnection, error) {
 		return tr.conn[n], nil
 	}
 	conn, _, err := tr.spawnConnection(n)
-	return conn, err
+	if err != nil {
+		return nil, err
+	}
+	tr.conn[n] = conn
+	return conn, nil
 }
 
 // ConnectionCount returns the number of connections this object has.


### PR DESCRIPTION
Commit 44b8801cbb57891b4c66fc3c43551802e5532bd1 introduced a bug where connections were being created on-demand but were not being stored in the connections slice.

When trying to end connections at the end of a transfer, there were no handles to them. As a result, all but the primary connection of the session were hung with no "quit" message. LFS clients (and servers) were simply hung until idle timeout kicked in.

Found this while implementing pure SSH protocol for Gitea (https://github.com/go-gitea/gitea/issues/17554).

This seems like important functionality, so I'd recommend adding some sort of pure SSH multiplexed tests in the suite as well.