### PR TITLE
Fix crash during pure SSH object transfer with multiple objects

### DIFF
--- a/docs/man/git-lfs-config.adoc
+++ b/docs/man/git-lfs-config.adoc
@@ -91,7 +91,8 @@ keepalive connections. Default: 30 minutes.
 +
 When using the pure SSH-based protocol, whether to multiplex requests
 over a single connection when possible. This option requires the use of
-OpenSSH or a compatible SSH client. Default: true.
+OpenSSH or a compatible SSH client. Default: false on Windows, otherwise
+true.
 * `lfs.ssh.retries`
 +
 Specifies the number of times Git LFS will attempt to obtain

--- a/lfsapi/lfsapi.go
+++ b/lfsapi/lfsapi.go
@@ -62,14 +62,14 @@ func (c *Client) SSHTransfer(operation, remote string) *ssh.SSHTransfer {
 	}
 	uc := config.NewURLConfig(c.context.GitEnv())
 	if val, ok := uc.Get("lfs", endpoint.OriginalUrl, "sshtransfer"); ok && val != "negotiate" && val != "always" {
-		tracerx.Printf("skipping pure SSH protocol connection by request")
+		tracerx.Printf("skipping pure SSH protocol connection by request (%s, %s)", operation, remote)
 		return nil
 	}
 	ctx := c.Context()
-	tracerx.Printf("attempting pure SSH protocol connection")
+	tracerx.Printf("attempting pure SSH protocol connection (%s, %s)", operation, remote)
 	sshTransfer, err := ssh.NewSSHTransfer(ctx.OSEnv(), ctx.GitEnv(), &endpoint.SSHMetadata, operation)
 	if err != nil {
-		tracerx.Printf("pure SSH protocol connection failed: %s", err)
+		tracerx.Printf("pure SSH protocol connection failed (%s, %s): %s", operation, remote, err)
 		return nil
 	}
 	return sshTransfer

