### PR TITLE
Always capture clone logs in tests and remove or update stale workarounds

### DIFF
--- a/t/t-batch-error-handling.sh
+++ b/t/t-batch-error-handling.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-# This is a sample Git LFS test.  See test/README.md and testhelpers.sh for
-# more documentation.
 
 . "$(dirname "$0")/testlib.sh"
 

--- a/t/t-batch-transfer.sh
+++ b/t/t-batch-transfer.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-# This is a sample Git LFS test.  See test/README.md and testhelpers.sh for
-# more documentation.
 
 . "$(dirname "$0")/testlib.sh"
 

--- a/t/t-chunked-transfer-encoding.sh
+++ b/t/t-chunked-transfer-encoding.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-# This is a sample Git LFS test.  See test/README.md and testhelpers.sh for
-# more documentation.
 
 . "$(dirname "$0")/testlib.sh"
 

--- a/t/t-clone.sh
+++ b/t/t-clone.sh
@@ -179,10 +179,6 @@ begin_test "clone ClientCert"
   reponame="test-cloneClientCert"
   setup_remote_repo "$reponame"
   clone_repo_clientcert "$reponame" "$reponame"
-  if [ $(grep -c "client-cert-mac-openssl" clone_client_cert.log) -gt 0 ]; then
-    echo "Skipping due to SSL client cert bug in Git"
-    exit 0
-  fi
 
   git lfs track "*.dat" 2>&1 | tee track.log
   grep "Tracking \"\*.dat\"" track.log
@@ -267,10 +263,6 @@ begin_test "clone ClientCert with homedir certs"
 
   setup_remote_repo "$reponame"
   clone_repo_clientcert "$reponame" "$reponame"
-  if [ $(grep -c "client-cert-mac-openssl" clone_client_cert.log) -gt 0 ]; then
-    echo "Skipping due to SSL client cert bug in Git"
-    exit 0
-  fi
 
   git lfs track "*.dat" 2>&1 | tee track.log
   grep "Tracking \"\*.dat\"" track.log

--- a/t/t-env.sh
+++ b/t/t-env.sh
@@ -10,6 +10,10 @@ if [ "$IS_WINDOWS" -eq 1 ]; then
   export MSYS2_ENV_CONV_EXCL="GIT_LFS_TEST_DIR"
 fi
 
