### PR TITLE
Fix improper negated test expressions and refine TLS client certificate tests

### DIFF
--- a/t/cmd/lfstest-gitserver.go
+++ b/t/cmd/lfstest-gitserver.go
@@ -156,7 +156,10 @@ func main() {
 	debug("init", "server client cert url: %s", serverClientCert.URL)
 
 	<-stopch
-	debug("init", "git server done")
+	server.Close()
+	serverTLS.Close()
+	serverClientCert.Close()
+	debug("close", "git server done")
 }
 
 // writeTestStateFile writes contents to either the file referenced by the

--- a/t/t-askpass.sh
+++ b/t/t-askpass.sh
@@ -112,7 +112,7 @@ begin_test "askpass: defaults to provided credentials"
 
   GIT_ASKPASS="lfs-askpass" GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push origin main 2>&1 | tee push.log
 
-  [ ! $(grep "filling with GIT_ASKPASS" push.log) ]
+  grep "filling with GIT_ASKPASS" push.log && exit 1
   grep "main -> main" push.log
 )
 end_test

--- a/t/t-clone.sh
+++ b/t/t-clone.sh
@@ -57,8 +57,8 @@ begin_test "clone"
   grep "Cloning into" lfsclone.log
   grep "Downloading LFS objects:" lfsclone.log
   # should be no filter errors
-  [ ! $(grep "filter" lfsclone.log) ]
-  [ ! $(grep "error" lfsclone.log) ]
+  grep "filter" lfsclone.log && exit 1
+  grep "error" lfsclone.log && exit 1
   # should be cloned into location as per arg
   [ -d "$newclonedir" ]
 
@@ -78,8 +78,8 @@ begin_test "clone"
   grep "Cloning into" lfsclone.log
   grep "Downloading LFS objects:" lfsclone.log
   # should be no filter errors
-  [ ! $(grep "filter" lfsclone.log) ]
-  [ ! $(grep "error" lfsclone.log) ]
+  grep "filter" lfsclone.log && exit 1
+  grep "error" lfsclone.log && exit 1
   # clone location should be implied
   [ -d "$reponame" ]
 
@@ -142,8 +142,8 @@ begin_test "cloneSSL"
   grep "Cloning into" lfsclone.log
   grep "Downloading LFS objects:" lfsclone.log
   # should be no filter errors
-  [ ! $(grep "filter" lfsclone.log) ]
-  [ ! $(grep "error" lfsclone.log) ]
+  grep "filter" lfsclone.log && exit 1
+  grep "error" lfsclone.log && exit 1
   # should be cloned into location as per arg
   [ -d "$newclonedir" ]
 
@@ -216,8 +216,8 @@ begin_test "clone ClientCert"
     grep "Cloning into" lfsclone.log
     grep "Downloading LFS objects:" lfsclone.log
     # should be no filter errors
-    [ ! $(grep "filter" lfsclone.log) ]
-    [ ! $(grep "error" lfsclone.log) ]
+    grep "filter" lfsclone.log && exit 1
+    grep "error" lfsclone.log && exit 1
     # should be cloned into location as per arg
     [ -d "$newclonedir" ]
 
@@ -804,8 +804,8 @@ begin_test "clone (HTTP server/proxy require cookies)"
   grep "Cloning into" lfsclone.log
   grep "Downloading LFS objects:" lfsclone.log
   # should be no filter errors
-  [ ! $(grep "filter" lfsclone.log) ]
-  [ ! $(grep "error" lfsclone.log) ]
+  grep "filter" lfsclone.log && exit 1
+  grep "error" lfsclone.log && exit 1
   # should be cloned into location as per arg
   [ -d "$newclonedir" ]
 
@@ -825,8 +825,8 @@ begin_test "clone (HTTP server/proxy require cookies)"
   grep "Cloning into" lfsclone.log
   grep "Downloading LFS objects:" lfsclone.log
   # should be no filter errors
-  [ ! $(grep "filter" lfsclone.log) ]
-  [ ! $(grep "error" lfsclone.log) ]
+  grep "filter" lfsclone.log && exit 1
+  grep "error" lfsclone.log && exit 1
   # clone location should be implied
   [ -d "$reponame" ]
 

--- a/t/t-clone.sh
+++ b/t/t-clone.sh
@@ -94,6 +94,26 @@ begin_test "clone"
     [ ! -e "lfs" ]
     assert_clean_status
   popd
+
+  # Now check clone with standard 'git clone' and smudge download
+  rm -rf "$reponame"
+  git clone "$GITSERVER/$reponame" 2>&1 | tee clone.log
+  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected clone to succeed ..."
+    exit 1
+  fi
+  grep "Cloning into" clone.log
+  [ -d "$reponame" ]
+
+  pushd "$reponame"
+    [ $(wc -c < "file1.dat") -eq 110 ]
+    [ $(wc -c < "file2.dat") -eq 75 ]
+    [ $(wc -c < "file3.dat") -eq 66 ]
+    assert_hooks "$(dot_git_dir)"
+    [ ! -e "lfs" ]
+    [ "6" -eq "$(find "$(dot_git_dir)/lfs/objects" -type f | wc -l)" ]
+    assert_clean_status
+  popd
 )
 end_test
 
@@ -161,7 +181,23 @@ begin_test "cloneSSL"
 
   # Now check SSL clone with standard 'git clone' and smudge download
   rm -rf "$reponame"
-  git clone "$SSLGITSERVER/$reponame"
+  git clone "$SSLGITSERVER/$reponame" 2>&1 | tee clone.log
+  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected clone to succeed ..."
+    exit 1
+  fi
+  grep "Cloning into" clone.log
+  [ -d "$reponame" ]
+
+  pushd "$reponame"
+    [ $(wc -c < "file1.dat") -eq 100 ]
+    [ $(wc -c < "file2.dat") -eq 75 ]
+    [ $(wc -c < "file3.dat") -eq 30 ]
+    assert_hooks "$(dot_git_dir)"
+    [ ! -e "lfs" ]
+    [ "3" -eq "$(find "$(dot_git_dir)/lfs/objects" -type f | wc -l)" ]
+    assert_clean_status
+  popd
 )
 end_test
 
