### PR TITLE
git-lfs: omit tags in show-ref; optimize pre-push

### DIFF
--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -274,7 +274,7 @@ func getRemoteRefs(l *tasklog.Logger) (map[string][]*git.Ref, error) {
 	for _, remote := range remotes {
 		var refsForRemote []*git.Ref
 		if migrateSkipFetch {
-			refsForRemote, err = git.CachedRemoteRefs(remote)
+			refsForRemote, err = git.CachedRemoteRefs(remote, true)
 		} else {
 			refsForRemote, err = git.RemoteRefs(remote, true)
 		}

--- a/git/git.go
+++ b/git/git.go
@@ -1219,11 +1219,17 @@ func Checkout(treeish string, paths []string, force bool) error {
 	return err
 }
 
-// CachedRemoteRefs returns the list of branches & tags for a remote which are
-// currently cached locally. No remote request is made to verify them.
-func CachedRemoteRefs(remoteName string) ([]*Ref, error) {
+// CachedRemoteRefs returns the list of branches & opionally tags for a remote 
+// which are currently cached locally. No remote request is made to verify them.
+func CachedRemoteRefs(remoteName string, withTags bool) ([]*Ref, error) {
 	var ret []*Ref
-	cmd, err := gitNoLFS("show-ref")
+	args := []string{"show-ref"}
+
+	if !withTags {
+		args = append(args, "--branches")
+	}
+
+	cmd, err := gitNoLFS(args...)
 	if err != nil {
 		return nil, errors.New(tr.Tr.Get("failed to find `git show-ref`: %v", err))
 	}

--- a/lfs/gitscanner_remotes.go
+++ b/lfs/gitscanner_remotes.go
@@ -12,7 +12,7 @@ import (
 // been deleted on the server if unreferenced. If some refs are missing on the
 // remote, use a more explicit diff command.
 func calcSkippedRefs(remote string) []string {
-	cachedRemoteRefs, _ := git.CachedRemoteRefs(remote)
+	cachedRemoteRefs, _ := git.CachedRemoteRefs(remote, false)
 
 	// Since CachedRemoteRefs() only returns branches, request that
 	// RemoteRefs() ignore tags and also return only branches.


### PR DESCRIPTION
Fixes #5883

Previously, the pre-push hook would execute 'git show-ref' without `--branches`, which could be slow in repositories with many tags.

Improves the performance of git lfs pre-push marginally for repositories that have a large number of local tags.