### PR TITLE
Run tests in parallel on Windows and always cleanup test directories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,6 @@ jobs:
       shell: bash
     - run: set GOPATH=%HOME%\go
     - run: choco install -y InnoSetup
-    - run: choco install -y strawberryperl
     - run: make man
       shell: bash
     - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" go install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,6 @@ jobs:
       shell: bash
     - run: set GOPATH=%HOME%\go
     - run: choco install -y InnoSetup
-    - run: choco install -y strawberryperl
     - run: choco install -y zip
     - run: choco install -y jq
     - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" go install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@latest

--- a/rpm/SPECS/git-lfs.spec
+++ b/rpm/SPECS/git-lfs.spec
@@ -71,7 +71,7 @@ export SKIPAPITESTCOMPILE=1
 
 pushd src/github.com/git-lfs/%{name}
   make test
-  make -C t PROVE_EXTRA_ARGS=-j4 test
+  make -C t PROVE_EXTRA_ARGS=-j9 test
 popd
 
 rm -rf ${GIT_LFS_TEST_DIR}

--- a/script/cibuild
+++ b/script/cibuild
@@ -10,7 +10,6 @@ if [[ $UNAME == MINGW* || $UNAME == MSYS* || $UNAME == CYGWIN* ]]; then
   X=".exe"
   WINDOWS=1
   export GIT_LFS_NO_TEST_COUNT=1
-  export GIT_LFS_LOCK_ACQUIRE_DISABLED=1
 fi
 
 # Build git-lfs-transfer from scutiger.

--- a/script/cibuild
+++ b/script/cibuild
@@ -9,7 +9,6 @@ X=""
 if [[ $UNAME == MINGW* || $UNAME == MSYS* || $UNAME == CYGWIN* ]]; then
   X=".exe"
   WINDOWS=1
-  export GIT_LFS_NO_TEST_COUNT=1
 fi
 
 # Build git-lfs-transfer from scutiger.

--- a/script/cibuild
+++ b/script/cibuild
@@ -30,12 +30,6 @@ GIT_TRACE=1 make GOIMPORTS="$GOIMPORTS" PKGS=git test
 pushd t >/dev/null
   PROVE="prove"
   PROVE_EXTRA_ARGS="-j9"
-  if [ "$WINDOWS" ]; then
-    export PATH="/c/Strawberry/perl/bin:.:$PATH"
-    PROVE="prove.bat"
-    PROVE_EXTRA_ARGS="$PROVE_EXTRA_ARGS --exec bash"
-  fi
-
   VERBOSE_LOGS=1 make X="$X" clean
   VERBOSE_LOGS=1 make X="$X" PROVE="$PROVE" PROVE_EXTRA_ARGS="$PROVE_EXTRA_ARGS"
 popd >/dev/null

--- a/t/Makefile
+++ b/t/Makefile
@@ -45,9 +45,9 @@ test-commands : $(TEST_CMDS)
 
 test : test-commands
 	$(RM) -r remote test_count{,.lock}
-	@GIT_LFS_NO_TEST_COUNT= bash -c '. ./testenv.sh && setup'
+	@bash -c '. ./testenv.sh && setup'
 	$(PROVE) $(PROVE_EXTRA_ARGS) ./t-*.sh
-	@GIT_LFS_NO_TEST_COUNT= bash -c '. ./testenv.sh && shutdown'
+	@bash -c '. ./testenv.sh && shutdown'
 
 .PHONY : $(TEST_SRCS)
 $(TEST_SRCS) : $(TEST_CMDS)

--- a/t/Makefile
+++ b/t/Makefile
@@ -45,9 +45,9 @@ test-commands : $(TEST_CMDS)
 
 test : test-commands
 	$(RM) -r remote test_count{,.lock}
-	@bash -c '. ./testenv.sh && setup'
-	$(PROVE) $(PROVE_EXTRA_ARGS) ./t-*.sh
-	@bash -c '. ./testenv.sh && shutdown'
+	@bash -c ". ./testenv.sh && setup && cd t && \
+		RM_GIT_LFS_TEST_DIR=no $(PROVE) $(PROVE_EXTRA_ARGS) t-*.sh && \
+		shutdown"
 
 .PHONY : $(TEST_SRCS)
 $(TEST_SRCS) : $(TEST_CMDS)

