### PR TITLE
Support relative paths to linked working trees

### DIFF
--- a/commands/command_prune.go
+++ b/commands/command_prune.go
@@ -508,7 +508,7 @@ func pruneTaskGetRetainedWorktree(gitscanner *lfs.GitScanner, fetchconf lfs.Fetc
 
 	// Retain other worktree HEADs too
 	// Working copy, branch & maybe commit is different but repo is shared
-	allWorktrees, err := git.GetAllWorkTrees(cfg.LocalGitStorageDir())
+	allWorktrees, err := git.GetAllWorktrees(cfg.LocalGitStorageDir())
 	if err != nil {
 		errorChan <- err
 		return

--- a/commands/command_prune.go
+++ b/commands/command_prune.go
@@ -536,9 +536,11 @@ func pruneTaskGetRetainedWorktree(gitscanner *lfs.GitScanner, fetchconf lfs.Fetc
 			go pruneTaskGetRetainedAtRef(gitscanner, worktree.Ref.Sha, retainChan, errorChan, waitg, sem)
 		}
 
-		// Always scan the index of the worktree
-		waitg.Add(1)
-		go pruneTaskGetRetainedIndex(gitscanner, worktree.Ref.Sha, worktree.Dir, retainChan, errorChan, waitg, sem)
+		if !worktree.Prunable {
+			// Always scan the index of the worktree if it exists
+			waitg.Add(1)
+			go pruneTaskGetRetainedIndex(gitscanner, worktree.Ref.Sha, worktree.Dir, retainChan, errorChan, waitg, sem)
+		}
 	}
 }
 

--- a/git/git.go
+++ b/git/git.go
@@ -908,11 +908,11 @@ type Worktree struct {
 	Dir string
 }
 
-// GetAllWorkTrees returns the refs that all worktrees are using as HEADs plus the worktree's path.
+// GetAllWorktrees returns the refs that all worktrees are using as HEADs plus the worktree's path.
 // This returns all worktrees plus the master working copy, and works even if
 // working dir is actually in a worktree right now
 // Pass in the git storage dir (parent of 'objects') to work from
