### PR TITLE
Update workflows to use ARM runners and new Apple signing certificate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,11 @@ jobs:
       with:
         fetch-depth: 0
         persist-credentials: false
-    - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
-      if: ${{ github.ref_type == 'tag' }}
-      # We update the current tag as the checkout step turns annotated tags
-      # into lightweight ones by accident, breaking "git describe".
-      # See https://github.com/actions/checkout/issues/882 for details.
+        ref: ${{ github.ref }}
+      # We specify the current ref because otherwise the checkout turns
+      # annotated tags into lightweight ones, breaking "git describe".
+      # See https://github.com/actions/checkout/issues/290 and
+      # https://github.com/actions/checkout/issues/882 for details.
     - uses: ruby/setup-ruby@v1
     - run: gem install asciidoctor
     - uses: actions/setup-go@v5
@@ -53,8 +53,7 @@ jobs:
       with:
         fetch-depth: 0
         persist-credentials: false
-    - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
-      if: ${{ github.ref_type == 'tag' }}
+        ref: ${{ github.ref }}
     - uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go }}
@@ -67,9 +66,7 @@ jobs:
       with:
         fetch-depth: 0
         persist-credentials: false
-    - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
-      if: ${{ github.ref_type == 'tag' }}
-      shell: bash
+        ref: ${{ github.ref }}
     - uses: ruby/setup-ruby@v1
     - run: gem install asciidoctor
     - run: Rename-Item -Path C:\msys64 -NewName msys64-tmp -Force
@@ -136,11 +133,10 @@ jobs:
       with:
         fetch-depth: 0
         persist-credentials: false
+        ref: ${{ github.ref }}
     - uses: actions/setup-go@v5
       with:
         go-version: '1.23.x'
-    - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
-      if: ${{ github.ref_type == 'tag' }}
     - run: git clone -b master https://github.com/git/git.git "$HOME/git"
     - run: |
         echo "GIT_INSTALL_DIR=$HOME/git" >> "$GITHUB_ENV"
@@ -161,11 +157,10 @@ jobs:
       with:
         fetch-depth: 0
         persist-credentials: false
+        ref: ${{ github.ref }}
     - uses: actions/setup-go@v5
       with:
         go-version: '1.23.x'
-    - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
-      if: ${{ github.ref_type == 'tag' }}
     - run: git clone -b v2.0.0 https://github.com/git/git.git "$HOME/git"
     - run: |
         echo "GIT_INSTALL_DIR=$HOME/git" >> "$GITHUB_ENV"
@@ -183,8 +178,7 @@ jobs:
       with:
         fetch-depth: 0
         persist-credentials: false
-    - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
-      if: ${{ github.ref_type == 'tag' }}
+        ref: ${{ github.ref }}
     - uses: ruby/setup-ruby@v1
     - run: git clone https://github.com/git-lfs/build-dockers.git "$HOME/build-dockers"
     - run: (cd "$HOME/build-dockers" && ./build_dockers.bsh)
@@ -201,8 +195,7 @@ jobs:
       with:
         fetch-depth: 0
         persist-credentials: false
-    - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
-      if: ${{ github.ref_type == 'tag' }}
+        ref: ${{ github.ref }}
     - uses: ruby/setup-ruby@v1
     - run: |
         echo '{"experimental": true}' | sudo tee /etc/docker/daemon.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,30 +182,15 @@ jobs:
     - run: git clone https://github.com/git-lfs/build-dockers.git "$HOME/build-dockers"
     - run: (cd "$HOME/build-dockers" && ./build_dockers.bsh)
     - run: ./docker/run_dockers.bsh --prune
-  build-docker-cross:
-    name: Build Cross Linux packages
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [arm64]
-        container: [debian_12]
+  build-docker-arm:
+    name: Build Linux ARM packages
+    runs-on: ubuntu-24.04-arm
     steps:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         persist-credentials: false
         ref: ${{ github.ref }}
-    - run: |
-        echo '{"experimental": true}' | sudo tee /etc/docker/daemon.json
-        sudo systemctl restart docker.service
-        docker version -f '{{.Server.Experimental}}'
-    - uses: docker/setup-qemu-action@v3
     - run: git clone https://github.com/git-lfs/build-dockers.git "$HOME/build-dockers"