@@ -269,7 +305,23 @@ begin_test "clone ClientCert"
 
     # Now check clone with standard 'git clone' and smudge download
     rm -rf "$reponame"
-    git clone "$CLIENTCERTGITSERVER/$reponame"
+    git clone "$CLIENTCERTGITSERVER/$reponame" 2>&1 | tee clone.log
+    if [ "0" -ne "${PIPESTATUS[0]}" ]; then
+      echo >&2 "fatal: expected clone to succeed ..."
+      exit 1
+    fi
+    grep "Cloning into" clone.log
+    [ -d "$reponame" ]
+
+    pushd "$reponame"
+      [ $(wc -c < "file1.dat") -eq 100 ]
+      [ $(wc -c < "file2.dat") -eq 75 ]
+      [ $(wc -c < "file3.dat") -eq 30 ]
+      assert_hooks "$(dot_git_dir)"
+      [ ! -e "lfs" ]
+      [ "3" -eq "$(find "$(dot_git_dir)/lfs/objects" -type f | wc -l)" ]
+      assert_clean_status
+    popd
   done
 )
 end_test
@@ -392,7 +444,23 @@ begin_test "clone ClientCert with homedir certs"
 
     # Now check clone with standard 'git clone' and smudge download
     rm -rf "$reponame"
-    git clone "$CLIENTCERTGITSERVER/$reponame"
+    git clone "$CLIENTCERTGITSERVER/$reponame" 2>&1 | tee clone.log
+    if [ "0" -ne "${PIPESTATUS[0]}" ]; then
+      echo >&2 "fatal: expected clone to succeed ..."
+      exit 1
+    fi
+    grep "Cloning into" clone.log
+    [ -d "$reponame" ]
+
+    pushd "$reponame"
+      [ $(wc -c < "file1.dat") -eq 100 ]
+      [ $(wc -c < "file2.dat") -eq 75 ]
+      [ $(wc -c < "file3.dat") -eq 30 ]
+      assert_hooks "$(dot_git_dir)"
+      [ ! -e "lfs" ]
+      [ "3" -eq "$(find "$(dot_git_dir)/lfs/objects" -type f | wc -l)" ]
+      assert_clean_status
+    popd
   done
 )
 end_test

--- a/t/t-clone.sh
+++ b/t/t-clone.sh
@@ -211,6 +211,7 @@ begin_test "clone ClientCert"
   git push origin main
 
   # Now clone again with 'git lfs clone', test specific clone dir
+  # Test with both unencrypted and encrypted client certificate keys
   cd "$TRASHDIR"
 
   for i in "$LFS_CLIENT_KEY_FILE" "$LFS_CLIENT_KEY_FILE_ENCRYPTED"
@@ -238,14 +239,11 @@ begin_test "clone ClientCert"
       [ ! -e "lfs" ]
       assert_clean_status
     popd
+
+    # Now check clone with standard 'git clone' and smudge download
+    rm -rf "$reponame"
+    git clone "$CLIENTCERTGITSERVER/$reponame"
   done
-
-  git config --global http.$LFS_CLIENT_CERT_URL/.sslKey "$LFS_CLIENT_KEY_FILE"
-
-  # Now check SSL clone with standard 'git clone' and smudge download
-  rm -rf "$reponame"
-  git clone "$CLIENTCERTGITSERVER/$reponame"
-
 )
 end_test
 

--- a/t/t-clone.sh
+++ b/t/t-clone.sh
@@ -11,6 +11,9 @@ if [ "$IS_WINDOWS" -eq 0 -a "$IS_MAC" -eq 0 ]; then
 fi
 export GIT_LIBNSS
 
+export CREDSDIR="$REMOTEDIR/creds-clone"
+setup_creds
+
 begin_test "clone"
 (
   set -e
@@ -174,6 +177,12 @@ begin_test "clone ClientCert"
   if [ "$IS_WINDOWS" -eq 1 ]; then
     git config --global "http.sslBackend" "openssl"
   fi
+
+  write_creds_file "::pass" "$CREDSDIR/--$(echo "$LFS_CLIENT_CERT_FILE" | tr / -)"
+  write_creds_file "::pass" "$CREDSDIR/--$(echo "$LFS_CLIENT_KEY_FILE_ENCRYPTED" | tr / -)"
+
+  git config --global "http.$LFS_CLIENT_CERT_URL/.sslCert" "$LFS_CLIENT_CERT_FILE"
+  git config --global "http.$LFS_CLIENT_CERT_URL/.sslKey" "$LFS_CLIENT_KEY_FILE"
 
   reponame="test-cloneClientCert"
   setup_remote_repo "$reponame"
@@ -844,8 +853,5 @@ begin_test "clone (HTTP server/proxy require cookies)"
     [ ! -e "lfs" ]
     assert_clean_status
   popd
-
-  # to avoid breaking t-credentials.sh
-  rm "$CREDSDIR/localhost"
 )
 end_test

--- a/t/t-clone.sh
+++ b/t/t-clone.sh
@@ -153,6 +153,7 @@ begin_test "cloneSSL"
   [ $(wc -c < "file2.dat") -eq 75 ]
   [ $(wc -c < "file3.dat") -eq 30 ]
   assert_hooks "$(dot_git_dir)"
+  [ ! -e "lfs" ]
   assert_clean_status
   popd
 
@@ -227,6 +228,7 @@ begin_test "clone ClientCert"
       [ $(wc -c < "file2.dat") -eq 75 ]
       [ $(wc -c < "file3.dat") -eq 30 ]
       assert_hooks "$(dot_git_dir)"
+      [ ! -e "lfs" ]
       assert_clean_status
     popd
   done
