### PR TITLE
release: v3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,90 @@
 # Git LFS Changelog
 
+## 3.6.0 (20 November 2024)
+
+This release is a feature release which includes support for multi-stage
+authentication with Git credential helpers (requires Git 2.46.0) and
+relative worktree paths (requires Git 2.48.0), a new object transfer batch
+size configuration option, better path handling when installing on Windows,
+more POSIX-compliant hook scripts, and improved performance with sparse
+checkouts, partial clones, and Git remotes with large numbers of tags.
+
+Note that the 3.6.x series of Git LFS releases will be the last releases
+for which we provide packages or support for versions of any Linux
+distribution based on either Red Hat Enterprise Linux 7 (RHEL 7) or
+SUSE Linux Enterprise Server 12 (SLES 12).
+
+Note also that the 3.6.x series of Git LFS releases may be the last
+releases for which we provide packages or support for versions of any
+Linux distribution based on Debian 10 ("buster").
+
+This release is built using Go v1.23 and therefore on macOS systems
+requires macOS 11 (Big Sur) or later, and on Windows systems requires
+at least Windows 10 or Windows Server 2016 (although Windows 8.1 may
+suffice).
+
+We would like to extend a special thanks to the following open-source
+contributors:
+
+* @blanet for fixing a crash bug when handling HTTP 429 responses
+* @bogomolets-owl for implementing a batch size configuration option
+* @ConcurrentCrab for preventing hung SSH transfer protocol connections
+* @jochenhz for ensuring files with Unicode names are not accidentally pruned
+* @pastelsky for optimizing performance of our pre-push hook
+* @rustfix for correcting some code comments
+* @rusttech for fixing an array size allocation bug
+* @xdavidwu for improving the portability of our tests and hooks
+
+### Features
+
+* git: improve sparse checkout support #5796 (@bk2204)
+* hook: fix newlines in command missing message #5886 (@xdavidwu)
+* Add batch size config value and use it everywhere #5876 (@bogomolets-owl)
+* Support relative paths to linked working trees #5898 (@chrisd8088)
+* git-lfs: omit tags in ls-remote; optimize pre-push #5863 (@pastelsky)
+* Support multistage authentication with a Git credential helper #5803 (@bk2204)
+* Support arbitrary HTTP credential schemes for authentication #5779 (@bk2204)
+* Optimize performance for scanning trees in partial clones #5699 (@bk2204)
+* Use lower-case file extensions in Windows installer path checks #5688 (@chrisd8088)
+* Match `PATH` case insensitively in Windows installer #5680 (@bk2204)
+
+### Bugs
+
+* Fix crash during pure SSH object transfer with multiple objects #5905 (@chrisd8088)
+* ssh: fix connection creation "leaking" connections #5816 (@ConcurrentCrab)
+* fix: fix slice init length #5874 (@rusttech)
+* Fix panic caused by accessing non-existent header #5804 (@blanet)
+* Avoid deadlocking on log scanning with lots of output on stderr #5738 (@bk2204)
+* checkout: gracefully handle files deleted from the index #5698 (@bk2204)
+* Fix logScanner fails to parse pointer file containing unicode chars #5655 (@jochenhz)
+
+### Misc
+
+* Fix improper negated test expressions and refine TLS client certificate tests #5914 (@chrisd8088)
+* Always capture clone logs in tests and remove or update stale workarounds #5906 (@chrisd8088)
+* Update Linux distribution package list for v3.6.0 release #5911 (@chrisd8088)
+* doc: mention the pointer size constraint #5900 (@bk2204)
+* Repair and restore all tests of cloning over TLS #5882 (@chrisd8088)
+* t: increase portability #5887 (@xdavidwu)
+* script/build-git: update Ubuntu 24.04 APT sources #5889 (@chrisd8088)
+* Run tests in parallel on Windows and always cleanup test directories #5879 (@chrisd8088)
+* Update release workflow to use Windows Trusted Signing Action #5873 (@chrisd8088)
+* Upgrade to Go 1.23 #5872 (@chrisd8088)
+* Use custom random data generator for all test objects and filenames #5868 (@chrisd8088)
+* Always build Git against custom libcurl in CI workflows on macOS #5866 (@chrisd8088)
+* Use expected version of Git on macOS in CI jobs #5813 (@chrisd8088)
+* Move @bk2204 to alumni #5808 (@bk2204)
+* docs/api: note API clients may send `charset` parameter in `Content-Type` header #5778 (@chrisd8088)
+* issue template: add more information we'd want to see #5728 (@bk2204)
+* .github/workflows: use actions/setup-go everywhere #5729 (@bk2204)
+* build(deps): bump golang.org/x/net from 0.17.0 to 0.23.0 #5718 (@dependabot[bot])
+* chore: fix function names in comment #5709 (@rustfix)
+* Include remote error when pure SSH protocol fails #5674 (@bk2204)
+* Build release assets with 1.22 #5673 (@bk2204)
+* Build release assets with Go 1.21 #5668 (@bk2204)
+* script/packagecloud: instantiate distro map properly #5662 (@bk2204)
+* Install msgfmt on Windows in CI and release workflows #5666 (@chrisd8088)
+
 ## 3.5.0 (28 February 2024)
 
 This release is a feature release which includes support for LoongArch and

