### PR TITLE
Use default Ruby provided by Actions runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,7 @@ jobs:
       # annotated tags into lightweight ones, breaking "git describe".
       # See https://github.com/actions/checkout/issues/290 and
       # https://github.com/actions/checkout/issues/882 for details.
-    - uses: ruby/setup-ruby@v1
-    - run: gem install asciidoctor
+    - run: sudo gem install asciidoctor
     - uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go }}
@@ -67,11 +66,7 @@ jobs:
         fetch-depth: 0
         persist-credentials: false
         ref: ${{ github.ref }}
-    - uses: ruby/setup-ruby@v1
     - run: gem install asciidoctor
-    - run: Rename-Item -Path C:\msys64 -NewName msys64-tmp -Force
-      # We move the MSYS2 installed for Ruby aside to prevent use of its Git,
-      # which does not honour the PATH we set to our built git-lfs binary.
     - uses: actions/setup-go@v5
       with:
         go-version: '1.23.x'
@@ -88,10 +83,8 @@ jobs:
         flavor: minimal
       # We install the SDK so as to have access to the msgfmt.exe binary
       # from the GNU gettext package.
-    - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" env -u TMPDIR script/cibuild
+    - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" script/cibuild
       shell: bash
-      # We clear the TMPDIR set for Ruby so mktemp and Go use the same
-      # volume for temporary files.
     - run: rm -f commands/mancontent_gen.go
       shell: bash
     - run: GOPATH="$HOME/go" PATH="$HOME/go/bin:$PATH" make GOARCH=386 -B

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,7 @@ jobs:
       # annotated tags into lightweight ones, breaking "git describe".
       # See https://github.com/actions/checkout/issues/290 and
       # https://github.com/actions/checkout/issues/882 for details.
-    - uses: ruby/setup-ruby@v1
     - run: gem install asciidoctor
-    - run: Rename-Item -Path C:\msys64 -NewName msys64-tmp -Force
-      # We move the MSYS2 installed for Ruby aside to prevent use of its Git,
-      # which does not honour the PATH we set to our built git-lfs binary.
     - uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go }}
@@ -46,21 +42,19 @@ jobs:
       # from the GNU gettext package.
     - run: mkdir -p bin/releases
       shell: bash
-      # We clear the TMPDIR set for Ruby so mktemp and Go use the same
-      # volume for temporary files.
-    - run: PATH="$HOME/go/bin:$PATH" GOARCH=amd64 go generate && env -u TMPDIR make bin/releases/git-lfs-windows-amd64-$(git describe).zip
+    - run: PATH="$HOME/go/bin:$PATH" GOARCH=amd64 go generate && make bin/releases/git-lfs-windows-amd64-$(git describe).zip
       shell: bash
       env:
         FORCE_LOCALIZE: true
-    - run: PATH="$HOME/go/bin:$PATH" GOARCH=386 go generate && env -u TMPDIR make bin/releases/git-lfs-windows-386-$(git describe).zip
+    - run: PATH="$HOME/go/bin:$PATH" GOARCH=386 go generate && make bin/releases/git-lfs-windows-386-$(git describe).zip
       shell: bash
       env:
         FORCE_LOCALIZE: true
-    - run: PATH="$HOME/go/bin:$PATH" GOARCH=arm64 go generate && env -u TMPDIR make bin/releases/git-lfs-windows-arm64-$(git describe).zip
+    - run: PATH="$HOME/go/bin:$PATH" GOARCH=arm64 go generate && make bin/releases/git-lfs-windows-arm64-$(git describe).zip
       shell: bash
       env:
         FORCE_LOCALIZE: true
-    - run: env -u TMPDIR make release-windows-stage-1
+    - run: make release-windows-stage-1
       shell: bash
       env:
         FORCE_LOCALIZE: true
@@ -77,7 +71,7 @@ jobs:
         file-digest: SHA256
         timestamp-rfc3161: http://timestamp.acs.microsoft.com
         timestamp-digest: SHA256
-    - run: env -u TMPDIR make release-windows-stage-2
+    - run: make release-windows-stage-2
       shell: bash
     - uses: azure/trusted-signing-action@v0.5.1
       with:
@@ -92,9 +86,9 @@ jobs:
         file-digest: SHA256
         timestamp-rfc3161: http://timestamp.acs.microsoft.com
         timestamp-digest: SHA256
-    - run: env -u TMPDIR make release-windows-stage-3
+    - run: make release-windows-stage-3
       shell: bash
-    - run: env -u TMPDIR make release-windows-rebuild
+    - run: make release-windows-rebuild
       shell: bash
     - uses: actions/upload-artifact@v4
       with:
@@ -113,7 +107,6 @@ jobs:
         fetch-depth: 0
         persist-credentials: false
         ref: ${{ github.ref }}
-    - uses: ruby/setup-ruby@v1
     - run: gem install asciidoctor
     - uses: actions/setup-go@v5
       with:
@@ -151,8 +144,7 @@ jobs:
         fetch-depth: 0
         persist-credentials: false
         ref: ${{ github.ref }}
-    - uses: ruby/setup-ruby@v1
-    - run: gem install asciidoctor
+    - run: sudo gem install asciidoctor
     - uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go }}
@@ -188,8 +180,7 @@ jobs:
         fetch-depth: 0
         persist-credentials: false
         ref: ${{ github.ref }}
-    - uses: ruby/setup-ruby@v1
-    - run: gem install packagecloud-ruby
+    - run: sudo gem install packagecloud-ruby
     - run: git clone https://github.com/git-lfs/build-dockers.git "$HOME/build-dockers"
     - run: (cd "$HOME/build-dockers" && ./build_dockers.bsh)
     - run: ./docker/run_dockers.bsh --prune
@@ -206,8 +197,7 @@ jobs:
         fetch-depth: 0
         persist-credentials: false
         ref: ${{ github.ref }}
-    - uses: ruby/setup-ruby@v1
-    - run: gem install packagecloud-ruby
+    - run: sudo gem install packagecloud-ruby
     - run: git clone https://github.com/git-lfs/build-dockers.git "$HOME/build-dockers"
     - run: (cd "$HOME/build-dockers" && ./build_dockers.bsh --arch=arm64 debian_11 debian_12)
     - run: ./docker/run_dockers.bsh --prune --arch=arm64 debian_11 debian_12


### PR DESCRIPTION
The default runners provided by GitHub Actions for the macOS, Windows, and Ubuntu Linux platforms are now all provisioned with an installation of Ruby 3.x, which along with the `asciidoctor` and `packagecloud-ruby` gems is all we require to run the several Ruby scripts used by our CI and release workflows.

We can therefore remove the `ruby/setup-ruby` action from our workflows.  On Windows in particular this also allows us to remove the special handling of the `TMPDIR` environment variable and the `MSYS2` environment, since these will no longer be installed by the `ruby/setup-ruby` action.

On the Ubuntu Linux runners, we do have to run the `gem` command with `sudo` as it otherwise encounters a file permission error trying to install our gems.

Note that the changes to our release workflow in this PR have been validated with a successful Actions run in a private repository.