### PR TITLE
Use custom random data generator for all test objects and filenames

### DIFF
--- a/t/Makefile
+++ b/t/Makefile
@@ -25,6 +25,7 @@ TEST_CMDS += ../bin/lfs-ssh-proxy-test$X
 TEST_CMDS += ../bin/lfstest-badpathcheck$X
 TEST_CMDS += ../bin/lfstest-count-tests$X
 TEST_CMDS += ../bin/lfstest-customadapter$X
+TEST_CMDS += ../bin/lfstest-genrandom$X
 TEST_CMDS += ../bin/lfstest-gitserver$X
 TEST_CMDS += ../bin/lfstest-nanomtime$X
 TEST_CMDS += ../bin/lfstest-realpath$X

--- a/t/cmd/lfstest-genrandom.go
+++ b/t/cmd/lfstest-genrandom.go
@@ -1,0 +1,72 @@
+//go:build testtools
+// +build testtools
+
+package main
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"strconv"
+)
+
+const usageFmt = "Usage: %s [--base64|--base64url] [<size>]\n"
+
+func main() {
+	offset := 1
+	b64 := false
+	b64url := false
+	if len(os.Args) > offset && (os.Args[offset] == "--base64" || os.Args[offset] == "--base64url") {
+		b64 = true
+		b64url = os.Args[offset] == "--base64url"
+		offset += 1
+	}
+
+	if len(os.Args) > offset+1 {
+		fmt.Fprintf(os.Stderr, usageFmt, os.Args[0])
+		os.Exit(2)
+	}
+
+	var count uint64 = ^uint64(0)
+	if len(os.Args) == offset+1 {
+		var err error
+		if count, err = strconv.ParseUint(os.Args[offset], 10, 64); err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading size: %s, %v\n", os.Args[offset], err)
+			os.Exit(3)
+		}
+	}
+
+	b := make([]byte, 32)
+	bb := make([]byte, max(base64.RawStdEncoding.EncodedLen(len(b)), base64.RawURLEncoding.EncodedLen(len(b))))
+	for count > 0 {
+		n, err := rand.Read(b)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading random bytes: %v\n", err)
+			os.Exit(4)
+		}
+		if b64 {
+			if b64url {
+				base64.RawURLEncoding.Encode(bb, b[:n])
+				n = base64.RawURLEncoding.EncodedLen(n)
+			} else {
+				base64.RawStdEncoding.Encode(bb, b[:n])
+				n = base64.RawStdEncoding.EncodedLen(n)
+			}
+		}
+
+		num := min(uint64(n), count)
+		if b64 {
+			err = binary.Write(os.Stdout, binary.LittleEndian, bb[:num])
+		} else {
+			err = binary.Write(os.Stdout, binary.LittleEndian, b[:num])
+		}
+
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error writing random bytes: %v\n", err)
+			os.Exit(5)
+		}
+		count -= num
+	}
+}

