### PR TITLE
docs/man/git-lfs-prune.adoc: fix --(no-)verify-unreachable description

### DIFF
--- a/docs/man/git-lfs-prune.adoc
+++ b/docs/man/git-lfs-prune.adoc
@@ -60,10 +60,10 @@ gitignore(5).
 `--no-verify-remote`::
   Disables remote verification if lfs.pruneverifyremotealways was enabled in
   settings. See <<_verify_remote>>.
-`--verify-reachable`::
+`--verify-unreachable`::
   When doing `--verify-remote` contact the remote and check unreachable
   objects as well. See <<_verify_remote>>.
-`--no-verify-reachable`::
+`--no-verify-unreachable`::
   Disables remote verification of unreachable files if
   lfs.pruneverifyunreachablealways was enabled in settings. See
   <<_verify_remote>>.


### PR DESCRIPTION
I could not find an option `--verify-reachable` / `--no-verify-reachable` on prune sub command.
```
$ git lfs prune --verify-reachable
Error: unknown flag: --verify-reachable

$ git lfs prune --no-verify-reachable
Error: unknown flag: --no-verify-reachable
```

On the other hand, the option `--verify-unreachable` / `--no-verify-unreachable` seems to exist.
```
$ git lfs prune --verify-unreachable
prune: 0 local objects, 1 retained, done.

$ git lfs prune --no-verify-unreachable
prune: 0 local objects, 1 retained, done.
```

So I changed the content of adoc to `--verify-unreachable` / `--no-verify-unreachable`.

