### PR TITLE
Prevent &{...}s(MISSING) message

### DIFF
--- a/lfshttp/errors.go
+++ b/lfshttp/errors.go
@@ -124,5 +124,5 @@ func defaultError(res *http.Response) error {
 		msgFmt = tr.Tr.Get("Server error %%s from HTTP %d", res.StatusCode)
 	}
 
-	return errors.Errorf(fmt.Sprintf(msgFmt), res.Request.URL)
+	return errors.Errorf(fmt.Sprintf(msgFmt, res.Request.URL))
 }


### PR DESCRIPTION
When encountering an HTTP 413 error, a message like the following is displayed:

```
LFS: Client error &{%!!(string=http) %!!(string=) %!!(*url.Userinfo=<nil>) %!!(string=my.example.com) %!!(string=/git/redacted/redcated.git/info/lfs/objects/9c4bf89ecc9faef1abab8a0c27a349a34b30b6d5816c5352dc26e0ceded0963f/1119460) %!!(string=) %!!(bool=false) %!!(bool=false) %!!(string=) %!!(string=) %!!(string=)}s(MISSING) from HTTP 413
```

This patch changes it to something readable:

```
LFS: Client error http://my.example.com/git/redacted/redacted.git/info/lfs/objects/9c4bf89ecc9faef1abab8a0c27a349a34b30b6d5816c5352dc26e0ceded0963f/1119460 from HTTP 413
```