### PR TITLE
Update Linux distribution package list for v3.6.0 release

### DIFF
--- a/script/lib/distro.rb
+++ b/script/lib/distro.rb
@@ -90,12 +90,12 @@ class DistroMap
         package_tag: "",
         equivalent: [
           "debian/bullseye",           # EOL June 2026
-          "ubuntu/jammy",              # EOL April 2027
-          "ubuntu/mantic",             # EOL July 2024
           "linuxmint/vanessa",         # EOL April 2027
           "linuxmint/vera",            # EOL April 2027
           "linuxmint/victoria",        # EOL April 2027
           "linuxmint/virginia",        # EOL April 2027
+          "ubuntu/jammy",              # EOL April 2027
+          "ubuntu/mantic",             # EOL July 2024
         ],
       },
       "debian/12" => {

--- a/script/lib/distro.rb
+++ b/script/lib/distro.rb
@@ -35,8 +35,7 @@ class DistroMap
         package_tag: "-1.el7",
         equivalent: [
           "el/7",                      # EOL June 2024
-          "scientific/7",              # EOL June 2024
-          "sles/12.5",                 # EOL October 2024 (LTSS October 2027)
+          "sles/12.5",                 # EOL October 2024
         ],
       },
       "centos/8" => {
@@ -59,10 +58,11 @@ class DistroMap
         package_tag: "-1.el9",
         equivalent: [
           "el/9",                      # EOL May 2032
-          "fedora/38",                 # EOL May 2024
           "fedora/39",                 # EOL November 2024
           "fedora/40",                 # EOL May 2025
+          "fedora/41",                 # EOL November 2025
           "opensuse/15.6",             # EOL December 2025
+          "sles/15.6",                 # Current
         ],
       },
       # Debian EOL https://wiki.debian.org/LTS/
@@ -96,7 +96,6 @@ class DistroMap
           "linuxmint/victoria",        # EOL April 2027
           "linuxmint/virginia",        # EOL April 2027
           "ubuntu/jammy",              # EOL April 2027
-          "ubuntu/mantic",             # EOL July 2024
         ],
       },
       "debian/12" => {
@@ -108,7 +107,9 @@ class DistroMap
         equivalent: [
           "debian/bookworm",           # EOL June 2028
           "debian/trixie",             # Current testing (Debian 13)
+          "linuxmint/wilma",           # EOL April 2029
           "ubuntu/noble",              # EOL June 2029
+          "ubuntu/oracular",           # EOL July 2025
         ]
       },
     }

--- a/script/lib/distro.rb
+++ b/script/lib/distro.rb
@@ -33,9 +33,9 @@ class DistroMap
         package_type: "rpm",
         package_tag: "-1.el7",
         equivalent: [
-          "el/7",         # EOL June 2024
-          "scientific/7", # EOL June 2024
-          "sles/12.5",    # EOL October 2024 (LTSS October 2027)
+          "el/7",                      # EOL June 2024
+          "scientific/7",              # EOL June 2024
+          "sles/12.5",                 # EOL October 2024 (LTSS October 2027)
         ],
       },
       "centos/8" => {
@@ -46,9 +46,9 @@ class DistroMap
         package_tag: "-1.el8",
         equivalent: [
           "el/8",
-          "opensuse/15.5", # EOL December 2024
-          "opensuse/15.6", # EOL December 2025
-          "sles/15.5",     # Current
+          "opensuse/15.5",             # EOL December 2024
+          "opensuse/15.6",             # EOL December 2025
+          "sles/15.5",                 # Current
         ],
       },
       "rocky/9" => {
@@ -59,9 +59,9 @@ class DistroMap
         package_tag: "-1.el9",
         equivalent: [
           "el/9",
-          "fedora/38", # EOL May 2024
-          "fedora/39", # EOL Dec 2024
-          "fedora/40", # Current
+          "fedora/38",                 # EOL May 2024
+          "fedora/39",                 # EOL Dec 2024
+          "fedora/40",                 # Current
         ],
       },
       # Debian EOL https://wiki.debian.org/LTS/