@@ -353,6 +355,7 @@ begin_test "clone with flags"
   # confirm remote is called differentorigin
   git remote get-url differentorigin
   assert_hooks "$(dot_git_dir)"
+  [ ! -e "lfs" ]
   assert_clean_status
   popd
   rm -rf "$newclonedir"
@@ -368,6 +371,7 @@ begin_test "clone with flags"
   [ -d "$gitdir/objects" ]
   assert_hooks "$gitdir"
   pushd "$newclonedir"
+    [ ! -e "lfs" ]
     assert_clean_status
   popd
   rm -rf "$newclonedir"
@@ -431,6 +435,7 @@ begin_test "clone (with include/exclude args)"
   [ "$(pointer $contents_a_oid 1)" = "$(cat dupe-a.dat)" ]
   [ "$(pointer $contents_b_oid 1)" = "$(cat b.dat)" ]
   assert_hooks "$(dot_git_dir)"
+  [ ! -e "lfs" ]
   assert_clean_status
   popd
 
@@ -442,6 +447,7 @@ begin_test "clone (with include/exclude args)"
   [ "$(pointer $contents_a_oid 1)" = "$(cat a.dat)" ]
   [ "b" = "$(cat b.dat)" ]
   assert_hooks "$(dot_git_dir)"
+  [ ! -e "lfs" ]
   assert_clean_status
   popd
 )
@@ -505,6 +511,7 @@ begin_test "clone (with .lfsconfig)"
   assert_local_object "$contents_a_oid" 1
   refute_local_object "$contents_b_oid"
   assert_hooks "$(dot_git_dir)"
+  [ ! -e "lfs" ]
   assert_clean_status
   popd
 
@@ -515,6 +522,7 @@ begin_test "clone (with .lfsconfig)"
   refute_local_object "$contents_a_oid"
   assert_local_object "$contents_b_oid" 1
   assert_hooks "$(dot_git_dir)"
+  [ ! -e "lfs" ]
   assert_clean_status
   popd
 
@@ -539,6 +547,7 @@ begin_test "clone (with .lfsconfig)"
   assert_local_object "$contents_b_oid" 1
   refute_local_object "$contents_a_oid"
   assert_hooks "$(dot_git_dir)"
+  [ ! -e "lfs" ]
   assert_clean_status
   popd
 
@@ -549,6 +558,7 @@ begin_test "clone (with .lfsconfig)"
   assert_local_object "$contents_a_oid" 1
   refute_local_object "$contents_b_oid"
   assert_hooks "$(dot_git_dir)"
+  [ ! -e "lfs" ]
   assert_clean_status
   popd
 
@@ -663,6 +673,7 @@ begin_test "clone with submodules"
   # check everything is where it should be
   cd $local_reponame
   assert_hooks "$(dot_git_dir)"
+  [ ! -e "lfs" ]
   assert_clean_status
   # check LFS store and working copy
   assert_local_object "$contents_root_oid" "${#contents_root}"
@@ -714,7 +725,7 @@ begin_test "clone in current directory"
 
     assert_local_object "$contents_oid" 8
     assert_hooks "$(dot_git_dir)"
-    [ ! -f ./lfs ]
+    [ ! -e "lfs" ]
     assert_clean_status
   popd
 )

--- a/t/t-clone.sh
+++ b/t/t-clone.sh
@@ -292,9 +292,6 @@ begin_test "clone with flags"
 (
   set -e
 
-  git config --global http.$LFS_CLIENT_CERT_URL/.sslCert "$LFS_CLIENT_CERT_FILE"
-  git config --global http.$LFS_CLIENT_CERT_URL/.sslKey "$LFS_CLIENT_KEY_FILE"
-
   reponame="$(basename "$0" ".sh")-flags"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"

--- a/t/t-clone.sh
+++ b/t/t-clone.sh
@@ -91,7 +91,6 @@ begin_test "clone"
     [ ! -e "lfs" ]
     assert_clean_status
   popd
-
 )
 end_test
 
@@ -149,14 +148,13 @@ begin_test "cloneSSL"
 
   # check a few file sizes to make sure pulled
   pushd "$newclonedir"
-  [ $(wc -c < "file1.dat") -eq 100 ]
-  [ $(wc -c < "file2.dat") -eq 75 ]
-  [ $(wc -c < "file3.dat") -eq 30 ]
-  assert_hooks "$(dot_git_dir)"
-  [ ! -e "lfs" ]
-  assert_clean_status
+    [ $(wc -c < "file1.dat") -eq 100 ]
+    [ $(wc -c < "file2.dat") -eq 75 ]
+    [ $(wc -c < "file3.dat") -eq 30 ]
+    assert_hooks "$(dot_git_dir)"
+    [ ! -e "lfs" ]
+    assert_clean_status
   popd
-
 
   # Now check SSL clone with standard 'git clone' and smudge download
   rm -rf "$reponame"
@@ -350,13 +348,13 @@ begin_test "clone with flags"
   # specific test for --branch and --origin
   git lfs clone --branch branch2 --recurse-submodules --origin differentorigin "$GITSERVER/$reponame" "$newclonedir"
   pushd "$newclonedir"
-  # this file is only on branch2
-  [ -e "fileonbranch2.dat" ]
-  # confirm remote is called differentorigin
-  git remote get-url differentorigin
-  assert_hooks "$(dot_git_dir)"
-  [ ! -e "lfs" ]
-  assert_clean_status
+    # this file is only on branch2
+    [ -e "fileonbranch2.dat" ]
+    # confirm remote is called differentorigin
+    git remote get-url differentorigin
+    assert_hooks "$(dot_git_dir)"
+    [ ! -e "lfs" ]
+    assert_clean_status
   popd
   rm -rf "$newclonedir"
 
@@ -428,27 +426,27 @@ begin_test "clone (with include/exclude args)"
   local_reponame="clone_with_includes"
   git lfs clone "$GITSERVER/$reponame" "$local_reponame" -I "a*.dat"
   pushd "$local_reponame"