--- a/ssh/connection.go
+++ b/ssh/connection.go
@@ -90,67 +90,67 @@ func startConnection(id int, osEnv config.Environment, gitEnv config.Environment
 
 // Connection returns the nth connection (starting from 0) in this transfer
 // instance or nil if there is no such item.
-func (tr *SSHTransfer) IsMultiplexingEnabled() bool {
-	return tr.multiplexing
+func (st *SSHTransfer) IsMultiplexingEnabled() bool {
+	return st.multiplexing
 }
 
 // Connection returns the nth connection (starting from 0) in this transfer
 // instance if it is initialized and otherwise initializes a new connection and
 // saves it in the nth position.  In all cases, nil is returned if n is greater
 // than the maximum number of connections.
-func (tr *SSHTransfer) Connection(n int) (*PktlineConnection, error) {
-	tr.lock.RLock()
-	if n >= len(tr.conn) {
-		tr.lock.RUnlock()
+func (st *SSHTransfer) Connection(n int) (*PktlineConnection, error) {
+	st.lock.RLock()
+	if n >= len(st.conn) {
+		st.lock.RUnlock()
 		return nil, nil
 	}
-	if tr.conn[n] != nil {
-		defer tr.lock.RUnlock()
-		return tr.conn[n], nil
+	if st.conn[n] != nil {
+		defer st.lock.RUnlock()
+		return st.conn[n], nil
 	}
-	tr.lock.RUnlock()
+	st.lock.RUnlock()
 
-	tr.lock.Lock()
-	defer tr.lock.Unlock()
-	if tr.conn[n] != nil {
-		return tr.conn[n], nil
+	st.lock.Lock()
+	defer st.lock.Unlock()
+	if st.conn[n] != nil {
+		return st.conn[n], nil
 	}
-	conn, _, err := tr.spawnConnection(n)
+	conn, _, err := st.spawnConnection(n)
 	if err != nil {
 		return nil, err
 	}
-	tr.conn[n] = conn
+	st.conn[n] = conn
 	return conn, nil
 }
 
 // ConnectionCount returns the number of connections this object has.
-func (tr *SSHTransfer) ConnectionCount() int {
-	tr.lock.RLock()
-	defer tr.lock.RUnlock()
-	return len(tr.conn)
+func (st *SSHTransfer) ConnectionCount() int {
+	st.lock.RLock()
+	defer st.lock.RUnlock()
+	return len(st.conn)
 }
 
 // SetConnectionCount sets the number of connections to the specified number.
-func (tr *SSHTransfer) SetConnectionCount(n int) error {
-	tr.lock.Lock()
-	defer tr.lock.Unlock()
-	return tr.setConnectionCount(n)
+func (st *SSHTransfer) SetConnectionCount(n int) error {
+	st.lock.Lock()
+	defer st.lock.Unlock()
+	return st.setConnectionCount(n)
 }
 
 // SetConnectionCountAtLeast sets the number of connections to be not less than
 // the specified number.
-func (tr *SSHTransfer) SetConnectionCountAtLeast(n int) error {
-	tr.lock.Lock()
-	defer tr.lock.Unlock()
-	count := len(tr.conn)
+func (st *SSHTransfer) SetConnectionCountAtLeast(n int) error {
+	st.lock.Lock()
+	defer st.lock.Unlock()
+	count := len(st.conn)
 	if n <= count {
 		return nil
 	}
-	return tr.setConnectionCount(n)
+	return st.setConnectionCount(n)
 }
 
-func (tr *SSHTransfer) spawnConnection(n int) (*PktlineConnection, string, error) {
-	conn, _, controlPath, err := startConnection(n, tr.osEnv, tr.gitEnv, tr.meta, tr.operation, tr.controlPath)
+func (st *SSHTransfer) spawnConnection(n int) (*PktlineConnection, string, error) {
+	conn, _, controlPath, err := startConnection(n, st.osEnv, st.gitEnv, st.meta, st.operation, st.controlPath)
 	if err != nil {
 		tracerx.Printf("failed to spawn pure SSH connection (#%d): %s", n, err)
 		return nil, "", err
@@ -158,14 +158,14 @@ func (tr *SSHTransfer) spawnConnection(n int) (*PktlineConnection, string, error
 	return conn, controlPath, err
 }
 
-func (tr *SSHTransfer) setConnectionCount(n int) error {
-	count := len(tr.conn)
+func (st *SSHTransfer) setConnectionCount(n int) error {
+	count := len(st.conn)
 	if n < count {
 		tn := n
 		if tn == 0 {
 			tn = 1
 		}
-		for i, item := range tr.conn[tn:count] {
+		for i, item := range st.conn[tn:count] {
 			if item == nil {
 				tracerx.Printf("skipping uninitialized lazy pure SSH connection (#%d) (resetting total from %d to %d)", i, count, n)
 				continue
@@ -175,33 +175,33 @@ func (tr *SSHTransfer) setConnectionCount(n int) error {
 				return err
 			}
 		}
-		tr.conn = tr.conn[0:tn]
+		st.conn = st.conn[0:tn]
 	} else if n > count {
 		for i := count; i < n; i++ {
 			if i == 0 {
-				conn, controlPath, err := tr.spawnConnection(i)
+				conn, controlPath, err := st.spawnConnection(i)
 				if err != nil {
 					return err
 				}
-				tr.conn = append(tr.conn, conn)
-				tr.controlPath = controlPath
+				st.conn = append(st.conn, conn)
+				st.controlPath = controlPath
 			} else {
-				tr.conn = append(tr.conn, nil)
+				st.conn = append(st.conn, nil)
 			}
 		}
 	}
 	if n == 0 && count > 0 {
 		tracerx.Printf("terminating pure SSH connection (#0) (resetting total from %d to %d)", count, n)
-		if err := tr.conn[0].End(); err != nil {
+		if err := st.conn[0].End(); err != nil {
 			return err
 		}
-		tr.conn = nil
-		tr.controlPath = ""
+		st.conn = nil
+		st.controlPath = ""
 	}
 	return nil
 }
 
-func (tr *SSHTransfer) Shutdown() error {
+func (st *SSHTransfer) Shutdown() error {
 	tracerx.Printf("shutting down pure SSH connections")
-	return tr.SetConnectionCount(0)
+	return st.SetConnectionCount(0)
 }

--- a/ssh/connection.go
+++ b/ssh/connection.go
@@ -96,13 +96,14 @@ func (st *SSHTransfer) IsMultiplexingEnabled() bool {
 
 // Connection returns the nth connection (starting from 0) in this transfer
 // instance if it is initialized and otherwise initializes a new connection and
-// saves it in the nth position.  In all cases, nil is returned if n is greater
-// than the maximum number of connections.
+// saves it in the nth position.  In all cases, nil is returned with an error
+// if n is greater than the maximum number of connections, including when
+// the connection array itself is nil.
 func (st *SSHTransfer) Connection(n int) (*PktlineConnection, error) {
 	st.lock.RLock()
 	if n >= len(st.conn) {
 		st.lock.RUnlock()
-		return nil, nil
+		return nil, errors.New(tr.Tr.Get("pure SSH connection unavailable (#%d)", n))
 	}
 	if st.conn[n] != nil {
 		defer st.lock.RUnlock()

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -30,7 +30,7 @@ type SSHMetadata struct {
 	Path        string
 }
 
-func FormatArgs(cmd string, args []string, needShell bool, multiplex bool, controlPath string) (string, []string) {
+func FormatArgs(cmd string, args []string, needShell bool) (string, []string) {
 	if !needShell {
 		return cmd, args
 	}
@@ -41,7 +41,7 @@ func FormatArgs(cmd string, args []string, needShell bool, multiplex bool, contr
 func GetLFSExeAndArgs(osEnv config.Environment, gitEnv config.Environment, meta *SSHMetadata, command, operation string, multiplexDesired bool, multiplexControlPath string) (exe string, args []string, multiplexing bool, controlPath string) {
 	exe, args, needShell, multiplexing, controlPath := GetExeAndArgs(osEnv, gitEnv, meta, multiplexDesired, multiplexControlPath)
 	args = append(args, fmt.Sprintf("%s %s %s", command, meta.Path, operation))
-	exe, args = FormatArgs(exe, args, needShell, multiplexing, controlPath)
+	exe, args = FormatArgs(exe, args, needShell)
 	tracerx.Printf("run_command: %s %s", exe, strings.Join(args, " "))
 	return exe, args, multiplexing, controlPath
 }

--- a/ssh/ssh_test.go
+++ b/ssh/ssh_test.go
@@ -45,7 +45,8 @@ func TestSSHGetExeAndArgsSsh(t *testing.T) {
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
 
-	exe, args := ssh.FormatArgs(ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, ""))
+	exe, args, needShell, _, _ := ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, "")
+	exe, args = ssh.FormatArgs(exe, args, needShell)
 	assert.Equal(t, "ssh", exe)
 	assert.Equal(t, []string{"user@foo.com"}, args)
 }
@@ -61,7 +62,8 @@ func TestSSHGetExeAndArgsSshCustomPort(t *testing.T) {
 	meta.UserAndHost = "user@foo.com"
 	meta.Port = "8888"
 
-	exe, args := ssh.FormatArgs(ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, ""))
+	exe, args, needShell, _, _ := ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, "")
+	exe, args = ssh.FormatArgs(exe, args, needShell)
 	assert.Equal(t, "ssh", exe)
 	assert.Equal(t, []string{"-p", "8888", "user@foo.com"}, args)
 }
@@ -79,7 +81,7 @@ func TestSSHGetExeAndArgsSshNoMultiplexing(t *testing.T) {
 	meta.UserAndHost = "user@foo.com"
 
 	exe, baseargs, needShell, multiplexing, controlPath := ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, true, "")
-	exe, args := ssh.FormatArgs(exe, baseargs, needShell, multiplexing, controlPath)
+	exe, args := ssh.FormatArgs(exe, baseargs, needShell)
 	assert.Equal(t, "ssh", exe)
 	assert.Equal(t, false, multiplexing)
 	assert.Equal(t, []string{"user@foo.com"}, args)
@@ -99,7 +101,7 @@ func TestSSHGetExeAndArgsSshMultiplexingMaster(t *testing.T) {
 	meta.UserAndHost = "user@foo.com"
 
 	exe, baseargs, needShell, multiplexing, controlPath := ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, true, "")
-	exe, args := ssh.FormatArgs(exe, baseargs, needShell, multiplexing, controlPath)
+	exe, args := ssh.FormatArgs(exe, baseargs, needShell)
 	assert.Equal(t, "ssh", exe)
 	assert.Equal(t, true, multiplexing)
 	assert.Equal(t, 3, len(args))
@@ -122,7 +124,7 @@ func TestSSHGetExeAndArgsSshMultiplexingExtra(t *testing.T) {
 	meta.UserAndHost = "user@foo.com"
 
 	exe, baseargs, needShell, multiplexing, controlPath := ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, true, "/tmp/lfs/lfs.sock")
-	exe, args := ssh.FormatArgs(exe, baseargs, needShell, multiplexing, controlPath)
+	exe, args := ssh.FormatArgs(exe, baseargs, needShell)
 	assert.Equal(t, "ssh", exe)
 	assert.Equal(t, true, multiplexing)
 	assert.Equal(t, []string{"-oControlMaster=no", "-oControlPath=/tmp/lfs/lfs.sock", "user@foo.com"}, args)
@@ -141,7 +143,8 @@ func TestSSHGetExeAndArgsPlink(t *testing.T) {
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
 
-	exe, args := ssh.FormatArgs(ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, ""))
+	exe, args, needShell, _, _ := ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, "")
+	exe, args = ssh.FormatArgs(exe, args, needShell)
 	assert.Equal(t, plink, exe)
 	assert.Equal(t, []string{"user@foo.com"}, args)
 }
@@ -159,7 +162,8 @@ func TestSSHGetExeAndArgsPlinkCustomPort(t *testing.T) {
 	meta.UserAndHost = "user@foo.com"
 	meta.Port = "8888"
 
-	exe, args := ssh.FormatArgs(ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, ""))
+	exe, args, needShell, _, _ := ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, "")
+	exe, args = ssh.FormatArgs(exe, args, needShell)
 	assert.Equal(t, plink, exe)
 	assert.Equal(t, []string{"-P", "8888", "user@foo.com"}, args)
 }
@@ -178,7 +182,8 @@ func TestSSHGetExeAndArgsPlinkCustomPortExplicitEnvironment(t *testing.T) {
 	meta.UserAndHost = "user@foo.com"
 	meta.Port = "8888"
 
-	exe, args := ssh.FormatArgs(ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, ""))
+	exe, args, needShell, _, _ := ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, "")
+	exe, args = ssh.FormatArgs(exe, args, needShell)
 	assert.Equal(t, plink, exe)
 	assert.Equal(t, []string{"-P", "8888", "user@foo.com"}, args)
 }
@@ -197,7 +202,8 @@ func TestSSHGetExeAndArgsPlinkCustomPortExplicitEnvironmentPutty(t *testing.T) {
 	meta.UserAndHost = "user@foo.com"
 	meta.Port = "8888"
 
-	exe, args := ssh.FormatArgs(ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, ""))
+	exe, args, needShell, _, _ := ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, "")
+	exe, args = ssh.FormatArgs(exe, args, needShell)
 	assert.Equal(t, plink, exe)
 	assert.Equal(t, []string{"-P", "8888", "user@foo.com"}, args)
 }
@@ -216,7 +222,8 @@ func TestSSHGetExeAndArgsPlinkCustomPortExplicitEnvironmentSsh(t *testing.T) {
 	meta.UserAndHost = "user@foo.com"
 	meta.Port = "8888"
 
-	exe, args := ssh.FormatArgs(ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, ""))
+	exe, args, needShell, _, _ := ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, "")
+	exe, args = ssh.FormatArgs(exe, args, needShell)
 	assert.Equal(t, plink, exe)
 	assert.Equal(t, []string{"-p", "8888", "user@foo.com"}, args)
 }
@@ -233,7 +240,8 @@ func TestSSHGetExeAndArgsTortoisePlink(t *testing.T) {
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
 
-	exe, args := ssh.FormatArgs(ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, ""))
+	exe, args, needShell, _, _ := ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, "")
+	exe, args = ssh.FormatArgs(exe, args, needShell)
 	assert.Equal(t, plink, exe)
 	assert.Equal(t, []string{"-batch", "user@foo.com"}, args)
 }
@@ -251,7 +259,8 @@ func TestSSHGetExeAndArgsTortoisePlinkCustomPort(t *testing.T) {
 	meta.UserAndHost = "user@foo.com"
 	meta.Port = "8888"
 
-	exe, args := ssh.FormatArgs(ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, ""))
+	exe, args, needShell, _, _ := ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, "")
+	exe, args = ssh.FormatArgs(exe, args, needShell)
 	assert.Equal(t, plink, exe)
 	assert.Equal(t, []string{"-batch", "-P", "8888", "user@foo.com"}, args)
 }
@@ -270,7 +279,8 @@ func TestSSHGetExeAndArgsTortoisePlinkCustomPortExplicitEnvironment(t *testing.T
 	meta.UserAndHost = "user@foo.com"
 	meta.Port = "8888"
 
-	exe, args := ssh.FormatArgs(ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, ""))
+	exe, args, needShell, _, _ := ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, "")
+	exe, args = ssh.FormatArgs(exe, args, needShell)
 	assert.Equal(t, plink, exe)
 	assert.Equal(t, []string{"-batch", "-P", "8888", "user@foo.com"}, args)
 }
@@ -291,7 +301,8 @@ func TestSSHGetExeAndArgsTortoisePlinkCustomPortExplicitConfig(t *testing.T) {
 	meta.UserAndHost = "user@foo.com"
 	meta.Port = "8888"
 
-	exe, args := ssh.FormatArgs(ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, ""))
+	exe, args, needShell, _, _ := ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, "")
+	exe, args = ssh.FormatArgs(exe, args, needShell)
 	assert.Equal(t, plink, exe)
 	assert.Equal(t, []string{"-batch", "-P", "8888", "user@foo.com"}, args)
 }
@@ -311,7 +322,8 @@ func TestSSHGetExeAndArgsTortoisePlinkCustomPortExplicitConfigOverride(t *testin
 	meta.UserAndHost = "user@foo.com"
 	meta.Port = "8888"
 
-	exe, args := ssh.FormatArgs(ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, ""))
+	exe, args, needShell, _, _ := ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, "")
+	exe, args = ssh.FormatArgs(exe, args, needShell)
 	assert.Equal(t, plink, exe)
 	assert.Equal(t, []string{"-P", "8888", "user@foo.com"}, args)
 }
