### PR TITLE
fix: fix slice init length

### DIFF
--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -76,7 +76,7 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 		}
 
 		if len(args) > 1 {
-			refShas := make([]string, len(refs))
+			refShas := make([]string, 0, len(refs))
 			for _, ref := range refs {
 				refShas = append(refShas, ref.Sha)
 			}


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of  len(refs)  rather than initializing the length of this slice.