-  assert_local_object "$contents_a_oid" 1
-  refute_local_object "$contents_b_oid"
-  [ "a" = "$(cat a.dat)" ]
-  [ "a" = "$(cat a-dupe.dat)" ]
-  [ "$(pointer $contents_a_oid 1)" = "$(cat dupe-a.dat)" ]
-  [ "$(pointer $contents_b_oid 1)" = "$(cat b.dat)" ]
-  assert_hooks "$(dot_git_dir)"
-  [ ! -e "lfs" ]
-  assert_clean_status
+    assert_local_object "$contents_a_oid" 1
+    refute_local_object "$contents_b_oid"
+    [ "a" = "$(cat a.dat)" ]
+    [ "a" = "$(cat a-dupe.dat)" ]
+    [ "$(pointer $contents_a_oid 1)" = "$(cat dupe-a.dat)" ]
+    [ "$(pointer $contents_b_oid 1)" = "$(cat b.dat)" ]
+    assert_hooks "$(dot_git_dir)"
+    [ ! -e "lfs" ]
+    assert_clean_status
   popd
 
   local_reponame="clone_with_excludes"
   git lfs clone "$GITSERVER/$reponame" "$local_reponame" -I "b.dat" -X "a.dat"
   pushd "$local_reponame"
-  assert_local_object "$contents_b_oid" 1
-  refute_local_object "$contents_a_oid"
-  [ "$(pointer $contents_a_oid 1)" = "$(cat a.dat)" ]
-  [ "b" = "$(cat b.dat)" ]
-  assert_hooks "$(dot_git_dir)"
-  [ ! -e "lfs" ]
-  assert_clean_status
+    assert_local_object "$contents_b_oid" 1
+    refute_local_object "$contents_a_oid"
+    [ "$(pointer $contents_a_oid 1)" = "$(cat a.dat)" ]
+    [ "b" = "$(cat b.dat)" ]
+    assert_hooks "$(dot_git_dir)"
+    [ ! -e "lfs" ]
+    assert_clean_status
   popd
 )
 end_test
@@ -493,38 +491,38 @@ begin_test "clone (with .lfsconfig)"
 
   pushd "$TRASHDIR"
 
-  echo "test: clone with lfs.fetchinclude in .lfsconfig"
-  local_reponame="clone_with_config_include"
-  set +x
-  git lfs clone "$GITSERVER/$reponame" "$local_reponame"
-  ok="$?"
-  set -x
-  if [ "0" -ne "$ok" ]; then
-    # TEMP: used to catch transient failure from above `clone` command, as in:
-    # https://github.com/git-lfs/git-lfs/pull/1782#issuecomment-267678319
-    echo >&2 "[!] \`git lfs clone $GITSERVER/$reponame $local_reponame\` failed"
-    git lfs logs last
+    echo "test: clone with lfs.fetchinclude in .lfsconfig"
+    local_reponame="clone_with_config_include"
+    set +x
+    git lfs clone "$GITSERVER/$reponame" "$local_reponame"
+    ok="$?"
+    set -x
+    if [ "0" -ne "$ok" ]; then
+      # TEMP: used to catch transient failure from above `clone` command, as in:
+      # https://github.com/git-lfs/git-lfs/pull/1782#issuecomment-267678319
+      echo >&2 "[!] \`git lfs clone $GITSERVER/$reponame $local_reponame\` failed"
+      git lfs logs last
 
-    exit 1
-  fi
-  pushd "$local_reponame"
-  assert_local_object "$contents_a_oid" 1
-  refute_local_object "$contents_b_oid"
-  assert_hooks "$(dot_git_dir)"
-  [ ! -e "lfs" ]
-  assert_clean_status
-  popd
+      exit 1
+    fi
+    pushd "$local_reponame"
+      assert_local_object "$contents_a_oid" 1
+      refute_local_object "$contents_b_oid"
+      assert_hooks "$(dot_git_dir)"
+      [ ! -e "lfs" ]
+      assert_clean_status
+    popd
 
-  echo "test: clone with lfs.fetchinclude in .lfsconfig, and args"
-  local_reponame="clone_with_config_include_and_args"
-  git lfs clone "$GITSERVER/$reponame" "$local_reponame" -I "b.dat"
-  pushd "$local_reponame"
-  refute_local_object "$contents_a_oid"
-  assert_local_object "$contents_b_oid" 1
-  assert_hooks "$(dot_git_dir)"
-  [ ! -e "lfs" ]
-  assert_clean_status
-  popd
+    echo "test: clone with lfs.fetchinclude in .lfsconfig, and args"
+    local_reponame="clone_with_config_include_and_args"
+    git lfs clone "$GITSERVER/$reponame" "$local_reponame" -I "b.dat"
+    pushd "$local_reponame"
+      refute_local_object "$contents_a_oid"
+      assert_local_object "$contents_b_oid" 1
+      assert_hooks "$(dot_git_dir)"
+      [ ! -e "lfs" ]
+      assert_clean_status
+    popd
 
   popd
 
@@ -539,28 +537,28 @@ begin_test "clone (with .lfsconfig)"
 
   pushd "$TRASHDIR"
 
-  echo "test: clone with lfs.fetchexclude in .lfsconfig"
-  local_reponame="clone_with_config_exclude"
-  git lfs clone "$GITSERVER/$reponame" "$local_reponame"
-  pushd "$local_reponame"
-  cat ".lfsconfig"
-  assert_local_object "$contents_b_oid" 1
-  refute_local_object "$contents_a_oid"
-  assert_hooks "$(dot_git_dir)"
-  [ ! -e "lfs" ]
-  assert_clean_status
-  popd
+    echo "test: clone with lfs.fetchexclude in .lfsconfig"
+    local_reponame="clone_with_config_exclude"
+    git lfs clone "$GITSERVER/$reponame" "$local_reponame"
+    pushd "$local_reponame"
+      cat ".lfsconfig"
+      assert_local_object "$contents_b_oid" 1
+      refute_local_object "$contents_a_oid"
+      assert_hooks "$(dot_git_dir)"
+      [ ! -e "lfs" ]
+      assert_clean_status
+    popd
 