-    - run: (cd "$HOME/build-dockers" && ./build_dockers.bsh --arch="$ARCH" "$CONTAINER")
-      env:
-        ARCH: ${{matrix.arch}}
-        CONTAINER: ${{matrix.container}}
-    - run: ./docker/run_dockers.bsh --prune --arch="$ARCH" "$CONTAINER"
-      env:
-        ARCH: ${{matrix.arch}}
-        CONTAINER: ${{matrix.container}}
+    - run: (cd "$HOME/build-dockers" && ./build_dockers.bsh --arch=arm64 debian_11 debian_12)
+    - run: ./docker/run_dockers.bsh --prune --arch=arm64 debian_11 debian_12

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,6 @@ jobs:
         fetch-depth: 0
         persist-credentials: false
         ref: ${{ github.ref }}
-    - uses: ruby/setup-ruby@v1
     - run: git clone https://github.com/git-lfs/build-dockers.git "$HOME/build-dockers"
     - run: (cd "$HOME/build-dockers" && ./build_dockers.bsh)
     - run: ./docker/run_dockers.bsh --prune
@@ -196,7 +195,6 @@ jobs:
         fetch-depth: 0
         persist-credentials: false
         ref: ${{ github.ref }}
-    - uses: ruby/setup-ruby@v1
     - run: |
         echo '{"experimental": true}' | sudo tee /etc/docker/daemon.json
         sudo systemctl restart docker.service

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,9 +170,13 @@ jobs:
     - run: rm -f bin/releases/*windows* bin/releases/*darwin*
     - run: 'find windows-assets -name "*windows*" -type f | xargs -I{} mv {} bin/releases'
     - run: 'find macos-assets -name "*darwin*" -type f | xargs -I{} mv {} bin/releases'
-    - run: script/upload --skip-verify $(git describe)
-      env:
-        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+    - run: rm -f bin/releases/git-lfs-windows-assets*.tar.gz
+    - run: mkdir -p release-assets/bin
+    - run: mv bin/releases release-assets/bin
+    - uses: actions/upload-artifact@v4
+      with:
+        name: release-assets
+        path: release-assets
   build-docker:
     name: Build Linux Packages
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ env:
 jobs:
   build-windows:
     name: Build Windows Assets
+    environment: production
     runs-on: windows-latest
     strategy:
       matrix:
@@ -101,6 +102,7 @@ jobs:
         path: bin/releases
   build-macos:
     name: Build macOS Assets
+    environment: production
     runs-on: macos-latest
     strategy:
       matrix:
@@ -121,10 +123,10 @@ jobs:
           FORCE_LOCALIZE: true
     - run: CERT_FILE="$HOME/cert.p12" make release-write-certificate
       env:
-        CERT_CONTENTS: ${{secrets.MACOS_CERT_BASE64}}
+        CERT_CONTENTS: ${{secrets.GATEWATCHER_DEVELOPER_ID_CERT}}
     - run: CERT_FILE="$HOME/cert.p12" make release-import-certificate
       env:
-        CERT_PASS: ${{secrets.MACOS_CERT_PASS}}
+        CERT_PASS: ${{secrets.GATEWATCHER_DEVELOPER_ID_PASSWORD}}
     - run: make release-darwin
       env:
         DARWIN_DEV_USER: ${{secrets.MACOS_DEV_USER}}
@@ -178,6 +180,7 @@ jobs:
         path: release-assets
   build-docker:
     name: Build Linux Packages
+    environment: production
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -196,6 +199,7 @@ jobs:
         PACKAGECLOUD_TOKEN: ${{secrets.PACKAGECLOUD_TOKEN}}
   build-docker-cross:
     name: Build Cross Linux packages
+    environment: production
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,6 @@ jobs:
         DARWIN_DEV_USER: ${{secrets.MACOS_DEV_USER}}
         DARWIN_DEV_PASS: ${{secrets.MACOS_DEV_PASS}}
         DARWIN_DEV_TEAM: ${{secrets.MACOS_DEV_TEAM}}
-        DARWIN_CERT_ID: ${{secrets.MACOS_CERT_ID}}
     - uses: actions/upload-artifact@v4
       with:
         name: macos-assets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,14 +197,9 @@ jobs:
     - run: '[ -z "${GITHUB_REF%%refs/tags/*-pre*}" ] || ./script/packagecloud.rb'
       env:
         PACKAGECLOUD_TOKEN: ${{secrets.PACKAGECLOUD_TOKEN}}
-  build-docker-cross:
-    name: Build Cross Linux packages
-    environment: production
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [arm64]
-        container: [debian_12]
+  build-docker-arm:
+    name: Build Linux ARM packages
+    runs-on: ubuntu-24.04-arm
     steps:
     - uses: actions/checkout@v4
       with:
@@ -213,20 +208,9 @@ jobs:
         ref: ${{ github.ref }}
     - uses: ruby/setup-ruby@v1
     - run: gem install packagecloud-ruby
-    - run: |
-        echo '{"experimental": true}' | sudo tee /etc/docker/daemon.json
-        sudo systemctl restart docker.service
-        docker version -f '{{.Server.Experimental}}'
-    - uses: docker/setup-qemu-action@v3
     - run: git clone https://github.com/git-lfs/build-dockers.git "$HOME/build-dockers"
-    - run: (cd "$HOME/build-dockers" && ./build_dockers.bsh --arch="$ARCH" "$CONTAINER")
-      env:
-        ARCH: ${{matrix.arch}}
-        CONTAINER: ${{matrix.container}}
-    - run: ./docker/run_dockers.bsh --prune --arch="$ARCH" "$CONTAINER"
-      env:
-        ARCH: ${{matrix.arch}}
-        CONTAINER: ${{matrix.container}}
+    - run: (cd "$HOME/build-dockers" && ./build_dockers.bsh --arch=arm64 debian_11 debian_12)
+    - run: ./docker/run_dockers.bsh --prune --arch=arm64 debian_11 debian_12
     # If this is a pre-release tag, don't upload anything to packagecloud.
     - run: '[ -z "${GITHUB_REF%%refs/tags/*-pre*}" ] || ./script/packagecloud.rb'
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,11 @@ jobs:
       with:
         fetch-depth: 0
         persist-credentials: false
-    - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
-      shell: bash
-      # We update the current tag as the checkout step turns annotated tags
-      # into lightweight ones by accident, breaking "git describe".
-      # See https://github.com/actions/checkout/issues/882 for details.
+        ref: ${{ github.ref }}
+      # We specify the current ref because otherwise the checkout turns
+      # annotated tags into lightweight ones, breaking "git describe".
+      # See https://github.com/actions/checkout/issues/290 and
+      # https://github.com/actions/checkout/issues/882 for details.
     - uses: ruby/setup-ruby@v1
     - run: gem install asciidoctor
     - run: Rename-Item -Path C:\msys64 -NewName msys64-tmp -Force
@@ -110,7 +110,7 @@ jobs:
       with:
         fetch-depth: 0
         persist-credentials: false
-    - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
+        ref: ${{ github.ref }}
     - uses: ruby/setup-ruby@v1
     - run: gem install asciidoctor
     - uses: actions/setup-go@v5
@@ -149,7 +149,7 @@ jobs:
       with:
         fetch-depth: 0
         persist-credentials: false
-    - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
+        ref: ${{ github.ref }}
     - uses: ruby/setup-ruby@v1
     - run: gem install asciidoctor
     - uses: actions/setup-go@v5
@@ -181,7 +181,7 @@ jobs:
       with:
         fetch-depth: 0
         persist-credentials: false
-    - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
+        ref: ${{ github.ref }}
     - uses: ruby/setup-ruby@v1
     - run: gem install packagecloud-ruby
     - run: git clone https://github.com/git-lfs/build-dockers.git "$HOME/build-dockers"
@@ -203,7 +203,7 @@ jobs:
       with:
         fetch-depth: 0
         persist-credentials: false
-    - run: git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
+        ref: ${{ github.ref }}
     - uses: ruby/setup-ruby@v1
     - run: gem install packagecloud-ruby
     - run: |

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ DARWIN_CERT_ID ?=
 
 # DARWIN_KEYCHAIN_ID is the name of the keychain (with suffix) where the
 # certificate is located.
-DARWIN_KEYCHAIN_ID ?= CI.keychain
+DARWIN_KEYCHAIN_ID ?= lfs.keychain
 
 export DARWIN_DEV_USER DARWIN_DEV_PASS DARWIN_DEV_TEAM
 
@@ -547,22 +547,22 @@ release-write-certificate:
 	@printf 'Wrote %d bytes (SHA256 %s) to certificate file\n' $$(wc -c <"$$CERT_FILE") $$(shasum -ba 256 "$$CERT_FILE" | cut -d' ' -f1)
 
 # release-import-certificate imports the given certificate into the macOS
-# keychain "CI".  It is not generally recommended to run this on a user system,
+# keychain "lfs".  It is not generally recommended to run this on a user system,
 # since it creates a new keychain and modifies the keychain search path.
 .PHONY : release-import-certificate
 release-import-certificate:
 	@[ -n "$(CI)" ] || { echo "Don't run this target by hand." >&2; false; }
-	@echo "Creating CI keychain"
-	security create-keychain -p default CI.keychain
-	security set-keychain-settings CI.keychain
-	security unlock-keychain -p default CI.keychain
+	@echo "Creating keychain"
+	security create-keychain -p default $(DARWIN_KEYCHAIN_ID)
+	security set-keychain-settings $(DARWIN_KEYCHAIN_ID)
+	security unlock-keychain -p default $(DARWIN_KEYCHAIN_ID)
 	@echo "Importing certificate from $(CERT_FILE)"
-	@security import "$$CERT_FILE" -f pkcs12 -k CI.keychain -P "$$CERT_PASS" -A
+	@security import "$$CERT_FILE" -f pkcs12 -k $(DARWIN_KEYCHAIN_ID) -P "$$CERT_PASS" -A
 	@echo "Verifying import and setting permissions"
-	security list-keychains -s CI.keychain
-	security default-keychain -s CI.keychain
-	security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k default CI.keychain
-	security find-identity -vp codesigning CI.keychain
+	security list-keychains -s $(DARWIN_KEYCHAIN_ID)
+	security default-keychain -s $(DARWIN_KEYCHAIN_ID)
+	security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k default $(DARWIN_KEYCHAIN_ID)
+	security find-identity -vp codesigning $(DARWIN_KEYCHAIN_ID)
 
 # TEST_TARGETS is a list of all phony test targets. Each one of them corresponds
 # to a specific kind or subset of tests to run.

--- a/docs/howto/release-git-lfs.md
+++ b/docs/howto/release-git-lfs.md
@@ -211,6 +211,9 @@ to zero, we are releasing a PATCH version.
      $ git push origin vM.N.P
      ```
 
+     Validate the pending `production` environment deployment rule in the UI
+     of the GitHub management application for macOS Developer ID certificates.
+
      This will kick off the process of building the release artifacts.  This
      process will take somewhere between 45 minutes and an hour.  When it's
      done, you'll end up with a set of release assets available for download,

--- a/docs/howto/release-git-lfs.md
+++ b/docs/howto/release-git-lfs.md
@@ -213,13 +213,26 @@ to zero, we are releasing a PATCH version.
 
      This will kick off the process of building the release artifacts.  This
      process will take somewhere between 45 minutes and an hour.  When it's
-     done, you'll end up with a draft release in the repository for the version
-     in question.
+     done, you'll end up with a set of release assets available for download,
+     and Linux RPM and Debian packages for the new release will be available
+     on Packagecloud.
 
-  6. From the command line, finalize the release process by signing the release:
+  6. Download the `release-assets` archive file from the "Artifacts" section
+     of the "Summary" page for the most recent run of the release GitHub
+     Actions
+     [workflow](https://github.com/git-lfs/git-lfs/actions/workflows/release.yml),
+     and then unpack the file at the top level of the repository:
+     ```
+     $ rm -rf bin/releases
+     $ unzip /path/to/release-assets.zip
+     ```
 
-     ```ShellSession
-     $ script/upload --finalize vM.N.P
+     The release assets should now be present in the `bin/releases` directory.
+     The `script/upload` utility will create a new draft release announcement
+     and then upload the release assets and attach them to the announcement:
+
+     ```
+     $ script/upload --skip-verify vM.N.P
      ```
 
      Note that this script requires GnuPG, with your signing key configured,
@@ -228,17 +241,25 @@ to zero, we are releasing a PATCH version.
      provide your GitHub credentials in your `~/.netrc` file or via a
      `GITHUB_TOKEN` environment variable.
 
+  7. Finalize the release process using the same `script/upload` utility but
+     with the `--finalize` option.  The script will add GPG signatures to the
+     `hashes` and `sha256sums` files and then upload the signed files:
+
+     ```ShellSession
+     $ script/upload --finalize vM.N.P
+     ```
+
      If you want to inspect the data before approving it, pass the `--inspect`
      option, which will drop you to a shell and let you look at things.  If the
      shell exits successfully, the build will be signed; otherwise, the process
      will be aborted.
 
-  7. Publish the release on GitHub, assuming it looks correct.
+  8. Publish the release on GitHub, assuming it looks correct.
 
-  8. Move any remaining items out of the milestone for the current release to a
+  9. Move any remaining items out of the milestone for the current release to a
      future release and close the milestone.
 
-  9. Update the `_config.yml` file in
+ 10. Update the `_config.yml` file in
      [`git-lfs/git-lfs.github.com`](https://github.com/git-lfs/git-lfs.github.com),
      similar to the following:
 
@@ -255,7 +276,7 @@ to zero, we are releasing a PATCH version.
       url: "https://git-lfs.com"
      ```
 
- 10. If Homebrew does not automatically update within a few hours,
+ 11. If Homebrew does not automatically update within a few hours,
      create a GitHub PR to update the Homebrew formula for Git LFS with
      the `brew bump-formula-pr` command on a macOS system.  The SHA-256 value
      should correspond with the packaged artifact containing the new


### PR DESCRIPTION
This PR updates our GitHub Actions workflows so they avoid several permissions issues, make use of the newly available ARM runners, and sign our macOS release binaries with a new Apple Developer ID certificate that replaces the previous one, which has now expired.

First, we revise our CI and release workflows to avoid a problem introduced when we changed the `actions/checkout` actions in PR #5930 to no longer leave Git credentials in place for subsequent steps to use.  While this had no effect on CI jobs run for PRs, it does affect CI and release jobs run when we push a new Git LFS version tag, because the `git fetch` commands we added in PR #5243 to work around the problem described in actions/checkout#290 and actions/checkout#882 now fail due to the lack of cached Git credentials.

Next, because we would like to run our Actions workflows with the minimal required permissions, we alter the `build-main` job in our release workflow so that is does not try to create a draft release announcement or attach binary release assets to that announcement.  At present, this step is the only one in our workflows which requires write permissions on our whole repository's contents, and GitHub does not offer a way to make those permissions more fine-grained (e.g., by limiting them to just the creation of release announcements, for instance).  Instead, in the future we will just run our `script/upload` script manually, which allows us to restrict all our workflows to having just read permissions on our repository contents.

We then change our release workflow to replace our expired Apple Developer ID certificate with a new one that is provided by GitHub.  Because Apple [limits](https://developer.apple.com/help/account/create-certificates/create-developer-id-certificates) the number of certificates which can be created for a Developer ID to just five, GitHub is no longer able to assign a dedicated certificate to this project.  In order to share a certificate with other projects, we adopt a GitHub management tool which allows us to approve our release workflow and confirm the use of the new certificate's secrets to sign our release binaries.

Finally, we revise our Actions workflows to make use of the ARM64 runners GitHub now [offers](https://github.com/orgs/community/discussions/148648) for public repositories like ours.  This allows us to bypass some recent issues seen in our Linux package builds that use QEMU-based ARM64 emulation, and because these jobs now run significantly faster than before, we can add a build of a Debian 11 release package for ARM64 systems.  (We should also be able to offer a Rocky 9 RPM package for ARM64 systems, once we make some adjustments to our RPM package metadata and Docker containers.)

The changes to our release workflow in this PR have been tested using a private repository to confirm they work as expected when a new version tag is pushed.  One exception is the use of ARM64 runners in the release workflow, as GitHub does not yet support ARM64 runners in private repositories without an Enterprise account, but we have tested these build jobs in our CI workflow in public repositories to confirm they succeed.

This PR will be most easily reviewed on a commit-by-commit basis.