+# The "git lfs env" command should ignore this environment variable
+# despite the "GIT_" strings in its name and value.
+export TEST_GIT_EXAMPLE="GIT_EXAMPLE"
+
 begin_test "env with no remote"
 (
   set -e

--- a/t/t-happy-path.sh
+++ b/t/t-happy-path.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# This is a sample Git LFS test.  See test/README.md and testhelpers.sh for
-# more documentation.
 
 . "$(dirname "$0")/testlib.sh"
 
+# This is a sample Git LFS test.  See test/README.md and testhelpers.sh for
+# more documentation.
 begin_test "happy path"
 (
   set -e

--- a/t/t-worktree.sh
+++ b/t/t-worktree.sh
@@ -11,6 +11,10 @@ if [ "$IS_WINDOWS" -eq 1 ]; then
   export MSYS2_ENV_CONV_EXCL="GIT_LFS_TEST_DIR"
 fi
 
+# The "git lfs env" command should ignore this environment variable
+# despite the "GIT_" strings in its name and value.
+export TEST_GIT_EXAMPLE="GIT_EXAMPLE"
+
 begin_test "git worktree"
 (
     set -e

--- a/t/testenv.sh
+++ b/t/testenv.sh
@@ -152,7 +152,6 @@ GIT_CONFIG_NOSYSTEM=1
 GIT_TERMINAL_PROMPT=0
 GIT_SSH=lfs-ssh-echo
 GIT_TEMPLATE_DIR="$(native_path "$ROOTDIR/t/fixtures/templates")"
-APPVEYOR_REPO_COMMIT_MESSAGE="test: env test should look for GIT_SSH too"
 LC_ALL=C
 
 export CREDSDIR
@@ -160,7 +159,6 @@ export GIT_LFS_FORCE_PROGRESS
 export GIT_CONFIG_NOSYSTEM
 export GIT_SSH
 export GIT_TEMPLATE_DIR
-export APPVEYOR_REPO_COMMIT_MESSAGE
 export LC_ALL
 
 # Don't fail if run under git rebase -x.

--- a/t/testhelpers.sh
+++ b/t/testhelpers.sh
@@ -482,11 +482,6 @@ clone_repo_clientcert() {
   fi
 
   echo "$out" > clone_client_cert.log
-  if [ $(grep -c "NSInvalidArgumentException" clone_client_cert.log) -gt 0 ]; then
-    echo "client-cert-mac-openssl" > clone_client_cert.log
-    return 0
-  fi
-
   return 1
 }
 

--- a/t/testhelpers.sh
+++ b/t/testhelpers.sh
@@ -417,12 +417,16 @@ clone_repo() {
   local reponame="$1"
   local dir="$2"
   echo "clone local git repository $reponame to $dir"
-  out=$(git clone "$GITSERVER/$reponame" "$dir" 2>&1)
+  git clone "$GITSERVER/$reponame" "$dir" 2>&1 | tee clone.log
+
+  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
+    return 1
+  fi
+
   cd "$dir"
+  mv ../clone.log .
 
   git config credential.helper lfstest
-  echo "$out" > clone.log
-  echo "$out"
 }
 
 # clone_repo_url clones a Git repository to the subdirectory $dir under $TRASHDIR.
@@ -433,12 +437,16 @@ clone_repo_url() {
   local repo="$1"
   local dir="$2"
   echo "clone git repository $repo to $dir"
-  out=$(git clone "$repo" "$dir" 2>&1)
+  git clone "$repo" "$dir" 2>&1 | tee clone.log
+
+  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
+    return 1
+  fi
+
   cd "$dir"
+  mv ../clone.log .
 
   git config credential.helper lfstest
-  echo "$out" > clone.log
-  echo "$out"
 }
 
 # clone_repo_ssl clones a repository from the test Git server to the subdirectory
@@ -450,13 +458,16 @@ clone_repo_ssl() {
   local reponame="$1"
   local dir="$2"
   echo "clone local git repository $reponame to $dir"
-  out=$(git clone "$SSLGITSERVER/$reponame" "$dir" 2>&1)
+  git clone "$SSLGITSERVER/$reponame" "$dir" 2>&1 | tee clone_ssl.log
+
+  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
+    return 1
+  fi
+
   cd "$dir"
+  mv ../clone_ssl.log .
 
   git config credential.helper lfstest
-
-  echo "$out" > clone_ssl.log
-  echo "$out"
 }
 
 # clone_repo_clientcert clones a repository from the test Git server to the subdirectory
@@ -468,21 +479,16 @@ clone_repo_clientcert() {
   local reponame="$1"
   local dir="$2"
   echo "clone $CLIENTCERTGITSERVER/$reponame to $dir"
-  set +e
-  out=$(git clone "$CLIENTCERTGITSERVER/$reponame" "$dir" 2>&1)
-  res="${PIPESTATUS[0]}"
-  set -e
+  git clone "$CLIENTCERTGITSERVER/$reponame" "$dir" 2>&1 | tee clone_client_cert.log
 
-  if [ "0" -eq "$res" ]; then
-    cd "$dir"
-    echo "$out" > clone_client_cert.log
-
-    git config credential.helper lfstest
-    return 0
+  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
+    return 1
   fi
 
-  echo "$out" > clone_client_cert.log
-  return 1
+  cd "$dir"
+  mv ../clone_client_cert.log .
+
+  git config credential.helper lfstest
 }
 
 # setup_remote_repo_with_file creates a remote repo, clones it locally, commits


### PR DESCRIPTION
This PR updates our test suite to remove or refine a number of stale comments and code, including [detection](https://github.com/git-lfs/git-lfs/blob/f979a7db3b11d77975bc241f2c5ae71b02457d2c/t/testhelpers.sh#L485-L488) of an old TLS/SSL client certificate problem with libcurl on macOS 10.12 ("Sierra") from 2016, which was used to [skip](https://github.com/git-lfs/git-lfs/blob/f979a7db3b11d77975bc241f2c5ae71b02457d2c/t/t-clone.sh#L182-L185) [some](https://github.com/git-lfs/git-lfs/blob/f979a7db3b11d77975bc241f2c5ae71b02457d2c/t/t-clone.sh#L270-L273) of our tests of the `git lfs clone` command, and the obscure [name](https://github.com/git-lfs/git-lfs/blob/f979a7db3b11d77975bc241f2c5ae71b02457d2c/t/testenv.sh#L155) of an environment variable intended to validate the behaviour of the `git lfs env` command.

We then refactor the family of `clone_repo*()` [functions](https://github.com/git-lfs/git-lfs/blob/f979a7db3b11d77975bc241f2c5ae71b02457d2c/t/testhelpers.sh#L411-L491) in our test suite's shell library so they all operate identically and always create a log file with the output of the `git clone` command, regardless of whether that command succeeds or fails.  This will allow us to write tests which intentionally perform a `git clone` command that fails, and then check the log file for particular error messages.

Regarding the issue with libcurl on macOS 10.12, the underlying issue was fixed by commit curl/curl@7c9b9add6ff5626fc8712d8f8b4e607dcbe8dbfe in libcurl version 7.52.0, and so we no longer need to work around any macOS-specific exceptions raised by the use of TLS/SSL client certificates in our tests.

As for the legacy `APPVEYOR_REPO_COMMIT_MESSAGE` environment variable set by our test suite, this was introduced in PR #1825 to demonstrate that a problem exposed by a commit in that PR had been addressed.  The `Envrion()` function in our `lfs` package, which is used to produce the output of the `git lfs env` command, currently [ignores](https://github.com/git-lfs/git-lfs/blob/f979a7db3b11d77975bc241f2c5ae71b02457d2c/lfs/lfs.go#L81-L83) any environment variables whose names do not begin with `GIT_`.  However, at the time of PR #1825 it would instead [include](https://github.com/git-lfs/git-lfs/blob/0951c698ad22a53c04d8d5d98a100f18f6e3993a/lfs/lfs.go#L112-L114) in the map it returns any variables whose names or values merely contained the string `GIT_`.  This issue was revealed when the AppVeyor CI service then in use populated one of its own environment variables with the message from commit 0951c698ad22a53c04d8d5d98a100f18f6e3993a that just happened to contain the string `GIT_`.  To confirm that the bug was fixed, a copy of the problematic variable was simply inserted into our test suite's environment, keeping both the name and value.  (For more discussion of this history, see the discussion in https://github.com/git-lfs/git-lfs/pull/5615#issuecomment-2445388603.)  The variable's name makes its purpose unclear, so we replace it with dedicated `TEST_GIT_EXAMPLE` environment variables in the specific test scripts that check the output of the `git lfs env` command.

This PR will be most easily reviewed on a commit-by-commit basis.