### PR TITLE
Add `--json` option to `fetch`

### DIFF
--- a/commands/command_clone.go
+++ b/commands/command_clone.go
@@ -83,7 +83,7 @@ func cloneCommand(cmd *cobra.Command, args []string) {
 		filter := buildFilepathFilter(cfg, includeArg, excludeArg, true)
 		if cloneFlags.NoCheckout || cloneFlags.Bare {
 			// If --no-checkout or --bare then we shouldn't check out, just fetch instead
-			fetchRef(ref.Name, filter)
+			fetchRef(ref.Name, filter, nil)
 		} else {
 			pull(filter)
 			err := postCloneSubmodules(args)

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -470,6 +470,6 @@ func init() {
 		cmd.Flags().BoolVarP(&fetchAllArg, "all", "a", false, "Fetch all LFS files ever referenced")
 		cmd.Flags().BoolVarP(&fetchPruneArg, "prune", "p", false, "After fetching, prune old data")
 		cmd.Flags().BoolVarP(&fetchDryRunArg, "dry-run", "d", false, "Do not fetch, only show what would be fetched")
-		cmd.Flags().BoolVar(&fetchJsonArg, "json", false, "Give the output in JSON format")
+		cmd.Flags().BoolVar(&fetchJsonArg, "json", false, "Give the output in a stable JSON format for scripts")
 	})
 }

--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -142,6 +142,6 @@ func lockPath(data *lockData, file string) (string, error) {
 func init() {
 	RegisterCommand("lock", lockCommand, func(cmd *cobra.Command) {
 		cmd.Flags().StringVarP(&lockRemote, "remote", "r", "", "specify which remote to use when interacting with locks")
-		cmd.Flags().BoolVarP(&locksCmdFlags.JSON, "json", "", false, "print output in json")
+		cmd.Flags().BoolVarP(&locksCmdFlags.JSON, "json", "j", false, "Give the output in a stable JSON format for scripts")
 	})
 }

--- a/commands/command_locks.go
+++ b/commands/command_locks.go
@@ -185,6 +185,6 @@ func init() {
 		cmd.Flags().BoolVarP(&locksCmdFlags.Local, "local", "", false, "only list cached local record of own locks")
 		cmd.Flags().BoolVarP(&locksCmdFlags.Cached, "cached", "", false, "list cached lock information from the last remote query, instead of actually querying the server")
 		cmd.Flags().BoolVarP(&locksCmdFlags.Verify, "verify", "", false, "verify lock owner on server and mark own locks by 'O'")
-		cmd.Flags().BoolVarP(&locksCmdFlags.JSON, "json", "", false, "print output in json")
+		cmd.Flags().BoolVarP(&locksCmdFlags.JSON, "json", "j", false, "Give the output in a stable JSON format for scripts")
 	})
 }

--- a/commands/command_ls_files.go
+++ b/commands/command_ls_files.go
@@ -203,6 +203,6 @@ func init() {
 		cmd.Flags().BoolVar(&lsFilesScanDeleted, "deleted", false, "")
 		cmd.Flags().StringVarP(&includeArg, "include", "I", "", "Include a list of paths")
 		cmd.Flags().StringVarP(&excludeArg, "exclude", "X", "", "Exclude a list of paths")
-		cmd.Flags().BoolVarP(&lsFilesJSON, "json", "", false, "print output in JSON")
+		cmd.Flags().BoolVarP(&lsFilesJSON, "json", "j", false, "Give the output in a stable JSON format for scripts")
 	})
 }

--- a/commands/command_status.go
+++ b/commands/command_status.go
@@ -367,7 +367,7 @@ func relativize(from, to string) string {
 
 func init() {
 	RegisterCommand("status", statusCommand, func(cmd *cobra.Command) {
-		cmd.Flags().BoolVarP(&porcelain, "porcelain", "p", false, "Give the output in an easy-to-parse format for scripts.")
-		cmd.Flags().BoolVarP(&statusJson, "json", "j", false, "Give the output in a stable json format for scripts.")
+		cmd.Flags().BoolVarP(&porcelain, "porcelain", "p", false, "Give the output in an easy-to-parse format for scripts")
+		cmd.Flags().BoolVarP(&statusJson, "json", "j", false, "Give the output in a stable JSON format for scripts")
 	})
 }

--- a/commands/command_unlock.go
+++ b/commands/command_unlock.go
@@ -186,6 +186,6 @@ func init() {
 		cmd.Flags().StringVarP(&lockRemote, "remote", "r", "", "specify which remote to use when interacting with locks")
 		cmd.Flags().StringVarP(&unlockCmdFlags.Id, "id", "i", "", "unlock a lock by its ID")
 		cmd.Flags().BoolVarP(&unlockCmdFlags.Force, "force", "f", false, "forcibly break another user's lock(s)")
-		cmd.Flags().BoolVarP(&locksCmdFlags.JSON, "json", "", false, "print output in json")
+		cmd.Flags().BoolVarP(&locksCmdFlags.JSON, "json", "j", false, "Give the output in a stable JSON format for scripts")
 	})
 }