-func GetAllWorkTrees(storageDir string) ([]*Worktree, error) {
+func GetAllWorktrees(storageDir string) ([]*Worktree, error) {
 	worktreesdir := filepath.Join(storageDir, "worktrees")
 	dirf, err := os.Open(worktreesdir)
 	if err != nil && !os.IsNotExist(err) {

--- a/git/git.go
+++ b/git/git.go
@@ -910,10 +910,106 @@ type Worktree struct {
 }
 
 // GetAllWorktrees returns the refs that all worktrees are using as HEADs plus the worktree's path.
-// This returns all worktrees plus the master working copy, and works even if
+// This returns all worktrees plus the main working copy, and works even if
 // working dir is actually in a worktree right now
-// Pass in the git storage dir (parent of 'objects') to work from
+//
+// Pass in the git storage dir (parent of 'objects') to work from, in case
+// we need to fall back to reading the worktree files directly.
 func GetAllWorktrees(storageDir string) ([]*Worktree, error) {
+	// Versions before 2.7.0 don't support "git-worktree list", and
+	// those before 2.36.0 don't support the "-z" option, so in these
+	// cases we fall back to reading the .git/worktrees directory entries
+	// and then reading the current worktree's HEAD ref.  This requires
+	// the contents of .git/worktrees/*/gitdir files to be absolute paths,
+	// which is only true for Git versions prior to 2.48.0.
+	if !IsGitVersionAtLeast("2.36.0") {
+		return getAllWorktreesFromGitDir(storageDir)
+	}
+
+	cmd, err := gitNoLFS(
+		"worktree",
+		"list",
+		"--porcelain",
+		"-z", // handle special chars in filenames
+	)
+	if err != nil {
+		return nil, errors.New(tr.Tr.Get("failed to find `git worktree`: %v", err))
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, errors.New(tr.Tr.Get("failed to open output pipe to `git worktree`: %v", err))
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, errors.New(tr.Tr.Get("failed to open error pipe to `git worktree`: %v", err))
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, errors.New(tr.Tr.Get("failed to start `git worktree`: %v", err))
+	}
+
+	scanner := bufio.NewScanner(stdout)
+	scanner.Split(tools.SplitOnNul)
+	var dir string
+	var ref *Ref
+	var prunable bool
+	var worktrees []*Worktree
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if len(line) == 0 {
+			if len(dir) > 0 && ref != nil && len(ref.Sha) > 0 {
+				worktrees = append(worktrees, &Worktree{
+					Ref:      *ref,
+					Dir:      dir,
+					Prunable: prunable,
+				})
+			}
+			dir = ""
+			ref = nil
+			continue
+		}
+
+		parts := strings.SplitN(scanner.Text(), " ", 2)
+
+		// We ignore other attributes such as "locked" for now.
+		switch parts[0] {
+		case "worktree":
+			if len(parts) == 2 && len(dir) == 0 {
+				dir = filepath.Clean(parts[1])
+				ref = &Ref{Type: RefTypeOther}
+				prunable = false
+			}
+		case "HEAD":
+			if len(parts) == 2 && ref != nil {
+				ref.Sha = parts[1]
+				ref.Name = parts[1]
+			}
+		case "branch":
+			if len(parts) == 2 && ref != nil && len(ref.Sha) > 0 {
+				ref = ParseRef(parts[1], ref.Sha)
+			}
+		case "bare":
+			// We ignore bare worktrees.
+			dir = ""
+			ref = nil
+		case "prunable":
+			prunable = true
+		}
+	}
+
+	// We assume any error output will be short and won't block
+	// command completion if it isn't drained by a separate goroutine.
+	msg, _ := io.ReadAll(stderr)
+	if err := cmd.Wait(); err != nil {
+		return nil, errors.New(tr.Tr.Get("error in `git worktree`: %v: %s", err, msg))
+	}
+
+	return worktrees, nil
+}
+
+func getAllWorktreesFromGitDir(storageDir string) ([]*Worktree, error) {
 	worktreesdir := filepath.Join(storageDir, "worktrees")
 	dirf, err := os.Open(worktreesdir)
 	if err != nil && !os.IsNotExist(err) {

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -381,6 +381,13 @@ func TestWorktrees(t *testing.T) {
 				{Filename: "file1.txt", Size: 40},
 			},
 		},
+		{ // 5
+			NewBranch:      "branch5",
+			ParentBranches: []string{"master"}, // back on master
+			Files: []*test.FileInput{
+				{Filename: "file1.txt", Size: 50},
+			},
+		},
 	}
 	outputs := repo.AddCommits(inputs)
 	// Checkout master again otherwise can't create a worktree from branch4 if we're on it here
@@ -392,6 +399,9 @@ func TestWorktrees(t *testing.T) {
 	test.RunGitCommand(t, true, "worktree", "add", "tag1_wt", "tag1")
 	test.RunGitCommand(t, true, "worktree", "add", "branch2_wt", "branch2")
 	test.RunGitCommand(t, true, "worktree", "add", "branch4_wt", "branch4")
+	test.RunGitCommand(t, true, "worktree", "add", "branch5_wt", "branch5")
+
+	os.RemoveAll(filepath.Join(repoDir, "branch5_wt"))
 
 	worktrees, err := GetAllWorktrees(filepath.Join(repo.Path, ".git"))
 	assert.NoError(t, err)
@@ -402,7 +412,8 @@ func TestWorktrees(t *testing.T) {
 				Type: RefTypeOther,
 				Sha:  outputs[0].Sha,
 			},
-			Dir: filepath.Join(repoDir, "tag1_wt"),
+			Dir:      filepath.Join(repoDir, "tag1_wt"),
+			Prunable: false,
 		},
 		{
 			Ref: Ref{
@@ -410,7 +421,8 @@ func TestWorktrees(t *testing.T) {
 				Type: RefTypeLocalBranch,
 				Sha:  outputs[1].Sha,
 			},
-			Dir: repoDir,
+			Dir:      repoDir,
+			Prunable: false,
 		},
 		{
 			Ref: Ref{
@@ -418,7 +430,8 @@ func TestWorktrees(t *testing.T) {
 				Type: RefTypeLocalBranch,
 				Sha:  outputs[2].Sha,
 			},
-			Dir: filepath.Join(repoDir, "branch2_wt"),
+			Dir:      filepath.Join(repoDir, "branch2_wt"),
+			Prunable: false,
 		},
 		{
 			Ref: Ref{
@@ -426,7 +439,17 @@ func TestWorktrees(t *testing.T) {
 				Type: RefTypeLocalBranch,
 				Sha:  outputs[4].Sha,
 			},
-			Dir: filepath.Join(repoDir, "branch4_wt"),
+			Dir:      filepath.Join(repoDir, "branch4_wt"),
+			Prunable: false,
+		},
+		{
+			Ref: Ref{
+				Name: "branch5",
+				Type: RefTypeLocalBranch,
+				Sha:  outputs[5].Sha,
+			},
+			Dir:      filepath.Join(repoDir, "branch5_wt"),
+			Prunable: true,
 		},
 	}
 	// Need to sort for consistent comparison

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -352,23 +352,29 @@ func TestWorkTrees(t *testing.T) {
 	inputs := []*test.CommitInput{
 		{ // 0
 			Files: []*test.FileInput{
+				{Filename: "file1.txt", Size: 10},
+			},
+			Tags: []string{"tag1"},
+		},
+		{ // 1
+			Files: []*test.FileInput{
 				{Filename: "file1.txt", Size: 20},
 			},
 		},
-		{ // 1
+		{ // 2
 			NewBranch: "branch2",
 			Files: []*test.FileInput{
 				{Filename: "file1.txt", Size: 25},
 			},
 		},
-		{ // 2
+		{ // 3
 			NewBranch:      "branch3",
 			ParentBranches: []string{"master"}, // back on master
 			Files: []*test.FileInput{
 				{Filename: "file1.txt", Size: 30},
 			},
 		},
-		{ // 3
+		{ // 4
 			NewBranch:      "branch4",
 			ParentBranches: []string{"master"}, // back on master
 			Files: []*test.FileInput{
@@ -383,17 +389,26 @@ func TestWorkTrees(t *testing.T) {
 	// We can create worktrees as subfolders for convenience
 	// Each one is checked out to a different branch
 	// Note that we *won't* create one for branch3
+	test.RunGitCommand(t, true, "worktree", "add", "tag1_wt", "tag1")
 	test.RunGitCommand(t, true, "worktree", "add", "branch2_wt", "branch2")
 	test.RunGitCommand(t, true, "worktree", "add", "branch4_wt", "branch4")
 
 	worktrees, err := GetAllWorkTrees(filepath.Join(repo.Path, ".git"))
-	assert.Equal(t, nil, err)
+	assert.NoError(t, err)
 	expectedWorktrees := []*Worktree{
+		{
+			Ref: Ref{
+				Name: outputs[0].Sha,
+				Type: RefTypeOther,
+				Sha:  outputs[0].Sha,
+			},
+			Dir: filepath.Join(repoDir, "tag1_wt"),
+		},
 		{
 			Ref: Ref{
 				Name: "master",
 				Type: RefTypeLocalBranch,
-				Sha:  outputs[0].Sha,
+				Sha:  outputs[1].Sha,
 			},
 			Dir: repoDir,
 		},
@@ -401,7 +416,7 @@ func TestWorkTrees(t *testing.T) {
 			Ref: Ref{
 				Name: "branch2",
 				Type: RefTypeLocalBranch,
-				Sha:  outputs[1].Sha,
+				Sha:  outputs[2].Sha,
 			},
 			Dir: filepath.Join(repoDir, "branch2_wt"),
 		},
@@ -409,7 +424,7 @@ func TestWorkTrees(t *testing.T) {
 			Ref: Ref{
 				Name: "branch4",
 				Type: RefTypeLocalBranch,
-				Sha:  outputs[3].Sha,
+				Sha:  outputs[4].Sha,
 			},
 			Dir: filepath.Join(repoDir, "branch4_wt"),
 		},
@@ -418,6 +433,24 @@ func TestWorkTrees(t *testing.T) {
 	sort.Sort(test.WorktreesByName(expectedWorktrees))
 	sort.Sort(test.WorktreesByName(worktrees))
 	assert.Equal(t, expectedWorktrees, worktrees, "Worktrees should be correct")
+}
+
+func TestWorktreesBareRepo(t *testing.T) {
+	// Only git 2.5+
+	if !IsGitVersionAtLeast("2.5.0") {
+		return
+	}
+
+	repo := test.NewBareRepo(t)
+	repo.Pushd()
+	defer func() {
+		repo.Popd()
+		repo.Cleanup()
+	}()
+
+	worktrees, err := GetAllWorkTrees(repo.Path)
+	assert.NoError(t, err)
+	assert.Nil(t, worktrees)
 }
 
 func TestVersionCompare(t *testing.T) {

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -332,7 +332,7 @@ func TestResolveEmptyCurrentRef(t *testing.T) {
 	assert.NotEqual(t, nil, err)
 }
 
-func TestWorkTrees(t *testing.T) {
+func TestWorktrees(t *testing.T) {
 	// Only git 2.5+
 	if !IsGitVersionAtLeast("2.5.0") {
 		return
@@ -393,7 +393,7 @@ func TestWorkTrees(t *testing.T) {
 	test.RunGitCommand(t, true, "worktree", "add", "branch2_wt", "branch2")
 	test.RunGitCommand(t, true, "worktree", "add", "branch4_wt", "branch4")
 
-	worktrees, err := GetAllWorkTrees(filepath.Join(repo.Path, ".git"))
+	worktrees, err := GetAllWorktrees(filepath.Join(repo.Path, ".git"))
 	assert.NoError(t, err)
 	expectedWorktrees := []*Worktree{
 		{
@@ -448,7 +448,7 @@ func TestWorktreesBareRepo(t *testing.T) {
 		repo.Cleanup()
 	}()
 
-	worktrees, err := GetAllWorkTrees(repo.Path)
+	worktrees, err := GetAllWorktrees(repo.Path)
 	assert.NoError(t, err)
 	assert.Nil(t, worktrees)
 }

--- a/t/cmd/util/testutils.go
+++ b/t/cmd/util/testutils.go
@@ -182,6 +182,14 @@ func NewRepo(callback RepoCallback) *Repo {
 	})
 }
 
+// NewBareRepo creates a new bare git repo in a new temp dir
+// Note that the repository's path does not end in ".git".
+func NewBareRepo(callback RepoCallback) *Repo {
+	return newRepo(callback, &RepoCreateSettings{
+		RepoType: RepoTypeBare,
+	})
+}
+
 // newRepo creates a new git repo in a new temp dir with more control over settings
 func newRepo(callback RepoCallback, settings *RepoCreateSettings) *Repo {
 	ret := &Repo{


### PR DESCRIPTION
This PR adds an alternative implementation of the [function](https://github.com/git-lfs/git-lfs/blob/a577e336ebdccfd312b6006c880f010b5d3fe796/git/git.go#L911-L972) used by the `git lfs prune` command to locate all linked working trees, in order to ensure that Git LFS continues to be compatible with future versions of Git.  This change addresses the recent CI job failures seen in our `Build with latest Git` jobs; for instance, in this job [run](https://github.com/git-lfs/git-lfs/actions/runs/11513482984/job/32050267427) for PR #5876.

Since the introduction of support in Git for multiple linked working trees, in version 2.5.0, paths to these working trees have been stored in the `.git/worktrees` internal file structure as full, absolute paths.  At present, Git LFS [reads](https://github.com/git-lfs/git-lfs/blob/a577e336ebdccfd312b6006c880f010b5d3fe796/git/git.go#L942-L948) some of these internal files in order to retrieve the full paths to all linked working trees, which it needs when running the `git lfs prune` command.  The `gitscanner.ScanIndex()` method [invoked](https://github.com/git-lfs/git-lfs/blob/a577e336ebdccfd312b6006c880f010b5d3fe796/commands/command_prune.go#L568-L575) by `git lfs prune` [results](https://github.com/git-lfs/git-lfs/blob/a577e336ebdccfd312b6006c880f010b5d3fe796/lfs/gitscanner_index.go#L113) in [two](https://github.com/git-lfs/git-lfs/blob/a577e336ebdccfd312b6006c880f010b5d3fe796/lfs/gitscanner_index.go#L23-L31) `git diff-index` [commands](https://github.com/git-lfs/git-lfs/blob/a577e336ebdccfd312b6006c880f010b5d3fe796/git/git.go#L248-L261) being [run](https://github.com/git-lfs/git-lfs/blob/a577e336ebdccfd312b6006c880f010b5d3fe796/lfs/diff_index_scanner.go#L136) in each linked working tree.  One of those, in particular, scans the staged changes in the working tree's Git index for pointers to Git LFS objects, as any such references mean that the corresponding Git LFS objects should be retained and not pruned.

The next release of Git (version 2.48.0) is expected to include changes to the representation of linked working tree file paths in the `.git/worktrees` internal file structure.  As of commit git/git@717af916cd69d2565aa2a7b7d73d895aa92ff392 the paths in the `.git/worktrees/*/gitdir` files will be stored as relative paths rather than absolute ones, while still supporting older `gitdir` files containing absolute paths.

While we could continue to read those `gitdir` files and try to detect relative paths, and then join those to the full path of the main working tree, we can avoid this complexity and the fragility it implies by using the `git worktree list` [command](https://git-scm.com/docs/git-worktree#Documentation/git-worktree.txt-list) instead.  Since Git version 2.36.0 this command has offered both a `--porcelain` mode and a `-z` option, which ensures any file paths with unusual characters can be easily parsed.

We therefore introduce an alternative implementation of our `GetAllWorktrees()` function—which we rename from `GetAllWorkTrees()`, for consistency with the rest of our codebase—that uses the `git worktree list` command to retrieve a list of all linked working trees, plus the main working tree, if it exists (i.e., if the main repository is not bare).

Before adding our new implementation, we first expand our Go and shell test suites to check a number of additional cases involving linked working trees, such as trees with detached `HEAD`s, bare main repositories, and working trees that have been deleted but for which Git still has internal metadata.

Because the `git worktree list` command provides a convenient `prunable` attribute which indicates whether a linked working tree actually still exists, we also update our legacy implementation to perform a similar check, which means the `git lfs prune` command can now quickly skip trying to run `git diff-index` in nonexistent working trees.

This PR should be most easily reviewed on a commit-by-commit basis.