### PR TITLE
Update release workflow to use Windows Trusted Signing Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,13 +63,13 @@ jobs:
       shell: bash
       env:
         FORCE_LOCALIZE: true
-    - uses: azure/azure-code-signing-action@v0.3.1
+    - uses: azure/trusted-signing-action@v0.4.0
       with:
         azure-tenant-id: ${{ secrets.SPN_GIT_LFS_SIGNING_TENANT_ID }}
         azure-client-id: ${{ secrets.SPN_GIT_LFS_SIGNING_CLIENT_ID }}
         azure-client-secret: ${{ secrets.SPN_GIT_LFS_SIGNING }}
         endpoint: https://wus.codesigning.azure.net/
-        code-signing-account-name: GitHubInc
+        trusted-signing-account-name: GitHubInc
         certificate-profile-name: GitHubInc
         files-folder: ${{ github.workspace }}/tmp/stage1
         files-folder-filter: exe
@@ -78,13 +78,13 @@ jobs:
         timestamp-digest: SHA256
     - run: env -u TMPDIR make release-windows-stage-2
       shell: bash
-    - uses: azure/azure-code-signing-action@v0.3.1
+    - uses: azure/trusted-signing-action@v0.4.0
       with:
         azure-tenant-id: ${{ secrets.SPN_GIT_LFS_SIGNING_TENANT_ID }}
         azure-client-id: ${{ secrets.SPN_GIT_LFS_SIGNING_CLIENT_ID }}
         azure-client-secret: ${{ secrets.SPN_GIT_LFS_SIGNING }}
         endpoint: https://wus.codesigning.azure.net/
-        code-signing-account-name: GitHubInc
+        trusted-signing-account-name: GitHubInc
         certificate-profile-name: GitHubInc
         files-folder: ${{ github.workspace }}/tmp/stage2
         files-folder-filter: exe


### PR DESCRIPTION
The `azure/azure-code-signing-action` GitHub repository has been removed and replaced with the `azure/trusted-signing-action` repository, so we update our release GitHub Actions workflow to use the latest version of the new action.

This PR's changes have been tested with a successful run of our release workflow in a private repository.