--- a/docs/man/git-lfs-fetch.adoc
+++ b/docs/man/git-lfs-fetch.adoc
@@ -42,6 +42,9 @@ This does not update the working copy.
 `--dry-run`::
 `-d`::
   Print what would be fetched, without actually fetching anything.
+`--porcelain`::
+  Give the output in an easy-to-parse format for scripts.
+
 
 == INCLUDE AND EXCLUDE
 

--- a/docs/man/git-lfs-fetch.adoc
+++ b/docs/man/git-lfs-fetch.adoc
@@ -42,8 +42,9 @@ This does not update the working copy.
 `--dry-run`::
 `-d`::
   Print what would be fetched, without actually fetching anything.
-`--porcelain`::
-  Give the output in an easy-to-parse format for scripts.
+`--json`::
+`-j`::
+  Give the output in a stable JSON format for scripts.
 
 
 == INCLUDE AND EXCLUDE

--- a/docs/man/git-lfs-fetch.adoc
+++ b/docs/man/git-lfs-fetch.adoc
@@ -46,7 +46,6 @@ This does not update the working copy.
 `-j`::
   Give the output in a stable JSON format for scripts.
 
-
 == INCLUDE AND EXCLUDE
 
 You can configure Git LFS to only fetch objects to satisfy references in

--- a/docs/man/git-lfs-lock.adoc
+++ b/docs/man/git-lfs-lock.adoc
@@ -24,6 +24,7 @@ config key in git-lfs-config(5) for details.
 `--remote=<name>`::
    Specify the Git LFS server to use. Ignored if the `lfs.url` config key is
    set.
+`-j`::
 `--json`::
   Writes lock info as JSON to STDOUT if the command exits successfully. Intended
   for interoperation with external tools. If the command returns with a non-zero

--- a/docs/man/git-lfs-locks.adoc
+++ b/docs/man/git-lfs-locks.adoc
@@ -43,6 +43,7 @@ meanwhile.
 `-l <num>`::
 `--limit=<num>`::
    Specifies number of results to return.
+`-j`::
 `--json`::
   Writes lock info as JSON to STDOUT if the command exits successfully. Intended
   for interoperation with external tools. If the command returns with a non-zero

--- a/docs/man/git-lfs-ls-files.adoc
+++ b/docs/man/git-lfs-ls-files.adoc
@@ -48,6 +48,9 @@ indicates an LFS pointer.
 `-n`::
 `--name-only`::
    Show only the lfs tracked file names.
+`-j`::
+`--json`::
+   Give the output in a stable json format for scripts.
 
 == SEE ALSO
 

--- a/docs/man/git-lfs-status.adoc
+++ b/docs/man/git-lfs-status.adoc
@@ -23,12 +23,12 @@ This command must be run in a non-bare repository.
 
 == OPTIONS
 
-`--porcelain`::
 `-p`::
+`--porcelain`::
   Give the output in an easy-to-parse format for scripts.
-`--json`::
 `-j`::
-  Give the output in a stable json format for scripts.
+`--json`::
+  Give the output in a stable JSON format for scripts.
 
 == SEE ALSO
 

--- a/docs/man/git-lfs-status.adoc
+++ b/docs/man/git-lfs-status.adoc
@@ -24,8 +24,10 @@ This command must be run in a non-bare repository.
 == OPTIONS
 
 `--porcelain`::
+`-p`::
   Give the output in an easy-to-parse format for scripts.
 `--json`::
+`-j`::
   Give the output in a stable json format for scripts.
 
 == SEE ALSO

--- a/docs/man/git-lfs-unlock.adoc
+++ b/docs/man/git-lfs-unlock.adoc
@@ -26,6 +26,7 @@ must exist and have a clean git status before they can be unlocked. The
 `-i <id>`::
 `--id=<id>`::
    Specifies a lock by its ID instead of path.
+`-j`::
 `--json`::
   Writes lock info as JSON to STDOUT if the command exits successfully. Intended
   for interoperation with external tools. If the command returns with a non-zero

--- a/t/t-fetch.sh
+++ b/t/t-fetch.sh
@@ -175,7 +175,7 @@ begin_test "fetch with remote and branches"
 
   rm -rf .git/lfs/objects
 
-  git lfs fetch origin main newbranch --dry-run | tee fetch.log
+  git lfs fetch origin main newbranch --dry-run 2>&1 | tee fetch.log
   grep "fetch $contents_oid => a\.dat" fetch.log
   grep "fetch $b_oid => b\.dat" fetch.log
   refute_local_object "$contents_oid"

--- a/t/t-fetch.sh
+++ b/t/t-fetch.sh
@@ -100,7 +100,7 @@ begin_test "fetch --json"
      "expires_at": "0001-01-01T00:00:00Z"
     }
    },
-   "path": "$(local_object_path "$contents_oid")"
+   "path": "$(native_path_escaped "$(local_object_path "$contents_oid")")"
   }
  ]
 }
@@ -203,55 +203,57 @@ begin_test "fetch --json with remote and branches"
 
   rm -rf .git/lfs/objects
 
