### PR TITLE
Tighten security of Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,11 +205,11 @@ jobs:
         docker version -f '{{.Server.Experimental}}'
     - uses: docker/setup-qemu-action@v3
     - run: git clone https://github.com/git-lfs/build-dockers.git "$HOME/build-dockers"
-    - run: (cd "$HOME/build-dockers" && ./build_dockers.bsh --arch=$ARCH $CONTAINER)
+    - run: (cd "$HOME/build-dockers" && ./build_dockers.bsh --arch="$ARCH" "$CONTAINER")
       env:
         ARCH: ${{matrix.arch}}
         CONTAINER: ${{matrix.container}}
-    - run: ./docker/run_dockers.bsh --prune --arch=$ARCH $CONTAINER
+    - run: ./docker/run_dockers.bsh --prune --arch="$ARCH" "$CONTAINER"
       env:
         ARCH: ${{matrix.arch}}
         CONTAINER: ${{matrix.container}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        persist-credentials: false
     - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
       if: ${{ github.ref_type == 'tag' }}
       # We update the current tag as the checkout step turns annotated tags
@@ -53,6 +54,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        persist-credentials: false
     - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
       if: ${{ github.ref_type == 'tag' }}
     - uses: actions/setup-go@v5
@@ -66,6 +68,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        persist-credentials: false
     - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
       if: ${{ github.ref_type == 'tag' }}
       shell: bash
@@ -134,6 +137,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        persist-credentials: false
     - uses: actions/setup-go@v5
       with:
         go-version: '1.23.x'
@@ -158,6 +162,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        persist-credentials: false
     - uses: actions/setup-go@v5
       with:
         go-version: '1.23.x'
@@ -179,6 +184,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        persist-credentials: false
     - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
       if: ${{ github.ref_type == 'tag' }}
     - uses: ruby/setup-ruby@v1
@@ -196,6 +202,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        persist-credentials: false
     - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
       if: ${{ github.ref_type == 'tag' }}
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        persist-credentials: false
     - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
       shell: bash
       # We update the current tag as the checkout step turns annotated tags
@@ -108,6 +109,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        persist-credentials: false
     - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
     - uses: ruby/setup-ruby@v1
     - run: gem install asciidoctor
@@ -147,6 +149,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        persist-credentials: false
     - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
     - uses: ruby/setup-ruby@v1
     - run: gem install asciidoctor
@@ -178,6 +181,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        persist-credentials: false
     - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
     - uses: ruby/setup-ruby@v1
     - run: gem install packagecloud-ruby
@@ -199,6 +203,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        persist-credentials: false
     - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
     - uses: ruby/setup-ruby@v1
     - run: gem install packagecloud-ruby

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,11 +208,11 @@ jobs:
         docker version -f '{{.Server.Experimental}}'
     - uses: docker/setup-qemu-action@v3
     - run: git clone https://github.com/git-lfs/build-dockers.git "$HOME/build-dockers"
-    - run: (cd "$HOME/build-dockers" && ./build_dockers.bsh --arch=$ARCH $CONTAINER)
+    - run: (cd "$HOME/build-dockers" && ./build_dockers.bsh --arch="$ARCH" "$CONTAINER")
       env:
         ARCH: ${{matrix.arch}}
         CONTAINER: ${{matrix.container}}
-    - run: ./docker/run_dockers.bsh --prune --arch=$ARCH $CONTAINER
+    - run: ./docker/run_dockers.bsh --prune --arch="$ARCH" "$CONTAINER"
       env:
         ARCH: ${{matrix.arch}}
         CONTAINER: ${{matrix.container}}


### PR DESCRIPTION
I was recently reading an article about a repository whose release workflow was compromised due to code injection and how it could have been detected using [zizmor](https://github.com/woodruffw/zizmor).  I did some auditing here of the Actions workflows, both manually and with zizmor, and I didn't find any obvious security problems, but I did some hardening.

The first patch was from my manual auditing and covers some improved shell quoting.  This isn't currently exploitable, but we might as well avoid the problem altogether and using proper shell quoting is a best practice anyway.  The second patch comes from the recommendation of zizmor.

We _are_ following the best practice of storing expanded Actions patterns (those with `${{}}`) in an environment variable before using them, because this prevents injections (such as from refs containing shell characters).  Actions doesn't have any sort of quoting for these cases, but by passing them in via the environment, we can use the normal shell quoting rules for these purposes.

So overall, I think we're in a good spot, but this PR just makes it a little less inviting as a target.

This PR contains independent, logical, bisectable commits each with their own commit message, and as such is best reviewed commit by commit.