@@ -327,7 +339,8 @@ func TestSSHGetExeAndArgsSshCommandPrecedence(t *testing.T) {
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
 
-	exe, args := ssh.FormatArgs(ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, ""))
+	exe, args, needShell, _, _ := ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, "")
+	exe, args = ssh.FormatArgs(exe, args, needShell)
 	assert.Equal(t, "sh", exe)
 	assert.Equal(t, []string{"-c", "sshcmd user@foo.com"}, args)
 }
@@ -342,7 +355,8 @@ func TestSSHGetExeAndArgsSshCommandArgs(t *testing.T) {
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
 
-	exe, args := ssh.FormatArgs(ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, ""))
+	exe, args, needShell, _, _ := ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, "")
+	exe, args = ssh.FormatArgs(exe, args, needShell)
 	assert.Equal(t, "sh", exe)
 	assert.Equal(t, []string{"-c", "sshcmd --args 1 user@foo.com"}, args)
 }
@@ -357,7 +371,8 @@ func TestSSHGetExeAndArgsSshCommandArgsWithMixedQuotes(t *testing.T) {
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
 
-	exe, args := ssh.FormatArgs(ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, ""))
+	exe, args, needShell, _, _ := ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, "")
+	exe, args = ssh.FormatArgs(exe, args, needShell)
 	assert.Equal(t, "sh", exe)
 	assert.Equal(t, []string{"-c", "sshcmd foo 'bar \"baz\"' user@foo.com"}, args)
 }