--- a/t/fixtures/migrate.sh
+++ b/t/fixtures/migrate.sh
@@ -37,7 +37,7 @@ setup_local_branch_with_gitattrs() {
 
   remove_and_create_local_repo "$reponame"
 
-  base64 < /dev/urandom | head -c 120 > a.txt
+  lfstest-genrandom --base64 120 >a.txt
 
   git add a.txt
   git commit -m "initial commit"
@@ -77,9 +77,9 @@ setup_local_branch_with_nested_gitattrs() {
 
   mkdir b
 
-  base64 < /dev/urandom | head -c 120 > a.txt
-  base64 < /dev/urandom | head -c 140 > a.md
-  base64 < /dev/urandom | head -c 140 > b/a.md
+  lfstest-genrandom --base64 120 >a.txt
+  lfstest-genrandom --base64 140 >a.md
+  lfstest-genrandom --base64 140 >b/a.md
 
   git add a.txt a.md b/a.md
   git commit -m "initial commit"
@@ -118,8 +118,8 @@ setup_single_local_branch_untracked() {
 
   git commit --allow-empty -m "initial commit"
 
-  base64 < /dev/urandom | head -c 120 > a.txt
-  base64 < /dev/urandom | head -c 140 > "$name"
+  lfstest-genrandom --base64 120 >a.txt
+  lfstest-genrandom --base64 140 >"$name"
 
   git add a.txt "$name"
   git commit -m "add a.txt and $name"
@@ -155,8 +155,8 @@ setup_single_local_branch_tracked() {
   git add .gitattributes
   git commit -m "initial commit"
 
-  base64 < /dev/urandom | head -c 120 > a.txt
-  base64 < /dev/urandom | head -c 140 > a.md
+  lfstest-genrandom --base64 120 >a.txt
+  lfstest-genrandom --base64 140 >a.md
 
   git add a.txt a.md
   git commit -m "add a.{txt,md}"
@@ -226,7 +226,7 @@ setup_single_local_branch_tracked_corrupt() {
 
   git lfs uninstall
 
-  base64 < /dev/urandom | head -c 120 > a.txt
+  lfstest-genrandom --base64 120 >a.txt
 
   if [[ $1 == "lfsmacro" ]]; then
     printf '[attr]lfs filter=lfs diff=lfs merge=lfs -text\n*.txt lfs\n' \
@@ -268,15 +268,15 @@ setup_multiple_local_branches() {
 
   remove_and_create_local_repo "$reponame"
 
-  base64 < /dev/urandom | head -c 120 > a.txt
-  base64 < /dev/urandom | head -c 140 > a.md
+  lfstest-genrandom --base64 120 >a.txt
+  lfstest-genrandom --base64 140 >a.md
 
   git add a.txt a.md
   git commit -m "initial commit"
 
   git checkout -b my-feature
 
-  base64 < /dev/urandom | head -c 30 > a.md
+  lfstest-genrandom --base64 30 >a.md
 
   git add a.md
   git commit -m "add an additional 30 bytes to a.md"
@@ -293,16 +293,16 @@ setup_multiple_local_branches_with_alternate_names() {
 
   remove_and_create_local_repo "$reponame"
 
-  base64 < /dev/urandom | head -c 120 > no_extension
-  base64 < /dev/urandom | head -c 140 > a.txt
+  lfstest-genrandom --base64 120 >no_extension
+  lfstest-genrandom --base64 140 >a.txt
 
   git add no_extension a.txt
   git commit -m "initial commit"
 
   git checkout -b my-feature
 
-  base64 < /dev/urandom | head -c 30 > a.txt
-  base64 < /dev/urandom | head -c 100 > no_extension
+  lfstest-genrandom --base64 30 >a.txt
+  lfstest-genrandom --base64 100 >no_extension
 
   git add no_extension a.txt
   git commit -m "add an additional 30 bytes to a.txt"
@@ -363,15 +363,15 @@ setup_multiple_local_branches_tracked() {
   git add .gitattributes
   git commit -m "initial commit"
 
-  base64 < /dev/urandom | head -c 120 > a.txt
-  base64 < /dev/urandom | head -c 140 > a.md
+  lfstest-genrandom --base64 120 >a.txt
+  lfstest-genrandom --base64 140 >a.md
 
   git add a.txt a.md
   git commit -m "add a.{txt,md}"
 
   git checkout -b my-feature
 
-  base64 < /dev/urandom | head -c 30 > a.md
+  lfstest-genrandom --base64 30 >a.md
 
   git add a.md
   git commit -m "add an additional 30 bytes to a.md"
@@ -394,7 +394,7 @@ setup_local_branch_with_space() {
 
   remove_and_create_local_repo "$reponame"
 
-  base64 < /dev/urandom | head -c 50 > "$filename"
+  lfstest-genrandom --base64 50 >"$filename"
 
   git add "$filename"
   git commit -m "initial commit"
@@ -419,16 +419,16 @@ setup_single_remote_branch() {
 
   remove_and_create_remote_repo "$reponame"
 
-  base64 < /dev/urandom | head -c 120 > a.txt
-  base64 < /dev/urandom | head -c 140 > a.md
+  lfstest-genrandom --base64 120 >a.txt
+  lfstest-genrandom --base64 140 >a.md
 
   git add a.txt a.md
   git commit -m "initial commit"
 
   git push origin main
 
-  base64 < /dev/urandom | head -c 30 > a.txt
-  base64 < /dev/urandom | head -c 50 > a.md
+  lfstest-genrandom --base64 30 >a.txt
+  lfstest-genrandom --base64 50 >a.md
 
   git add a.md a.txt
   git commit -m "add an additional 30, 50 bytes to a.{txt,md}"
@@ -459,16 +459,16 @@ setup_single_remote_branch_tracked() {
   git add .gitattributes
   git commit -m "initial commit"
 
-  base64 < /dev/urandom | head -c 120 > a.txt
-  base64 < /dev/urandom | head -c 140 > a.md
+  lfstest-genrandom --base64 120 >a.txt
+  lfstest-genrandom --base64 140 >a.md
 
   git add a.txt a.md
   git commit -m "add a.{txt,md}"
 
   git push origin main
 
-  base64 < /dev/urandom | head -c 30 > a.txt
-  base64 < /dev/urandom | head -c 50 > a.md
+  lfstest-genrandom --base64 30 >a.txt
+  lfstest-genrandom --base64 50 >a.md
 
   git add a.md a.txt
   git commit -m "add an additional 30, 50 bytes to a.{txt,md}"
@@ -498,22 +498,22 @@ setup_multiple_remote_branches() {
 
   remove_and_create_remote_repo "$reponame"
 
-  base64 < /dev/urandom | head -c 10 > a.txt
-  base64 < /dev/urandom | head -c 11 > a.md
+  lfstest-genrandom --base64 10 >a.txt
+  lfstest-genrandom --base64 11 >a.md
   git add a.txt a.md
   git commit -m "add 10, 11 bytes, a.{txt,md}"
 
   git push origin main
 
-  base64 < /dev/urandom | head -c 20 > a.txt
-  base64 < /dev/urandom | head -c 21 > a.md
+  lfstest-genrandom --base64 20 >a.txt
+  lfstest-genrandom --base64 21 >a.md
   git add a.txt a.md
   git commit -m "add 20, 21 bytes, a.{txt,md}"
 
   git checkout -b my-feature
 
-  base64 < /dev/urandom | head -c 30 > a.txt
-  base64 < /dev/urandom | head -c 31 > a.md
+  lfstest-genrandom --base64 30 >a.txt
+  lfstest-genrandom --base64 31 >a.md
   git add a.txt a.md
   git commit -m "add 30, 31 bytes, a.{txt,md}"
 
@@ -533,22 +533,22 @@ setup_multiple_remote_branches_gitattrs() {
   git add .gitattributes
   git commit -m "initial commit"
 
-  base64 < /dev/urandom | head -c 10 > a.txt
-  base64 < /dev/urandom | head -c 11 > a.md
+  lfstest-genrandom --base64 10 >a.txt
+  lfstest-genrandom --base64 11 >a.md
   git add a.txt a.md
   git commit -m "add 10, 11 bytes, a.{txt,md}"
 
   git push origin main
 
-  base64 < /dev/urandom | head -c 20 > a.txt
-  base64 < /dev/urandom | head -c 21 > a.md
+  lfstest-genrandom --base64 20 >a.txt
+  lfstest-genrandom --base64 21 >a.md
   git add a.txt a.md
   git commit -m "add 20, 21 bytes, a.{txt,md}"
 
   git checkout -b my-feature
 
-  base64 < /dev/urandom | head -c 30 > a.txt
-  base64 < /dev/urandom | head -c 31 > a.md
+  lfstest-genrandom --base64 30 >a.txt
+  lfstest-genrandom --base64 31 >a.md
   git add a.txt a.md
   git commit -m "add 30, 31 bytes, a.{txt,md}"
 
@@ -573,12 +573,12 @@ setup_single_local_branch_with_tags() {
 
   remove_and_create_local_repo "$reponame"
 
-  base64 < /dev/urandom | head -c 1 > a.txt
+  lfstest-genrandom --base64 1 >a.txt
 
   git add a.txt
   git commit -m "initial commit"
 
-  base64 < /dev/urandom | head -c 2 > a.txt
+  lfstest-genrandom --base64 2 >a.txt
 
   git add a.txt
   git commit -m "secondary commit"
@@ -604,12 +604,12 @@ setup_single_local_branch_with_annotated_tags() {
 
   remove_and_create_local_repo "$reponame"
 
-  base64 < /dev/urandom | head -c 1 > a.txt
+  lfstest-genrandom --base64 1 >a.txt
 
   git add a.txt
   git commit -m "initial commit"
 
-  base64 < /dev/urandom | head -c 2 > a.txt
+  lfstest-genrandom --base64 2 >a.txt
 
   git add a.txt
   git commit -m "secondary commit"
@@ -630,12 +630,12 @@ setup_multiple_remotes() {
 
   git remote add fork "$GITSERVER/$forkname"
 
-  base64 < /dev/urandom | head -c 16 > a.txt
+  lfstest-genrandom --base64 16 >a.txt
   git add a.txt
   git commit -m "initial commit"
   git push origin main
 
-  base64 < /dev/urandom | head -c 16 > a.txt
+  lfstest-genrandom --base64 16 >a.txt
   git add a.txt
   git commit -m "another commit"
   git push fork main
@@ -655,7 +655,7 @@ setup_single_local_branch_deep_trees() {
   remove_and_create_local_repo "$reponame"
 
   mkdir -p foo/bar/baz
-  base64 < /dev/urandom | head -c 120 > foo/bar/baz/a.txt
+  lfstest-genrandom --base64 120 >foo/bar/baz/a.txt
 
   git add foo/bar/baz/a.txt
   git commit -m "initial commit"
@@ -676,10 +676,10 @@ setup_single_local_branch_same_file_tree_ext() {
   remove_and_create_local_repo "$reponame"
 
   mkdir -p foo bar.txt
-  base64 < /dev/urandom | head -c 120 > a.txt
-  base64 < /dev/urandom | head -c 120 > foo/a.txt
-  base64 < /dev/urandom | head -c 120 > bar.txt/b.md
-  base64 < /dev/urandom | head -c 120 > bar.txt/b.txt
+  lfstest-genrandom --base64 120 >a.txt
+  lfstest-genrandom --base64 120 >foo/a.txt
+  lfstest-genrandom --base64 120 >bar.txt/b.md
+  lfstest-genrandom --base64 120 >bar.txt/b.txt
 
   git add a.txt foo bar.txt
   git commit -m "initial commit"
@@ -699,7 +699,7 @@ setup_local_branch_with_symlink() {
 
   remove_and_create_local_repo "$reponame"
 
-  base64 < /dev/urandom | head -c 120 > a.txt
+  lfstest-genrandom --base64 120 >a.txt
 
   git add a.txt
   git commit -m "initial commit"
@@ -765,10 +765,10 @@ setup_local_branch_with_special_character_files() {
   reponame="migrate-single-local-branch-with-special-filenames"
   remove_and_create_local_repo "$reponame"
 
-  head -c 80 /dev/urandom > './test - special.bin'
-  head -c 100 /dev/urandom > './test (test2) special.bin'
+  lfstest-genrandom 80 >'./test - special.bin'
+  lfstest-genrandom 100 >'./test (test2) special.bin'
   # Windows does not allow creation of files with '*'
-  [ "$IS_WINDOWS" -eq '1' ] || head -c 120 /dev/urandom > './test * ** special.bin'
+  [ "$IS_WINDOWS" -eq '1' ] || lfstest-genrandom 120 >'./test * ** special.bin'
 
   git add *.bin
   git commit -m "initial commit"
@@ -793,7 +793,7 @@ make_bare() {
 #
 #   remove_and_create_local_repo "$reponame"
 remove_and_create_local_repo() {
-  local reponame="$(base64 < /dev/urandom | head -c 8 | $SHASUM | cut -f 1 -d ' ')-$1"
+  local reponame="$1-$(lfstest-genrandom --base64url 32)"
 
   git init "$reponame"
   cd "$reponame"
@@ -804,7 +804,7 @@ remove_and_create_local_repo() {
 #
 #   remove_and_create_remote_repo "$reponame"
 remove_and_create_remote_repo() {
-  local reponame="$(base64 < /dev/urandom | head -c 8 | $SHASUM | cut -f 1 -d ' ')-$1"
+  local reponame="$1-$(lfstest-genrandom --base64url 32)"
 
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"

--- a/t/t-clean.sh
+++ b/t/t-clean.sh
@@ -67,8 +67,8 @@ begin_test "clean stdin"
   git init "$reponame"
   cd "$reponame"
 
-  base64 < /dev/urandom | head -c 1024 > small.dat
-  base64 < /dev/urandom | head -c 2048 > large.dat
+  lfstest-genrandom --base64 1024 >small.dat
+  lfstest-genrandom --base64 2048 >large.dat
 
   expected_small="$(calc_oid_file "small.dat")"
   expected_large="$(calc_oid_file "large.dat")"

--- a/t/t-fsck.sh
+++ b/t/t-fsck.sh
@@ -142,7 +142,7 @@ create_invalid_pointers() {
   ext="${2:-dat}"
 
   git cat-file blob ":$valid" | awk '{ sub(/$/, "\r"); print }' >"crlf.$ext"
-  base64 < /dev/urandom | head -c 1025 >"large.$ext"
+  lfstest-genrandom --base64 1025 >"large.$ext"
   git \
     -c "filter.lfs.process=" \
     -c "filter.lfs.clean=cat" \

--- a/t/t-malformed-pointers.sh
+++ b/t/t-malformed-pointers.sh
@@ -14,10 +14,10 @@ begin_test "malformed pointers"
   git add .gitattributes
   git commit -m "initial commit"
 
-  base64 < /dev/urandom | head -c 1023 > malformed_small.dat
-  base64 < /dev/urandom | head -c 1024 > malformed_exact.dat
-  base64 < /dev/urandom | head -c 1025 > malformed_large.dat
-  base64 < /dev/urandom | head -c 1048576 > malformed_xxl.dat
+  lfstest-genrandom --base64 1023 >malformed_small.dat
+  lfstest-genrandom --base64 1024 >malformed_exact.dat
+  lfstest-genrandom --base64 1025 >malformed_large.dat
+  lfstest-genrandom --base64 1048576 >malformed_xxl.dat
 
   git \
     -c "filter.lfs.process=" \

--- a/t/t-migrate-export.sh
+++ b/t/t-migrate-export.sh
@@ -455,7 +455,8 @@ begin_test "migrate export (--object-map)"
 
   setup_multiple_local_branches_tracked
 
-  output_dir=$(mktemp -d)
+  output_dir="$GIT_LFS_TEST_DIR/export-object-map-$(lfstest-genrandom --base64url 32)"
+  mkdir -p "$output_dir"
 
   git log --all --pretty='format:%H' > "${output_dir}/old_sha.txt"
   git lfs migrate export --everything --include="*" --object-map "${output_dir}/object-map.txt"

--- a/t/t-migrate-export.sh
+++ b/t/t-migrate-export.sh
@@ -10,7 +10,7 @@ begin_test "migrate export (default branch)"
   setup_multiple_local_branches_tracked
 
   # Add b.md, a pointer existing only on main
-  base64 < /dev/urandom | head -c 160 > b.md
+  lfstest-genrandom --base64 160 >b.md
   git add b.md
   git commit -m "add b.md"
 

--- a/t/t-migrate-fixup.sh
+++ b/t/t-migrate-fixup.sh
@@ -109,7 +109,7 @@ begin_test "migrate import (--fixup with remote tags)"
 
   git lfs uninstall
 
-  base64 < /dev/urandom | head -c 120 > b.txt
+  lfstest-genrandom --base64 120 >b.txt
   git add b.txt
   git commit -m "b.txt"
 
@@ -220,7 +220,7 @@ begin_test "migrate import (no potential fixup, --fixup, .gitattributes with mac
   setup_multiple_local_branches
 
   echo "[attr]foo foo" >.gitattributes
-  base64 < /dev/urandom | head -c 30 > a.md
+  lfstest-genrandom --base64 30 >a.md
   git add .gitattributes a.md
   git commit -m macro
 

--- a/t/t-migrate-import.sh
+++ b/t/t-migrate-import.sh
@@ -935,7 +935,8 @@ begin_test "migrate import (--object-map)"
 
   setup_multiple_local_branches
 
-  output_dir=$(mktemp -d)
+  output_dir="$GIT_LFS_TEST_DIR/import-object-map-$(lfstest-genrandom --base64url 32)"
+  mkdir -p "$output_dir"
 
   git log --all --pretty='format:%H' > "${output_dir}/old_sha.txt"
   git lfs migrate import --everything --object-map "${output_dir}/object-map.txt"

--- a/t/t-migrate-info.sh
+++ b/t/t-migrate-info.sh
@@ -293,7 +293,7 @@ begin_test "migrate info (above threshold, top)"
 
   setup_multiple_local_branches
 
-  base64 < /dev/urandom | head -c 160 > b.bin
+  lfstest-genrandom --base64 160 >b.bin
   git add b.bin
   git commit -m "b.bin"
 
@@ -316,7 +316,7 @@ begin_test "migrate info (top)"
 
   setup_multiple_local_branches
 
-  base64 < /dev/urandom | head -c 160 > b.bin
+  lfstest-genrandom --base64 160 >b.bin
   git add b.bin
   git commit -m "b.bin"
 
@@ -518,7 +518,7 @@ begin_test "migrate info (no potential fixup, --fixup, .gitattributes with macro
   setup_multiple_local_branches
 
   echo "[attr]foo foo" >.gitattributes
-  base64 < /dev/urandom | head -c 30 > a.md
+  lfstest-genrandom --base64 30 >a.md
   git add .gitattributes a.md
   git commit -m macro
 

--- a/t/t-prune.sh
+++ b/t/t-prune.sh
@@ -695,7 +695,8 @@ begin_test "prune verify large numbers of refs"
 
   content_head="HEAD content"
   content_commit1="Recent commit"
-  content_oldcommit="Old content"
+  content_oldcommit1="Old content $(lfstest-genrandom --base64 40)"
+  content_oldcommit2="Old content $(lfstest-genrandom --base64 40)"
   oid_head=$(calc_oid "$content_head")
 
   # Add two recent commits that should not be pruned
@@ -703,12 +704,12 @@ begin_test "prune verify large numbers of refs"
   {
     \"CommitDate\":\"$(get_date -50d)\",
     \"Files\":[
-      {\"Filename\":\"file.dat\",\"Size\":${#content_oldcommit}, \"Data\":\"$(uuidgen)\"}]
+      {\"Filename\":\"file.dat\",\"Size\":${#content_oldcommit1}, \"Data\":\"$content_oldcommit1\"}]
   },
   {
     \"CommitDate\":\"$(get_date -45d)\",
     \"Files\":[
-      {\"Filename\":\"file.dat\",\"Size\":${#content_oldcommit}, \"Data\":\"$(uuidgen)\"}]
+      {\"Filename\":\"file.dat\",\"Size\":${#content_oldcommit2}, \"Data\":\"$content_oldcommit2\"}]
   },
   {
     \"CommitDate\":\"$(get_date -2d)\",
@@ -740,7 +741,6 @@ begin_test "prune verify large numbers of refs"
 
   # confirm that prune does not hang
   git lfs prune --dry-run --verify-remote --verbose 2>&1 | tee prune.log
-
 )
 end_test
 

--- a/t/t-smudge.sh
+++ b/t/t-smudge.sh
@@ -56,7 +56,7 @@ begin_test "smudge with invalid pointer"
   [ "version " = "$(echo "version " | git lfs smudge)" ]
 
   # force use of a spool file with non-pointer input longer than max buffer
-  spool="$(base64 < /dev/urandom | head -c 2048)"
+  spool="$(lfstest-genrandom --base64 2048)"
   [ "$spool" = "$(echo "$spool" | git lfs smudge)" ]
 )
 end_test

--- a/t/testenv.sh
+++ b/t/testenv.sh
@@ -77,7 +77,12 @@ BINPATH="$ROOTDIR/bin"
 PATH="$BINPATH:$PATH"
 
 # Always provide a test dir outside our git repo if not specified
-TEMPDIR_PREFIX="git-lfs_TEMP.XXXXXX"
+if [ "$IS_MAC" -eq 1 ]; then
+  TEMPDIR_PREFIX="git-lfs_TEMP"
+else
+  TEMPDIR_PREFIX="git-lfs_TEMP.XXXXXX"
+fi
+
 if [ -z "$GIT_LFS_TEST_DIR" ]; then
     GIT_LFS_TEST_DIR=$(mktemp -d -t "$TEMPDIR_PREFIX")
     GIT_LFS_TEST_DIR=$(resolve_symlink $GIT_LFS_TEST_DIR)


### PR DESCRIPTION
For the past several months our CI test suite has experienced intermittent failures when running on Windows, which are caused when no data is returned from the simulated `/dev/urandom` special file in Git Bash.

While the cause of this regression in the Git Bash/MSYS2 environment is unclear, to avoid this and any similar issues in the future, we introduce a new test helper program named `lfstest-genrandom`, and then use it to generate the contents of all the test files we need throughout our test suite.

Further, we make use of this new utility to generate random filenames and directory names, which permits us to replace calls to `mktemp(1)` and `uuidgen(1)` (which doesn't exist in Git Bash) in a number of our tests.

Each commit in this PR has a detailed description; however, it should also be possible to review this PR as a single patch diff.

#### CI Failures on Windows

In the most recent CI job [run](https://github.com/git-lfs/git-lfs/actions/runs/10909284461/job/30277149886) from the merge of PR #5866 earlier this week, we can see the consequences when `/dev/urandom` does not return any data.

As one example among many other test failures, the `clean stdin` [test](https://github.com/git-lfs/git-lfs/blob/17aaf6fbea3c2d9af5e429592a19c7dab2d7e1a8/t/t-clean.sh#L60-L89) in our `t/t-clean.sh` test script does not succeed.  The test [creates](https://github.com/git-lfs/git-lfs/blob/17aaf6fbea3c2d9af5e429592a19c7dab2d7e1a8/t/t-clean.sh#L70-L71) two files filled with data from `/dev/urandom` and [calculates](https://github.com/git-lfs/git-lfs/blob/17aaf6fbea3c2d9af5e429592a19c7dab2d7e1a8/t/t-clean.sh#L73-L74) their Git LFS OIDs.  In the error log from the failed test, we can see these OIDs were both `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`, which is the SHA-256 hash of an empty string.  When the test then [runs](https://github.com/git-lfs/git-lfs/blob/17aaf6fbea3c2d9af5e429592a19c7dab2d7e1a8/t/t-clean.sh#L76-L77) `git lfs clean` on the files, that command produces no output (which is expected in the case of zero-byte input files), so when the test [compares](https://github.com/git-lfs/git-lfs/blob/17aaf6fbea3c2d9af5e429592a19c7dab2d7e1a8/t/t-clean.sh#L79-L87) the OIDs to the output of `git lfs clean`, they don't match and the test fails.

<details><summary>stderr log</summary>

```
# -- stderr --
#     + set -e
#     + reponame=clean-over-stdin
#     + git init clean-over-stdin
#     + cd clean-over-stdin
#     + base64
#     + head -c 1024
#     + base64
#     + head -c 2048
#     ++ calc_oid_file small.dat
#     ++ sha256sum small.dat
#     ++ cut -f 1 -d ' '
#     + expected_small=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
#     ++ calc_oid_file large.dat
#     ++ sha256sum large.dat
#     ++ cut -f 1 -d ' '
#     + expected_large=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
#     ++ git lfs clean
#     ++ grep oid
#     ++ cut -d : -f 2
#     + actual_small=
#     ++ git lfs clean
#     ++ grep oid
#     ++ cut -d : -f 2
#     + actual_large=
#     + '[' e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 '!=' '' ']'
#     + echo 'fatal: expected small OID of: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855, got: '
#     fatal: expected small OID of: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855, got: 
#     + exit 1
#     + test_status=1
```
</details>

#### New Test Helper Program

Our new `lfstest-genrandom` program takes an optional command-line argument specifying the number of random bytes to return, as well as optional `--base64` or `--base64url` flag arguments.

When no size argument is provided, the program returns an effectively endless stream of random data, following the [model](https://github.com/git/git/blob/a7dae3bdc8b516d36f630b12bb01e853a667e0d9/t/helper/test-genrandom.c#L25) of the `test-genrandom` helper program in the Git test suite.  Otherwise the program returns exactly the specified number of bytes of random data.

When the `--base64` argument is given, the output is encoded in regular Base64, as [defined](https://datatracker.ietf.org/doc/html/rfc4648#section-4) by RFC 4648, including `/` and `+` characters.  If the `--base64url` argument is used instead, the output is encoded in the alternate Base64 encoding format [defined](https://datatracker.ietf.org/doc/html/rfc4648#section-5) in RFC 4648, which uses the `-` and `_` characters.  In both cases, no Base64 [padding](https://datatracker.ietf.org/doc/html/rfc4648#section-3.2) is added, and if a size argument was provided, the output is truncated to the specified size after encoding, not before.

The program follows the example of several of our other test helper programs, such as `lfstest-realpath` and `lfstest-testutils`, in using distinct exit codes (specifically, the values 2 and above) for each error condition.

With this helper program available, we can then replace all our shell pipelines of the form `base64 < /dev/urandom | head -c 120 >foo.txt` with equivalents  like`lfstest-genrandom --base64 120 >foo.txt`.

We can also rewrite a handful of calls to `mktemp(1)` and `uuidgen(1)`, simplifying them and also ensuring we always use data of the expected length and type.

In particular, the `prune verify large numbers of refs` test in our `t/t-prune.sh` script [calls](https://github.com/git-lfs/git-lfs/blob/17aaf6fbea3c2d9af5e429592a19c7dab2d7e1a8/t/t-prune.sh#L706-L711) `uuidgen(1)` to create random Git LFS object data; however, that command is not available in the Git Bash environment on Windows, so in practice the test uses empty data.  While that test's success is not conditional on having valid Git LFS object data, having invalid data is not an ideal practice, and we can easily correct this issue now using the `lfstest-genrandom` program.

#### Temporary Directory Names

Both our `t/t-migrate-export.sh` and `t/t-migrate-import.sh` test scripts [make](https://github.com/git-lfs/git-lfs/blob/17aaf6fbea3c2d9af5e429592a19c7dab2d7e1a8/t/t-migrate-export.sh#L458) [calls](https://github.com/git-lfs/git-lfs/blob/17aaf6fbea3c2d9af5e429592a19c7dab2d7e1a8/t/t-migrate-import.sh#L938) to the `mktemp(1)` command to create temporary directories.  However, they do not remove these after the tests complete, in part because the directories are created outside of the location specified by our `GIT_LFS_TEST_DIR` variable (but see the notes below on this point).

We can replace these calls to `mktemp(1)` with the use of our `lfstest-genrandom` program and thus ensure the directories we create have paths which begin with the path stored in the `GIT_LFS_TEST_DIR` variable, so at least they will be removed if and when that directory is deleted.  Note, though, that due to the fact that we do not export that variable, and because each test script runs in its own shell session, each script [creates](https://github.com/git-lfs/git-lfs/blob/17aaf6fbea3c2d9af5e429592a19c7dab2d7e1a8/t/testenv.sh#L82) another temporary directory for its own private `GIT_LFS_TEST_DIR` variable.  Moreover, we do not consistently remove these directories after the test suites are run, as we never check or make use of the `yes` value we [store](https://github.com/git-lfs/git-lfs/blob/17aaf6fbea3c2d9af5e429592a19c7dab2d7e1a8/t/testenv.sh#L85) in the `RM_GIT_LFS_TEST_DIR` variable.  We expect to address both issues in subsequent PRs.

For now, one additional change we do make is to fix the path generated on macOS by our sole remaining [call](https://github.com/git-lfs/git-lfs/blob/17aaf6fbea3c2d9af5e429592a19c7dab2d7e1a8/t/testenv.sh#L82) to `mktemp(1)`.  On macOS, the BSD version of `mktemp(1)` treats the `X` characters in our directory name [template](https://github.com/git-lfs/git-lfs/blob/17aaf6fbea3c2d9af5e429592a19c7dab2d7e1a8/t/testenv.sh#L80) as literals, leading to names like `git-lfs_TEMP.XXXXXX.y3IwCMwm` instead of `git-lfs_TEMP.y3IwCMwm`.  (This version of the command treats the argument following the `-t` option as a prefix rather than a template, unlike the GNU version.)  So we simply set our `TEMPDIR_PREFIX` to `git-lfs_TEMP` on macOS, which ensures we are returned directory names of the form we intend, without spurious `X` characters.

#### Expected and Unrelated CI Failures

Note that we expect our `Build with specific Go` CI [job](https://github.com/git-lfs/git-lfs/blob/17aaf6fbea3c2d9af5e429592a19c7dab2d7e1a8/.github/workflows/ci.yml#L46-L61) to fail at the moment, due to the recent release of Go version 1.23.  We [install](https://github.com/git-lfs/git-lfs/blob/fc61febe9cc2d9ddc6ffe3e8d1ae546512632552/script/cibuild#L21) the latest version of the `goimports` package, and the installation [fails](https://github.com/git-lfs/git-lfs/actions/runs/10909284461/job/30277153013) in the `Build with specific Go` CI job because the `x/tools` module requires Go 1.22 as of commit golang/tools@70f56264139c00af8ea420899cdb440c32b5599e, and we are still [using](https://github.com/git-lfs/git-lfs/blob/17aaf6fbea3c2d9af5e429592a19c7dab2d7e1a8/.github/workflows/ci.yml#L50) Go 1.21 for that CI job.  We will address this issue in a subsequent PR.