### PR TITLE
git-lfs: omit tags in ls-remote; optimize pre-push

### DIFF
--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -276,7 +276,7 @@ func getRemoteRefs(l *tasklog.Logger) (map[string][]*git.Ref, error) {
 		if migrateSkipFetch {
 			refsForRemote, err = git.CachedRemoteRefs(remote)
 		} else {
-			refsForRemote, err = git.RemoteRefs(remote)
+			refsForRemote, err = git.RemoteRefs(remote, false)
 		}
 
 		if err != nil {

--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -276,7 +276,7 @@ func getRemoteRefs(l *tasklog.Logger) (map[string][]*git.Ref, error) {
 		if migrateSkipFetch {
 			refsForRemote, err = git.CachedRemoteRefs(remote)
 		} else {
-			refsForRemote, err = git.RemoteRefs(remote, false)
+			refsForRemote, err = git.RemoteRefs(remote, true)
 		}
 
 		if err != nil {

--- a/git/git.go
+++ b/git/git.go
@@ -1277,12 +1277,12 @@ func Fetch(remotes ...string) error {
 	return err
 }
 
-// RemoteRefs returns a list of branches & tags for a remote by actually
-// accessing the remote via git ls-remote.
-func RemoteRefs(remoteName string, ignoreTags bool) ([]*Ref, error) {
+// RemoteRefs returns a list of branches and, optionally, tags for a remote
+// by actually accessing the remote via git ls-remote.
+func RemoteRefs(remoteName string, withTags bool) ([]*Ref, error) {
 	var ret []*Ref
 	args := []string{"ls-remote", "--heads", "-q"}
-	if !ignoreTags {
+	if withTags {
 		args = append(args, "--tags")
 	}
 	args = append(args, remoteName)
@@ -1308,7 +1308,7 @@ func RemoteRefs(remoteName string, ignoreTags bool) ([]*Ref, error) {
 
 			typ := RefTypeRemoteBranch
 			if ns == "tags" {
-				if ignoreTags {
+				if !withTags {
 					return nil, errors.New(tr.Tr.Get("unexpected tag returned by `git ls-remote --heads`: %s %s", name, sha))
 				}
 				typ = RefTypeRemoteTag

--- a/git/git.go
+++ b/git/git.go
@@ -1279,9 +1279,15 @@ func Fetch(remotes ...string) error {
 
 // RemoteRefs returns a list of branches & tags for a remote by actually
 // accessing the remote via git ls-remote.
-func RemoteRefs(remoteName string) ([]*Ref, error) {
+func RemoteRefs(remoteName string, ignoreTags bool) ([]*Ref, error) {
 	var ret []*Ref
-	cmd, err := gitNoLFS("ls-remote", "--heads", "--tags", "-q", remoteName)
+	args := []string{"ls-remote", "--heads", "-q"}
+	if !ignoreTags {
+		args = append(args, "--tags")
+	}
+	args = append(args, remoteName)
+	
+	cmd, err := gitNoLFS(args...)
 	if err != nil {
 		return nil, errors.New(tr.Tr.Get("failed to find `git ls-remote`: %v", err))
 	}

--- a/git/git.go
+++ b/git/git.go
@@ -1286,7 +1286,7 @@ func RemoteRefs(remoteName string, ignoreTags bool) ([]*Ref, error) {
 		args = append(args, "--tags")
 	}
 	args = append(args, remoteName)
-	
+
 	cmd, err := gitNoLFS(args...)
 	if err != nil {
 		return nil, errors.New(tr.Tr.Get("failed to find `git ls-remote`: %v", err))
@@ -1308,6 +1308,9 @@ func RemoteRefs(remoteName string, ignoreTags bool) ([]*Ref, error) {
 
 			typ := RefTypeRemoteBranch
 			if ns == "tags" {
+				if ignoreTags {
+					return nil, errors.New(tr.Tr.Get("unexpected tag returned by `git ls-remote --heads`: %s %s", name, sha))
+				}
 				typ = RefTypeRemoteTag
 			}
 			ret = append(ret, &Ref{name, typ, sha})

--- a/lfs/gitscanner_remotes.go
+++ b/lfs/gitscanner_remotes.go
@@ -16,7 +16,7 @@ func calcSkippedRefs(remote string) []string {
 
 	// Since CachedRemoteRefs() only returns branches, request that
 	// RemoteRefs() ignore tags and also return only branches.
-	actualRemoteRefs, _ := git.RemoteRefs(remote, true)
+	actualRemoteRefs, _ := git.RemoteRefs(remote, false)
 
 	// The list of remote refs can be very large, so convert them to
 	// a set for faster lookups in the skip calculation loop.

--- a/lfs/gitscanner_remotes.go
+++ b/lfs/gitscanner_remotes.go
@@ -13,16 +13,16 @@ import (
 // remote, use a more explicit diff command.
 func calcSkippedRefs(remote string) []string {
 	cachedRemoteRefs, _ := git.CachedRemoteRefs(remote)
+
+	// Since CachedRemoteRefs() only returns branches, request that
+	// RemoteRefs() ignore tags and also return only branches.
 	actualRemoteRefs, _ := git.RemoteRefs(remote, true)
 
-	// The set of remote refs can be very large. Since CachedRemoteRefs only
-	// returns branches, filter the remote refs and convert them to a set for
-	// faster lookups in the skip calculation loop.
-	actualRemoteBranchRefs := tools.NewStringSet()
+	// The list of remote refs can be very large, so convert them to
+	// a set for faster lookups in the skip calculation loop.
+	actualRemoteRefsSet := tools.NewStringSet()
 	for _, ref := range actualRemoteRefs {
-		if ref.Type == git.RefTypeRemoteBranch {
-			actualRemoteBranchRefs.Add(ref.Name)
-		}
+		actualRemoteRefsSet.Add(ref.Name)
 	}
 
 	// Only check for missing refs on remote; if the ref is different it has moved
@@ -30,7 +30,7 @@ func calcSkippedRefs(remote string) []string {
 	// (force push) then that will cause a re-evaluation in a subsequent command.
 	var skippedRefs []string
 	for _, cachedRef := range cachedRemoteRefs {
-		if actualRemoteBranchRefs.Contains(cachedRef.Name) {
+		if actualRemoteRefsSet.Contains(cachedRef.Name) {
 			skippedRefs = append(skippedRefs, "^"+cachedRef.Sha)
 		}
 	}

--- a/lfs/gitscanner_remotes.go
+++ b/lfs/gitscanner_remotes.go
@@ -13,7 +13,7 @@ import (
 // remote, use a more explicit diff command.
 func calcSkippedRefs(remote string) []string {
 	cachedRemoteRefs, _ := git.CachedRemoteRefs(remote)
-	actualRemoteRefs, _ := git.RemoteRefs(remote)
+	actualRemoteRefs, _ := git.RemoteRefs(remote, true)
 
 	// The set of remote refs can be very large. Since CachedRemoteRefs only
 	// returns branches, filter the remote refs and convert them to a set for

--- a/t/t-push.sh
+++ b/t/t-push.sh
@@ -874,6 +874,44 @@ begin_test 'push with multiple refs and data the server already has'
 )
 end_test
 
+begin_test 'push with multiple tag refs'
+(
+  set -e
+
+  reponame="push-multi-ref-tags"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  contents="abc123"
+  contents_oid="$(calc_oid "$contents")"
+  printf "%s" "$contents" > a.dat
+  git add a.dat
+  git commit -m "add a.dat"
+
+  git tag v1.0.0
+
+  git push origin main v1.0.0
+
+  assert_server_object "$reponame" "$contents_oid"
+
+  contents2="def456"
+  contents2_oid="$(calc_oid "$contents2")"
+  printf "%s" "$contents2" > b.dat
+  git add b.dat
+  git commit -m "add b.dat"
+
+  git tag v1.0.1
+
+  git lfs push origin v1.0.1
+
+  assert_server_object "$reponame" "$contents2_oid"
+)
+end_test
+
 begin_test "push custom reference"
 (
   set -e


### PR DESCRIPTION
Fixes #5848.

Improves the performance of git lfs pre-push particularly for large repositories with numerous tags.

Previously, the pre-push hook would execute 'git ls-remote' with both --heads and --tags flags, which could be slow in repositories with many tags.

Tags can be omitted for pre-push however.