@@ -372,7 +387,8 @@ func TestSSHGetExeAndArgsSshCommandCustomPort(t *testing.T) {
 	meta.UserAndHost = "user@foo.com"
 	meta.Port = "8888"
 
-	exe, args := ssh.FormatArgs(ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, ""))
+	exe, args, needShell, _, _ := ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, "")
+	exe, args = ssh.FormatArgs(exe, args, needShell)
 	assert.Equal(t, "sh", exe)
 	assert.Equal(t, []string{"-c", "sshcmd -p 8888 user@foo.com"}, args)
 }
@@ -388,7 +404,8 @@ func TestSSHGetExeAndArgsCoreSshCommand(t *testing.T) {
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
 
-	exe, args := ssh.FormatArgs(ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, ""))
+	exe, args, needShell, _, _ := ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, "")
+	exe, args = ssh.FormatArgs(exe, args, needShell)
 	assert.Equal(t, "sh", exe)
 	assert.Equal(t, []string{"-c", "sshcmd --args 2 user@foo.com"}, args)
 }
@@ -402,7 +419,8 @@ func TestSSHGetExeAndArgsCoreSshCommandArgsWithMixedQuotes(t *testing.T) {
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
 
-	exe, args := ssh.FormatArgs(ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, ""))
+	exe, args, needShell, _, _ := ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, "")
+	exe, args = ssh.FormatArgs(exe, args, needShell)
 	assert.Equal(t, "sh", exe)
 	assert.Equal(t, []string{"-c", "sshcmd foo 'bar \"baz\"' user@foo.com"}, args)
 }