@@ -74,12 +74,12 @@ class DistroMap
         package_type: "deb",
         package_tag: "",
         equivalent: [
-          "debian/buster",    # EOL June 2024
-          "linuxmint/ulyana", # EOL April 2025
-          "linuxmint/ulyssa", # EOL April 2025
-          "linuxmint/uma",    # EOL April 2025
-          "linuxmint/una",    # EOL April 2025
-          "ubuntu/focal",     # EOL April 2025
+          "debian/buster",             # EOL June 2024
+          "linuxmint/ulyana",          # EOL April 2025
+          "linuxmint/ulyssa",          # EOL April 2025
+          "linuxmint/uma",             # EOL April 2025
+          "linuxmint/una",             # EOL April 2025
+          "ubuntu/focal",              # EOL April 2025
         ],
       },
       "debian/11" => {
@@ -89,13 +89,13 @@ class DistroMap
         package_type: "deb",
         package_tag: "",
         equivalent: [
-          "debian/bullseye",    # EOL June 2026
-          "ubuntu/jammy",       # EOL April 2027
-          "ubuntu/mantic",      # EOL July 2024
-          "linuxmint/vanessa",  # EOL April 2027
-          "linuxmint/vera",     # EOL April 2027
-          "linuxmint/victoria", # EOL April 2027
-          "linuxmint/virginia", # EOL April 2027
+          "debian/bullseye",           # EOL June 2026
+          "ubuntu/jammy",              # EOL April 2027
+          "ubuntu/mantic",             # EOL July 2024
+          "linuxmint/vanessa",         # EOL April 2027
+          "linuxmint/vera",            # EOL April 2027
+          "linuxmint/victoria",        # EOL April 2027
+          "linuxmint/virginia",        # EOL April 2027
         ],
       },
       "debian/12" => {
@@ -105,9 +105,9 @@ class DistroMap
         package_type: "deb",
         package_tag: "",
         equivalent: [
-          "debian/bookworm",  # Current stable
-          "debian/trixie",    # Current testing
-          "ubuntu/noble",     # EOL June 2029
+          "debian/bookworm",           # Current stable
+          "debian/trixie",             # Current testing
+          "ubuntu/noble",              # EOL June 2029
         ]
       },
     }

--- a/script/lib/distro.rb
+++ b/script/lib/distro.rb
@@ -48,7 +48,6 @@ class DistroMap
         equivalent: [
           "el/8",                      # EOL May 2029
           "opensuse/15.5",             # EOL December 2024
-          "opensuse/15.6",             # EOL December 2025
           "sles/15.5",                 # EOL December 2024
         ],
       },
@@ -63,6 +62,7 @@ class DistroMap
           "fedora/38",                 # EOL May 2024
           "fedora/39",                 # EOL November 2024
           "fedora/40",                 # EOL May 2025
+          "opensuse/15.6",             # EOL December 2025
         ],
       },
       # Debian EOL https://wiki.debian.org/LTS/

--- a/script/lib/distro.rb
+++ b/script/lib/distro.rb
@@ -23,6 +23,7 @@ class DistroMap
   def self.builtin_map
     {
       # RHEL EOL https://access.redhat.com/support/policy/updates/errata
+      # Fedora EOL https://docs.fedoraproject.org/en-US/releases/
       # SLES EOL https://www.suse.com/lifecycle/
       # opensuse https://en.opensuse.org/Lifetime
       # or https://en.wikipedia.org/wiki/OpenSUSE_version_history
@@ -45,10 +46,10 @@ class DistroMap
         package_type: "rpm",
         package_tag: "-1.el8",
         equivalent: [
-          "el/8",
+          "el/8",                      # EOL May 2029
           "opensuse/15.5",             # EOL December 2024
           "opensuse/15.6",             # EOL December 2025
-          "sles/15.5",                 # Current
+          "sles/15.5",                 # EOL December 2024
         ],
       },
       "rocky/9" => {
@@ -58,10 +59,10 @@ class DistroMap
         package_type: "rpm",
         package_tag: "-1.el9",
         equivalent: [
-          "el/9",
+          "el/9",                      # EOL May 2032
           "fedora/38",                 # EOL May 2024
-          "fedora/39",                 # EOL Dec 2024
-          "fedora/40",                 # Current
+          "fedora/39",                 # EOL November 2024
+          "fedora/40",                 # EOL May 2025
         ],
       },
       # Debian EOL https://wiki.debian.org/LTS/
