### PR TITLE
Upgrade to Go 1.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        go: ['1.22.x']
+        go: ['1.23.x']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
     name: Build with specific Go
     strategy:
       matrix:
-        go: ['1.21.x']
+        go: ['1.22.x']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -76,7 +76,7 @@ jobs:
       # which does not honour the PATH we set to our built git-lfs binary.
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.22.x'
+        go-version: '1.23.x'
     - run: mkdir -p "$HOME/go/bin"
       shell: bash
     - run: set GOPATH=%HOME%\go
@@ -137,7 +137,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.22.x'
+        go-version: '1.23.x'
     - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
       if: ${{ github.ref_type == 'tag' }}
     - run: git clone -b master https://github.com/git/git.git "$HOME/git"
@@ -161,7 +161,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.22.x'
+        go-version: '1.23.x'
     - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
       if: ${{ github.ref_type == 'tag' }}
     - run: git clone -b v2.0.0 https://github.com/git/git.git "$HOME/git"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        go: ['1.22.x']
+        go: ['1.23.x']
     steps:
     - uses: actions/checkout@v4
       with:
@@ -104,7 +104,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        go: ['1.22.x']
+        go: ['1.23.x']
     steps:
     - uses: actions/checkout@v4
       with:
@@ -143,7 +143,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.22.x']
+        go: ['1.23.x']
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Go version 1.23 has been released, and because we aim to build and test Git LFS against only supported versions of Go, we upgrade our GitHub Actions CI workflows to test against Go versions 1.23 and 1.22.

This resolves a problem now seen in our `Build with specific Go` CI job, where we [install](https://github.com/git-lfs/git-lfs/blob/17aaf6fbea3c2d9af5e429592a19c7dab2d7e1a8/script/cibuild#L21) the latest version of the `goimports` package and it fails because the `x/tools` module requires Go 1.22 as of commit golang/tools@70f56264139c00af8ea420899cdb440c32b5599e, and we are still using Go 1.21 for that CI job.

After this PR is merged, we will revise the required set of jobs in our CI test suite, and also upgrade the version of Go [used](https://github.com/git-lfs/build-dockers/blob/6cf995fe0090ef10955e6a5a82c6fbddf0e304d7/build_dockers.bsh#L24) in the scripts and Dockerfiles in our `github/build-dockers` project in PR git-lfs/build-dockers#68.

The changes from this PR and PR git-lfs/build-dockers#68 have been tested successfully together using a full run of our CI suite in a private repository.