@@ -416,7 +434,8 @@ func TestSSHGetExeAndArgsConfigVersusEnv(t *testing.T) {
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
 
-	exe, args := ssh.FormatArgs(ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, ""))
+	exe, args, needShell, _, _ := ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, "")
+	exe, args = ssh.FormatArgs(exe, args, needShell)
 	assert.Equal(t, "sh", exe)
 	assert.Equal(t, []string{"-c", "sshcmd --args 1 user@foo.com"}, args)
 }
@@ -432,7 +451,8 @@ func TestSSHGetExeAndArgsPlinkCommand(t *testing.T) {
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
 
-	exe, args := ssh.FormatArgs(ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, ""))
+	exe, args, needShell, _, _ := ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, "")
+	exe, args = ssh.FormatArgs(exe, args, needShell)
 	assert.Equal(t, "sh", exe)
 	assert.Equal(t, []string{"-c", plink + " user@foo.com"}, args)
 }
@@ -449,7 +469,8 @@ func TestSSHGetExeAndArgsPlinkCommandCustomPort(t *testing.T) {
 	meta.UserAndHost = "user@foo.com"
 	meta.Port = "8888"
 
-	exe, args := ssh.FormatArgs(ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, ""))
+	exe, args, needShell, _, _ := ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, "")
+	exe, args = ssh.FormatArgs(exe, args, needShell)
 	assert.Equal(t, "sh", exe)
 	assert.Equal(t, []string{"-c", plink + " -P 8888 user@foo.com"}, args)
 }