--- a/config/version.go
+++ b/config/version.go
@@ -13,7 +13,7 @@ var (
 )
 
 const (
-	Version = "3.5.0"
+	Version = "3.6.0"
 )
 
 func init() {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+git-lfs (3.6.0) stable; urgency=low
+
+  * New upstream version
+
+ -- Chris Darroch <chrisd8088@github.com>  Wed, 20 Nov 2024 14:29:00 -0000
+
 git-lfs (3.5.0) stable; urgency=low
 
   * New upstream version

--- a/rpm/SPECS/git-lfs.spec
+++ b/rpm/SPECS/git-lfs.spec
@@ -1,5 +1,5 @@
 Name:           git-lfs
-Version:        3.5.0
+Version:        3.6.0
 Release:        1%{?dist}
 Summary:        Git extension for versioning large files
 

--- a/versioninfo.json
+++ b/versioninfo.json
@@ -3,7 +3,7 @@
 	{
 		"FileVersion": {
 			"Major": 3,
-			"Minor": 5,
+			"Minor": 6,
 			"Patch": 0,
 			"Build": 0
 		}
@@ -13,7 +13,7 @@
 		"FileDescription": "Git LFS",
 		"LegalCopyright": "GitHub, Inc. and Git LFS contributors",
 		"ProductName": "Git Large File Storage (LFS)",
-		"ProductVersion": "3.5.0"
+		"ProductVersion": "3.6.0"
 	},
 	"IconPath": "script/windows-installer/git-lfs-logo.ico"
 }


### PR DESCRIPTION
This is an in-progress look at the next release of Git LFS, v3.6.0, which is scheduled for Wednesday, November 20, 2024.

I've attached some builds below for people to use for testing:

[git-lfs-darwin-amd64-v3.6.0-pre.zip](https://github.com/user-attachments/files/17810624/git-lfs-darwin-amd64-v3.6.0-pre.zip)
[git-lfs-darwin-arm64-v3.6.0-pre.zip](https://github.com/user-attachments/files/17810625/git-lfs-darwin-arm64-v3.6.0-pre.zip)
[git-lfs-freebsd-386-v3.6.0-pre.tar.gz](https://github.com/user-attachments/files/17810627/git-lfs-freebsd-386-v3.6.0-pre.tar.gz)
[git-lfs-freebsd-amd64-v3.6.0-pre.tar.gz](https://github.com/user-attachments/files/17810628/git-lfs-freebsd-amd64-v3.6.0-pre.tar.gz)
[git-lfs-linux-386-v3.6.0-pre.tar.gz](https://github.com/user-attachments/files/17810629/git-lfs-linux-386-v3.6.0-pre.tar.gz)
[git-lfs-linux-amd64-v3.6.0-pre.tar.gz](https://github.com/user-attachments/files/17810630/git-lfs-linux-amd64-v3.6.0-pre.tar.gz)
[git-lfs-linux-arm-v3.6.0-pre.tar.gz](https://github.com/user-attachments/files/17810633/git-lfs-linux-arm-v3.6.0-pre.tar.gz)
[git-lfs-linux-arm64-v3.6.0-pre.tar.gz](https://github.com/user-attachments/files/17810634/git-lfs-linux-arm64-v3.6.0-pre.tar.gz)
[git-lfs-linux-loong64-v3.6.0-pre.tar.gz](https://github.com/user-attachments/files/17810635/git-lfs-linux-loong64-v3.6.0-pre.tar.gz)
[git-lfs-linux-ppc64le-v3.6.0-pre.tar.gz](https://github.com/user-attachments/files/17810636/git-lfs-linux-ppc64le-v3.6.0-pre.tar.gz)
[git-lfs-linux-riscv64-v3.6.0-pre.tar.gz](https://github.com/user-attachments/files/17810637/git-lfs-linux-riscv64-v3.6.0-pre.tar.gz)
[git-lfs-linux-s390x-v3.6.0-pre.tar.gz](https://github.com/user-attachments/files/17810639/git-lfs-linux-s390x-v3.6.0-pre.tar.gz)
[git-lfs-v3.6.0-pre.tar.gz](https://github.com/user-attachments/files/17810640/git-lfs-v3.6.0-pre.tar.gz)
[git-lfs-windows-386-v3.6.0-pre.zip](https://github.com/user-attachments/files/17810641/git-lfs-windows-386-v3.6.0-pre.zip)
[git-lfs-windows-amd64-v3.6.0-pre.zip](https://github.com/user-attachments/files/17810642/git-lfs-windows-amd64-v3.6.0-pre.zip)
[git-lfs-windows-arm64-v3.6.0-pre.zip](https://github.com/user-attachments/files/17810643/git-lfs-windows-arm64-v3.6.0-pre.zip)

In addition, the CI system will produce artifacts for Windows, Linux, and macOS if you prefer to use those; they should be equivalent.

Note that the 3.6.x series of Git LFS releases will be the last releases for which we provide packages or support for versions of any Linux distribution based on either Red Hat Enterprise Linux 7 (RHEL 7) or SUSE Linux Enterprise Server 12 (SLES 12).

Note also that the 3.6.x series of Git LFS releases may be the last releases for which we provide packages or support for versions of any Linux distribution based on Debian 10 ("buster").

This release is built using Go v1.23 and therefore on macOS systems requires macOS 11 (Big Sur) or later, and on Windows systems requires at least Windows 10 or Windows Server 2016 (although Windows 8.1 may suffice).

/cc @git-lfs/core
/cc @git-lfs/implementers
/cc @git-lfs/releases