@@ -89,7 +90,7 @@ class DistroMap
         package_type: "deb",
         package_tag: "",
         equivalent: [
-          "debian/bullseye",           # EOL June 2026
+          "debian/bullseye",           # EOL August 2026
           "linuxmint/vanessa",         # EOL April 2027
           "linuxmint/vera",            # EOL April 2027
           "linuxmint/victoria",        # EOL April 2027
@@ -105,8 +106,8 @@ class DistroMap
         package_type: "deb",
         package_tag: "",
         equivalent: [
-          "debian/bookworm",           # Current stable
-          "debian/trixie",             # Current testing
+          "debian/bookworm",           # EOL June 2028
+          "debian/trixie",             # Current testing (Debian 13)
           "ubuntu/noble",              # EOL June 2029
         ]
       },


### PR DESCRIPTION
As we anticipate releasing Git LFS version 3.6.0 in the near future, we first update our list of the Linux distributions and versions for which our scripts will publish RPM and Debian packages.

This PR will be most easily reviewed on a commit-by-commit basis.

We first reformat and correct several details of in our [list](https://github.com/git-lfs/git-lfs/blob/9d69005f1be8d860f4f5ee51dd2a81758ea1c1cd/script/lib/distro.rb#L24-L113) of Linux distribution versions and the end dates of their regular support lifecycles.

We then update our list to remove distribution versions that are no longer supported and add those which have become available since our last revisions in PR #5647, prior to our Git LFS v3.5.0 release.

There are several points of note in terms of what we change and do not change:

- We move openSUSE Leap 15.6 and add SLES 15 SP6 into the set of distribution versions for which we consider the RPM package we build for RHEL/Rocky Linux 9 to be compatible.  Testing with both openSUSE Leap 15.6 and SLES 15 SP6 demonstrates that our full Git LFS test suite passes on those platforms when using the Git LFS binary from our v3.5.1 RPM package for RHEL/Rocky Linux 9.  (This follows from the fact that the glibc version in the RHEL 9 family of distributions is v2.34, while both of the latest SUSE distributions have a newer glibc v2.38, for which the ABI is backwards-compatible.)

- We leave Debian 10 ("buster") in our list for now, until the other distributions in that family reach the end of their regular support lifecycles, which will occur in April 2025.  If we removed this enty, we would have to either rename the "Debian 10" link we provide in our release notes or generate a "Debian 10" link which does not point to a `debian/*` package, neither of which seems desirable.

- We also leave RHEL/CentOS 7 in our list, because SLES 12 SP5, which was the last distribution version similar to this platform to reach the end of its regular support lifecycle, did so only at the end of last month, and because we have not yet clearly announced that we will no longer build packages for any distribution based on either RHEL/CentOS 7 or SLES 12.  We have also a [comment](https://github.com/git-lfs/git-lfs/blob/9d69005f1be8d860f4f5ee51dd2a81758ea1c1cd/script/lib/distro.rb#L38) which suggests that we might support SLES 12 SP5 through its LTSS (Long Term Service Pack Support) period, although this does not comport with our usual practice regarding extended support from vendors.

To be clear, then, the v3.6.x Git LFS releases will be the last ones for which we build a package for any distribution based on RHEL 7 or SLES 12.

Further, it is likely that the v3.6.x Git LFS releases will be the last ones for which we build a package for any distribution based on Debian 10.