@@ -465,7 +486,8 @@ func TestSSHGetExeAndArgsTortoisePlinkCommand(t *testing.T) {
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
 
-	exe, args := ssh.FormatArgs(ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, ""))
+	exe, args, needShell, _, _ := ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, "")
+	exe, args = ssh.FormatArgs(exe, args, needShell)
 	assert.Equal(t, "sh", exe)
 	assert.Equal(t, []string{"-c", plink + " -batch user@foo.com"}, args)
 }
@@ -482,7 +504,8 @@ func TestSSHGetExeAndArgsTortoisePlinkCommandCustomPort(t *testing.T) {
 	meta.UserAndHost = "user@foo.com"
 	meta.Port = "8888"
 
-	exe, args := ssh.FormatArgs(ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, ""))
+	exe, args, needShell, _, _ := ssh.GetExeAndArgs(cli.OSEnv(), cli.GitEnv(), &meta, false, "")
+	exe, args = ssh.FormatArgs(exe, args, needShell)
 	assert.Equal(t, "sh", exe)
 	assert.Equal(t, []string{"-c", plink + " -batch -P 8888 user@foo.com"}, args)
 }

--- a/t/cmd/lfs-ssh-echo.go
+++ b/t/cmd/lfs-ssh-echo.go
@@ -73,8 +73,12 @@ func main() {
 		}
 		if pathArg, found := strings.CutPrefix(os.Args[offset+1], "-oControlPath="); found {
 			if master {
-				if file, err := os.OpenFile(pathArg, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0); err != nil {
-					fmt.Fprintf(os.Stderr, "expected %q to not exist", pathArg)
+				if file, err := os.OpenFile(pathArg, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0666); err != nil {
+					if os.IsExist(err) {
+						fmt.Fprintf(os.Stderr, "expected %q to not exist", pathArg)
+					} else {
+						fmt.Fprintf(os.Stderr, "unable to create %q: %s", pathArg, err)
+					}
 					os.Exit(1)
 				} else {
 					file.Close()
@@ -82,7 +86,11 @@ func main() {
 				}
 			} else {
 				if file, err := os.OpenFile(pathArg, os.O_RDONLY, 0); err != nil {
-					fmt.Fprintf(os.Stderr, "expected %q to exist", pathArg)
+					if os.IsNotExist(err) {
+						fmt.Fprintf(os.Stderr, "expected %q to exist", pathArg)
+					} else {
+						fmt.Fprintf(os.Stderr, "unable to open %q: %s", pathArg, err)
+					}
 					os.Exit(1)
 				} else {
 					file.Close()

--- a/t/t-batch-transfer.sh
+++ b/t/t-batch-transfer.sh
@@ -262,8 +262,8 @@ begin_test "batch transfers with ssh endpoint (git-lfs-transfer)"
   assert_remote_object "$reponame" "$(calc_oid "$contents")" "${#contents}"
 
   cd ..
-  GIT_TRACE=1 git clone "$sshurl" "$reponame-2" 2>&1 | tee trace.log
-  assert_ssh_transfer_sessions 'trace.log' 'download' 1 8
+  GIT_TRACE=1 git clone "$sshurl" "$reponame-2" 2>&1 | tee clone.log
+  assert_ssh_transfer_sessions 'clone.log' 'download' 1 8
 
   cd "$reponame-2"
   git lfs fsck
@@ -304,8 +304,8 @@ begin_test "batch transfers with ssh endpoint and multiple objects (git-lfs-tran
   assert_remote_object "$reponame" "$(calc_oid "$contents3")" "${#contents3}"
 
   cd ..
-  GIT_TRACE=1 git clone "$sshurl" "$reponame-2" 2>&1 | tee trace.log
-  assert_ssh_transfer_sessions 'trace.log' 'download' 3 8
+  GIT_TRACE=1 git clone "$sshurl" "$reponame-2" 2>&1 | tee clone.log
+  assert_ssh_transfer_sessions 'clone.log' 'download' 3 8
 
   cd "$reponame-2"
   git lfs fsck
@@ -349,8 +349,8 @@ begin_test "batch transfers with ssh endpoint and multiple objects and batches (
   assert_remote_object "$reponame" "$(calc_oid "$contents3")" "${#contents3}"
 
   cd ..
-  GIT_TRACE=1 git clone "$sshurl" "$reponame-2" 2>&1 | tee trace.log
-  assert_ssh_transfer_sessions 'trace.log' 'download' 3 2
+  GIT_TRACE=1 git clone "$sshurl" "$reponame-2" 2>&1 | tee clone.log
+  assert_ssh_transfer_sessions 'clone.log' 'download' 3 2
 
   cd "$reponame-2"
   git lfs fsck

--- a/t/t-batch-transfer.sh
+++ b/t/t-batch-transfer.sh
@@ -186,6 +186,7 @@ begin_test "batch transfers with ssh endpoint (git-lfs-transfer)"
 
   GIT_TRACE=1 git push origin main >push.log 2>&1
   grep "lfs-ssh-echo.*git-lfs-transfer .*$reponame.git upload" push.log
+  assert_remote_object "$reponame" "$(calc_oid "$contents")" "${#contents}"
 
   cd ..
   GIT_TRACE=1 git clone "$sshurl" "$reponame-2" 2>&1 | tee trace.log

--- a/t/testhelpers.sh
+++ b/t/testhelpers.sh
@@ -176,6 +176,22 @@ assert_server_object() {
   }
 }
 
+# assert_remote_object() confirms that an object file with the given OID and
+# size is stored in the "remote" copy of a repository
+assert_remote_object() {
+  local reponame="$1"
+  local oid="$2"
+  local size="$3"
+  local destination="$(canonical_path "$REMOTEDIR/$reponame.git")"
+
+  pushd "$destination"
+    local cfg="$(git lfs env | grep LocalMediaDir)"
+    local f="${cfg:14}/${oid:0:2}/${oid:2:2}/$oid"
+    actualsize="$(wc -c <"$f" | tr -d '[[:space:]]')"
+    [ "$size" -eq "$actualsize" ]
+  popd
+}
+
 check_server_lock_ssh() {
   local reponame="$1"
   local id="$2"


### PR DESCRIPTION
This PR fixes a bug where the Git LFS client may crash while cloning a repository with multiple Git LFS objects using the  "pure" SSH version of the Git LFS transfer [protocol](https://github.com/git-lfs/git-lfs/blob/f979a7db3b11d77975bc241f2c5ae71b02457d2c/docs/proposals/ssh_adapter.md).

Our existing [test](https://github.com/git-lfs/git-lfs/blob/f979a7db3b11d77975bc241f2c5ae71b02457d2c/t/t-batch-transfer.sh#L166-L192) of the SSH object transfer protocol did not detect the problem because it only pushes and fetches a single object, so we add more tests to confirm that the changes in this PR are effective.

In order for these additional tests to succeed, we also fix a latent issue in our `lfs-ssh-echo` test utility program whereby it silently fails while trying to emulate the behaviour of the OpenSSH client when it is asked to multiplex a new SSH session over an existing SSH connection's control socket.

As well, we revise the trace log messages generated by our SSH session handling code and make several other minor adjustments, including renaming the receiver variables of our `SSHTransfer` structure so they do not conflict with the name of our `tr` text localization package, and expanding our existing single-object test of the SSH object transfer protocol to align with the more comprehensive checks performed by our new tests.

This PR will be most easily reviewed on a commit-by-commit basis.

Resolves #5880.