### PR TITLE
Add --append-old-sha option to migrate import command, appends old-SH…

### DIFF
--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -63,6 +63,10 @@ var (
 	// migrateFixup is the flag indicating whether or not to infer the
 	// included and excluded filepath patterns.
 	migrateFixup bool
+
+	// appendOldShaToMessages is the flag indicating whether or not to append
+	// to rewritten commit messages the old commit SHA.
+	appendOldShaToMessages bool
 )
 
 // migrate takes the given command and arguments, *gitobj.ObjectDatabase, as well
@@ -115,9 +119,10 @@ func rewriteOptions(args []string, opts *githistory.RewriteOptions, l *tasklog.L
 		Include: include,
 		Exclude: exclude,
 
-		UpdateRefs:        opts.UpdateRefs,
-		Verbose:           opts.Verbose,
-		ObjectMapFilePath: opts.ObjectMapFilePath,
+		UpdateRefs:             opts.UpdateRefs,
+		Verbose:                opts.Verbose,
+		ObjectMapFilePath:      opts.ObjectMapFilePath,
+		AppendOldShaToMessages: opts.AppendOldShaToMessages,
 
 		BlobFn:            opts.BlobFn,
 		TreePreCallbackFn: opts.TreePreCallbackFn,
@@ -401,6 +406,7 @@ func init() {
 	importCmd.Flags().BoolVar(&migrateNoRewrite, "no-rewrite", false, "Add new history without rewriting previous")
 	importCmd.Flags().StringVarP(&migrateCommitMessage, "message", "m", "", "With --no-rewrite, an optional commit message")
 	importCmd.Flags().BoolVar(&migrateFixup, "fixup", false, "Infer filepaths based on .gitattributes")
+	importCmd.Flags().BoolVar(&appendOldShaToMessages, "append-old-sha", false, "Append old commit SHA to rewritten commit messages")
 
 	exportCmd := NewCommand("export", migrateExportCommand)
 	exportCmd.Flags().BoolVar(&migrateVerbose, "verbose", false, "Verbose logging")

--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -147,8 +147,9 @@ func migrateImportCommand(cmd *cobra.Command, args []string) {
 	}
 
 	migrate(args, rewriter, l, &githistory.RewriteOptions{
-		Verbose:           migrateVerbose,
-		ObjectMapFilePath: objectMapFilePath,
+		Verbose:                migrateVerbose,
+		ObjectMapFilePath:      objectMapFilePath,
+		AppendOldShaToMessages: appendOldShaToMessages,
 		BlobFn: func(path string, b *gitobj.Blob) (*gitobj.Blob, error) {
 			if filepath.Base(path) == ".gitattributes" {
 				return b, nil

--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -55,6 +55,10 @@ type RewriteOptions struct {
 	// Verbose mode prints migrated objects.
 	Verbose bool
 
+	// AppendOldShaToMessages specifies whether Rewriter should append the
+	// old commit SHA to rewritten commit messages.
+	AppendOldShaToMessages bool
+
 	// ObjectMapFilePath is the path to the map of old sha1 to new sha1
 	// commits
 	ObjectMapFilePath string
@@ -285,6 +289,9 @@ func (r *Rewriter) Rewrite(opt *RewriteOptions) ([]byte, error) {
 			newSha = make([]byte, len(oid))
 			copy(newSha, oid)
 		} else {
+			if opt.AppendOldShaToMessages {
+				rewrittenCommit.Message = rewrittenCommit.Message + "\n\nold-SHA=" + fmt.Sprintf("%x", oid) + "\n"
+			}
 			newSha, err = r.db.WriteCommit(rewrittenCommit)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Hi, this PR is a candidate solution to the issue that I opened today: 
https://github.com/git-lfs/git-lfs/issues/5947

The original tests passes (tested on WSL) but I'm not sure how to add tests for this feature. It also lacks mention on documentation. Any help is appreciated if this PR is reviewed as useful.