### PR TITLE
Update Windows CI jobs to find Perl `prove` command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,10 +88,12 @@ jobs:
         flavor: minimal
       # We install the SDK so as to have access to the msgfmt.exe binary
       # from the GNU gettext package.
-    - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" env -u TMPDIR script/cibuild
+    - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:/usr/bin/core_perl:$PATH" env -u TMPDIR script/cibuild
       shell: bash
       # We clear the TMPDIR set for Ruby so mktemp and Go use the same
       # volume for temporary files.
+      # We include the /usr/bin/core_perl path in PATH so the Perl prove
+      # command provided by the SDK can be located.
     - run: rm -f commands/mancontent_gen.go
       shell: bash
     - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" make GOARCH=386 -B


### PR DESCRIPTION
As described in commit 8d456a76727bbadf690b0093e1343331bff9ac23 of PR #5879, we currently depend on the Git for Windows SDK to install a version of the `prove(1)` command from the Perl `Test::Harness` distribution, because we use that command to run our suite of shell tests.

However, in our CI jobs on Windows, the SDK does not at present install the `prove` command into a location listed in the `PATH` environment variable, so these CI jobs having begun failing, as seen in this job [run](https://github.com/git-lfs/git-lfs/actions/runs/13166188381/job/36746979899) for PR #5973.

This change may be related to the recent migration of the SDK's release artifacts to GitHub from Azure Blobs, as outlined in PR git-for-windows/git-for-windows-automation#109, and is possibly a consequence of PR git-for-windows/build-extra#588.

Regardless, the `prove` command is fortunately still included in the `minimal` flavour of the SDK, since it is [listed](https://github.com/git-for-windows/git-sdk-64/blob/f845bb725e56e058a0fbf93aba18c70906a1068e/.sparse/minimal-sdk#L188) in the manifest for that flavour. We simply need to ensure that the directory in which the command is now located, namely `/usr/bin/core_perl`, is added to the set of paths in the `PATH` variable for the Git Bash environment.

Note that we only need to add this extra path to `PATH` when we are running our `script/cibuild` script, as that [runs](https://github.com/git-lfs/git-lfs/blob/19a879b885a762c9d00895a49edd84af5b7b345b/script/cibuild#L32) the default recipe from our `t/Makefile` file, which in turn [executes](https://github.com/git-lfs/git-lfs/blob/19a879b885a762c9d00895a49edd84af5b7b345b/t/Makefile#L43) the `test` recipe, which [uses](https://github.com/git-lfs/git-lfs/blob/19a879b885a762c9d00895a49edd84af5b7b345b/t/Makefile#L50) the `prove` command to run and summarize all our shell test scripts.

/cc @dscho as a Git for Windows maintainer who may have additional recommendations