### PR TITLE
Remove command name prefixes from progress messages

### DIFF
--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -154,7 +154,7 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 
 		// Fetch refs sequentially per arg order; duplicates in later refs will be ignored
 		for _, ref := range refs {
-			printProgress("fetch: %s", tr.Tr.Get("Fetching reference %s", ref.Refspec()))
+			printProgress(tr.Tr.Get("Fetching reference %s", ref.Refspec()))
 			s := fetchRef(ref.Sha, filter, watcher)
 			success = success && s
 		}
@@ -240,7 +240,7 @@ func pointersToFetchForRefs(refs []string) ([]*lfs.WrappedPointer, error) {
 		}
 
 		numObjs++
-		task.Logf("fetch: %s", tr.Tr.GetN("%d object found", "%d objects found", int(numObjs), numObjs))
+		task.Log(tr.Tr.GetN("%d object found", "%d objects found", int(numObjs), numObjs))
 		pointers = append(pointers, p)
 	})
 
@@ -296,7 +296,7 @@ func fetchRecent(fetchconf lfs.FetchPruneConfig, alreadyFetchedRefs []*git.Ref, 
 	}
 	// First find any other recent refs
 	if fetchconf.FetchRecentRefsDays > 0 {
-		printProgress("fetch: %s", tr.Tr.GetN(
+		printProgress(tr.Tr.GetN(
 			"Fetching recent branches within %v day",
 			"Fetching recent branches within %v days",
 			fetchconf.FetchRecentRefsDays,
@@ -315,7 +315,7 @@ func fetchRecent(fetchconf lfs.FetchPruneConfig, alreadyFetchedRefs []*git.Ref, 
 				}
 			} else {
 				uniqueRefShas[ref.Sha] = ref.Name
-				printProgress("fetch: %s", tr.Tr.Get("Fetching reference %s", ref.Name))
+				printProgress(tr.Tr.Get("Fetching reference %s", ref.Name))
 				k := fetchRef(ref.Sha, filter, watcher)
 				ok = ok && k
 			}
@@ -330,7 +330,7 @@ func fetchRecent(fetchconf lfs.FetchPruneConfig, alreadyFetchedRefs []*git.Ref, 
 				Error(tr.Tr.Get("Couldn't scan commits at %v: %v", refName, err))
 				continue
 			}
-			printProgress("fetch: %s", tr.Tr.GetN(
+			printProgress(tr.Tr.GetN(
 				"Fetching changes within %v day of %v",
 				"Fetching changes within %v days of %v",
 				fetchconf.FetchRecentCommitsDays,
@@ -348,7 +348,7 @@ func fetchRecent(fetchconf lfs.FetchPruneConfig, alreadyFetchedRefs []*git.Ref, 
 
 func fetchAll(watcher *fetchWatcher) bool {
 	pointers := scanAll()
-	printProgress("fetch: %s", tr.Tr.Get("Fetching all references..."))
+	printProgress(tr.Tr.Get("Fetching all references..."))
 	return fetch(pointers, watcher)
 }
 
@@ -375,7 +375,7 @@ func scanAll() []*lfs.WrappedPointer {
 		}
 
 		numObjs++
-		task.Logf("fetch: %s", tr.Tr.GetN("%d object found", "%d objects found", int(numObjs), numObjs))
+		task.Log(tr.Tr.GetN("%d object found", "%d objects found", int(numObjs), numObjs))
 		pointers = append(pointers, p)
 	})
 

--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -290,7 +290,7 @@ func getRemoteRefs(l *tasklog.Logger) (map[string][]*git.Ref, error) {
 }
 
 func fetchRemoteRefs(l *tasklog.Logger, remotes []string) error {
-	w := l.Waiter(fmt.Sprintf("migrate: %s", tr.Tr.Get("Fetching remote refs")))
+	w := l.Waiter(tr.Tr.Get("Fetching remote refs"))
 	defer w.Complete()
 
 	return git.Fetch(remotes...)
@@ -352,7 +352,7 @@ func ensureWorkingCopyClean(in io.Reader, out io.Writer) {
 		answer := bufio.NewReader(in)
 	L:
 		for {
-			fmt.Fprintf(out, "migrate: %s", tr.Tr.Get("override changes in your working copy?  All uncommitted changes will be lost! [y/N] "))
+			fmt.Fprint(out, tr.Tr.Get("override changes in your working copy?  All uncommitted changes will be lost! [y/N] "))
 			s, err := answer.ReadString('\n')
 			if err != nil {
 				if err == io.EOF {
@@ -380,9 +380,9 @@ func ensureWorkingCopyClean(in io.Reader, out io.Writer) {
 	}
 
 	if proceed {
-		fmt.Fprintf(out, "migrate: %s\n", tr.Tr.Get("changes in your working copy will be overridden ..."))
+		fmt.Fprintln(out, tr.Tr.Get("changes in your working copy will be overridden ..."))
 	} else {
-		Exit("migrate: %s", tr.Tr.Get("working copy must not be dirty"))
+		Exit(tr.Tr.Get("working copy must not be dirty"))
 	}
 }
 

--- a/commands/command_migrate_export.go
+++ b/commands/command_migrate_export.go
@@ -176,7 +176,7 @@ func migrateExportCommand(cmd *cobra.Command, args []string) {
 }
 
 func performForceCheckout(l *tasklog.Logger) error {
-	t := l.Waiter(tr.Tr.Get("checkout"))
+	t := l.Waiter(tr.Tr.Get("Checkout"))
 	defer t.Complete()
 
 	return git.Checkout("", nil, true)

--- a/commands/command_migrate_export.go
+++ b/commands/command_migrate_export.go
@@ -176,7 +176,7 @@ func migrateExportCommand(cmd *cobra.Command, args []string) {
 }
 
 func performForceCheckout(l *tasklog.Logger) error {
-	t := l.Waiter(fmt.Sprintf("migrate: %s", tr.Tr.Get("checkout")))
+	t := l.Waiter(tr.Tr.Get("checkout"))
 	defer t.Complete()
 
 	return git.Checkout("", nil, true)

--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -282,7 +282,7 @@ func checkoutNonBare(l *tasklog.Logger) error {
 		return nil
 	}
 
-	t := l.Waiter(tr.Tr.Get("checkout"))
+	t := l.Waiter(tr.Tr.Get("Checkout"))
 	defer t.Complete()
 
 	return git.Checkout("", nil, true)

--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -282,7 +282,7 @@ func checkoutNonBare(l *tasklog.Logger) error {
 		return nil
 	}
 
-	t := l.Waiter(fmt.Sprintf("migrate: %s", tr.Tr.Get("checkout")))
+	t := l.Waiter(tr.Tr.Get("checkout"))
 	defer t.Complete()
 
 	return git.Checkout("", nil, true)
@@ -322,7 +322,7 @@ func trackedFromAttrs(db *gitobj.ObjectDatabase, t *gitobj.Tree) (*tools.Ordered
 	for _, e := range t.Entries {
 		if strings.ToLower(e.Name) == ".gitattributes" && e.Type() == gitobj.BlobObjectType {
 			if e.IsLink() {
-				return nil, errors.Errorf("migrate: %s", tr.Tr.Get("expected '.gitattributes' to be a file, got a symbolic link"))
+				return nil, errors.New(tr.Tr.Get("expected '.gitattributes' to be a file, got a symbolic link"))
 			} else {
 				oid = e.Oid
 				break
@@ -438,7 +438,7 @@ func rewriteTree(gf *lfs.GitFilter, db *gitobj.ObjectDatabase, root []byte, path
 
 		subtreeEntry := tree.Entries[index]
 		if subtreeEntry.Type() != gitobj.TreeObjectType {
-			return nil, errors.Errorf("migrate: %s", tr.Tr.Get("expected %s to be a tree, got %s", head, subtreeEntry.Type()))
+			return nil, errors.New(tr.Tr.Get("expected %s to be a tree, got %s", head, subtreeEntry.Type()))
 		}
 
 		rewrittenSubtree, err := rewriteTree(gf, db, subtreeEntry.Oid, tail)

--- a/commands/command_migrate_info.go
+++ b/commands/command_migrate_info.go
@@ -179,7 +179,7 @@ func migrateInfoCommand(cmd *cobra.Command, args []string) {
 			for _, e := range t.Entries {
 				if strings.ToLower(e.Name) == ".gitattributes" && e.Type() == gitobj.BlobObjectType {
 					if e.IsLink() {
-						return errors.Errorf("migrate: %s", tr.Tr.Get("expected '.gitattributes' to be a file, got a symbolic link"))
+						return errors.New(tr.Tr.Get("expected '.gitattributes' to be a file, got a symbolic link"))
 					} else {
 						break
 					}

--- a/commands/command_prune.go
+++ b/commands/command_prune.go
@@ -233,7 +233,7 @@ func logVerboseOutput(logger *tasklog.Logger, verboseOutput []string, numPrunabl
 	defer info.Complete()
 
 	if dryRun {
-		info.Logf("prune: %s", tr.Tr.GetN(
+		info.Log(tr.Tr.GetN(
 			"%d file would be pruned (%s)",
 			"%d files would be pruned (%s)",
 			numPrunableObjects,
@@ -307,7 +307,7 @@ func pruneTaskDisplayProgress(progressChan PruneProgressChan, waitg *sync.WaitGr
 		case PruneProgressTypeUnverified:
 			notRemoteCount += p.Count
 		}
-		msg = fmt.Sprintf("prune: %s, %s",
+		msg = fmt.Sprintf("%s, %s",
 			tr.Tr.GetN("%d local object", "%d local objects", localCount, localCount),
 			tr.Tr.GetN("%d retained", "%d retained", retainCount, retainCount))
 		if verifyCount > 0 {
@@ -342,7 +342,7 @@ func pruneTaskCollectErrors(outtaskErrors *[]error, errorChan chan error, errorw
 }
 
 func pruneDeleteFiles(prunableObjects []string, logger *tasklog.Logger) {
-	task := logger.Percentage(fmt.Sprintf("prune: %s", tr.Tr.Get("Deleting objects")), uint64(len(prunableObjects)))
+	task := logger.Percentage(tr.Tr.Get("Deleting objects"), uint64(len(prunableObjects)))
 	defer task.Complete()
 
 	var problems bytes.Buffer

--- a/docs/l10n.md
+++ b/docs/l10n.md
@@ -27,15 +27,15 @@ The easiest way to make a string translatable is to wrap the string and any form
 For example, you might write this:
 
 ```
-Print(tr.Tr.Get("fetch: Fetching reference %s", ref.Name))
+Print(tr.Tr.Get("Fetching reference %s", ref.Name))
 ```
 
 If you have a string which varies based on a number, use `tr.Tr.GetN`, provide the singular string, the plural string, the number upon which it varies, and then the arguments:
 
 ```
 Print(tr.Tr.GetN(
-	"fetch: Fetching changes within %v day of %v",
-	"fetch: Fetching changes within %v days of %v",
+	"Fetching changes within %v day of %v",
+	"Fetching changes within %v days of %v",
 	fetchconf.FetchRecentCommitsDays,
 	fetchconf.FetchRecentCommitsDays,
 	refName,

--- a/docs/man/git-lfs-migrate.adoc
+++ b/docs/man/git-lfs-migrate.adoc
@@ -392,9 +392,9 @@ most space in your repository:
 
 ....
 $ git lfs migrate info
-migrate: Fetching remote refs: ..., done
-migrate: Sorting commits: ..., done
-migrate: Examining commits: 100% (1/1), done
+Fetching remote refs: ..., done
+Sorting commits: ..., done
+Examining commits: 100% (1/1), done
 *.mp3   284 MB    1/1 files(s)  100%
 *.pdf   42 MB     8/8 files(s)  100%
 *.psd   9.8 MB  15/15 files(s)  100%
@@ -407,11 +407,11 @@ LFS:
 
 ....
 $ git lfs migrate import --include="*.mp3,*.psd"
-migrate: Fetching remote refs: ..., done
-migrate: Sorting commits: ..., done
-migrate: Rewriting commits: 100% (1/1), done
+Fetching remote refs: ..., done
+Sorting commits: ..., done
+Rewriting commits: 100% (1/1), done
   main  d2b959babd099fe70da1c1512e2475e8a24de163 -> 136e706bf1ae79643915c134e17a6c933fd53c61
-migrate: Updating refs: ..., done
+Updating refs: ..., done
 ....
 
 If after conversion you find that some files in your working directory

--- a/git/gitattr/tree.go
+++ b/git/gitattr/tree.go
@@ -66,7 +66,7 @@ func linesInTree(db *gitobj.ObjectDatabase, t *gitobj.Tree) ([]Line, string, err
 	for i, e := range t.Entries {
 		if e.Name == ".gitattributes" {
 			if e.IsLink() {
-				return nil, "", errors.Errorf("migrate: %s", tr.Tr.Get("expected '.gitattributes' to be a file, got a symbolic link"))
+				return nil, "", errors.New(tr.Tr.Get("expected '.gitattributes' to be a file, got a symbolic link"))
 			}
 			at = i
 			break

--- a/git/githistory/ref_updater.go
+++ b/git/githistory/ref_updater.go
@@ -16,22 +16,23 @@ import (
 // refUpdater is a type responsible for moving references from one point in the
 // Git object graph to another.
 type refUpdater struct {
-	// CacheFn is a function that returns the SHA1 transformation from an
+	// cacheFn is a function that returns the SHA1 transformation from an
 	// original hash to a new one. It specifies a "bool" return value
 	// signaling whether or not that given "old" SHA1 was migrated.
-	CacheFn func(old []byte) ([]byte, bool)
-	// Logger logs the progress of reference updating.
-	Logger *tasklog.Logger
-	// Refs is a set of *git.Ref's to migrate.
-	Refs []*git.Ref
-	// Root is the given directory on disk in which the repository is
+	cacheFn func(old []byte) ([]byte, bool)
+	// logger logs the progress of reference updating.
+	logger *tasklog.Logger
+	// refs is a set of *git.Ref's to migrate.
+	refs []*git.Ref
+	// root is the given directory on disk in which the repository is
 	// located.
-	Root string
-
+	root string
+	// db is the *ObjectDatabase from which blobs, commits, and trees are
+	// loaded.
 	db *gitobj.ObjectDatabase
 }
 
-// UpdateRefs performs the reference update(s) from existing locations (see:
+// updateRefs performs the reference update(s) from existing locations (see:
 // Refs) to their respective new locations in the graph (see CacheFn).
 //
 // It creates reflog entries as well as stderr log entries as it progresses
@@ -39,17 +40,17 @@ type refUpdater struct {
 //
 // It returns any error encountered, or nil if the reference update(s) was/were
 // successful.
-func (r *refUpdater) UpdateRefs() error {
-	list := r.Logger.List(tr.Tr.Get("Updating refs"))
+func (r *refUpdater) updateRefs() error {
+	list := r.logger.List(tr.Tr.Get("Updating refs"))
 	defer list.Complete()
 
 	var maxNameLen int
-	for _, ref := range r.Refs {
+	for _, ref := range r.refs {
 		maxNameLen = tools.MaxInt(maxNameLen, len(ref.Name))
 	}
 
 	seen := make(map[string]struct{})
-	for _, ref := range r.Refs {
+	for _, ref := range r.refs {
 		if err := r.updateOneRef(list, maxNameLen, seen, ref); err != nil {
 			return err
 		}
@@ -86,7 +87,7 @@ func (r *refUpdater) updateOneRef(list *tasklog.ListTask, maxNameLen int, seen m
 	}
 	seen[refspec] = struct{}{}
 
-	to, ok := r.CacheFn(sha1)
+	to, ok := r.cacheFn(sha1)
 
 	if ref.Type == git.RefTypeLocalTag {
 		tag, _ := r.db.Tag(sha1)
@@ -121,7 +122,7 @@ func (r *refUpdater) updateOneRef(list *tasklog.ListTask, maxNameLen int, seen m
 			to = newTag
 			ok = true
 		} else if tag != nil && tag.ObjectType == gitobj.CommitObjectType {
-			toObj, okObj := r.CacheFn(tag.Object)
+			toObj, okObj := r.cacheFn(tag.Object)
 			if !okObj {
 				return nil
 			}
@@ -139,7 +140,7 @@ func (r *refUpdater) updateOneRef(list *tasklog.ListTask, maxNameLen int, seen m
 		return nil
 	}
 
-	if err := git.UpdateRefIn(r.Root, ref, to, ""); err != nil {
+	if err := git.UpdateRefIn(r.root, ref, to, ""); err != nil {
 		return err
 	}
 

--- a/git/githistory/ref_updater.go
+++ b/git/githistory/ref_updater.go
@@ -40,7 +40,7 @@ type refUpdater struct {
 // It returns any error encountered, or nil if the reference update(s) was/were
 // successful.
 func (r *refUpdater) UpdateRefs() error {
-	list := r.Logger.List(fmt.Sprintf("migrate: %s", tr.Tr.Get("Updating refs")))
+	list := r.Logger.List(tr.Tr.Get("Updating refs"))
 	defer list.Complete()
 
 	var maxNameLen int

--- a/git/githistory/ref_updater_test.go
+++ b/git/githistory/ref_updater_test.go
@@ -15,21 +15,21 @@ func TestRefUpdaterMovesRefs(t *testing.T) {
 		"refs/tags/middle", HexDecode(t, "228afe30855933151f7a88e70d9d88314fd2f191"))
 
 	updater := &refUpdater{
-		CacheFn: func(old []byte) ([]byte, bool) {
+		cacheFn: func(old []byte) ([]byte, bool) {
 			return HexDecode(t, "d941e4756add6b06f5bee766fcf669f55419f13f"), true
 		},
-		Refs: []*git.Ref{
+		refs: []*git.Ref{
 			{
 				Name: "middle",
 				Sha:  "228afe30855933151f7a88e70d9d88314fd2f191",
 				Type: git.RefTypeLocalTag,
 			},
 		},
-		Root: root,
+		root: root,
 		db:   db,
 	}
 
-	err := updater.UpdateRefs()
+	err := updater.updateRefs()
 
 	assert.NoError(t, err)
 
@@ -45,21 +45,21 @@ func TestRefUpdaterMovesRefsWithAnnotatedTags(t *testing.T) {
 		"refs/tags/middle", HexDecode(t, "05797a38b05f910e6efe40dc1a5c0a046a9403e8"))
 
 	updater := &refUpdater{
-		CacheFn: func(old []byte) ([]byte, bool) {
+		cacheFn: func(old []byte) ([]byte, bool) {
 			return HexDecode(t, "d941e4756add6b06f5bee766fcf669f55419f13f"), true
 		},
-		Refs: []*git.Ref{
+		refs: []*git.Ref{
 			{
 				Name: "middle",
 				Sha:  "05797a38b05f910e6efe40dc1a5c0a046a9403e8",
 				Type: git.RefTypeLocalTag,
 			},
 		},
-		Root: root,
+		root: root,
 		db:   db,
 	}
 
-	err := updater.UpdateRefs()
+	err := updater.updateRefs()
 
 	assert.NoError(t, err)
 
@@ -75,21 +75,21 @@ func TestRefUpdaterIgnoresUnovedRefs(t *testing.T) {
 		"refs/tags/middle", HexDecode(t, "228afe30855933151f7a88e70d9d88314fd2f191"))
 
 	updater := &refUpdater{
-		CacheFn: func(old []byte) ([]byte, bool) {
+		cacheFn: func(old []byte) ([]byte, bool) {
 			return nil, false
 		},
-		Refs: []*git.Ref{
+		refs: []*git.Ref{
 			{
 				Name: "middle",
 				Sha:  "228afe30855933151f7a88e70d9d88314fd2f191",
 				Type: git.RefTypeLocalTag,
 			},
 		},
-		Root: root,
+		root: root,
 		db:   db,
 	}
 
-	err := updater.UpdateRefs()
+	err := updater.updateRefs()
 
 	assert.NoError(t, err)
 

--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -32,10 +32,10 @@ type Rewriter struct {
 	// filter will cull out any unmodifiable subtrees and blobs.
 	filter *filepathfilter.Filter
 	// db is the *ObjectDatabase from which blobs, commits, and trees are
-	// loaded from.
+	// loaded.
 	db *gitobj.ObjectDatabase
-	// l is the *tasklog.Logger to which updates are written.
-	l *tasklog.Logger
+	// logger is the *tasklog.Logger to which updates are written.
+	logger *tasklog.Logger
 }
 
 // RewriteOptions is an options type given to the Rewrite() function.
@@ -161,7 +161,7 @@ var (
 	// be given to the provided logger, "l".
 	WithLogger = func(l *tasklog.Logger) rewriterOption {
 		return func(r *Rewriter) {
-			r.l = l
+			r.logger = l
 		}
 	}
 
@@ -204,9 +204,9 @@ func (r *Rewriter) Rewrite(opt *RewriteOptions) ([]byte, error) {
 
 	var perc *tasklog.PercentageTask
 	if opt.UpdateRefs {
-		perc = r.l.Percentage(tr.Tr.Get("Rewriting commits"), uint64(len(commits)))
+		perc = r.logger.Percentage(tr.Tr.Get("Rewriting commits"), uint64(len(commits)))
 	} else {
-		perc = r.l.Percentage(tr.Tr.Get("Examining commits"), uint64(len(commits)))
+		perc = r.logger.Percentage(tr.Tr.Get("Examining commits"), uint64(len(commits)))
 	}
 	defer perc.Complete()
 
@@ -317,7 +317,7 @@ func (r *Rewriter) Rewrite(opt *RewriteOptions) ([]byte, error) {
 
 		updater := &refUpdater{
 			cacheFn: r.uncacheCommit,
-			logger:  r.l,
+			logger:  r.logger,
 			refs:    refs,
 			root:    root,
 			db:      r.db,
@@ -500,7 +500,7 @@ func (r *Rewriter) rewriteBlob(commitOID, from []byte, path string, fn BlobRewri
 //
 // If any error was encountered, it will be returned.
 func (r *Rewriter) commitsToMigrate(opt *RewriteOptions) ([][]byte, error) {
-	waiter := r.l.Waiter(tr.Tr.Get("Sorting commits"))
+	waiter := r.logger.Waiter(tr.Tr.Get("Sorting commits"))
 	defer waiter.Complete()
 
 	scanner, err := git.NewRevListScanner(

--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -316,15 +316,14 @@ func (r *Rewriter) Rewrite(opt *RewriteOptions) ([]byte, error) {
 		root, _ := r.db.Root()
 
 		updater := &refUpdater{
-			CacheFn: r.uncacheCommit,
-			Logger:  r.l,
-			Refs:    refs,
-			Root:    root,
-
-			db: r.db,
+			cacheFn: r.uncacheCommit,
+			logger:  r.l,
+			refs:    refs,
+			root:    root,
+			db:      r.db,
 		}
 
-		if err := updater.UpdateRefs(); err != nil {
+		if err := updater.updateRefs(); err != nil {
 			return nil, errors.Wrap(err, tr.Tr.Get("could not update refs"))
 		}
 	}

--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -481,7 +481,7 @@ func (r *Rewriter) rewriteBlob(commitOID, from []byte, path string, fn BlobRewri
 		}
 
 		if perc != nil {
-			perc.Entry(tr.Tr.Get("commit %s: %s", hex.EncodeToString(commitOID), path))
+			perc.Entry(tr.Tr.Get("  commit %s: %s", hex.EncodeToString(commitOID), path))
 		}
 
 		return sha, nil

--- a/git/githistory/rewriter.go
+++ b/git/githistory/rewriter.go
@@ -204,9 +204,9 @@ func (r *Rewriter) Rewrite(opt *RewriteOptions) ([]byte, error) {
 
 	var perc *tasklog.PercentageTask
 	if opt.UpdateRefs {
-		perc = r.l.Percentage(fmt.Sprintf("migrate: %s", tr.Tr.Get("Rewriting commits")), uint64(len(commits)))
+		perc = r.l.Percentage(tr.Tr.Get("Rewriting commits"), uint64(len(commits)))
 	} else {
-		perc = r.l.Percentage(fmt.Sprintf("migrate: %s", tr.Tr.Get("Examining commits")), uint64(len(commits)))
+		perc = r.l.Percentage(tr.Tr.Get("Examining commits"), uint64(len(commits)))
 	}
 	defer perc.Complete()
 
@@ -481,7 +481,7 @@ func (r *Rewriter) rewriteBlob(commitOID, from []byte, path string, fn BlobRewri
 		}
 
 		if perc != nil {
-			perc.Entry(fmt.Sprintf("migrate: %s", tr.Tr.Get("commit %s: %s", hex.EncodeToString(commitOID), path)))
+			perc.Entry(tr.Tr.Get("commit %s: %s", hex.EncodeToString(commitOID), path))
 		}
 
 		return sha, nil
@@ -501,7 +501,7 @@ func (r *Rewriter) rewriteBlob(commitOID, from []byte, path string, fn BlobRewri
 //
 // If any error was encountered, it will be returned.
 func (r *Rewriter) commitsToMigrate(opt *RewriteOptions) ([][]byte, error) {
-	waiter := r.l.Waiter(fmt.Sprintf("migrate: %s", tr.Tr.Get("Sorting commits")))
+	waiter := r.l.Waiter(tr.Tr.Get("Sorting commits"))
 	defer waiter.Complete()
 
 	scanner, err := git.NewRevListScanner(

--- a/t/t-migrate-export.sh
+++ b/t/t-migrate-export.sh
@@ -438,7 +438,7 @@ begin_test "migrate export (.gitattributes symlink)"
     exit 1
   fi
 
-  grep "migrate: expected '.gitattributes' to be a file, got a symbolic link" migrate.log
+  grep "expected '.gitattributes' to be a file, got a symbolic link" migrate.log
 
   main="$(git rev-parse refs/heads/main)"
 
@@ -475,7 +475,7 @@ begin_test "migrate export (--verbose)"
 
   setup_multiple_local_branches_tracked
 
-  git lfs migrate export --everything --include="*" --verbose 2>&1 | grep -q "migrate: commit "
+  git lfs migrate export --everything --include="*" --verbose 2>&1 | grep -q "commit "
 )
 end_test
 

--- a/t/t-migrate-export.sh
+++ b/t/t-migrate-export.sh
@@ -475,7 +475,10 @@ begin_test "migrate export (--verbose)"
 
   setup_multiple_local_branches_tracked
 
-  git lfs migrate export --everything --include="*" --verbose 2>&1 | grep -q "commit "
+  original_head="$(git rev-parse HEAD)"
+
+  git lfs migrate export --everything --include="*" --verbose --yes 2>&1 | tee migrate.log
+  grep -q "  commit ${original_head}: a\.md" migrate.log
 )
 end_test
 

--- a/t/t-migrate-fixup.sh
+++ b/t/t-migrate-fixup.sh
@@ -142,7 +142,7 @@ begin_test "migrate import (--fixup, .gitattributes symlink)"
     exit 1
   fi
 
-  grep "migrate: expected '.gitattributes' to be a file, got a symbolic link" migrate.log
+  grep "expected '.gitattributes' to be a file, got a symbolic link" migrate.log
 
   main="$(git rev-parse refs/heads/main)"
 

--- a/t/t-migrate-import.sh
+++ b/t/t-migrate-import.sh
@@ -823,7 +823,10 @@ begin_test "migrate import (--everything and --include with glob pattern)"
   md_feature_oid="$(calc_oid "$(git cat-file -p "refs/heads/my-feature:a.md")")"
   txt_feature_oid="$(calc_oid "$(git cat-file -p "refs/heads/my-feature:a.txt")")"
 
-  git lfs migrate import --verbose --everything --include='*.[mM][dD]'
+  original_head="$(git rev-parse HEAD)"
+
+  git lfs migrate import --verbose --everything --include='*.[mM][dD]' --yes 2>&1 | tee migrate.log
+  grep -q "  commit ${original_head}: a\.md" migrate.log
 
   assert_pointer "refs/heads/main" "a.md" "$md_main_oid" "140"
   assert_pointer "refs/heads/my-feature" "a.md" "$md_feature_oid" "30"
@@ -849,7 +852,10 @@ begin_test "migrate import (--everything with tag pointing to tag)"
   git tag -a -m abc abc refs/heads/main
   git tag -a -m def def refs/tags/abc
 
-  git lfs migrate import --verbose --everything --include='*.[mM][dD]'
+  original_head="$(git rev-parse HEAD)"
+
+  git lfs migrate import --verbose --everything --include='*.[mM][dD]' --yes 2>&1 | tee migrate.log
+  grep -q "  commit ${original_head}: a\.md" migrate.log
 
   assert_pointer "refs/heads/main" "a.md" "$md_main_oid" "140"
   assert_pointer "refs/tags/abc" "a.md" "$md_main_oid" "140"

--- a/t/t-migrate-import.sh
+++ b/t/t-migrate-import.sh
@@ -629,7 +629,7 @@ begin_test "migrate import (existing .gitattributes symlink)"
     exit 1
   fi
 
-  grep "migrate: expected '.gitattributes' to be a file, got a symbolic link" migrate.log
+  grep "expected '.gitattributes' to be a file, got a symbolic link" migrate.log
 
   main="$(git rev-parse refs/heads/main)"
 
@@ -1030,7 +1030,7 @@ begin_test "migrate import (dirty copy, default negative answer)"
   original_main="$(git rev-parse main)"
 
   echo | git lfs migrate import --everything 2>&1 | tee migrate.log
-  grep "migrate: working copy must not be dirty" migrate.log
+  grep "working copy must not be dirty" migrate.log
 
   migrated_main="$(git rev-parse main)"
 
@@ -1047,7 +1047,7 @@ begin_test "migrate import (dirty copy, negative answer)"
   original_main="$(git rev-parse main)"
 
   echo "n" | git lfs migrate import --everything 2>&1 | tee migrate.log
-  grep "migrate: working copy must not be dirty" migrate.log
+  grep "working copy must not be dirty" migrate.log
 
   migrated_main="$(git rev-parse main)"
 
@@ -1069,7 +1069,7 @@ begin_test "migrate import (dirty copy, unknown then negative answer)"
 
   [ "2" -eq "$(grep -o "override changes in your working copy" migrate.log \
     | wc -l | awk '{ print $1 }')" ]
-  grep "migrate: working copy must not be dirty" migrate.log
+  grep "working copy must not be dirty" migrate.log
 
   migrated_main="$(git rev-parse main)"
 
@@ -1086,7 +1086,7 @@ begin_test "migrate import (dirty copy, positive answer)"
   oid="$(calc_oid "$(git cat-file -p :a.txt)")"
 
   echo "y" | git lfs migrate import --everything 2>&1 | tee migrate.log
-  grep "migrate: changes in your working copy will be overridden ..." \
+  grep "changes in your working copy will be overridden ..." \
     migrate.log
 
   assert_pointer "refs/heads/main" "a.txt" "$oid" "5"

--- a/t/t-migrate-info.sh
+++ b/t/t-migrate-info.sh
@@ -455,7 +455,7 @@ begin_test "migrate info (existing .gitattributes symlink)"
     exit 1
   fi
 
-  grep "migrate: expected '.gitattributes' to be a file, got a symbolic link" migrate.log
+  grep "expected '.gitattributes' to be a file, got a symbolic link" migrate.log
 
   main="$(git rev-parse refs/heads/main)"
 
@@ -480,7 +480,7 @@ begin_test "migrate info (potential fixup, --fixup, .gitattributes symlink)"
     exit 1
   fi
 
-  grep "migrate: expected '.gitattributes' to be a file, got a symbolic link" migrate.log
+  grep "expected '.gitattributes' to be a file, got a symbolic link" migrate.log
 
   main="$(git rev-parse refs/heads/main)"
 

--- a/t/t-prune-worktree.sh
+++ b/t/t-prune-worktree.sh
@@ -90,8 +90,8 @@ begin_test "prune worktree"
 
   # before worktree, everything except current checkout would be pruned
   git lfs prune --dry-run 2>&1 | tee prune.log
-  grep "prune: 8 local objects, 1 retained, done." prune.log
-  grep "prune: 7 files would be pruned" prune.log
+  grep "8 local objects, 1 retained, done." prune.log
+  grep "7 files would be pruned" prune.log
 
   # now add worktrees on the other branches
   git worktree add "../w1_$reponame" "branch1"
@@ -112,29 +112,29 @@ begin_test "prune worktree"
 
   # now should retain all 3 heads except for paths excluded by filter plus the indexed files
   git lfs prune --dry-run 2>&1 | tee prune.log
-  grep "prune: 10 local objects, 5 retained, done." prune.log
-  grep "prune: 5 files would be pruned" prune.log
+  grep "10 local objects, 5 retained, done." prune.log
+  grep "5 files would be pruned" prune.log
 
   # also check that the same result is obtained when inside worktree rather than main
   cd "../w1_$reponame"
   git lfs prune --dry-run 2>&1 | tee prune.log
-  grep "prune: 10 local objects, 5 retained, done." prune.log
-  grep "prune: 5 files would be pruned" prune.log
+  grep "10 local objects, 5 retained, done." prune.log
+  grep "5 files would be pruned" prune.log
 
   # now remove a worktree and prove that frees up the object staged in the
   # worktree's index but leaves the non-excluded object in its HEAD commit
   cd "../$reponame"
   rm -rf "../w1_$reponame"
   git lfs prune --dry-run 2>&1 | tee prune.log
-  grep "prune: 10 local objects, 4 retained, done." prune.log
-  grep "prune: 6 files would be pruned" prune.log
+  grep "10 local objects, 4 retained, done." prune.log
+  grep "6 files would be pruned" prune.log
 
   # now ask Git to tidy the worktree metadata and prove that frees up the
   # non-excluded object in the removed worktree's HEAD commit
   git worktree prune
   git lfs prune --dry-run 2>&1 | tee prune.log
-  grep "prune: 10 local objects, 3 retained, done." prune.log
-  grep "prune: 7 files would be pruned" prune.log
+  grep "10 local objects, 3 retained, done." prune.log
+  grep "7 files would be pruned" prune.log
 )
 end_test
 
@@ -221,7 +221,7 @@ begin_test "prune worktree (bare main)"
   # should retain all objects because there are no remote branches
   # in a bare repo, so all objects are considered unpushed
   git lfs prune --dry-run 2>&1 | tee prune.log
-  grep "prune: 6 local objects, 6 retained, done." prune.log
+  grep "6 local objects, 6 retained, done." prune.log
   [ "0" -eq "$(grep -c "files would be pruned" prune.log)" ]
 )
 end_test

--- a/t/t-prune.sh
+++ b/t/t-prune.sh
@@ -70,8 +70,8 @@ begin_test "prune unreferenced and old"
 
   git lfs prune --dry-run --verbose 2>&1 | tee prune.log
 
-  grep "prune: 5 local objects, 3 retained" prune.log
-  grep "prune: 2 files would be pruned" prune.log
+  grep "5 local objects, 3 retained" prune.log
+  grep "2 files would be pruned" prune.log
   grep "$oid_oldandpushed" prune.log
   grep "$oid_unreferenced" prune.log
 
@@ -88,8 +88,8 @@ begin_test "prune unreferenced and old"
   git config lfs.fetchrecentcommitsdays 0
 
   git lfs prune --verbose 2>&1 | tee prune.log
-  grep "prune: 3 local objects, 2 retained" prune.log
-  grep "prune: Deleting objects: 100% (1/1), done." prune.log
+  grep "3 local objects, 2 retained" prune.log
+  grep "Deleting objects: 100% (1/1), done." prune.log
   grep "$oid_retain1" prune.log
   refute_local_object "$oid_retain1"
   assert_local_object "$oid_retain2" "${#content_retain2}"
@@ -163,8 +163,8 @@ begin_test "prune all excluded paths"
 
   git lfs prune --dry-run --verbose 2>&1 | tee prune.log
 
-  grep "prune: 6 local objects, 2 retained" prune.log
-  grep "prune: 4 files would be pruned" prune.log
+  grep "6 local objects, 2 retained" prune.log
+  grep "4 files would be pruned" prune.log
   grep "$oid_oldandexcluded" prune.log
   grep "$oid_prevandexcluded" prune.log
   grep "$oid_unreferencedandexcluded" prune.log
@@ -299,8 +299,8 @@ begin_test "prune keep unpushed"
   git push origin main
 
   git lfs prune --verbose 2>&1 | tee prune.log
-  grep "prune: 12 local objects, 10 retained" prune.log
-  grep "prune: Deleting objects: 100% (2/2), done." prune.log
+  grep "12 local objects, 10 retained" prune.log
+  grep "Deleting objects: 100% (2/2), done." prune.log
   grep "$oid_keepunpushedhead1" prune.log
   grep "$oid_keepunpushedhead2" prune.log
   refute_local_object "$oid_keepunpushedhead1"
@@ -317,8 +317,8 @@ begin_test "prune keep unpushed"
   # Now make sure we purged all the intermediate commits but also make sure
   # they are on the remote.
   git lfs prune --verbose 2>&1 | tee prune.log
-  grep "prune: 10 local objects, 2 retained" prune.log
-  grep "prune: Deleting objects: 100% (8/8), done." prune.log
+  grep "10 local objects, 2 retained" prune.log
+  grep "Deleting objects: 100% (8/8), done." prune.log
   grep "$oid_keepunpushedbranch1" prune.log
   grep "$oid_keepunpushedbranch2" prune.log
   grep "$oid_keepunpushedandexcludedbranch1" prune.log
@@ -468,8 +468,8 @@ begin_test "prune keep recent"
   git push origin main:main branch_old:branch_old branch1:branch1 branch2:branch2
 
   git lfs prune --verbose 2>&1 | tee prune.log
-  grep "prune: 11 local objects, 6 retained, done." prune.log
-  grep "prune: Deleting objects: 100% (5/5), done." prune.log
+  grep "11 local objects, 6 retained, done." prune.log
+  grep "Deleting objects: 100% (5/5), done." prune.log
   grep "$oid_prunecommitoldbranch" prune.log
   grep "$oid_prunecommitoldbranch2" prune.log
   grep "$oid_prunecommitbranch1" prune.log
@@ -492,8 +492,8 @@ begin_test "prune keep recent"
   # still retain tips of branches
   git config lfs.fetchrecentcommitsdays 0
   git lfs prune --verbose 2>&1 | tee prune.log
-  grep "prune: 6 local objects, 3 retained, done." prune.log
-  grep "prune: Deleting objects: 100% (3/3), done." prune.log
+  grep "6 local objects, 3 retained, done." prune.log
+  grep "Deleting objects: 100% (3/3), done." prune.log
   assert_local_object "$oid_keephead" "${#content_keephead}"
   assert_local_object "$oid_keeprecentbranch1tip" "${#content_keeprecentbranch1tip}"
   assert_local_object "$oid_keeprecentbranch2tip" "${#content_keeprecentbranch2tip}"
@@ -504,8 +504,8 @@ begin_test "prune keep recent"
   # now don't include any recent refs at all, only keep HEAD
   git config lfs.fetchrecentrefsdays 0
   git lfs prune --verbose 2>&1 | tee prune.log
-  grep "prune: 3 local objects, 1 retained, done." prune.log
-  grep "prune: Deleting objects: 100% (2/2), done." prune.log
+  grep "3 local objects, 1 retained, done." prune.log
+  grep "Deleting objects: 100% (2/2), done." prune.log
   assert_local_object "$oid_keephead" "${#content_keephead}"
   refute_local_object "$oid_keeprecentbranch1tip"
   refute_local_object "$oid_keeprecentbranch2tip"
@@ -554,7 +554,7 @@ begin_test "prune remote tests"
 
   # can never prune with no remote
   git lfs prune --verbose 2>&1 | tee prune.log
-  grep "prune: 4 local objects, 4 retained, done." prune.log
+  grep "4 local objects, 4 retained, done." prune.log
 
 
   # also make sure nothing is pruned when remote is not origin
@@ -566,15 +566,15 @@ begin_test "prune remote tests"
   git push not_origin main
 
   git lfs prune --verbose 2>&1 | tee prune.log
-  grep "prune: 4 local objects, 4 retained, done." prune.log
+  grep "4 local objects, 4 retained, done." prune.log
 
   # now set the prune remote to be not_origin, should now prune
   # do a dry run so we can also verify
   git config lfs.pruneremotetocheck not_origin
 
   git lfs prune --verbose --dry-run 2>&1 | tee prune.log
-  grep "prune: 4 local objects, 1 retained, done." prune.log
-  grep "prune: 3 files would be pruned" prune.log
+  grep "4 local objects, 1 retained, done." prune.log
+  grep "3 files would be pruned" prune.log
 )
 end_test
 
@@ -633,8 +633,8 @@ begin_test "prune verify"
 
   # confirm that it would prune with verify when no issues
   git lfs prune --dry-run --verify-remote --verbose 2>&1 | tee prune.log
-  grep "prune: 4 local objects, 1 retained, 3 verified with remote, done." prune.log
-  grep "prune: 3 files would be pruned" prune.log
+  grep "4 local objects, 1 retained, 3 verified with remote, done." prune.log
+  grep "3 files would be pruned" prune.log
   grep "$oid_commit3" prune.log
   grep "$oid_commit2_failverify" prune.log
   grep "$oid_commit1" prune.log
@@ -643,7 +643,7 @@ begin_test "prune verify"
   delete_server_object "remote_$reponame" "$oid_commit2_failverify"
   # this should now fail
   git lfs prune --verify-remote 2>&1 | tee prune.log
-  grep "prune: 4 local objects, 1 retained, 2 verified with remote, 1 not on remote, done." prune.log
+  grep "4 local objects, 1 retained, 2 verified with remote, 1 not on remote, done." prune.log
   grep "missing on remote:" prune.log
   grep "$oid_commit2_failverify" prune.log
   # Nothing should have been deleted
@@ -655,7 +655,7 @@ begin_test "prune verify"
   git config lfs.pruneverifyremotealways true
   # no verify arg but should be pulled from global
   git lfs prune 2>&1 | tee prune.log
-  grep "prune: 4 local objects, 1 retained, 2 verified with remote, 1 not on remote, done." prune.log
+  grep "4 local objects, 1 retained, 2 verified with remote, 1 not on remote, done." prune.log
   grep "missing on remote:" prune.log
   grep "$oid_commit2_failverify" prune.log
   # Nothing should have been deleted
@@ -665,15 +665,15 @@ begin_test "prune verify"
 
   # --when-unverified=continue we would prune verified objects but skip unverified objects
   git lfs prune --when-unverified=continue --dry-run --verbose 2>&1 | tee prune.log
-  grep "prune: 4 local objects, 1 retained, 2 verified with remote, 1 not on remote, done." prune.log
-  grep "prune: 2 files would be pruned" prune.log
+  grep "4 local objects, 1 retained, 2 verified with remote, 1 not on remote, done." prune.log
+  grep "2 files would be pruned" prune.log
   grep "$oid_commit1" prune.log
   grep "$oid_commit3" prune.log
 
   # now try overriding the global option
   git lfs prune --no-verify-remote 2>&1 | tee prune.log
-  grep "prune: 4 local objects, 1 retained, done." prune.log
-  grep "prune: Deleting objects: 100% (3/3), done." prune.log
+  grep "4 local objects, 1 retained, done." prune.log
+  grep "Deleting objects: 100% (3/3), done." prune.log
   # should now have been deleted
   refute_local_object "$oid_commit1"
   refute_local_object "$oid_commit2_failverify"
@@ -806,8 +806,8 @@ begin_test "prune unreachable"
 
   # confirm that it would prune without --verify-unreachable
   git lfs prune --dry-run --verify-remote --verbose 2>&1 | tee prune.log
-  grep "prune: 5 local objects, 1 retained, 3 verified with remote, done." prune.log
-  grep "prune: 4 files would be pruned" prune.log
+  grep "5 local objects, 1 retained, 3 verified with remote, done." prune.log
+  grep "4 files would be pruned" prune.log
   grep "$oid_commit3" prune.log
   grep "$oid_commit2" prune.log
   grep "$oid_commit1" prune.log
@@ -815,7 +815,7 @@ begin_test "prune unreachable"
 
   # this should now halt as one file cannot be verified
   git lfs prune --verify-remote --verify-unreachable 2>&1 | tee prune.log
-  grep "prune: 5 local objects, 1 retained, 3 verified with remote, 1 not on remote, done." prune.log
+  grep "5 local objects, 1 retained, 3 verified with remote, 1 not on remote, done." prune.log
   grep "missing on remote:" prune.log
   grep "$oid_orphan" prune.log
 
@@ -829,19 +829,19 @@ begin_test "prune unreachable"
   # test config option
   git config lfs.pruneverifyunreachablealways true
   git lfs prune --verify-remote 2>&1 | tee prune.log
-  grep "prune: 5 local objects, 1 retained, 3 verified with remote, 1 not on remote, done." prune.log
+  grep "5 local objects, 1 retained, 3 verified with remote, 1 not on remote, done." prune.log
   grep "missing on remote:" prune.log
   grep "$oid_orphan" prune.log
 
   # now try overriding the global option
   git lfs prune --verify-remote --no-verify-unreachable --dry-run 2>&1 | tee prune.log
-  grep "prune: 5 local objects, 1 retained, 3 verified with remote, done." prune.log
-  grep "prune: 4 files would be pruned" prune.log
+  grep "5 local objects, 1 retained, 3 verified with remote, done." prune.log
+  grep "4 files would be pruned" prune.log
 
   # now test with continue to see that it does prune verified objects
   git lfs prune --verify-remote --when-unverified=continue 2>&1 | tee prune.log
-  grep "prune: 5 local objects, 1 retained, 3 verified with remote, 1 not on remote, done." prune.log
-  grep "prune: Deleting objects: 100% (3/3), done." prune.log
+  grep "5 local objects, 1 retained, 3 verified with remote, 1 not on remote, done." prune.log
+  grep "Deleting objects: 100% (3/3), done." prune.log
 
   # The orphan file should not have been deleted
   refute_local_object "$oid_commit1" "${#content_commit1}"


### PR DESCRIPTION
Three of the Git LFS commands, namely the `git lfs fetch`, `git lfs prune`, and `git lfs migrate` commands, all output informational messages prefixed by their Git LFS subcommand names.

This behaviour differs from all of our other commands, and from the messages output by Git commands, so we revise these three Git LFS commands now to remove these message prefixes, and make some other minor adjustments to the format of the `git lfs migrate` command's output to improve its readability.

As an example, our existing output from these commands looks like the following.  Note the inconsistency in some of the lines output by the `git lfs migrate` command in particular.

```
$ git lfs prune
prune: 2 local objects, 0 retained, done.                                       
prune: Deleting objects: 100% (2/2), done.

$ git lfs fetch
fetch: Fetching reference refs/heads/main
Downloading LFS objects: 100% (2/2), 108 B | 0 B/s 

$ git lfs migrate import --verbose --include="*.bin"
migrate: Sorting commits: ..., done.                                            
migrate: commit 33dc05eafb8435c90404dc2ebdbdd7897ce3d1d9: foo.bin               
migrate: commit 01228a55ec03011a64168400dc143689c3d41237: bar.bin
migrate: Rewriting commits: 100% (2/2), done.
  main	01228a55ec03011a64168400dc143689c3d41237 -> 241ac413649fa10a6c9460233a2aad7261bc54f5
migrate: Updating refs: ..., done.                                              
migrate: checkout: ..., done. 
```

With the revisions in this PR, the output from the same commands now appears as follows.

```
$ git lfs prune
2 local objects, 0 retained, done.                                       
Deleting objects: 100% (2/2), done.

$ git lfs fetch
Fetching reference refs/heads/main
Downloading LFS objects: 100% (2/2), 108 B | 0 B/s 

$ git lfs migrate import --verbose --include="*.bin"
Fetching remote refs: ..., done.                                                
Sorting commits: ..., done.                                                     
  commit 33dc05eafb8435c90404dc2ebdbdd7897ce3d1d9: foo.bin                      
  commit 01228a55ec03011a64168400dc143689c3d41237: bar.bin
Rewriting commits: 100% (2/2), done.
  main	01228a55ec03011a64168400dc143689c3d41237 -> 241ac413649fa10a6c9460233a2aad7261bc54f5
Updating refs: ..., done.                                                       
Checkout: ..., done.
```

Note that while we try to guarantee stable and machine-readable output formats from some of our commands, those require the use of options such as `--porcelain` or `--json`.  Users should not depend on the exact format of our other informational and error messages.

In addition to these changes, we also update several of the structures and methods in our `githistory` package to avoid exporting unnecessary structure elements or methods outside of the package, and we align the name of the `tasklog.Logger` element in [two](https://github.com/git-lfs/git-lfs/blob/0534b10d870acd31b13ea2c23d94a710b44ab98f/git/githistory/rewriter.go#L38) [structures](https://github.com/git-lfs/git-lfs/blob/0534b10d870acd31b13ea2c23d94a710b44ab98f/git/githistory/ref_updater.go#L24) in that package.

This PR will be most easily reviewed on a commit-by-commit basis, as each commit includes a detailed description of its changes.