### PR TITLE
script/build-git: update Ubuntu 24.04 APT sources

### DIFF
--- a/script/build-git
+++ b/script/build-git
@@ -9,7 +9,13 @@ case $(uname -s) in
     CURLDIR="$(curl-config --prefix)";;
   Linux)
     export DEBIAN_FRONTEND=noninteractive
-    sed -e 's/^deb/deb-src/' /etc/apt/sources.list | sudo tee /etc/apt/sources.list.d/src.list
+    if test -f /etc/apt/sources.list.d/ubuntu.sources; then
+      # Ubuntu 24.04
+      sed -e 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources | sudo tee /etc/apt/sources.list.d/ubuntu.sources
+    else
+      # Ubuntu 22.04 and earlier
+      sed -e 's/^deb/deb-src/' /etc/apt/sources.list | sudo tee /etc/apt/sources.list.d/src.list
+    fi
     sudo apt-get update
     sudo apt-get install build-essential
     sudo apt-get -y build-dep git;;


### PR DESCRIPTION
As of Ubuntu 24.04, the primary list of sources for APT [moved](https://discourse.ubuntu.com/t/spec-apt-deb822-sources-by-default/29333) to the `/etc/apt/sources.list.d/ubuntu.sources` file instead of the legacy `/etc/apt/sources.list` file, and was [rewritten](https://manpages.ubuntu.com/manpages/noble/man5/sources.list.5.html) to make use of the `deb822` [format](https://manpages.debian.org/bookworm/dpkg-dev/deb822.5.en.html), which is based on RFC 822.  From the Ubuntu 24.04 [release notes](https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-release-notes/39890#deb822-sources-management):

> The sources configuration for Ubuntu has moved from `/etc/apt/sources.list` to `/etc/apt/sources.list.d/ubuntu.sources` in the more featureful deb822 format, aligning with PPAs that already migrated to deb822 last year.
  
As GitHub Actions are now migrating their `ubuntu-latest` runners to Ubuntu 24.04, per actions/runner-images#10636, we need to adjust the script our CI jobs use to build custom versions of Git so that it is able to fetch the necessary source packages it requires.

We therefore update the script so it checks for the presence of an `/etc/apt/sources.list.d/ubuntu.sources` file, and if that exists, adds the `deb-src` archive type to the `Types:` lines of the entries in that file; otherwise, the script adds the `deb-src` type to the entries in the `/etc/apt/sources.list` file as it did previously.

A successful [run](https://github.com/chrisd8088/git-lfs/actions/runs/11371303054) of our `Build with latest Git` and `Build with earliest Git` CI jobs on an `ubuntu-24.04` runner demonstrates these changes work as expected.