--- a/t/cmd/lfstest-count-tests.go
+++ b/t/cmd/lfstest-count-tests.go
@@ -170,10 +170,6 @@ var (
 // acquire acquires the lock file necessary to perform updates to test_count,
 // and returns an error if that lock cannot be acquired.
 func acquire(ctx context.Context) error {
-	if disabled() {
-		return nil
-	}
-
 	path, err := path(lockFile)
 	if err != nil {
 		return err
@@ -205,10 +201,6 @@ func acquire(ctx context.Context) error {
 // release releases the lock file so that another process can take over, or
 // returns an error.
 func release() error {
-	if disabled() {
-		return nil
-	}
-
 	path, err := path(lockFile)
 	if err != nil {
 		return err
@@ -277,16 +269,6 @@ func path(s string) (string, error) {
 		return "", err
 	}
 	return p, nil
-}
-
-// disabled returns true if and only if the lock acquisition phase is disabled.
-func disabled() bool {
-	s := os.Getenv("GIT_LFS_LOCK_ACQUIRE_DISABLED")
-	b, err := strconv.ParseBool(s)
-	if err != nil {
-		return false
-	}
-	return b
 }
 
 // fatal reports the given error (if non-nil), and then dies. If the error was

--- a/t/t-env.sh
+++ b/t/t-env.sh
@@ -6,6 +6,10 @@ envInitConfig='git config filter.lfs.process = "git-lfs filter-process"
 git config filter.lfs.smudge = "git-lfs smudge -- %f"
 git config filter.lfs.clean = "git-lfs clean -- %f"'
 
+if [ "$IS_WINDOWS" -eq 1 ]; then
+  export MSYS2_ENV_CONV_EXCL="GIT_LFS_TEST_DIR"
+fi
+
 begin_test "env with no remote"
 (
   set -e

--- a/t/t-env.sh
+++ b/t/t-env.sh
@@ -6,16 +6,10 @@ envInitConfig='git config filter.lfs.process = "git-lfs filter-process"
 git config filter.lfs.smudge = "git-lfs smudge -- %f"
 git config filter.lfs.clean = "git-lfs clean -- %f"'
 
-unset_vars() {
-    # If set, these will cause the test to fail.
-    unset GIT_LFS_NO_TEST_COUNT
-}
-
 begin_test "env with no remote"
 (
   set -e
   reponame="env-no-remote"
-  unset_vars
   mkdir $reponame
   cd $reponame
   git init
@@ -67,7 +61,6 @@ begin_test "env with origin remote"
 (
   set -e
   reponame="env-origin-remote"
-  unset_vars
   mkdir $reponame
   cd $reponame
   git init
@@ -125,7 +118,6 @@ begin_test "env with multiple remotes"
 (
   set -e
   reponame="env-multiple-remotes"
-  unset_vars
   mkdir $reponame
   cd $reponame
   git init
@@ -186,7 +178,6 @@ begin_test "env with other remote"
 (
   set -e
   reponame="env-other-remote"
-  unset_vars
   mkdir $reponame
   cd $reponame
   git init
@@ -245,7 +236,6 @@ begin_test "env with multiple remotes and lfs.url config"
 (
   set -e
   reponame="env-multiple-remotes-with-lfs-url"
-  unset_vars
   mkdir $reponame
   cd $reponame
   git init
@@ -305,7 +295,6 @@ begin_test "env with multiple remotes and lfs configs"
 (
   set -e
   reponame="env-multiple-remotes-lfs-configs"
-  unset_vars
   mkdir $reponame
   cd $reponame
   git init
@@ -367,7 +356,6 @@ begin_test "env with multiple remotes and batch configs"
 (
   set -e
   reponame="env-multiple-remotes-lfs-batch-configs"
-  unset_vars
   mkdir $reponame
   cd $reponame
   git init
@@ -429,8 +417,6 @@ begin_test "env with .lfsconfig"
 (
   set -e
   reponame="env-with-lfsconfig"
-  unset_vars
-
   git init $reponame
   cd $reponame
 
@@ -499,7 +485,6 @@ begin_test "env with environment variables"
 (
   set -e
   reponame="env-with-envvars"
-  unset_vars
   git init $reponame
   mkdir -p $reponame/a/b/c
 
@@ -677,7 +662,6 @@ begin_test "env with bare repo"
 (
   set -e
   reponame="env-with-bare-repo"
-  unset_vars
   git init --bare $reponame
   cd $reponame
 
@@ -725,7 +709,6 @@ begin_test "env with multiple ssh remotes"
 (
   set -e
   reponame="env-with-ssh"
-  unset_vars
   mkdir $reponame
   cd $reponame
   git init
@@ -877,7 +860,6 @@ begin_test "env with extra transfer methods"
 (
   set -e
   reponame="env-with-transfers"
-  unset_vars
   git init $reponame
   cd $reponame
 
@@ -938,7 +920,6 @@ begin_test "env with multiple remotes and ref"
 (
   set -e
   reponame="env-multiple-remotes-ref"
-  unset_vars
   mkdir $reponame
   cd $reponame
   git init
@@ -1001,7 +982,6 @@ begin_test "env with unicode"
   # This contains a Unicode apostrophe, an E with grave accent, and a Euro sign.
   # Only the middle one is representable in ISO-8859-1.
   reponame="env-d’autre-nom-très-bizarr€"
-  unset_vars
   mkdir $reponame
   cd $reponame
   git init
@@ -1063,7 +1043,6 @@ end_test
 begin_test "env outside a repository"
 (
   set -e
-  unset_vars
 
   # This may or may not work, depending on the system, but it should at least
   # potentially cause Git to print non-English messages.
@@ -1113,7 +1092,6 @@ begin_test "env with duplicate endpoints"
 (
   set -e
   reponame="env-duplicate-endpoints"
-  unset_vars
   mkdir $reponame
   cd $reponame
   git init

--- a/t/t-env.sh
+++ b/t/t-env.sh
@@ -8,7 +8,7 @@ git config filter.lfs.clean = "git-lfs clean -- %f"'
 
 unset_vars() {
     # If set, these will cause the test to fail.
-    unset GIT_LFS_NO_TEST_COUNT GIT_LFS_LOCK_ACQUIRE_DISABLED
+    unset GIT_LFS_NO_TEST_COUNT
 }
 
 begin_test "env with no remote"

--- a/t/t-worktree.sh
+++ b/t/t-worktree.sh
@@ -7,16 +7,10 @@ envInitConfig='git config filter.lfs.process = "git-lfs filter-process"
 git config filter.lfs.smudge = "git-lfs smudge -- %f"
 git config filter.lfs.clean = "git-lfs clean -- %f"'
 
-unset_vars () {
-    # If set, these will cause the test to fail.
-    unset GIT_LFS_NO_TEST_COUNT
-}
-
 begin_test "git worktree"
 (
     set -e
     reponame="worktree-main"
-    unset_vars
     mkdir $reponame
     cd $reponame
     git init
@@ -99,7 +93,6 @@ begin_test "git worktree with hooks"
 (
     set -e
     reponame="worktree-hooks"
-    unset_vars
     mkdir $reponame
     cd $reponame
     git init

--- a/t/t-worktree.sh
+++ b/t/t-worktree.sh
@@ -9,7 +9,7 @@ git config filter.lfs.clean = "git-lfs clean -- %f"'
 
 unset_vars () {
     # If set, these will cause the test to fail.
-    unset GIT_LFS_NO_TEST_COUNT GIT_LFS_LOCK_ACQUIRE_DISABLED
+    unset GIT_LFS_NO_TEST_COUNT
 }
 
 begin_test "git worktree"

--- a/t/t-worktree.sh
+++ b/t/t-worktree.sh
@@ -7,6 +7,10 @@ envInitConfig='git config filter.lfs.process = "git-lfs filter-process"
 git config filter.lfs.smudge = "git-lfs smudge -- %f"
 git config filter.lfs.clean = "git-lfs clean -- %f"'
 
+if [ "$IS_WINDOWS" -eq 1 ]; then
+  export MSYS2_ENV_CONV_EXCL="GIT_LFS_TEST_DIR"
+fi
+
 begin_test "git worktree"
 (
     set -e

--- a/t/testenv.sh
+++ b/t/testenv.sh
@@ -111,10 +111,6 @@ REMOTEDIR="$ROOTDIR/t/remote"
 #
 CREDSDIR="$REMOTEDIR/creds/"
 
-# This is the prefix for Git config files.  See the "Test Suite" section in
-# t/README.md
-LFS_CONFIG="$REMOTEDIR/config"
-
 # This file contains the URL of the test Git server. See the "Test Suite"
 # section in t/README.md
 LFS_URL_FILE="$REMOTEDIR/url"

--- a/t/testenv.sh
+++ b/t/testenv.sh
@@ -62,7 +62,6 @@ resolve_symlink() {
   else
     readlink -f "$arg"
   fi
-
 }
 
 # The root directory for the git-lfs repository by default.
@@ -84,11 +83,17 @@ else
 fi
 
 if [ -z "$GIT_LFS_TEST_DIR" ]; then
-    GIT_LFS_TEST_DIR=$(mktemp -d -t "$TEMPDIR_PREFIX")
-    GIT_LFS_TEST_DIR=$(resolve_symlink $GIT_LFS_TEST_DIR)
+    GIT_LFS_TEST_DIR="$(mktemp -d -t "$TEMPDIR_PREFIX")"
+    GIT_LFS_TEST_DIR="$(resolve_symlink "$GIT_LFS_TEST_DIR")"
     # cleanup either after single test or at end of integration (except on fail)
-    RM_GIT_LFS_TEST_DIR=yes
+    RM_GIT_LFS_TEST_DIR="yes"
 fi
+
+# Make these variables available to all test files run in the same shell,
+# particularly when setup() is run first by itself to start a single
+# common lfstest-gitserver instance.
+export GIT_LFS_TEST_DIR RM_GIT_LFS_TEST_DIR
+
 # create a temporary work space
 TMPDIR=$GIT_LFS_TEST_DIR
 

--- a/t/testhelpers.sh
+++ b/t/testhelpers.sh
@@ -647,6 +647,11 @@ shutdown() {
   LFSTEST_DIR="$REMOTEDIR" \
   LFS_URL_FILE="$LFS_URL_FILE" \
     lfstest-count-tests decrement
+
+  # delete entire lfs test root if we created it (double check pattern)
+  if [ -z "$KEEPTRASH" ] && [ "$RM_GIT_LFS_TEST_DIR" = "yes" ] && [[ $GIT_LFS_TEST_DIR == *"$TEMPDIR_PREFIX"* ]]; then
+    rm -rf "$GIT_LFS_TEST_DIR"
+  fi
 }
 
 tap_show_plan() {

--- a/t/testhelpers.sh
+++ b/t/testhelpers.sh
@@ -578,17 +578,15 @@ setup() {
   git lfs version | sed -e 's/^/# /g'
   git version | sed -e 's/^/# /g'
 
-  if [ -z "$GIT_LFS_NO_TEST_COUNT" ]; then
-    LFSTEST_URL="$LFS_URL_FILE" \
-    LFSTEST_SSL_URL="$LFS_SSL_URL_FILE" \
-    LFSTEST_CLIENT_CERT_URL="$LFS_CLIENT_CERT_URL_FILE" \
-    LFSTEST_DIR="$REMOTEDIR" \
-    LFSTEST_CERT="$LFS_CERT_FILE" \
-    LFSTEST_CLIENT_CERT="$LFS_CLIENT_CERT_FILE" \
-    LFSTEST_CLIENT_KEY="$LFS_CLIENT_KEY_FILE" \
-    LFSTEST_CLIENT_KEY_ENCRYPTED="$LFS_CLIENT_KEY_FILE_ENCRYPTED" \
-      lfstest-count-tests increment
-  fi
+  LFSTEST_URL="$LFS_URL_FILE" \
+  LFSTEST_SSL_URL="$LFS_SSL_URL_FILE" \
+  LFSTEST_CLIENT_CERT_URL="$LFS_CLIENT_CERT_URL_FILE" \
+  LFSTEST_DIR="$REMOTEDIR" \
+  LFSTEST_CERT="$LFS_CERT_FILE" \
+  LFSTEST_CLIENT_CERT="$LFS_CLIENT_CERT_FILE" \
+  LFSTEST_CLIENT_KEY="$LFS_CLIENT_KEY_FILE" \
+  LFSTEST_CLIENT_KEY_ENCRYPTED="$LFS_CLIENT_KEY_FILE_ENCRYPTED" \
+    lfstest-count-tests increment
 
   wait_for_file "$LFS_URL_FILE"
   wait_for_file "$LFS_SSL_URL_FILE"
@@ -646,11 +644,9 @@ shutdown() {
   # every t/t-*.sh file should cleanup its trashdir
   [ -z "$KEEPTRASH" ] && rm -rf "$TRASHDIR"
 
-  if [ -z "$GIT_LFS_NO_TEST_COUNT" ]; then
-    LFSTEST_DIR="$REMOTEDIR" \
-    LFS_URL_FILE="$LFS_URL_FILE" \
-      lfstest-count-tests decrement
-  fi
+  LFSTEST_DIR="$REMOTEDIR" \
+  LFS_URL_FILE="$LFS_URL_FILE" \
+    lfstest-count-tests decrement
 }
 
 tap_show_plan() {

--- a/t/testlib.sh
+++ b/t/testlib.sh
@@ -44,7 +44,6 @@ atexit () {
 # create the trash dir
 trap "atexit" SIGKILL SIGINT SIGTERM EXIT
 
-SHUTDOWN_LFS=yes
 GITSERVER=undefined
 
 setup


### PR DESCRIPTION
Since we revised our test suite to use the `prove` command in PR #3125, an undiagnosed bug in our `lfstest-count-tests` test helper [program](https://github.com/git-lfs/git-lfs/blob/8b2882b7b791635d5deefebcc4edaa9e8eef638a/t/cmd/lfstest-count-tests.go) has prevented us from running our test scripts in parallel on Windows.  Instead, several workarounds were introduced in that PR to avoid counting parallel test script executions and run all our test scripts sequentially on Windows, which slows down our CI jobs.

(The `lfstest-count-tests` program is used to track the number of active test scripts, so our `lfstest-gitserver` test server [program](https://github.com/git-lfs/git-lfs/blob/8b2882b7b791635d5deefebcc4edaa9e8eef638a/t/cmd/lfstest-gitserver.go) can be started once, shared by all our test scripts, and then stopped after they are all complete.  This works as expected on Linux and macOS systems.)

In this PR, we fix the bug in the `lfstest-count-tests` program, which is the result of the fact that we never call `Close()` on the `test_count.lock` file we [open](https://github.com/git-lfs/git-lfs/blob/8b2882b7b791635d5deefebcc4edaa9e8eef638a/t/cmd/lfstest-count-tests.go#L186) to ensure exclusive access to the `test_count` file.  On Unix systems, this causes no problems, because when we [call](https://github.com/git-lfs/git-lfs/blob/8b2882b7b791635d5deefebcc4edaa9e8eef638a/t/cmd/lfstest-count-tests.go#L209) `Remove()` to delete the lock file, the operating system allows us to unlink the file while a file handle remains open.  On Windows, however, this is not permitted, so the `Remove()` call does not succeed, leaving the lock file in place.  Thus when we run the `lfstest-count-tests` program a second time, it is unable to acquire the lock and exits with an error.

With the bug fixed, we then remove the workarounds from PR #3125, which set the `GIT_LFS_NO_TEST_COUNT` and `GIT_LFS_LOCK_ACQUIRE_DISABLED` environment variables on Windows and use their presence to avoid running the `lfstest-count-tests` program and, when it is run, to avoid creating or removing the lock file.

---

In addition, we also make sure our test suite once again removes all the temporary directories it creates to hold the Git repositories created by our tests.  Although we [set](https://github.com/git-lfs/git-lfs/blob/8b2882b7b791635d5deefebcc4edaa9e8eef638a/t/testenv.sh#L89-L90) the `RM_GIT_LFS_TEST_DIR` environment variable to `yes` when we use `mktemp(1)` to [create](https://github.com/git-lfs/git-lfs/blob/8b2882b7b791635d5deefebcc4edaa9e8eef638a/t/testenv.sh#L87) a temporary directory, this is a remnant of PR #1107, and has not been honoured since the relevant cleanup code was removed from our `shutdown()` shell [function](https://github.com/git-lfs/git-lfs/blob/8b2882b7b791635d5deefebcc4edaa9e8eef638a/t/testhelpers.sh#L644-L654) in PR #3125.  In this PR, we restore the cleanup steps from the original implementation.

Moreover, we ensure that we export the `GIT_LFS_TEST_DIR` and `RM_GIT_LFS_TEST_DIR` environment variables so that our test scripts can reuse the same temporary directory, instead of each script creating a unique directory, as happens now.

At present, running the `make test` build target on any platform results in a large number of stale temporary directories being left behind, which no longer occurs with the changes in this PR.

---

Finally, we remove some unused test variables, improve the `lfstest-count-tests` program's handling of file permissions and errors, revise our Linux RPM package builds to run more test scripts in parallel, and skip installing Strawberry Perl on Windows as our CI workflow now [installs](https://github.com/git-lfs/git-lfs/blob/8b2882b7b791635d5deefebcc4edaa9e8eef638a/.github/workflows/ci.yml#L89-L93) the Git for Windows SDK, which includes Perl and the `prove` command.

This PR will be most easily reviewed on a commit-by-commit basis, with whitespace differences ignored.  Each commit has a detailed description of its changes.