### PR TITLE
Update license copyright dates and minimum supported Git version

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2014-2021 GitHub, Inc. and Git LFS contributors
+Copyright (c) 2014- GitHub, Inc. and Git LFS contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -23,7 +23,7 @@ SOFTWARE.
 Portions of the subprocess and tools directories are copied from Go and are
 under the following license:
 
-Copyright (c) 2010 The Go Authors. All rights reserved.
+Copyright (c) 2009,2010 The Go Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -51,5 +51,5 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-Note that Git LFS uses components from other Go modules (included in `vendor/`)
-which are under different licenses.  See those LICENSE files for details.
+Note that Git LFS uses components from other Go modules, which are under
+different licenses.  See those LICENSE files for details.

--- a/README.md
+++ b/README.md
@@ -140,8 +140,6 @@ To https://github.com/git-lfs/git-lfs-test
    67fcf6a..47b2002  main -> main
 ```
 
-Note: Git LFS requires at least Git 1.8.2 on Linux or 1.8.5 on macOS.
-
 ### Uninstalling
 
 If you've decided that Git LFS isn't right for you, you can convert your
@@ -162,6 +160,10 @@ know in an issue, and we'll definitely try to help or get it fixed.
 
 Git LFS maintains a list of currently known limitations, which you can find and
 edit [here](https://github.com/git-lfs/git-lfs/wiki/Limitations).
+
+Current releases of Git LFS will work with Git versions as early as
+Git 2.0.0.  However, for best performance, using a recent version of Git
+is highly recommended.
 
 Git LFS source code utilizes Go modules in its build system, and therefore this
 project contains a `go.mod` file with a defined Go module path.  However, we


### PR DESCRIPTION
This PR updates the copyright [statement](https://github.com/git-lfs/git-lfs/blob/6340befc60876f4f039f215479d9d5a945f817e1/LICENSE.md?plain=1#L3) in our `LICENSE.md` file to bring its format into line with that of our [other](https://github.com/git-lfs/gitobj/blob/e2a3f83197c1bccd24936097eb429949341d9f61/LICENSE.md?plain=1#L3) Git LFS projects' [licenses](https://github.com/git-lfs/pktline/blob/ca444d533ef1e474d0aab99cdbeed9b048d65241/LICENSE.md?plain=1#L3), by removing the current year from the statement.  This also aligns with the practice of other major open-source software projects, such as the copyright [statement](https://github.com/golang/go/blob/b68f8ca89a2fb6b33d1e78fadc33d1c35693f6b8/LICENSE#L1) for the Go language and standard library, and will avoid the necessity that we update our copyright statement every year.

As well, we add the year 2009 to the copyright [statement](https://github.com/git-lfs/git-lfs/blob/6340befc60876f4f039f215479d9d5a945f817e1/LICENSE.md?plain=1#L26) for the Go language project in our `LICENSE.md` file, as the portions of that project's source code we incorporate into our `tools` package have a copyright [date](https://github.com/golang/go/blob/b68f8ca89a2fb6b33d1e78fadc33d1c35693f6b8/src/os/file_windows.go#L1) of 2009.  (We also incorporate some portions of the Go standard library whose source files have a [copyright](https://github.com/golang/go/blob/b68f8ca89a2fb6b33d1e78fadc33d1c35693f6b8/src/os/exec/lp_unix.go#L1) [date](https://github.com/golang/go/blob/b68f8ca89a2fb6b33d1e78fadc33d1c35693f6b8/src/os/exec/lp_windows.go#L1) of 2010, so we leave that date in place.)

Further, because we stopped using a `vendor` directory with copies of our dependencies in PR #4903, we remove the [reference](https://github.com/git-lfs/git-lfs/blob/6340befc60876f4f039f215479d9d5a945f817e1/LICENSE.md?plain=1#L54] to that directory from our `LICENSE.md` file.

Lastly, we also update our `README.md` file to remove an outdated [note](https://github.com/git-lfs/git-lfs/blob/6340befc60876f4f039f215479d9d5a945f817e1/README.md?plain=1#L143) regarding the minimum versions of Git required by Git LFS, and expand the "Limitations" section in that file to clarify that the current minimum Git version required by Git LFS is Git v2.0.0 (as is [verified](https://github.com/git-lfs/git-lfs/blob/6340befc60876f4f039f215479d9d5a945f817e1/.github/workflows/ci.yml#L166) by our GitHub Actions `Build with earliest Git` CI job).