### PR TITLE
docs/man/git-lfs-migrate.adoc: remove duplicate flag

### DIFF
--- a/docs/man/git-lfs-migrate.adoc
+++ b/docs/man/git-lfs-migrate.adoc
@@ -140,8 +140,6 @@ export::
   See <<_include_and_exclude>>.
 `--include-ref=<refname>`::
   See <<_include_and_exclude_references>>.
-`--include-ref=<refname>`::
-  See <<_include_and_exclude_references>>.
 `--exclude-ref=<refname>`::
   See <<_include_and_exclude_references>>.
 `--skip-fetch`::


### PR DESCRIPTION
Removed the duplicate flag `--include-ref` flag mention.
Before:
```
--include-ref=<refname>:
  See "Include and exclude references".
--include-ref=<refname>:
  See "Include and exclude references".
```
After:
```
--include-ref=<refname>:
  See "Include and exclude references".
```