### PR TITLE
Add `--dry-run` option to `fetch`

### DIFF
--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -361,7 +361,7 @@ func fetch(allpointers []*lfs.WrappedPointer) bool {
 		ok = false
 		FullError(err)
 	}
-	if (fetchDryRunArg) {
+	if fetchDryRunArg {
 		wg.Wait()
 	}
 	return ok

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -107,7 +107,7 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 		verifyUnreachable := fetchPruneCfg.PruneVerifyUnreachableAlways
 
 		// assume false for non available options in fetch
-		prune(fetchPruneCfg, verify, verifyUnreachable, false, false, false)
+		prune(fetchPruneCfg, verify, verifyUnreachable, false, fetchDryRunArg, fetchDryRunArg)
 	}
 
 	if !success {

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -324,7 +324,7 @@ func scanAll() []*lfs.WrappedPointer {
 	return pointers
 }
 
-func PrintTransfers(out <-chan *tq.Transfer) {
+func printTransfers(out <-chan *tq.Transfer) {
 	for p := range out {
 		Print("%s %s => %s", tr.Tr.Get("fetch"), p.Oid, p.Name)
 	}
@@ -333,14 +333,14 @@ func PrintTransfers(out <-chan *tq.Transfer) {
 // Fetch
 // Returns true if all completed with no errors, false if errors were written to stderr/log
 func fetch(allpointers []*lfs.WrappedPointer) bool {
-	pointers, meter := MissingPointers(allpointers)
+	pointers, meter := missingPointers(allpointers)
 	q := newDownloadQueue(
 		getTransferManifestOperationRemote("download", cfg.Remote()),
 		cfg.Remote(), tq.WithProgress(meter), tq.DryRun(fetchDryRunArg),
 	)
 
 	if fetchDryRunArg {
-		go PrintTransfers(q.Watch())
+		go printTransfers(q.Watch())
 	}
 
 	for _, p := range pointers {
@@ -361,7 +361,7 @@ func fetch(allpointers []*lfs.WrappedPointer) bool {
 	return ok
 }
 
-func MissingPointers(allpointers []*lfs.WrappedPointer) ([]*lfs.WrappedPointer, *tq.Meter) {
+func missingPointers(allpointers []*lfs.WrappedPointer) ([]*lfs.WrappedPointer, *tq.Meter) {
 	logger := tasklog.NewLogger(os.Stdout,
 		tasklog.ForceProgress(cfg.ForceProgress()),
 	)

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -3,8 +3,8 @@ package commands
 import (
 	"fmt"
 	"os"
-	"time"
 	"sync"
+	"time"
 
 	"github.com/git-lfs/git-lfs/v3/filepathfilter"
 	"github.com/git-lfs/git-lfs/v3/git"

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -336,10 +336,11 @@ func fetch(allpointers []*lfs.WrappedPointer) bool {
 	var wg sync.WaitGroup
 
 	if fetchDryRunArg {
+		watcher := q.Watch()
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			for p := range q.Watch() {
+			for p := range watcher {
 				Print("%s %s => %s", tr.Tr.Get("fetch"), p.Oid, p.Name)
 			}
 		}()

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -148,7 +148,7 @@ func fetchRef(ref string, filter *filepathfilter.Filter) bool {
 	if err != nil {
 		Panic(err, tr.Tr.Get("Could not scan for Git LFS files"))
 	}
-	return fetch(pointers, filter)
+	return fetch(pointers)
 }
 
 func pointersToFetchForRefs(refs []string) ([]*lfs.WrappedPointer, error) {
@@ -190,7 +190,7 @@ func fetchRefs(refs []string) bool {
 	if err != nil {
 		Panic(err, tr.Tr.Get("Could not scan for Git LFS files"))
 	}
-	return fetch(pointers, nil)
+	return fetch(pointers)
 }
 
 // Fetch all previous versions of objects from since to ref (not including final state at ref)
@@ -213,7 +213,7 @@ func fetchPreviousVersions(ref string, since time.Time, filter *filepathfilter.F
 		ExitWithError(err)
 	}
 
-	return fetch(pointers, filter)
+	return fetch(pointers)
 }
 
 // Fetch recent objects based on config
@@ -283,7 +283,7 @@ func fetchRecent(fetchconf lfs.FetchPruneConfig, alreadyFetchedRefs []*git.Ref, 
 func fetchAll() bool {
 	pointers := scanAll()
 	Print("fetch: %s", tr.Tr.Get("Fetching all references..."))
-	return fetch(pointers, nil)
+	return fetch(pointers)
 }
 
 func scanAll() []*lfs.WrappedPointer {
@@ -339,8 +339,8 @@ func StartProcessingFetchedPointers() chan<- *lfs.WrappedPointer {
 
 // Fetch
 // Returns true if all completed with no errors, false if errors were written to stderr/log
-func fetch(allpointers []*lfs.WrappedPointer, filter *filepathfilter.Filter) bool {
-	pointers, meter := MissingPointers(allpointers, filter)
+func fetch(allpointers []*lfs.WrappedPointer) bool {
+	pointers, meter := MissingPointers(allpointers)
 	q := newDownloadQueue(
 		getTransferManifestOperationRemote("download", cfg.Remote()),
 		cfg.Remote(), tq.WithProgress(meter), tq.DryRun(fetchDryRunArg),
@@ -391,7 +391,7 @@ func fetch(allpointers []*lfs.WrappedPointer, filter *filepathfilter.Filter) boo
 	return ok
 }
 
-func MissingPointers(allpointers []*lfs.WrappedPointer, filter *filepathfilter.Filter) ([]*lfs.WrappedPointer, *tq.Meter) {
+func MissingPointers(allpointers []*lfs.WrappedPointer) ([]*lfs.WrappedPointer, *tq.Meter) {
 	logger := tasklog.NewLogger(os.Stdout,
 		tasklog.ForceProgress(cfg.ForceProgress()),
 	)

--- a/docs/man/git-lfs-fetch.adoc
+++ b/docs/man/git-lfs-fetch.adoc
@@ -39,6 +39,9 @@ This does not update the working copy.
 `-p`::
   Prune old and unreferenced objects after fetching, equivalent to running `git
   lfs prune` afterwards. See git-lfs-prune(1) for more details.
+`--dry-run`::
+`-d`::
+  Print what would be fetched, without actually fetching anything.
 
 == INCLUDE AND EXCLUDE
 

--- a/t/t-fetch.sh
+++ b/t/t-fetch.sh
@@ -63,11 +63,18 @@ begin_test "fetch"
   cd clone
   rm -rf .git/lfs/objects
 
+  git lfs fetch --dry-run 2>&1 | tee fetch.log
+  grep "fetch $contents_oid => a\.dat" fetch.log
+  refute_local_object "$contents_oid"
+
   git lfs fetch
   assert_local_object "$contents_oid" 1
 
   git lfs fsck 2>&1 | tee fsck.log
   grep "Git LFS fsck OK" fsck.log
+
+  git lfs fetch --dry-run 2>&1 | tee fetch.log
+  ! grep "fetch .* => a\.dat" fetch.log
 )
 end_test
 
@@ -128,12 +135,21 @@ begin_test "fetch with remote and branches"
 
   rm -rf .git/lfs/objects
 
+  git lfs fetch origin main newbranch --dry-run | tee fetch.log
+  grep "fetch $contents_oid => a\.dat" fetch.log
+  grep "fetch $b_oid => b\.dat" fetch.log
+  refute_local_object "$contents_oid"
+  refute_local_object "$b_oid"
+
   git lfs fetch origin main newbranch
   assert_local_object "$contents_oid" 1
   assert_local_object "$b_oid" 1
 
   git lfs fsck 2>&1 | tee fsck.log
   grep "Git LFS fsck OK" fsck.log
+
+  git lfs fetch origin main newbranch --dry-run | tee fetch.log
+  ! grep "fetch .* => [ab]\.dat" fetch.log
 )
 end_test
 

--- a/t/t-fetch.sh
+++ b/t/t-fetch.sh
@@ -74,7 +74,7 @@ begin_test "fetch"
   grep "Git LFS fsck OK" fsck.log
 
   git lfs fetch --dry-run 2>&1 | tee fetch.log
-  ! grep "fetch .* => a\.dat" fetch.log
+  grep "fetch .* => a\.dat" fetch.log && exit 1 || true
 )
 end_test
 
@@ -149,7 +149,7 @@ begin_test "fetch with remote and branches"
   grep "Git LFS fsck OK" fsck.log
 
   git lfs fetch origin main newbranch --dry-run | tee fetch.log
-  ! grep "fetch .* => [ab]\.dat" fetch.log
+  grep "fetch .* => [ab]\.dat" fetch.log && exit 1 || true
 )
 end_test
 


### PR DESCRIPTION
This was modelled after the `git-lfs push --dry-run` option. I've removed some apparently unused code:
* computing and reporting of ready nodes
* deduplication of multiple objects with the same OID (as far as I can tell, that is already carried out by the transfer queue class, so no need to redo it in the fetch command)
* the output channel of the main fetch function which was always `nil`.

For testing, I added `--dry-run` testing to a couple of cases, but I wonder if we should add it for _all_ cases.

This is a part of what was discussed in https://github.com/git-lfs/git-lfs/issues/5888.