### PR TITLE
Replace unused debug mode with trace logging

### DIFF
--- a/commands/command_clean.go
+++ b/commands/command_clean.go
@@ -8,6 +8,7 @@ import (
 	"github.com/git-lfs/git-lfs/v3/lfs"
 	"github.com/git-lfs/git-lfs/v3/tools"
 	"github.com/git-lfs/git-lfs/v3/tr"
+	"github.com/rubyist/tracerx"
 	"github.com/spf13/cobra"
 )
 
@@ -76,13 +77,13 @@ func clean(gf *lfs.GitFilter, to io.Writer, from io.Reader, fileName string, fil
 		if stat.Size() != cleaned.Size && len(cleaned.Pointer.Extensions) == 0 {
 			Exit("%s\n%s\n%s", tr.Tr.Get("Files don't match:"), mediafile, tmpfile)
 		}
-		Debug("%s exists", mediafile)
+		tracerx.Printf("%s exists", mediafile)
 	} else {
 		if err := os.Rename(tmpfile, mediafile); err != nil {
 			Panic(err, tr.Tr.Get("Unable to move %s to %s", tmpfile, mediafile))
 		}
 
-		Debug(tr.Tr.Get("Writing %s", mediafile))
+		tracerx.Printf("Writing %s", mediafile)
 	}
 
 	_, err = lfs.EncodePointer(to, cleaned.Pointer)

--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -15,6 +15,7 @@ import (
 	"github.com/git-lfs/git-lfs/v3/lfs"
 	"github.com/git-lfs/git-lfs/v3/tools"
 	"github.com/git-lfs/git-lfs/v3/tr"
+	"github.com/rubyist/tracerx"
 	"github.com/spf13/cobra"
 )
 
@@ -170,7 +171,7 @@ func doFsckPointers(include, exclude string) []corruptPointer {
 	var corruptPointers []corruptPointer
 	gitscanner := lfs.NewGitScanner(cfg, func(p *lfs.WrappedPointer, err error) {
 		if p != nil {
-			Debug(tr.Tr.Get("Examining %v (%v)", p.Oid, p.Name))
+			tracerx.Printf("Examining %v (%v)", p.Oid, p.Name)
 			if !p.Canonical {
 				cp := corruptPointer{
 					blobOid: p.Sha1,
@@ -214,7 +215,7 @@ func doFsckPointers(include, exclude string) []corruptPointer {
 func fsckPointer(name, oid string, size int64) (bool, error) {
 	path := cfg.Filesystem().ObjectPathname(oid)
 
-	Debug(tr.Tr.Get("Examining %v (%v)", name, path))
+	tracerx.Printf("Examining %v (%v)", name, path)
 
 	f, err := os.Open(path)
 	if pErr, pOk := err.(*os.PathError); pOk {

--- a/commands/command_logs.go
+++ b/commands/command_logs.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/git-lfs/git-lfs/v3/errors"
 	"github.com/git-lfs/git-lfs/v3/tr"
+	"github.com/rubyist/tracerx"
 	"github.com/spf13/cobra"
 )
 
@@ -37,7 +38,7 @@ func logsShowCommand(cmd *cobra.Command, args []string) {
 		Exit(tr.Tr.Get("Error reading log: %s", name))
 	}
 
-	Debug(tr.Tr.Get("Reading log: %s", name))
+	tracerx.Printf("Reading log: %s", name)
 	os.Stdout.Write(by)
 }
 
@@ -51,7 +52,7 @@ func logsClearCommand(cmd *cobra.Command, args []string) {
 }
 
 func logsBoomtownCommand(cmd *cobra.Command, args []string) {
-	Debug(tr.Tr.Get("Sample debug message"))
+	tracerx.Printf("Sample trace message")
 	err := errors.Wrapf(errors.New(tr.Tr.Get("Sample wrapped error message")), tr.Tr.Get("Sample error message"))
 	Panic(err, tr.Tr.Get("Sample panic message"))
 }

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"os"
 	"path/filepath"
@@ -29,7 +28,6 @@ import (
 //go:generate go run ../docs/man/mangen.go
 
 var (
-	Debugging    = false
 	ErrorBuffer  = &bytes.Buffer{}
 	ErrorWriter  = newMultiWriter(os.Stderr, ErrorBuffer)
 	OutputWriter = newMultiWriter(os.Stdout, ErrorBuffer)
@@ -237,21 +235,12 @@ func FullError(err error) {
 }
 
 func errorWith(err error, fatalErrFn func(error, string, ...interface{}), errFn func(string, ...interface{})) {
-	if Debugging || errors.IsFatalError(err) {
+	if errors.IsFatalError(err) {
 		fatalErrFn(err, "%s", err)
 		return
 	}
 
 	errFn("%s", err)
-}
-
-// Debug prints a formatted message if debugging is enabled.  The formatted
-// message also shows up in the panic log, if created.
-func Debug(format string, args ...interface{}) {
-	if !Debugging {
-		return
-	}
-	log.Printf(format, args...)
 }
 
 // LoggedError prints the given message formatted with its arguments (if any) to


### PR DESCRIPTION
In PR #68 the `commands` package was updated with several logging functions such as `Panic()`, `Print()`, and `Debug()`.  The last of these [only outputs](https://github.com/git-lfs/git-lfs/blob/d0d1ed06177d78e2222ed3d9a7bb07db6effb033/commands/commands.go#L251-L254) a log message if the `Debugging` [variable](https://github.com/git-lfs/git-lfs/blob/d0d1ed06177d78e2222ed3d9a7bb07db6effb033/commands/commands.go#L32) in the same package is set to `true`, which at the time was controlled by the `setupDebugging()` [function](https://github.com/git-lfs/git-lfs/blob/f83d26fa39acad6618ca537286ac710c3e6d3e8d/commands/commands.go#L163-L169).  If the user supplied the `--debug` option to a given Git LFS command, `setupDebugging()` function would set the `Debugging` variable to `true`, and any calls to `Debug()` would then generate log messages.

However,  in PR #84 the `setupDebugging()` function was removed, along with a lot of the earlier command-line parsing and setup code, and replaced with the Cobra library from the `spf13/cobra` project. Since then it has not been possible to set the `Debugging` variable to a value other than `false`, so the remaining references to the `Debug()` function will never generate log messages.

We therefore remove the `Debugging` variable and the `Debug()` function, and replace any calls to that function with ones to our standard trace logging function.

This change should help reduce the number of non-constant format strings we need to revise before adopting Go 1.24, as has been reported in #5968.