### PR TITLE
Upgrade `golang.org/x/net` from 0.23.0 to 0.33.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/ssgelm/cookiejarparser v1.0.1
 	github.com/stretchr/testify v1.6.1
 	github.com/xeipuuv/gojsonschema v0.0.0-20170210233622-6b67b3fab74d
-	golang.org/x/net v0.23.0
+	golang.org/x/net v0.33.0
 	golang.org/x/sync v0.10.0
 	golang.org/x/sys v0.28.0
 )

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
 golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
+golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
+golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=
 golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=


### PR DESCRIPTION
As noted in https://github.com/git-lfs/git-lfs/issues/5939#issuecomment-2553105997, the vulnerability addressed by this update to the `x/net` Go module, reported as CVE-2024-45338, only pertains to the `x/net/html` package and the Git LFS client doesn't parse any HTML, so there is no immediate need to release a new version of Git LFS.

While we do import some packages from the `x/net` module, both directly and indirectly, none of them are the `x/net/html` package. We can confirm this is the case by running `go list -json all | grep x/net/html`, which returns no output.

Nevertheless, we might as well upgrade the module, so that when we do release v3.7.0 of the Git LFS client, security scanners will not generate false positive reports.

For reference, the details of the vulnerability are described in golang/go#70906, the GO-2024-3333 [report](https://pkg.go.dev/vuln/GO-2024-3333), and in the release [announcement](https://groups.google.com/g/golang-announce/c/wSCRmFnNmPA/m/Lvcd0mRMAwAJ) for version 0.33.0 of the `x/net` module.

Resolves #5939.