-  echo "test: clone with lfs.fetchexclude in .lfsconfig, and args"
-  local_reponame="clone_with_config_exclude_and_args"
-  git lfs clone "$GITSERVER/$reponame" "$local_reponame" -I "a.dat" -X "b.dat"
-  pushd "$local_reponame"
-  assert_local_object "$contents_a_oid" 1
-  refute_local_object "$contents_b_oid"
-  assert_hooks "$(dot_git_dir)"
-  [ ! -e "lfs" ]
-  assert_clean_status
-  popd
+    echo "test: clone with lfs.fetchexclude in .lfsconfig, and args"
+    local_reponame="clone_with_config_exclude_and_args"
+    git lfs clone "$GITSERVER/$reponame" "$local_reponame" -I "a.dat" -X "b.dat"
+    pushd "$local_reponame"
+      assert_local_object "$contents_a_oid" 1
+      refute_local_object "$contents_b_oid"
+      assert_hooks "$(dot_git_dir)"
+      [ ! -e "lfs" ]
+      assert_clean_status
+    popd
 
   popd
 )
@@ -667,24 +665,24 @@ begin_test "clone with submodules"
 
   pushd "$TRASHDIR"
 
-  local_reponame="submod-clone"
-  git lfs clone --recursive "$GITSERVER/$reponame" "$local_reponame"
+    local_reponame="submod-clone"
+    git lfs clone --recursive "$GITSERVER/$reponame" "$local_reponame"
 