-  echo ONE
   git lfs fetch origin main newbranch --json --dry-run | tee fetch-dry-run.json
   refute_local_object "$contents_oid"
   refute_local_object "$b_oid"
 
-  echo TWO
   git lfs fetch origin main newbranch --json | tee fetch.json
   assert_local_object "$contents_oid" 1
   assert_local_object "$b_oid" 1
 
   # Check the JSON output, without enforcing order between a.dat and b.dat
-  cat fetch-dry-run.json | jq '.transfers[] | select(.name == "a.dat")' > fetch-dry-run-a.json
-  cat fetch-dry-run.json | jq '.transfers[] | select(.name == "b.dat")' > fetch-dry-run-b.json
-  cat fetch.json | jq '.transfers[] | select(.name == "a.dat")' > fetch-a.json
-  cat fetch.json | jq '.transfers[] | select(.name == "b.dat")' > fetch-b.json
-
-  cat > expected-a.json <<-EOF
-{
-  "name": "a.dat",
-  "oid": "$contents_oid",
-  "size": 1,
-  "actions": {
+  expected_a='{
+   "name": "a.dat",
+   "oid": "'$contents_oid'",
+   "size": 1,
+   "actions": {
     "download": {
-      "href": "$GITSERVER/storage/$contents_oid?r=$reponame",
-      "expires_at": "0001-01-01T00:00:00Z"
+     "href": "'$GITSERVER'/storage/'$contents_oid'?r='$reponame'",
+     "expires_at": "0001-01-01T00:00:00Z"
     }
-  },
-  "path": "$(local_object_path "$contents_oid")"
+   },
+   "path": "'$(native_path_escaped "$(local_object_path "$contents_oid")")'"
+  }'
+  expected_b='{
+   "name": "b.dat",
+   "oid": "'$b_oid'",
+   "size": 1,
+   "actions": {
+    "download": {
+     "href": "'$GITSERVER'/storage/'$b_oid'?r='$reponame'",
+     "expires_at": "0001-01-01T00:00:00Z"
+    }
+   },
+   "path": "'$(native_path_escaped "$(local_object_path "$b_oid")")'"
+  }'
+  cat > expected-a-b.json <<-EOF
+{
+ "transfers": [
+  $expected_a,
+  $expected_b
+ ]
 }
 EOF
-  cat > expected-b.json <<-EOF
+  cat > expected-b-a.json <<-EOF
 {
-  "name": "b.dat",
-  "oid": "$b_oid",
-  "size": 1,
-  "actions": {
-    "download": {
-      "href": "$GITSERVER/storage/$b_oid?r=$reponame",
-      "expires_at": "0001-01-01T00:00:00Z"
-    }
-  },
-  "path": "$(local_object_path "$b_oid")"
+  "transfers": [
+    $expected_b,
+    $expected_a
+  ]
 }
 EOF
-  ls -l fetch-dry-run-a.json fetch-dry-run-b.json fetch-a.json fetch-b.json
-  diff -u expected-a.json fetch-dry-run-a.json
-  diff -u expected-b.json fetch-dry-run-b.json
-  diff -u expected-a.json fetch-a.json
-  diff -u expected-b.json fetch-b.json
+  diff -u expected-a-b.json fetch-dry-run.json || diff -u expected-b-a.json fetch-dry-run.json || exit 1
+  diff -u expected-a-b.json fetch.json || diff -u expected-b-a.json fetch-dry-run.json || exit 1
 )
 end_test
 

--- a/t/t-fetch.sh
+++ b/t/t-fetch.sh
@@ -246,10 +246,10 @@ begin_test "fetch --json with remote and branches"
 EOF
   cat > expected-b-a.json <<-EOF
 {
-  "transfers": [
-    $expected_b,
-    $expected_a
-  ]
+ "transfers": [
+  $expected_b,
+  $expected_a
+ ]
 }
 EOF
   diff -u expected-a-b.json fetch-dry-run.json || diff -u expected-b-a.json fetch-dry-run.json || exit 1

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -854,10 +854,12 @@ func (q *TransferQueue) handleTransferResult(
 			// same OID.
 			for _, t := range objects.All() {
 				c <- &Transfer{
-					Name: t.Name,
-					Path: t.Path,
-					Oid:  t.Oid,
-					Size: t.Size,
+					Name:    t.Name,
+					Path:    t.Path,
+					Oid:     t.Oid,
+					Size:    t.Size,
+					Actions: res.Transfer.Actions,
+					Links:   res.Transfer.Links,
 				}
 			}
 		}


### PR DESCRIPTION
This adds a `--json` option to fetch, which is done on top of https://github.com/git-lfs/git-lfs/pull/5973.

It turned out there was a minor bug in `--dry-run`, where the same object was being reported fetched multiple times from different references, which diverged from non-dry-run behaviour, where the object being fetched for one ref prevented refetching for the other. This has been fixed by keeping a set of virtually fetched OIDs. This and gathering the transfers across references required sharing a `fetchWatcher` object across `fetch*` calls.

Additionally, this PR also harmonizes the `--json` flag occurring in different commands:
* all now accept `-j` as a shorcut (previously only `status` did)
* all now have the same documentation