### PR TITLE
Use constant format strings and fix HTTP error messages

### DIFF
--- a/commands/command_dedup.go
+++ b/commands/command_dedup.go
@@ -129,7 +129,7 @@ func dedup(p *lfs.WrappedPointer) (success bool, err error) {
 	if ok, err := tools.CloneFileByPath(dstFile, srcFile); err != nil {
 		return false, err
 	} else if !ok {
-		return false, errors.Errorf(tr.Tr.Get("unknown clone file error"))
+		return false, errors.New(tr.Tr.Get("unknown clone file error"))
 	}
 
 	// Recover original state

--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -2,11 +2,11 @@ package commands
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"sync"
 	"time"
 
+	"github.com/git-lfs/git-lfs/v3/errors"
 	"github.com/git-lfs/git-lfs/v3/filepathfilter"
 	"github.com/git-lfs/git-lfs/v3/git"
 	"github.com/git-lfs/git-lfs/v3/lfs"
@@ -184,11 +184,7 @@ func pointersToFetchForRef(ref string, filter *filepathfilter.Filter) ([]*lfs.Wr
 	var multiErr error
 	tempgitscanner := lfs.NewGitScanner(cfg, func(p *lfs.WrappedPointer, err error) {
 		if err != nil {
-			if multiErr != nil {
-				multiErr = fmt.Errorf("%v\n%v", multiErr, err)
-			} else {
-				multiErr = err
-			}
+			multiErr = errors.Join(multiErr, err)
 			return
 		}
 
@@ -227,11 +223,7 @@ func pointersToFetchForRefs(refs []string) ([]*lfs.WrappedPointer, error) {
 	var numObjs int64
 	tempgitscanner := lfs.NewGitScanner(cfg, func(p *lfs.WrappedPointer, err error) {
 		if err != nil {
-			if multiErr != nil {
-				multiErr = fmt.Errorf("%v\n%v", multiErr, err)
-			} else {
-				multiErr = err
-			}
+			multiErr = errors.Join(multiErr, err)
 			return
 		}
 
@@ -362,11 +354,7 @@ func scanAll() []*lfs.WrappedPointer {
 	var numObjs int64
 	tempgitscanner := lfs.NewGitScanner(cfg, func(p *lfs.WrappedPointer, err error) {
 		if err != nil {
-			if multiErr != nil {
-				multiErr = fmt.Errorf("%v\n%v", multiErr, err)
-			} else {
-				multiErr = err
-			}
+			multiErr = errors.Join(multiErr, err)
 			return
 		}
 

--- a/commands/command_logs.go
+++ b/commands/command_logs.go
@@ -53,7 +53,7 @@ func logsClearCommand(cmd *cobra.Command, args []string) {
 
 func logsBoomtownCommand(cmd *cobra.Command, args []string) {
 	tracerx.Printf("Sample trace message")
-	err := errors.Wrapf(errors.New(tr.Tr.Get("Sample wrapped error message")), tr.Tr.Get("Sample error message"))
+	err := errors.Wrap(errors.New(tr.Tr.Get("Sample wrapped error message")), tr.Tr.Get("Sample error message"))
 	Panic(err, tr.Tr.Get("Sample panic message"))
 }
 

--- a/commands/command_migrate.go
+++ b/commands/command_migrate.go
@@ -319,7 +319,7 @@ func currentRefToMigrate() (*git.Ref, error) {
 	if current.Type == git.RefTypeOther ||
 		current.Type == git.RefTypeRemoteBranch {
 
-		return nil, errors.Errorf(tr.Tr.Get("Cannot migrate non-local ref: %s", current.Name))
+		return nil, errors.New(tr.Tr.Get("Cannot migrate non-local ref: %s", current.Name))
 	}
 	return current, nil
 }

--- a/commands/command_migrate_export.go
+++ b/commands/command_migrate_export.go
@@ -35,7 +35,7 @@ func migrateExportCommand(cmd *cobra.Command, args []string) {
 
 	filter := rewriter.Filter()
 	if len(filter.Include()) <= 0 {
-		ExitWithError(errors.Errorf(tr.Tr.Get("One or more files must be specified with --include")))
+		ExitWithError(errors.New(tr.Tr.Get("One or more files must be specified with --include")))
 	}
 
 	tracked := trackedFromExportFilter(filter)
@@ -116,7 +116,7 @@ func migrateExportCommand(cmd *cobra.Command, args []string) {
 	}
 	remoteURL := getAPIClient().Endpoints.RemoteEndpoint("download", remote).Url
 	if remoteURL == "" && cmd.Flag("remote").Changed {
-		ExitWithError(errors.Errorf(tr.Tr.Get("Invalid remote %s provided", remote)))
+		ExitWithError(errors.New(tr.Tr.Get("Invalid remote %s provided", remote)))
 	}
 
 	// If we have a valid remote, pre-download all objects using the Transfer Queue

--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -44,11 +44,11 @@ func migrateImportCommand(cmd *cobra.Command, args []string) {
 
 	if migrateNoRewrite {
 		if migrateFixup {
-			ExitWithError(errors.Errorf(tr.Tr.Get("--no-rewrite and --fixup cannot be combined")))
+			ExitWithError(errors.New(tr.Tr.Get("--no-rewrite and --fixup cannot be combined")))
 		}
 
 		if len(args) == 0 {
-			ExitWithError(errors.Errorf(tr.Tr.Get("Expected one or more files with --no-rewrite")))
+			ExitWithError(errors.New(tr.Tr.Get("Expected one or more files with --no-rewrite")))
 		}
 
 		ref, err := git.CurrentRef()
@@ -66,14 +66,14 @@ func migrateImportCommand(cmd *cobra.Command, args []string) {
 
 		filter := git.GetAttributeFilter(cfg.LocalWorkingDir(), cfg.LocalGitDir())
 		if len(filter.Include()) == 0 {
-			ExitWithError(errors.Errorf(tr.Tr.Get("No Git LFS filters found in '.gitattributes'")))
+			ExitWithError(errors.New(tr.Tr.Get("No Git LFS filters found in '.gitattributes'")))
 		}
 
 		gf := lfs.NewGitFilter(cfg)
 
 		for _, file := range args {
 			if !filter.Allows(file) {
-				ExitWithError(errors.Errorf(tr.Tr.Get("File %s did not match any Git LFS filters in '.gitattributes'", file)))
+				ExitWithError(errors.New(tr.Tr.Get("File %s did not match any Git LFS filters in '.gitattributes'", file)))
 			}
 		}
 
@@ -124,7 +124,7 @@ func migrateImportCommand(cmd *cobra.Command, args []string) {
 	if migrateFixup {
 		include, exclude := getIncludeExcludeArgs(cmd)
 		if include != nil || exclude != nil {
-			ExitWithError(errors.Errorf(tr.Tr.Get("Cannot use --fixup with --include, --exclude")))
+			ExitWithError(errors.New(tr.Tr.Get("Cannot use --fixup with --include, --exclude")))
 		}
 	}
 
@@ -142,7 +142,7 @@ func migrateImportCommand(cmd *cobra.Command, args []string) {
 	if above > 0 {
 		include, exclude := getIncludeExcludeArgs(cmd)
 		if include != nil || exclude != nil || migrateFixup {
-			ExitWithError(errors.Errorf(tr.Tr.Get("Cannot use --above with --include, --exclude, --fixup")))
+			ExitWithError(errors.New(tr.Tr.Get("Cannot use --above with --include, --exclude, --fixup")))
 		}
 	}
 
@@ -395,7 +395,7 @@ func rewriteTree(gf *lfs.GitFilter, db *gitobj.ObjectDatabase, root []byte, path
 		// Try to replace this blob with a Git LFS pointer.
 		index := findEntry(tree, splits[0])
 		if index < 0 {
-			return nil, errors.Errorf(tr.Tr.Get("unable to find entry %s in tree", splits[0]))
+			return nil, errors.New(tr.Tr.Get("unable to find entry %s in tree", splits[0]))
 		}
 
 		blobEntry := tree.Entries[index]
@@ -433,7 +433,7 @@ func rewriteTree(gf *lfs.GitFilter, db *gitobj.ObjectDatabase, root []byte, path
 
 		index := findEntry(tree, head)
 		if index < 0 {
-			return nil, errors.Errorf(tr.Tr.Get("unable to find entry %s in tree", head))
+			return nil, errors.New(tr.Tr.Get("unable to find entry %s in tree", head))
 		}
 
 		subtreeEntry := tree.Entries[index]
@@ -455,7 +455,7 @@ func rewriteTree(gf *lfs.GitFilter, db *gitobj.ObjectDatabase, root []byte, path
 		return db.WriteTree(tree)
 
 	default:
-		return nil, errors.Errorf(tr.Tr.Get("error parsing path %s", path))
+		return nil, errors.New(tr.Tr.Get("error parsing path %s", path))
 	}
 }
 

--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -80,7 +80,7 @@ func migrateImportCommand(cmd *cobra.Command, args []string) {
 		for _, file := range args {
 			root, err = rewriteTree(gf, db, root, file)
 			if err != nil {
-				ExitWithError(errors.Wrapf(err, tr.Tr.Get("Could not rewrite %q", file)))
+				ExitWithError(errors.Wrap(err, tr.Tr.Get("Could not rewrite %q", file)))
 			}
 		}
 

--- a/commands/command_migrate_info.go
+++ b/commands/command_migrate_info.go
@@ -96,17 +96,17 @@ func migrateInfoCommand(cmd *cobra.Command, args []string) {
 		case "ignore":
 			migrateInfoPointersMode = migrateInfoPointersIgnore
 		default:
-			ExitWithError(errors.Errorf(tr.Tr.Get("Unsupported --pointers option value")))
+			ExitWithError(errors.New(tr.Tr.Get("Unsupported --pointers option value")))
 		}
 	}
 
 	if migrateFixup {
 		include, exclude := getIncludeExcludeArgs(cmd)
 		if include != nil || exclude != nil {
-			ExitWithError(errors.Errorf(tr.Tr.Get("Cannot use --fixup with --include, --exclude")))
+			ExitWithError(errors.New(tr.Tr.Get("Cannot use --fixup with --include, --exclude")))
 		}
 		if pointers.Changed && migrateInfoPointersMode != migrateInfoPointersIgnore {
-			ExitWithError(errors.Errorf(tr.Tr.Get("Cannot use --fixup with --pointers=%s", pointers.Value.String())))
+			ExitWithError(errors.New(tr.Tr.Get("Cannot use --fixup with --pointers=%s", pointers.Value.String())))
 		}
 		migrateInfoPointersMode = migrateInfoPointersIgnore
 	}

--- a/commands/command_pointer.go
+++ b/commands/command_pointer.go
@@ -129,7 +129,7 @@ func pointerCommand(cmd *cobra.Command, args []string) {
 			os.Exit(1)
 		}
 
-		fmt.Fprintf(os.Stderr, buf.String())
+		fmt.Fprint(os.Stderr, buf.String())
 		if comparing {
 			compareOid, err = git.HashObject(bytes.NewReader(buf.Bytes()))
 			if err != nil {

--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -44,7 +44,7 @@ func delayedSmudge(gf *lfs.GitFilter, s *git.FilterProcessScanner, to io.Writer,
 		}
 
 		if n != 0 {
-			return 0, false, nil, errors.NewNotAPointerError(errors.Errorf(
+			return 0, false, nil, errors.NewNotAPointerError(errors.New(
 				tr.Tr.Get("Unable to parse pointer at: %q", filename),
 			))
 		}
@@ -107,7 +107,7 @@ func smudge(gf *lfs.GitFilter, to io.Writer, from io.Reader, filename string, sk
 		}
 
 		if n != 0 {
-			return 0, errors.NewNotAPointerError(errors.Errorf(
+			return 0, errors.NewNotAPointerError(errors.New(
 				tr.Tr.Get("Unable to parse pointer at: %q", filename),
 			))
 		}

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"fmt"
 	"io"
 	"net/url"
 	"os"
@@ -139,11 +138,7 @@ func (c *uploadContext) addScannerError(err error) {
 	c.errMu.Lock()
 	defer c.errMu.Unlock()
 
-	if c.scannerErr != nil {
-		c.scannerErr = fmt.Errorf("%v\n%v", c.scannerErr, err)
-	} else {
-		c.scannerErr = err
-	}
+	c.scannerErr = errors.Join(c.scannerErr, err)
 }
 
 func (c *uploadContext) buildGitScanner() *lfs.GitScanner {

--- a/creds/creds.go
+++ b/creds/creds.go
@@ -66,13 +66,13 @@ func (c Creds) buffer(protectProtocol bool) (*bytes.Buffer, error) {
 	for k, v := range c {
 		for _, item := range v {
 			if strings.Contains(item, "\n") {
-				return nil, errors.Errorf(tr.Tr.Get("credential value for %s contains newline: %q", k, item))
+				return nil, errors.New(tr.Tr.Get("credential value for %s contains newline: %q", k, item))
 			}
 			if protectProtocol && strings.Contains(item, "\r") {
-				return nil, errors.Errorf(tr.Tr.Get("credential value for %s contains carriage return: %q\nIf this is intended, set `credential.protectProtocol=false`", k, item))
+				return nil, errors.New(tr.Tr.Get("credential value for %s contains carriage return: %q\nIf this is intended, set `credential.protectProtocol=false`", k, item))
 			}
 			if strings.Contains(item, string(rune(0))) {
-				return nil, errors.Errorf(tr.Tr.Get("credential value for %s contains null byte: %q", k, item))
+				return nil, errors.New(tr.Tr.Get("credential value for %s contains null byte: %q", k, item))
 			}
 
 			buf.Write([]byte(k))
@@ -249,7 +249,7 @@ func (a *AskPassCredentialHelper) getValue(what Creds, valueType credValueType, 
 	case credValueTypePassword:
 		valueString = "password"
 	default:
-		return "", errors.Errorf(tr.Tr.Get("Invalid Credential type queried from AskPass"))
+		return "", errors.New(tr.Tr.Get("Invalid Credential type queried from AskPass"))
 	}
 
 	// Return the existing credential if it was already provided, otherwise
@@ -274,7 +274,7 @@ func (a *AskPassCredentialHelper) getFromProgram(valueType credValueType, u *url
 	case credValueTypePassword:
 		valueString = "Password"
 	default:
-		return "", errors.Errorf(tr.Tr.Get("Invalid Credential type queried from AskPass"))
+		return "", errors.New(tr.Tr.Get("Invalid Credential type queried from AskPass"))
 	}
 
 	// 'cmd' will run the GIT_ASKPASS (or core.askpass) command prompting

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -50,7 +50,7 @@ package errors
 // docs for more info: https://godoc.org/github.com/pkg/errors
 
 import (
-	"bytes"
+	goerrors "errors"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -102,19 +102,8 @@ func StackTrace(err error) []string {
 	return nil
 }
 
-func Combine(errs []error) error {
-	if len(errs) == 0 {
-		return nil
-	}
-
-	var buf bytes.Buffer
-	for i, err := range errs {
-		if i > 0 {
-			buf.WriteString("\n")
-		}
-		buf.WriteString(err.Error())
-	}
-	return fmt.Errorf(buf.String())
+func Join(errs ...error) error {
+	return goerrors.Join(errs...)
 }
 
 func Cause(err error) error {

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -85,23 +85,6 @@ func Wrapf(err error, format string, args ...interface{}) error {
 	return newWrappedError(err, message)
 }
 
-func StackTrace(err error) []string {
-	type stacktrace interface {
-		StackTrace() errors.StackTrace
-	}
-
-	if err, ok := err.(stacktrace); ok {
-		frames := err.StackTrace()
-		lines := make([]string, len(frames))
-		for i, f := range frames {
-			lines[i] = fmt.Sprintf("%+v", f)
-		}
-		return lines
-	}
-
-	return nil
-}
-
 func Join(errs ...error) error {
 	return goerrors.Join(errs...)
 }

--- a/errors/types.go
+++ b/errors/types.go
@@ -205,7 +205,6 @@ func IsRetriableLaterError(err error) (time.Time, bool) {
 
 type errorWithCause interface {
 	Cause() error
-	StackTrace() errors.StackTrace
 	error
 	fmt.Formatter
 }

--- a/errors/types.go
+++ b/errors/types.go
@@ -386,7 +386,7 @@ func (e badPointerKeyError) BadPointerKeyError() bool {
 }
 
 func NewBadPointerKeyError(expected, actual string) error {
-	err := Errorf(tr.Tr.Get("Expected key %s, got %s", expected, actual))
+	err := New(tr.Tr.Get("Expected key %s, got %s", expected, actual))
 	return badPointerKeyError{expected, actual, newWrappedError(err, tr.Tr.Get("pointer parsing"))}
 }
 

--- a/git/githistory/rewriter_test.go
+++ b/git/githistory/rewriter_test.go
@@ -377,7 +377,7 @@ func TestHistoryRewriterCallbacksSubtrees(t *testing.T) {
 }
 
 func TestHistoryRewriterTreePreCallbackPropagatesErrors(t *testing.T) {
-	expected := errors.Errorf("my error")
+	expected := errors.New("my error")
 
 	db := DatabaseFromFixture(t, "linear-history.git")
 	r := NewRewriter(db)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/avast/retry-go v2.4.2+incompatible
 	github.com/dpotapov/go-spnego v0.0.0-20210315154721-298b63a54430
 	github.com/git-lfs/gitobj/v2 v2.1.1
-	github.com/git-lfs/go-netrc v0.0.0-20210914205454-f0c862dd687a
+	github.com/git-lfs/go-netrc v0.0.0-20250218165306-ba0029b43d11
 	github.com/git-lfs/pktline v0.0.0-20210330133718-06e9096e2825
 	github.com/git-lfs/wildmatch/v2 v2.0.1
 	github.com/jmhodges/clock v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/dpotapov/go-spnego v0.0.0-20210315154721-298b63a54430 h1:oempk9HjNt6r
 github.com/dpotapov/go-spnego v0.0.0-20210315154721-298b63a54430/go.mod h1:AVSs/gZKt1bOd2AhkhbS7Qh56Hv7klde22yXVbwYJhc=
 github.com/git-lfs/gitobj/v2 v2.1.1 h1:tf/VU6zL1kxa3he+nf6FO/syX+LGkm6WGDsMpfuXV7Q=
 github.com/git-lfs/gitobj/v2 v2.1.1/go.mod h1:q6aqxl6Uu3gWsip5GEKpw+7459F97er8COmU45ncAxw=
-github.com/git-lfs/go-netrc v0.0.0-20210914205454-f0c862dd687a h1:6pskVZacdMUL93pCpMAYnMDLjH1yDFhssPYGe32sjdk=
-github.com/git-lfs/go-netrc v0.0.0-20210914205454-f0c862dd687a/go.mod h1:70O4NAtvWn1jW8V8V+OKrJJYcxDLTmIozfi2fmSz5SI=
+github.com/git-lfs/go-netrc v0.0.0-20250218165306-ba0029b43d11 h1:LotqdxyBRc7u2fxoBrzW6Mn3ZBvv7FlcBPlAa10DKAg=
+github.com/git-lfs/go-netrc v0.0.0-20250218165306-ba0029b43d11/go.mod h1:GTFwpcANSAXgAw+IaUFijK1DZFT0D1x0Wh9rG+Fa814=
 github.com/git-lfs/pktline v0.0.0-20210330133718-06e9096e2825 h1:riQhgheTL7tMF4d5raz9t3+IzoR1i1wqxE1kZC6dY+U=
 github.com/git-lfs/pktline v0.0.0-20210330133718-06e9096e2825/go.mod h1:fenKRzpXDjNpsIBhuhUzvjCKlDjKam0boRAenTE0Q6A=
 github.com/git-lfs/wildmatch/v2 v2.0.1 h1:Ds+aobrV5bK0wStILUOn9irllPyf9qrFETbKzwzoER8=
@@ -80,8 +80,6 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20191027093000-83d349e8ac1a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
-golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
 golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
 golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/lfs/diff_index_scanner.go
+++ b/lfs/diff_index_scanner.go
@@ -185,12 +185,12 @@ func (s *DiffIndexScanner) scan(line string) (*DiffIndexEntry, error) {
 
 	parts := strings.Split(line, "\t")
 	if len(parts) < 2 {
-		return nil, errors.Errorf(tr.Tr.Get("invalid line: %s", line))
+		return nil, errors.New(tr.Tr.Get("invalid line: %s", line))
 	}
 
 	desc := strings.Fields(parts[0])
 	if len(desc) < 5 {
-		return nil, errors.Errorf(tr.Tr.Get("invalid description: %s", parts[0]))
+		return nil, errors.New(tr.Tr.Get("invalid description: %s", parts[0]))
 	}
 
 	entry := &DiffIndexEntry{

--- a/lfs/gitfilter_smudge.go
+++ b/lfs/gitfilter_smudge.go
@@ -123,16 +123,7 @@ func (f *GitFilter) downloadFile(writer io.Writer, ptr *Pointer, workingfile, me
 	q.Wait()
 
 	if errs := q.Errors(); len(errs) > 0 {
-		var multiErr error
-		for _, e := range errs {
-			if multiErr != nil {
-				multiErr = fmt.Errorf("%v\n%v", multiErr, e)
-			} else {
-				multiErr = e
-			}
-		}
-
-		return 0, errors.Wrap(multiErr, tr.Tr.Get("Error downloading %s (%s)", workingfile, ptr.Oid))
+		return 0, errors.Wrap(errors.Join(errs...), tr.Tr.Get("Error downloading %s (%s)", workingfile, ptr.Oid))
 	}
 
 	return f.readLocalFile(writer, ptr, mediafile, workingfile, nil)
@@ -155,15 +146,7 @@ func (f *GitFilter) downloadFileFallBack(writer io.Writer, ptr *Pointer, working
 		q.Wait()
 
 		if errs := q.Errors(); len(errs) > 0 {
-			var multiErr error
-			for _, e := range errs {
-				if multiErr != nil {
-					multiErr = fmt.Errorf("%v\n%v", multiErr, e)
-				} else {
-					multiErr = e
-				}
-			}
-			wrappedError := errors.Wrap(multiErr, tr.Tr.Get("Error downloading %s (%s)", workingfile, ptr.Oid))
+			wrappedError := errors.Wrap(errors.Join(errs...), tr.Tr.Get("Error downloading %s (%s)", workingfile, ptr.Oid))
 			if index >= len(remotes)-1 {
 				return 0, wrappedError
 			} else {

--- a/lfs/gitfilter_smudge.go
+++ b/lfs/gitfilter_smudge.go
@@ -132,7 +132,7 @@ func (f *GitFilter) downloadFile(writer io.Writer, ptr *Pointer, workingfile, me
 			}
 		}
 
-		return 0, errors.Wrapf(multiErr, tr.Tr.Get("Error downloading %s (%s)", workingfile, ptr.Oid))
+		return 0, errors.Wrap(multiErr, tr.Tr.Get("Error downloading %s (%s)", workingfile, ptr.Oid))
 	}
 
 	return f.readLocalFile(writer, ptr, mediafile, workingfile, nil)
@@ -163,7 +163,7 @@ func (f *GitFilter) downloadFileFallBack(writer io.Writer, ptr *Pointer, working
 					multiErr = e
 				}
 			}
-			wrappedError := errors.Wrapf(multiErr, tr.Tr.Get("Error downloading %s (%s)", workingfile, ptr.Oid))
+			wrappedError := errors.Wrap(multiErr, tr.Tr.Get("Error downloading %s (%s)", workingfile, ptr.Oid))
 			if index >= len(remotes)-1 {
 				return 0, wrappedError
 			} else {
@@ -176,13 +176,13 @@ func (f *GitFilter) downloadFileFallBack(writer io.Writer, ptr *Pointer, working
 			return f.readLocalFile(writer, ptr, mediafile, workingfile, nil)
 		}
 	}
-	return 0, errors.Wrapf(errors.New(tr.Tr.Get("No known remotes")), tr.Tr.Get("Error downloading %s (%s)", workingfile, ptr.Oid))
+	return 0, errors.Wrap(errors.New(tr.Tr.Get("No known remotes")), tr.Tr.Get("Error downloading %s (%s)", workingfile, ptr.Oid))
 }
 
 func (f *GitFilter) readLocalFile(writer io.Writer, ptr *Pointer, mediafile string, workingfile string, cb tools.CopyCallback) (int64, error) {
 	reader, err := tools.RobustOpen(mediafile)
 	if err != nil {
-		return 0, errors.Wrapf(err, tr.Tr.Get("error opening media file"))
+		return 0, errors.Wrap(err, tr.Tr.Get("error opening media file"))
 	}
 	defer reader.Close()
 
@@ -250,14 +250,14 @@ func (f *GitFilter) readLocalFile(writer io.Writer, ptr *Pointer, mediafile stri
 		// setup reader
 		reader, err = os.Open(response.file.Name())
 		if err != nil {
-			return 0, errors.Wrapf(err, tr.Tr.Get("Error opening smudged file: %s", err))
+			return 0, errors.Wrap(err, tr.Tr.Get("Error opening smudged file: %s", err))
 		}
 		defer reader.Close()
 	}
 
 	n, err := tools.CopyWithCallback(writer, reader, ptr.Size, cb)
 	if err != nil {
-		return n, errors.Wrapf(err, tr.Tr.Get("Error reading from media file: %s", err))
+		return n, errors.Wrap(err, tr.Tr.Get("Error reading from media file: %s", err))
 	}
 
 	return n, nil

--- a/lfs/gitfilter_smudge.go
+++ b/lfs/gitfilter_smudge.go
@@ -176,7 +176,7 @@ func (f *GitFilter) downloadFileFallBack(writer io.Writer, ptr *Pointer, working
 			return f.readLocalFile(writer, ptr, mediafile, workingfile, nil)
 		}
 	}
-	return 0, errors.Wrapf(errors.New("No known remotes"), tr.Tr.Get("Error downloading %s (%s)", workingfile, ptr.Oid))
+	return 0, errors.Wrapf(errors.New(tr.Tr.Get("No known remotes")), tr.Tr.Get("Error downloading %s (%s)", workingfile, ptr.Oid))
 }
 
 func (f *GitFilter) readLocalFile(writer io.Writer, ptr *Pointer, mediafile string, workingfile string, cb tools.CopyCallback) (int64, error) {

--- a/lfs/scanner_git_test.go
+++ b/lfs/scanner_git_test.go
@@ -5,12 +5,12 @@ package lfs_test // to avoid import cycles
 // which avoids import cycles with testutils
 
 import (
-	"fmt"
 	"sort"
 	"testing"
 	"time"
 
 	"github.com/git-lfs/git-lfs/v3/config"
+	"github.com/git-lfs/git-lfs/v3/errors"
 	. "github.com/git-lfs/git-lfs/v3/lfs"
 	test "github.com/git-lfs/git-lfs/v3/t/cmd/util"
 	"github.com/stretchr/testify/assert"
@@ -94,11 +94,7 @@ func scanUnpushed(remoteName string) ([]*WrappedPointer, error) {
 
 	gitscanner := NewGitScanner(config.New(), func(p *WrappedPointer, err error) {
 		if err != nil {
-			if multiErr != nil {
-				multiErr = fmt.Errorf("%v\n%v", multiErr, err)
-			} else {
-				multiErr = err
-			}
+			multiErr = errors.Join(multiErr, err)
 			return
 		}
 

--- a/lfshttp/certs.go
+++ b/lfshttp/certs.go
@@ -76,23 +76,23 @@ func getClientCertForHost(c *Client, host string) (*tls.Certificate, error) {
 
 	hostSslKey, err := tools.ExpandPath(hostSslKey, false)
 	if err != nil {
-		return nil, errors.Wrapf(err, tr.Tr.Get("Error resolving key path %q", hostSslKey))
+		return nil, errors.Wrap(err, tr.Tr.Get("Error resolving key path %q", hostSslKey))
 	}
 
 	hostSslCert, err = tools.ExpandPath(hostSslCert, false)
 	if err != nil {
-		return nil, errors.Wrapf(err, tr.Tr.Get("Error resolving cert path %q", hostSslCert))
+		return nil, errors.Wrap(err, tr.Tr.Get("Error resolving cert path %q", hostSslCert))
 	}
 
 	cert, err := os.ReadFile(hostSslCert)
 	if err != nil {
 		tracerx.Printf("Error reading client cert file %q: %v", hostSslCert, err)
-		return nil, errors.Wrapf(err, tr.Tr.Get("Error reading client cert file %q", hostSslCert))
+		return nil, errors.Wrap(err, tr.Tr.Get("Error reading client cert file %q", hostSslCert))
 	}
 	key, err := os.ReadFile(hostSslKey)
 	if err != nil {
 		tracerx.Printf("Error reading client key file %q: %v", hostSslKey, err)
-		return nil, errors.Wrapf(err, tr.Tr.Get("Error reading client key file %q", hostSslKey))
+		return nil, errors.Wrap(err, tr.Tr.Get("Error reading client key file %q", hostSslKey))
 	}
 
 	block, _ := pem.Decode(key)
@@ -103,14 +103,14 @@ func getClientCertForHost(c *Client, host string) (*tls.Certificate, error) {
 		key, err = decryptPEMBlock(c, block, hostSslKey, key)
 		if err != nil {
 			tracerx.Printf("Unable to decrypt client key file %q: %v", hostSslKey, err)
-			return nil, errors.Wrapf(err, tr.Tr.Get("Error reading client key file %q (not a PKCS#1 file?)", hostSslKey))
+			return nil, errors.Wrap(err, tr.Tr.Get("Error reading client key file %q (not a PKCS#1 file?)", hostSslKey))
 		}
 	}
 
 	certobj, err := tls.X509KeyPair(cert, key)
 	if err != nil {
 		tracerx.Printf("Error reading client cert/key %v", err)
-		return nil, errors.Wrapf(err, tr.Tr.Get("Error reading client cert/key"))
+		return nil, errors.Wrap(err, tr.Tr.Get("Error reading client cert/key"))
 	}
 	return &certobj, nil
 }

--- a/lfshttp/errors.go
+++ b/lfshttp/errors.go
@@ -1,7 +1,6 @@
 package lfshttp
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -102,27 +101,27 @@ func (e *statusCodeError) HTTPResponse() *http.Response {
 }
 
 func defaultError(res *http.Response) error {
-	var msgFmt string
+	var msg string
 
 	defaultErrors := map[int]string{
-		400: tr.Tr.Get("Client error: %%s"),
-		401: tr.Tr.Get("Authorization error: %%s\nCheck that you have proper access to the repository"),
-		403: tr.Tr.Get("Authorization error: %%s\nCheck that you have proper access to the repository"),
-		404: tr.Tr.Get("Repository or object not found: %%s\nCheck that it exists and that you have proper access to it"),
-		422: tr.Tr.Get("Unprocessable entity: %%s"),
-		429: tr.Tr.Get("Rate limit exceeded: %%s"),
-		500: tr.Tr.Get("Server error: %%s"),
-		501: tr.Tr.Get("Not Implemented: %%s"),
-		507: tr.Tr.Get("Insufficient server storage: %%s"),
-		509: tr.Tr.Get("Bandwidth limit exceeded: %%s"),
+		400: "Client error: %s",
+		401: "Authorization error: %s\nCheck that you have proper access to the repository",
+		403: "Authorization error: %s\nCheck that you have proper access to the repository",
+		404: "Repository or object not found: %s\nCheck that it exists and that you have proper access to it",
+		422: "Unprocessable entity: %s",
+		429: "Rate limit exceeded: %s",
+		500: "Server error: %s",
+		501: "Not Implemented: %s",
+		507: "Insufficient server storage: %s",
+		509: "Bandwidth limit exceeded: %s",
 	}
 	if f, ok := defaultErrors[res.StatusCode]; ok {
-		msgFmt = f
+		msg = tr.Tr.Get(f, res.Request.URL)
 	} else if res.StatusCode < 500 {
-		msgFmt = tr.Tr.Get("Client error %%s from HTTP %d", res.StatusCode)
+		msg = tr.Tr.Get("Client error %s from HTTP %d", res.Request.URL, res.StatusCode)
 	} else {
-		msgFmt = tr.Tr.Get("Server error %%s from HTTP %d", res.StatusCode)
+		msg = tr.Tr.Get("Server error %s from HTTP %d", res.Request.URL, res.StatusCode)
 	}
 
-	return errors.Errorf(fmt.Sprintf(msgFmt), res.Request.URL)
+	return errors.New(msg)
 }

--- a/lfshttp/lfshttp.go
+++ b/lfshttp/lfshttp.go
@@ -84,7 +84,7 @@ func DecodeJSON(res *http.Response, obj interface{}) error {
 	res.Body.Close()
 
 	if err != nil {
-		return errors.Wrapf(err, tr.Tr.Get("Unable to parse HTTP response for %s %s", res.Request.Method, res.Request.URL))
+		return errors.Wrap(err, tr.Tr.Get("Unable to parse HTTP response for %s %s", res.Request.Method, res.Request.URL))
 	}
 
 	return nil

--- a/lfshttp/standalone/standalone.go
+++ b/lfshttp/standalone/standalone.go
@@ -290,13 +290,13 @@ func ProcessStandaloneData(cfg *config.Configuration, input *os.File, output *os
 	for scanner.Scan() {
 		var msg inputMessage
 		if err := json.NewDecoder(strings.NewReader(scanner.Text())).Decode(&msg); err != nil {
-			return errors.Wrapf(err, tr.Tr.Get("error decoding JSON"))
+			return errors.Wrap(err, tr.Tr.Get("error decoding JSON"))
 		}
 		if handler == nil {
 			var err error
 			handler, err = newHandler(cfg, output, &msg)
 			if err != nil {
-				err := errors.Wrapf(err, tr.Tr.Get("error creating handler"))
+				err := errors.Wrap(err, tr.Tr.Get("error creating handler"))
 				errMsg := outputErrorMessage{
 					Error: errorMessage{
 						Message: err.Error(),
@@ -314,7 +314,7 @@ func ProcessStandaloneData(cfg *config.Configuration, input *os.File, output *os
 		os.RemoveAll(handler.tempdir)
 	}
 	if err := scanner.Err(); err != nil {
-		return errors.Wrapf(err, tr.Tr.Get("error reading input"))
+		return errors.Wrap(err, tr.Tr.Get("error reading input"))
 	}
 	return nil
 }

--- a/lfshttp/standalone/standalone.go
+++ b/lfshttp/standalone/standalone.go
@@ -256,7 +256,7 @@ func (h *fileHandler) upload(oid string, size int64, path string) (string, strin
 func (h *fileHandler) download(oid string, size int64) (string, string, error) {
 	if !h.remoteConfig.LFSObjectExists(oid, size) {
 		tracerx.Printf("missing object in %q (%s)", h.remotePath, oid)
-		return oid, "", errors.Errorf(tr.Tr.Get("remote missing object %s", oid))
+		return oid, "", errors.New(tr.Tr.Get("remote missing object %s", oid))
 	}
 
 	src, err := h.remoteConfig.Filesystem().ObjectPath(oid)

--- a/locking/lockable.go
+++ b/locking/lockable.go
@@ -142,15 +142,15 @@ func (c *Client) FixLockableFileWriteFlags(files []string) error {
 		return nil
 	}
 
-	var errs []error
+	var multiErr error
 	for _, f := range files {
 		err := c.fixSingleFileWriteFlags(f, c.getLockableFilter(), nil)
 		if err != nil {
-			errs = append(errs, err)
+			multiErr = errors.Join(multiErr, err)
 		}
 	}
 
-	return errors.Combine(errs)
+	return multiErr
 }
 
 // fixSingleFileWriteFlags fixes write flags on a single file

--- a/ssh/connection.go
+++ b/ssh/connection.go
@@ -2,7 +2,6 @@ package ssh
 
 import (
 	"bytes"
-	"fmt"
 	"sync"
 
 	"github.com/git-lfs/git-lfs/v3/config"
@@ -80,7 +79,7 @@ func startConnection(id int, osEnv config.Environment, gitEnv config.Environment
 		r.Close()
 		w.Close()
 		cmd.Wait()
-		err = errors.Combine([]error{err, fmt.Errorf(tr.Tr.Get("Failed to connect to remote SSH server: %s", cmd.Stderr))})
+		err = errors.Combine([]error{err, errors.New(tr.Tr.Get("Failed to connect to remote SSH server: %s", cmd.Stderr))})
 		tracerx.Printf("pure SSH connection unsuccessful (#%d)", id)
 	} else {
 		tracerx.Printf("pure SSH connection successful (#%d)", id)

--- a/ssh/connection.go
+++ b/ssh/connection.go
@@ -79,7 +79,7 @@ func startConnection(id int, osEnv config.Environment, gitEnv config.Environment
 		r.Close()
 		w.Close()
 		cmd.Wait()
-		err = errors.Combine([]error{err, errors.New(tr.Tr.Get("Failed to connect to remote SSH server: %s", cmd.Stderr))})
+		err = errors.Join(err, errors.New(tr.Tr.Get("Failed to connect to remote SSH server: %s", cmd.Stderr)))
 		tracerx.Printf("pure SSH connection unsuccessful (#%d)", id)
 	} else {
 		tracerx.Printf("pure SSH connection successful (#%d)", id)

--- a/t/git-lfs-test-server-api/main.go
+++ b/t/git-lfs-test-server-api/main.go
@@ -74,7 +74,7 @@ func testServerApi(cmd *cobra.Command, args []string) {
 
 	manifest, err := buildManifest(repo)
 	if err != nil {
-		exit("error building tq.Manifest: " + err.Error())
+		exit("error building tq.Manifest: %s", err.Error())
 	}
 
 	var oidsExist, oidsMissing []TestObject

--- a/tasklog/simple_task.go
+++ b/tasklog/simple_task.go
@@ -28,7 +28,7 @@ func NewSimpleTask() *SimpleTask {
 
 // Log logs a string with no formatting verbs.
 func (s *SimpleTask) Log(str string) {
-	s.Logf(str)
+	s.Logf("%s", str)
 }
 
 // Logf logs some formatted string, which is interpreted according to the rules

--- a/tools/channels.go
+++ b/tools/channels.go
@@ -1,6 +1,6 @@
 package tools
 
-import "fmt"
+import "github.com/git-lfs/git-lfs/v3/errors"
 
 // Interface for all types of wrapper around a channel of results and an error channel
 // Implementors will expose a type-specific channel for results
@@ -17,18 +17,13 @@ type BaseChannelWrapper struct {
 }
 
 func (w *BaseChannelWrapper) Wait() error {
-	var err error
-	for e := range w.errorChan {
-		if err != nil {
-			// Combine in case multiple errors
-			err = fmt.Errorf("%v\n%v", err, e)
-
-		} else {
-			err = e
-		}
+	var multiErr error
+	for err := range w.errorChan {
+		// Combine in case multiple errors
+		multiErr = errors.Join(multiErr, err)
 	}
 
-	return err
+	return multiErr
 }
 
 func NewBaseChannelWrapper(errChan <-chan error) *BaseChannelWrapper {

--- a/tools/filetools.go
+++ b/tools/filetools.go
@@ -181,14 +181,14 @@ func ExpandPath(path string, expand bool) (string, error) {
 	}
 
 	if err != nil {
-		return "", errors.Wrapf(err, tr.Tr.Get("could not find user %s", username))
+		return "", errors.Wrap(err, tr.Tr.Get("could not find user %s", username))
 	}
 
 	homedir := who.HomeDir
 	if expand {
 		homedir, err = filepath.EvalSymlinks(homedir)
 		if err != nil {
-			return "", errors.Wrapf(err, tr.Tr.Get("cannot eval symlinks for %s", homedir))
+			return "", errors.Wrap(err, tr.Tr.Get("cannot eval symlinks for %s", homedir))
 		}
 	}
 	return filepath.Join(homedir, path[len(username)+1:]), nil

--- a/tq/basic_download.go
+++ b/tq/basic_download.go
@@ -118,7 +118,7 @@ func (a *basicDownloadAdapter) download(t *Transfer, cb ProgressCallback, authOk
 		return err
 	}
 	if rel == nil {
-		return errors.Errorf(tr.Tr.Get("Object %s not found on the server.", t.Oid))
+		return errors.New(tr.Tr.Get("Object %s not found on the server.", t.Oid))
 	}
 
 	req, err := a.newHTTPRequest("GET", rel)

--- a/tq/basic_download.go
+++ b/tq/basic_download.go
@@ -243,7 +243,7 @@ func (a *basicDownloadAdapter) download(t *Transfer, cb ProgressCallback, authOk
 	}
 	written, err := tools.CopyWithCallback(dlFile, hasher, res.ContentLength, ccb)
 	if err != nil {
-		return errors.Wrapf(err, tr.Tr.Get("cannot write data to temporary file %q", dlfilename))
+		return errors.Wrap(err, tr.Tr.Get("cannot write data to temporary file %q", dlfilename))
 	}
 
 	if actual := hasher.Hash(); actual != t.Oid {

--- a/tq/basic_upload.go
+++ b/tq/basic_upload.go
@@ -142,7 +142,7 @@ func (a *basicUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb Progres
 	}
 
 	if res.StatusCode > 299 {
-		return errors.Wrapf(nil, tr.Tr.Get("Invalid status for %s %s: %d",
+		return errors.New(tr.Tr.Get("Invalid status for %s %s: %d",
 			req.Method,
 			strings.SplitN(req.URL.String(), "?", 2)[0],
 			res.StatusCode,

--- a/tq/basic_upload.go
+++ b/tq/basic_upload.go
@@ -47,7 +47,7 @@ func (a *basicUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb Progres
 		return err
 	}
 	if rel == nil {
-		return errors.Errorf(tr.Tr.Get("No upload action for object: %s", t.Oid))
+		return errors.New(tr.Tr.Get("No upload action for object: %s", t.Oid))
 	}
 
 	req, err := a.newHTTPRequest("PUT", rel)

--- a/tq/custom.go
+++ b/tq/custom.go
@@ -272,7 +272,7 @@ func (a *customAdapter) DoTransfer(ctx interface{}, t *Transfer, cb ProgressCall
 		return err
 	}
 	if rel == nil && !a.standalone {
-		return errors.Errorf(tr.Tr.Get("Object %s not found on the server.", t.Oid))
+		return errors.New(tr.Tr.Get("Object %s not found on the server.", t.Oid))
 	}
 	var req *customAdapterTransferRequest
 	if a.direction == Upload {

--- a/tq/ssh.go
+++ b/tq/ssh.go
@@ -194,7 +194,7 @@ func (a *SSHAdapter) download(t *Transfer, workerNum int, cb ProgressCallback) e
 		return err
 	}
 	if rel == nil {
-		return errors.Errorf(tr.Tr.Get("No download action for object: %s", t.Oid))
+		return errors.New(tr.Tr.Get("No download action for object: %s", t.Oid))
 	}
 	// Reserve a temporary filename. We need to make sure nobody operates on the file simultaneously with us.
 	f, err := tools.TempFile(a.tempDir(), t.Oid, a.fs)
@@ -346,7 +346,7 @@ func (a *SSHAdapter) upload(t *Transfer, workerNum int, cb ProgressCallback) err
 		return err
 	}
 	if rel == nil {
-		return errors.Errorf(tr.Tr.Get("No upload action for object: %s", t.Oid))
+		return errors.New(tr.Tr.Get("No upload action for object: %s", t.Oid))
 	}
 
 	f, err := os.OpenFile(t.Path, os.O_RDONLY, 0644)

--- a/tq/ssh.go
+++ b/tq/ssh.go
@@ -267,7 +267,7 @@ func (a *SSHAdapter) doDownload(t *Transfer, workerNum int, f *os.File, cb Progr
 	hasher := tools.NewHashingReader(data)
 	written, err := tools.CopyWithCallback(f, hasher, t.Size, ccb)
 	if err != nil {
-		return errors.Wrapf(err, tr.Tr.Get("cannot write data to temporary file %q", dlfilename))
+		return errors.Wrap(err, tr.Tr.Get("cannot write data to temporary file %q", dlfilename))
 	}
 
 	if actual := hasher.Hash(); actual != t.Oid {

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -648,7 +648,7 @@ func (q *TransferQueue) enqueueAndCollectRetriesFor(batch batch) (batch, error) 
 			// Transfer object, then we give up on the
 			// transfer by telling the progress meter to
 			// skip the number of bytes in "o".
-			q.errorc <- errors.Errorf(tr.Tr.Get("[%v] The server returned an unknown OID.", o.Oid))
+			q.errorc <- errors.New(tr.Tr.Get("[%v] The server returned an unknown OID.", o.Oid))
 
 			q.Skip(o.Size)
 			q.wait.Done()
@@ -748,7 +748,7 @@ func (q *TransferQueue) partitionTransfers(transfers []*Transfer) (present []*Tr
 		var err error
 
 		if t.Size < 0 {
-			err = errors.Errorf(tr.Tr.Get("object %q has invalid size (got: %d)", t.Oid, t.Size))
+			err = errors.New(tr.Tr.Get("object %q has invalid size (got: %d)", t.Oid, t.Size))
 		} else {
 			fd, serr := os.Stat(t.Path)
 			if serr != nil {

--- a/tq/tus_upload.go
+++ b/tq/tus_upload.go
@@ -142,7 +142,7 @@ func (a *tusUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb ProgressC
 	}
 
 	if res.StatusCode > 299 {
-		return errors.Wrapf(nil, tr.Tr.Get("Invalid status for %s %s: %d",
+		return errors.New(tr.Tr.Get("Invalid status for %s %s: %d",
 			req.Method,
 			strings.SplitN(req.URL.String(), "?", 2)[0],
 			res.StatusCode,

--- a/tq/tus_upload.go
+++ b/tq/tus_upload.go
@@ -34,7 +34,7 @@ func (a *tusUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb ProgressC
 		return err
 	}
 	if rel == nil {
-		return errors.Errorf(tr.Tr.Get("No upload action for object: %s", t.Oid))
+		return errors.New(tr.Tr.Get("No upload action for object: %s", t.Oid))
 	}
 
 	// Note not supporting the Creation extension since the batch API generates URLs


### PR DESCRIPTION
As described in #5968, when we upgrade to Go 1.24, and when we bump the Go version number in our `go.mod` file to 1.24 or higher, the `go vet` command will identify instances where we pass a non-constant value as the format string parameter to a formatting function such as `fmt.Sprintf()`.  This feature was implemented by the change in golang/go#60529 and is [noted](https://tip.golang.org/doc/go1.24#vet) in the Go 1.24 release documentation.

Some of the misuses of format functions in our code result from the introduction of our localization support in PR #4781, as in this [instance](https://github.com/git-lfs/git-lfs/blob/aa0ca91e2287d4b7b9e060e7141a61531290113e/commands/command_migrate_import.go#L458), because as shown below we moved format strings and their accompanying arguments into our message localization function, but did not change the existing string formatting function into one which only accepts a fixed string.

```diff
-		return nil, errors.Errorf("error parsing path %s", path)
+		return nil, errors.Errorf(tr.Tr.Get("error parsing path %s", path))
```

In other instances, though, this problem predates PR #4781, such as in this [example](https://github.com/git-lfs/git-lfs/blob/aa0ca91e2287d4b7b9e060e7141a61531290113e/commands/command_pointer.go#L132) where we accidentally used a formatting function with an non-constant, dynamic value.

Before addressing these issues, we first ensure one additional [message](https://github.com/git-lfs/git-lfs/blob/aa0ca91e2287d4b7b9e060e7141a61531290113e/lfs/gitfilter_smudge.go#L179) output by our `smudge` filter is fully localizable, as we currently allow translation for only a portion of the message.

Next, we fully resolve the problem reported in PR #5822, where we return an error message with multiple format error markers of the form `&{...}s(MISSING)` when we encounter an HTTP status code that does not have a specific error message [defined](https://github.com/git-lfs/git-lfs/blob/aa0ca91e2287d4b7b9e060e7141a61531290113e/lfshttp/errors.go#L107-L118) in the `defaultError()` function of our `lfshttp` package.  This behaviour stems from the final steps in the function, where we [call](https://github.com/git-lfs/git-lfs/blob/aa0ca91e2287d4b7b9e060e7141a61531290113e/lfshttp/errors.go#L127) `fmt.Sprintf()` on a format string which contains a `%s` verb, but do not pass an argument to be interpolated into that verb.  We call that function without arguments other than a format string in an attempt to work around the issue reported in leonelquinteros/gotext#57.

While the changes proposed in PR #5822 fix this issue for the generic error messages we [use](https://github.com/git-lfs/git-lfs/blob/aa0ca91e2287d4b7b9e060e7141a61531290113e/lfshttp/errors.go#L121-L125) when an HTTP status code is not one for which a specific message is defined, it introduces a similar problem for those code-specific messages.  To completely resolve these issues, we refactor our `defaultError()` function so we avoid the use of our message localization function until we have selected an error message.  This obviates any need for doubly-escaped format string verbs like `%%s` or for the use of any formatting functions other than the localization function.

With those initial corrections in place, in a series of commits we then revise all the instances where we pass a dynamic value as the format string to a formatting function.  Each commit corrects the all misuses of a given formatting function, such as `fmt.Fprintf()` or the `Errorf()` and `Wrapf()` functions from our custom `errors` package.

The last of these commits removes the `Combine()` [function](https://github.com/git-lfs/git-lfs/blob/aa0ca91e2287d4b7b9e060e7141a61531290113e/errors/errors.go#L105-L118) from our `errors` package and replaces it with a `Join()` function that simply invokes the `Join()` [function](https://pkg.go.dev/errors#Join) that was added to the standard library's `errors` package in Go 1.20.  This change has the advantage that it eliminates the [call](https://github.com/git-lfs/git-lfs/blob/aa0ca91e2287d4b7b9e060e7141a61531290113e/errors/errors.go#L117) at the end of our `Combine()` function where we pass a dynamic string value to our `Errorf()` function.  We then update the [two](https://github.com/git-lfs/git-lfs/blob/aa0ca91e2287d4b7b9e060e7141a61531290113e/ssh/connection.go#L83) [locations](https://github.com/git-lfs/git-lfs/blob/aa0ca91e2287d4b7b9e060e7141a61531290113e/locking/lockable.go#L153) where we call the `Combine()` function to use our new `Join()` function instead.

We next refactor a number of instances throughout our code where we collect multiple errors and combine them into a single error.  In all these cases, we now use the new `Join()` function in our `errors` package.  Note that we could have used the `Combine()` function to do this in the past, but did not take advantage of that option, and this PR provides an opportunity to make these simplifications.

To further streamline our `errors` package, we also remove the `StackTrace()` [function](https://github.com/git-lfs/git-lfs/blob/aa0ca91e2287d4b7b9e060e7141a61531290113e/errors/errors.go#L88-L103) function, as it has not been used since PR #2178.

Finally, we update our `go.mod` file to use the latest version of the Go package from our `git-lfs/go-netrc` repository, which includes the correction in PR git-lfs/go-netrc#3 of another use of a non-constant format string, and run `go mod tidy` to update the corresponding `go.sum` file.

This PR will be most easily reviewed on a commit-by-commit basis, as each commit in this PR represents a discrete and logically related set of changes accompanied by a detailed description.

---

This PR includes the work from PR #5822 and resolves the issue reported in that PR.
Resolves #5968.

/cc @philip-peterson as the author of PR #5822
/cc @QuLogic as the reporter of #5968