-  # check everything is where it should be
-  cd $local_reponame
-  assert_hooks "$(dot_git_dir)"
-  [ ! -e "lfs" ]
-  assert_clean_status
-  # check LFS store and working copy
-  assert_local_object "$contents_root_oid" "${#contents_root}"
-  [ $(wc -c < "root.dat") -eq ${#contents_root} ]
-  # and so on for nested subs
-  cd sub1
-  assert_local_object "$contents_sub1_oid" "${#contents_sub1}"
-  [ $(wc -c < "sub1.dat") -eq ${#contents_sub1} ]
-  cd sub2
-  assert_local_object "$contents_sub2_oid" "${#contents_sub2}"
-  [ $(wc -c < "sub2.dat") -eq ${#contents_sub2} ]
+    # check everything is where it should be
+    cd $local_reponame
+    assert_hooks "$(dot_git_dir)"
+    [ ! -e "lfs" ]
+    assert_clean_status
+    # check LFS store and working copy
+    assert_local_object "$contents_root_oid" "${#contents_root}"
+    [ $(wc -c < "root.dat") -eq ${#contents_root} ]
+    # and so on for nested subs
+    cd sub1
+    assert_local_object "$contents_sub1_oid" "${#contents_sub1}"
+    [ $(wc -c < "sub1.dat") -eq ${#contents_sub1} ]
+    cd sub2
+    assert_local_object "$contents_sub2_oid" "${#contents_sub2}"
+    [ $(wc -c < "sub2.dat") -eq ${#contents_sub2} ]
 
   popd
 )

--- a/t/t-credentials.sh
+++ b/t/t-credentials.sh
@@ -637,7 +637,7 @@ begin_test "credentials from lfs.url"
   grep "HTTP: 401" push.log
   # Ensure we didn't make a second batch request, which means the request
   # was successfully retried internally
-  [ ! "$(grep "tq: retrying object" push.log)" ]
+  grep "tq: retrying object" push.log && exit 1
   grep "Uploading LFS objects:   0% (0/1), 0 B" push.log
 
   echo "bad fetch"
@@ -654,7 +654,7 @@ begin_test "credentials from lfs.url"
   GIT_TRACE=1 git lfs fetch --all 2>&1 | tee fetch.log
   # No 401 should occur as we've already set an access mode for the
   # storage endpoint during the push
-  [ ! "$(grep "HTTP: 401" fetch.log)" ]
+  grep "HTTP: 401" fetch.log && exit 1
   git lfs fsck
 
   echo "good fetch, setting access mode"
@@ -668,7 +668,7 @@ begin_test "credentials from lfs.url"
   grep "HTTP: 401" fetch.log
   # Ensure we didn't make a second batch request, which means the request
   # was successfully retried internally
-  [ ! "$(grep "tq: retrying object" fetch.log)" ]
+  grep "tq: retrying object" fetch.log && exit 1
 
   git lfs fsck
 )
@@ -702,7 +702,7 @@ begin_test "credentials from remote.origin.url"
   grep "HTTP: 401" push.log
   # Ensure we didn't make a second batch request, which means the request
   # was successfully retried internally
-  [ ! "$(grep "tq: retrying object" push.log)" ]
+  grep "tq: retrying object" push.log && exit 1
   grep "Uploading LFS objects: 100% (1/1), 7 B" push.log
 
   echo "bad fetch"
@@ -720,7 +720,7 @@ begin_test "credentials from remote.origin.url"
   GIT_TRACE=1 git lfs fetch --all 2>&1 | tee fetch.log
   # No 401 should occur as we've already set an access mode for the
   # storage endpoint during the push
-  [ ! "$(grep "HTTP: 401" fetch.log)" ]
+  grep "HTTP: 401" fetch.log && exit 1
   git lfs fsck
 
   echo "good fetch, setting access mode"
@@ -734,7 +734,7 @@ begin_test "credentials from remote.origin.url"
   grep "HTTP: 401" fetch.log
   # Ensure we didn't make a second batch request, which means the request
   # was successfully retried internally
-  [ ! "$(grep "tq: retrying object" fetch.log)" ]
+  grep "tq: retrying object" fetch.log && exit 1
 
   git lfs fsck
 )

--- a/t/t-filter-process.sh
+++ b/t/t-filter-process.sh
@@ -2,10 +2,8 @@
 
 . "$(dirname "$0")/testlib.sh"
 
-# HACK(taylor): git uses ".g<hash>" in the version name to signal that it is
-# from the "next" branch, which is the only (current) version of Git that has
-# support for the filter protocol.
-#
+# Only test with Git version 2.11.0 and above as that version introduced
+# support for the "filter" attribute and protocol.
 ensure_git_version_isnt $VERSION_LOWER "2.11.0"
 
 begin_test "filter process: checking out a branch"

--- a/t/t-lock.sh
+++ b/t/t-lock.sh
@@ -141,6 +141,10 @@ end_test
 begin_test "create lock with server using client cert"
 (
   set -e
+
+  git config --global "http.$LFS_CLIENT_CERT_URL/.sslCert" "$LFS_CLIENT_CERT_FILE"
+  git config --global "http.$LFS_CLIENT_CERT_URL/.sslKey" "$LFS_CLIENT_KEY_FILE"
+
   reponame="lock_create_client_cert"
   setup_remote_repo_with_file "$reponame" "cc.dat"
 

--- a/t/t-migrate-export.sh
+++ b/t/t-migrate-export.sh
@@ -52,8 +52,9 @@ begin_test "migrate export (default branch)"
   echo "$main_attrs" | grep -q "*.md !text !filter !merge !diff"
   echo "$main_attrs" | grep -q "*.txt !text !filter !merge !diff"
 
-  [ ! $(echo "$feature_attrs" | grep -q "*.md !text !filter !merge !diff") ]
-  [ ! $(echo "$feature_attrs" | grep -q "*.txt !text !filter !merge !diff") ]
+  echo "$feature_attrs" | grep -q "*.md !text !filter !merge !diff" && exit 1
+  echo "$feature_attrs" | grep -q "*.txt !text !filter !merge !diff" && exit 1
+  true
 )
 end_test
 
@@ -253,8 +254,9 @@ begin_test "migrate export (exclude remote refs)"
   echo "$main_attrs" | grep -q "*.md !text !filter !merge !diff"
   echo "$main_attrs" | grep -q "*.txt !text !filter !merge !diff"
 
-  [ ! $(echo "$remote_attrs" | grep -q "*.md !text !filter !merge !diff") ]
-  [ ! $(echo "$remote_attrs" | grep -q "*.txt !text !filter !merge !diff") ]
+  echo "$remote_attrs" | grep -q "*.md !text !filter !merge !diff" && exit 1
+  echo "$remote_attrs" | grep -q "*.txt !text !filter !merge !diff" && exit 1
+  true
 )
 end_test
 
@@ -361,8 +363,8 @@ begin_test "migrate export (include/exclude ref)"
   remote_attrs="$(git cat-file -p "$remote:.gitattributes")"
   feature_attrs="$(git cat-file -p "$feature:.gitattributes")"
 
-  [ ! $(echo "$main_attrs" | grep -q "*.txt !text !filter !merge !diff") ]
-  [ ! $(echo "$remote_attrs" | grep -q "*.txt !text !filter !merge !diff") ]
+  echo "$main_attrs" | grep -q "*.txt !text !filter !merge !diff" && exit 1
+  echo "$remote_attrs" | grep -q "*.txt !text !filter !merge !diff" && exit 1
   echo "$feature_attrs" | grep -q "*.txt !text !filter !merge !diff"
 )
 end_test

--- a/t/t-migrate-import-no-rewrite.sh
+++ b/t/t-migrate-import-no-rewrite.sh
@@ -132,7 +132,7 @@ begin_test "migrate import --no-rewrite (nested .gitattributes)"
 
   # Ensure a .md filter does not exist in the top-level .gitattributes
   main_attrs="$(git cat-file -p "$main:.gitattributes")"
-  [ !"$(echo "$main_attrs" | grep -q ".md")" ]
+  echo "$main_attrs" | grep -q ".md" && exit 1
 
   # Ensure a .md filter exists in the nested .gitattributes
   nested_attrs="$(git cat-file -p "$main:b/.gitattributes")"

--- a/t/t-migrate-import.sh
+++ b/t/t-migrate-import.sh
@@ -26,7 +26,7 @@ begin_test "migrate import (default branch)"
   feature="$(git rev-parse refs/heads/my-feature)"
 
   main_attrs="$(git cat-file -p "$main:.gitattributes")"
-  [ ! $(git cat-file -p "$feature:.gitattributes") ]
+  [ -z "$(git cat-file -p "$feature:.gitattributes")" ]
 
   echo "$main_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
   echo "$main_attrs" | grep -q "*.txt filter=lfs diff=lfs merge=lfs"
@@ -103,7 +103,7 @@ begin_test "migrate import (default branch with filter)"
   feature="$(git rev-parse refs/heads/my-feature)"
 
   main_attrs="$(git cat-file -p "$main:.gitattributes")"
-  [ ! $(git cat-file -p "$feature:.gitattributes") ]
+  [ -z "$(git cat-file -p "$feature:.gitattributes")" ]
 
   echo "$main_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
   echo "$main_attrs" | grep -vq "*.txt filter=lfs diff=lfs merge=lfs"
@@ -167,7 +167,7 @@ begin_test "migrate import (default branch, exclude remote refs)"
   remote="$(git rev-parse refs/remotes/origin/main)"
 
   main_attrs="$(git cat-file -p "$main:.gitattributes")"
-  [ ! $(git cat-file -p "$remote:.gitattributes") ]
+  [ -z "$(git cat-file -p "$remote:.gitattributes")" ]
 
   echo "$main_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
   echo "$main_attrs" | grep -vq "*.txt filter=lfs diff=lfs merge=lfs"
@@ -206,7 +206,7 @@ begin_test "migrate import (given branch, exclude remote refs)"
   remote="$(git rev-parse refs/remotes/origin/main)"
 
   main_attrs="$(git cat-file -p "$main:.gitattributes")"
-  [ ! $(git cat-file -p "$remote:.gitattributes") ]
+  [ -z "$(git cat-file -p "$remote:.gitattributes")" ]
   feature_attrs="$(git cat-file -p "$feature:.gitattributes")"
 
   echo "$main_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
@@ -322,8 +322,8 @@ begin_test "migrate import (include/exclude ref)"
   feature="$(git rev-parse refs/heads/my-feature)"
   remote="$(git rev-parse refs/remotes/origin/main)"
 
-  [ ! $(git cat-file -p "$main:.gitattributes") ]
-  [ ! $(git cat-file -p "$remote:.gitattributes") ]
+  [ -z "$(git cat-file -p "$main:.gitattributes")" ]
+  [ -z "$(git cat-file -p "$remote:.gitattributes")" ]
   feature_attrs="$(git cat-file -p "$feature:.gitattributes")"
 
   echo "$feature_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
@@ -360,8 +360,8 @@ begin_test "migrate import (include/exclude ref args)"
   feature="$(git rev-parse refs/heads/my-feature)"
   remote="$(git rev-parse refs/remotes/origin/main)"
 
-  [ ! $(git cat-file -p "$main:.gitattributes") ]
-  [ ! $(git cat-file -p "$remote:.gitattributes") ]
+  [ -z "$(git cat-file -p "$main:.gitattributes")" ]
+  [ -z "$(git cat-file -p "$remote:.gitattributes")" ]
   feature_attrs="$(git cat-file -p "$feature:.gitattributes")"
 
   echo "$feature_attrs" | grep -q "*.md filter=lfs diff=lfs merge=lfs"
@@ -400,8 +400,8 @@ begin_test "migrate import (include/exclude ref with filter)"
   feature="$(git rev-parse refs/heads/my-feature)"
   remote="$(git rev-parse refs/remotes/origin/main)"
 
-  [ ! $(git cat-file -p "$main:.gitattributes") ]
-  [ ! $(git cat-file -p "$remote:.gitattributes") ]
+  [ -z "$(git cat-file -p "$main:.gitattributes")" ]
+  [ -z "$(git cat-file -p "$remote:.gitattributes")" ]
   feature_attrs="$(git cat-file -p "$feature:.gitattributes")"
 
   echo "$feature_attrs" | grep -vq "*.md filter=lfs diff=lfs merge=lfs"

--- a/t/t-track-wildcards.sh
+++ b/t/t-track-wildcards.sh
@@ -30,7 +30,7 @@ begin_test "track files using wildcard pattern with leading slash"
   git lfs ls-files | tee files.log
 
   grep "a.dat" files.log
-  [ ! $(grep "dir/b.dat" files.log) ] # Subdirectories ignored
+  grep "dir/b.dat" files.log && exit 1 # Subdirectories ignored
 
   # Add files after being tracked by LFS
   printf "contents" > c.dat
@@ -43,9 +43,10 @@ begin_test "track files using wildcard pattern with leading slash"
   git lfs ls-files | tee new_files.log
 
   grep "a.dat" new_files.log
-  [ ! $(grep "dir/b.dat" new_files.log) ]
+  grep "dir/b.dat" new_files.log && exit 1
   grep "c.dat" new_files.log
-  [ ! $(grep "dir/d.dat" new_files.log) ]
+  grep "dir/d.dat" new_files.log && exit 1
+  true
 )
 end_test
 

--- a/t/testenv.sh
+++ b/t/testenv.sh
@@ -137,7 +137,7 @@ LFS_CLIENT_CERT_FILE="$REMOTEDIR/client.crt"
 # This file contains the client key of the client cert endpoint of the test Git server.
 LFS_CLIENT_KEY_FILE="$REMOTEDIR/client.key"
 
-# This file contains the client key of the client cert endpoint of the test Git server.
+# This file contains the encrypted client key of the client cert endpoint of the test Git server.
 LFS_CLIENT_KEY_FILE_ENCRYPTED="$REMOTEDIR/client.enc.key"
 
 # the fake home dir used for the initial setup

--- a/t/testhelpers.sh
+++ b/t/testhelpers.sh
@@ -576,8 +576,6 @@ write_creds_file() {
 setup_creds() {
   mkdir -p "$CREDSDIR"
   write_creds_file ":user:pass" "$CREDSDIR/127.0.0.1"
-  write_creds_file "::pass" "$CREDSDIR/--$homecertpath"
-  write_creds_file "::pass" "$CREDSDIR/--$homekeypath"
 }
 
 # setup initializes the clean, isolated environment for integration tests.
@@ -633,8 +631,6 @@ setup() {
   fi | sed -e 's/^/# /g'
 
   # setup the git credential password storage
-  local homecertpath="$(echo "$TRASHDIR/home/lfs-client-cert-file" | tr / -)"
-  local homekeypath="$(echo "$TRASHDIR/home/lfs-client-key-file" | tr / -)"
   setup_creds
 
   echo "#"

--- a/t/testhelpers.sh
+++ b/t/testhelpers.sh
@@ -576,8 +576,6 @@ write_creds_file() {
 setup_creds() {
   mkdir -p "$CREDSDIR"
   write_creds_file ":user:pass" "$CREDSDIR/127.0.0.1"
-  write_creds_file "::pass" "$CREDSDIR/--$certpath"
-  write_creds_file "::pass" "$CREDSDIR/--$keypath"
   write_creds_file "::pass" "$CREDSDIR/--$homecertpath"
   write_creds_file "::pass" "$CREDSDIR/--$homekeypath"
 }
@@ -631,14 +629,10 @@ setup() {
     git config --global user.name "Git LFS Tests"
     git config --global user.email "git-lfs@example.com"
     git config --global http.sslcainfo "$LFS_CERT_FILE"
-    git config --global http.$LFS_CLIENT_CERT_URL/.sslKey "$LFS_CLIENT_KEY_FILE"
-    git config --global http.$LFS_CLIENT_CERT_URL/.sslCert "$LFS_CLIENT_CERT_FILE"
     git config --global init.defaultBranch main
   fi | sed -e 's/^/# /g'
 
   # setup the git credential password storage
-  local certpath="$(echo "$LFS_CLIENT_CERT_FILE" | tr / -)"
-  local keypath="$(echo "$LFS_CLIENT_KEY_FILE_ENCRYPTED" | tr / -)"
   local homecertpath="$(echo "$TRASHDIR/home/lfs-client-cert-file" | tr / -)"
   local homekeypath="$(echo "$TRASHDIR/home/lfs-client-key-file" | tr / -)"
   setup_creds

--- a/t/testhelpers.sh
+++ b/t/testhelpers.sh
@@ -62,7 +62,7 @@ assert_local_object() {
   local oid="$1"
   local size="$2"
   local cfg=`git lfs env | grep LocalMediaDir`
-  local f="${cfg:14}/${oid:0:2}/${oid:2:2}/$oid"
+  local f="${cfg#LocalMediaDir=}/${oid:0:2}/${oid:2:2}/$oid"
   actualsize=$(wc -c <"$f" | tr -d '[[:space:]]')
   if [ "$size" != "$actualsize" ]; then
     exit 1
@@ -79,8 +79,7 @@ refute_local_object() {
   local oid="$1"
   local size="$2"
   local cfg=`git lfs env | grep LocalMediaDir`
-  local regex="LocalMediaDir=(\S+)"
-  local f="${cfg:14}/${oid:0:2}/${oid:2:2}/$oid"
+  local f="${cfg#LocalMediaDir=}/${oid:0:2}/${oid:2:2}/$oid"
   if [ -e $f ]; then
     if [ -z "$size" ]; then
       exit 1
@@ -99,7 +98,7 @@ refute_local_object() {
 delete_local_object() {
   local oid="$1"
   local cfg=`git lfs env | grep LocalMediaDir`
-  local f="${cfg:14}/${oid:0:2}/${oid:2:2}/$oid"
+  local f="${cfg#LocalMediaDir=}/${oid:0:2}/${oid:2:2}/$oid"
   rm "$f"
 }
 
@@ -108,7 +107,7 @@ delete_local_object() {
 corrupt_local_object() {
   local oid="$1"
   local cfg=`git lfs env | grep LocalMediaDir`
-  local f="${cfg:14}/${oid:0:2}/${oid:2:2}/$oid"
+  local f="${cfg#LocalMediaDir=}/${oid:0:2}/${oid:2:2}/$oid"
   cp /dev/null "$f"
 }
 
@@ -186,7 +185,7 @@ assert_remote_object() {
 
   pushd "$destination"
     local cfg="$(git lfs env | grep LocalMediaDir)"
-    local f="${cfg:14}/${oid:0:2}/${oid:2:2}/$oid"
+    local f="${cfg#LocalMediaDir=}/${oid:0:2}/${oid:2:2}/$oid"
     actualsize="$(wc -c <"$f" | tr -d '[[:space:]]')"
     [ "$size" -eq "$actualsize" ]
   popd


### PR DESCRIPTION
Following from the work in PR #5882 to fully enable all the tests in our `t/t-clone.sh` test script, this PR further refines the `clone ClientCert` and `clone ClientCert with homedir certs` [tests](https://github.com/git-lfs/git-lfs/blob/3990c7ab4fa6c99540af3f73f33da47a72df08af/t/t-clone.sh#L166-L289) so they both perform the same sets of checks, including a reworked version of the loop in the `clone ClientCert` test which clarifies when the encrypted version of the TLS/SSL certificate's private key is in use.

In particular, the `clone ClientCert with homedir certs` test does not, at the moment, actually test the `git lfs clone` command, unlike all the other tests in `t/t-clone.sh` test script, and it also does not use the encrypted private key file at all, although we [create](https://github.com/git-lfs/git-lfs/blob/3990c7ab4fa6c99540af3f73f33da47a72df08af/t/testhelpers.sh#L582-L583) some record files for our `git-credential-lfstest` helper program as if this were the case.

We also make minor formatting adjustments and simplifications to our `t/t-clone.sh` test script, and update an incorrect [comment](https://github.com/git-lfs/git-lfs/blob/3990c7ab4fa6c99540af3f73f33da47a72df08af/t/testenv.sh#L140) in our `t/testenv.sh` shell library.

In addition to these changes, we fix a number of instances throughout our test suite where we use incorrectly negated test expressions of the form `[ ! $(grep "foo" bar.log) ]` to try to check that a given log file does not contain a specific string.  These checks succeed at present, but for the wrong reason.  When the given string is not found in the log file, the command substitution returns an empty value, so the test devolves to just `[ ! ]`, and the shell treats the lack of a test expression as a false value, which it then inverts due to the `!` operator, and so the test always passes.  We replace these incorrectly formed checks using either a `-z` test operator (when appropriate) or a simple `grep(1)` command in an `AND` list with an `exit 1` statement, as we already did in PR #5282 to deal with incorrect uses of the `!` shell word.

Prior to these corrections, we adopt a [suggestion](https://github.com/git-lfs/git-lfs/pull/5905#discussion_r1829271742) made during review of PR #5905 to improve the readability of the commands [used](https://github.com/git-lfs/git-lfs/blob/3990c7ab4fa6c99540af3f73f33da47a72df08af/t/testhelpers.sh#L65) to parse the `LocalMediaDir` line from `git lfs env` command's output in various functions in our `t/testhelpers.sh` shell library.

Lastly, we make sure our `lfstest-gitserver` program closes all of its instances of the `Server` structure from the `net/http/httptest` Go package before it [exits](https://github.com/git-lfs/git-lfs/blob/3990c7ab4fa6c99540af3f73f33da47a72df08af/t/cmd/lfstest-gitserver.go#L159).  This has no effect on our tests, but is idiomatic and recommended by the Go documentation.

This PR will be most easily reviewed on a commit-by-commit basis, with whitespace changes ignored.