### PR TITLE
Always build Git against custom libcurl in CI workflows on macOS

### DIFF
--- a/script/build-git
+++ b/script/build-git
@@ -5,7 +5,8 @@ DIR="$1"
 case $(uname -s) in
   Darwin)
     brew install curl zlib pcre2 openssl
-    brew link --force curl zlib pcre2 openssl;;
+    brew link --force curl zlib pcre2 openssl
+    CURLDIR="$(curl-config --prefix)";;
   Linux)
     export DEBIAN_FRONTEND=noninteractive
     sed -e 's/^deb/deb-src/' /etc/apt/sources.list | sudo tee /etc/apt/sources.list.d/src.list
@@ -22,6 +23,11 @@ printf "%s\n" \
   "NO_OPENSSL=YesPlease" \
   "prefix=$GIT_INSTALL_PATH" \
   > config.mak
+if test -n "$CURLDIR"; then
+  printf "%s\n" \
+    "CURLDIR=$CURLDIR" \
+    >> config.mak
+fi
 make -j2
 sudo make install
 


### PR DESCRIPTION
This PR resolves a problem which is causing our `Build with earliest Git` CI [jobs](https://github.com/git-lfs/git-lfs/blob/fc61febe9cc2d9ddc6ffe3e8d1ae546512632552/.github/workflows/ci.yml#L152-L175) to [fail](https://github.com/chrisd8088/git-lfs/actions/runs/10859593753/job/30144599507) at present on macOS.  The failures are due to a regression in the system-installed version 8.7.1 of libcurl currently available on macOS.

We therefore revise our scripts to ensure we build Git so it links against the newer version of libcurl we [install](https://github.com/git-lfs/git-lfs/blob/fc61febe9cc2d9ddc6ffe3e8d1ae546512632552/script/build-git#L6-L8) with Homebrew.  The regression in the 8.7.x versions of libcurl is described in curl/curl#13229 and affects programs such as `git-http-push(1)` and `git-http-backend(1)`, which are utilized by our `lfstest-gitserver` test utility.

#### Details

The `does not look in current directory for git with credential helper` [test](https://github.com/git-lfs/git-lfs/blob/fc61febe9cc2d9ddc6ffe3e8d1ae546512632552/t/t-path.sh#L27-L147) in our `t/t-path.sh` test script [commits](https://github.com/git-lfs/git-lfs/blob/fc61febe9cc2d9ddc6ffe3e8d1ae546512632552/t/t-path.sh#L81-L86) a compiled Go binary file to a Git repository and tries to [push](https://github.com/git-lfs/git-lfs/blob/fc61febe9cc2d9ddc6ffe3e8d1ae546512632552/t/t-path.sh#L87) it, and when our `lfstest-gitserver` program [passes](https://github.com/git-lfs/git-lfs/blob/fc61febe9cc2d9ddc6ffe3e8d1ae546512632552/t/cmd/lfstest-gitserver.go#L984-L1005) the HTTP `POST` request body on the `git-http-backend` program, the large binary data in the request body includes byte sequences which just happen to trigger the bug in libcurl, resulting in a Git push failure and a test failure.

The reason this problem only affects our `Build with earliest Git` CI job is that as of commit git/git@23c4bbe28e61974577164db09cbd1d1c7e568ca4, which was included in Git version 2.20.0, Git's own `Makefile` uses the output of `curl-config --libs` to [populate](https://github.com/git/git/blob/23c4bbe28e61974577164db09cbd1d1c7e568ca4/Makefile#L1321) its `CURL_LIBCURL` variable, and on our GitHub Actions macOS runners, the Homebrew-installed version of `curl-config` is found first in `PATH`.  Therefore that version of `curl-config` is run, and since it returns linker arguments referencing the corresponding `libcurl.4.dylib` dynamic library, in the majority of our CI jobs all the Git programs which utilize libcurl are linked against the newer libcurl library.

However, we [build](https://github.com/git-lfs/git-lfs/blob/fc61febe9cc2d9ddc6ffe3e8d1ae546512632552/.github/workflows/ci.yml#L167) Git version 2.0.0 in our `Build with earliest Git` CI job, and in its `Makefile`, the `CURL_LIBCURL` variable is simply [set](https://github.com/git/git/blob/v2.0.0/Makefile#L1125) to `-lcurl` (unless `CURLDIR` is defined).  As a result, the default version of libcurl in `/usr/lib` is linked into Git's programs, rather than the one installed under Homebrew's paths.

To resolve this problem and avoid similar ones in the future, we revise our `script/build-git` script to set the `CURLDIR` variable with the output of `curl-config --prefix` when running on macOS, and then include `CURLDIR` in the `Makefile` configuration we use to build our custom Git.  This works with both old and new versions of Git, since when `CURLDIR` is defined, its value is [used](https://github.com/git/git/blob/v2.0.0/Makefile#L1120-L1123) to set an appropriate path for the `-L` linker argument, ensuring that our custom Git is built against the Homebrew-installed libcurl dynamic library.

Further details are provided in the description of the sole commit in this PR.

#### Expected and Unrelated CI Failures

Note that we expect our `Build with specific Go` CI [job](https://github.com/git-lfs/git-lfs/blob/fc61febe9cc2d9ddc6ffe3e8d1ae546512632552/.github/workflows/ci.yml#L46-L61) to fail at the moment, due to the recent release of Go version 1.23.  We [install](https://github.com/git-lfs/git-lfs/blob/fc61febe9cc2d9ddc6ffe3e8d1ae546512632552/script/cibuild#L21) the latest version of the `goimports` package, and the installation [fails](https://github.com/chrisd8088/git-lfs/actions/runs/10859593753/job/30144599569) in the `Build with specific Go` CI job because the `x/tools` module requires Go 1.22 as of commit golang/tools@70f56264139c00af8ea420899cdb440c32b5599e, and we are still [using](https://github.com/git-lfs/git-lfs/blob/fc61febe9cc2d9ddc6ffe3e8d1ae546512632552/.github/workflows/ci.yml#L50) Go 1.21 for that CI job.  We will address this issue in a subsequent PR.