### PR TITLE
Replace min/max helpers with built-in min/max

### DIFF
--- a/commands/command_locks.go
+++ b/commands/command_locks.go
@@ -9,7 +9,6 @@ import (
 	"github.com/git-lfs/git-lfs/v3/errors"
 	"github.com/git-lfs/git-lfs/v3/git"
 	"github.com/git-lfs/git-lfs/v3/locking"
-	"github.com/git-lfs/git-lfs/v3/tools"
 	"github.com/git-lfs/git-lfs/v3/tr"
 	"github.com/spf13/cobra"
 )
@@ -96,9 +95,9 @@ func locksCommand(cmd *cobra.Command, args []string) {
 	for _, lock := range locks {
 		lockPaths = append(lockPaths, lock.Path)
 		locksByPath[lock.Path] = lock
-		maxPathLen = tools.MaxInt(maxPathLen, len(lock.Path))
+		maxPathLen = max(maxPathLen, len(lock.Path))
 		if lock.Owner != nil {
-			maxNameLen = tools.MaxInt(maxNameLen, len(lock.Owner.Name))
+			maxNameLen = max(maxNameLen, len(lock.Owner.Name))
 		}
 	}
 
@@ -110,8 +109,8 @@ func locksCommand(cmd *cobra.Command, args []string) {
 			ownerName = lock.Owner.Name
 		}
 
-		pathPadding := tools.MaxInt(maxPathLen-len(lock.Path), 0)
-		namePadding := tools.MaxInt(maxNameLen-len(ownerName), 0)
+		pathPadding := max(maxPathLen-len(lock.Path), 0)
+		namePadding := max(maxNameLen-len(ownerName), 0)
 		kind := ""
 		if locksOwned != nil {
 			if locksOwned[lock] {

--- a/git/githistory/ref_updater.go
+++ b/git/githistory/ref_updater.go
@@ -8,7 +8,6 @@ import (
 	"github.com/git-lfs/git-lfs/v3/errors"
 	"github.com/git-lfs/git-lfs/v3/git"
 	"github.com/git-lfs/git-lfs/v3/tasklog"
-	"github.com/git-lfs/git-lfs/v3/tools"
 	"github.com/git-lfs/git-lfs/v3/tr"
 	"github.com/git-lfs/gitobj/v2"
 )
@@ -45,7 +44,7 @@ func (r *refUpdater) UpdateRefs() error {
 
 	var maxNameLen int
 	for _, ref := range r.Refs {
-		maxNameLen = tools.MaxInt(maxNameLen, len(ref.Name))
+		maxNameLen = max(maxNameLen, len(ref.Name))
 	}
 
 	seen := make(map[string]struct{})
@@ -143,7 +142,7 @@ func (r *refUpdater) updateOneRef(list *tasklog.ListTask, maxNameLen int, seen m
 		return err
 	}
 
-	namePadding := tools.MaxInt(maxNameLen-len(ref.Name), 0)
+	namePadding := max(maxNameLen-len(ref.Name), 0)
 	list.Entry(fmt.Sprintf("  %s%s\t%s -> %x", ref.Name, strings.Repeat(" ", namePadding), ref.Sha, to))
 	return nil
 }

--- a/lfshttp/client.go
+++ b/lfshttp/client.go
@@ -21,7 +21,6 @@ import (
 	"github.com/git-lfs/git-lfs/v3/config"
 	"github.com/git-lfs/git-lfs/v3/creds"
 	"github.com/git-lfs/git-lfs/v3/errors"
-	"github.com/git-lfs/git-lfs/v3/tools"
 	"github.com/git-lfs/git-lfs/v3/tr"
 	"github.com/rubyist/tracerx"
 	"golang.org/x/net/http2"
@@ -215,7 +214,7 @@ func (c *Client) sshResolveWithRetries(e Endpoint, method string) (*sshAuthRespo
 		return nil, errors.New("git-lfs-authenticate has been disabled by request")
 	}
 
-	requests := tools.MaxInt(0, c.sshTries) + 1
+	requests := max(0, c.sshTries) + 1
 	for i := 0; i < requests; i++ {
 		sshRes, err = c.SSH.Resolve(e, method)
 		if err == nil {
@@ -293,7 +292,7 @@ func (c *Client) DoWithRedirect(cli *http.Client, req *http.Request, remote stri
 
 	var res *http.Response
 
-	requests := tools.MaxInt(0, retries) + 1
+	requests := max(0, retries) + 1
 	for i := 0; i < requests; i++ {
 		res, err = cli.Do(req)
 		if err == nil {

--- a/lfshttp/stats.go
+++ b/lfshttp/stats.go
@@ -11,8 +11,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-
-	"github.com/git-lfs/git-lfs/v3/tools"
 )
 
 type httpTransfer struct {
@@ -140,11 +138,11 @@ func (l *syncLogger) LogResponse(req *http.Request, status int, bodySize int64) 
 			fmt.Sprintf(" status=%d body=%d conntime=%d dnstime=%d tlstime=%d restime=%d time=%d",
 				status,
 				bodySize,
-				tools.MaxInt64(t.ConnEnd-t.ConnStart, 0),
-				tools.MaxInt64(t.DNSEnd-t.DNSStart, 0),
-				tools.MaxInt64(t.TLSEnd-t.TLSStart, 0),
-				tools.MaxInt64(now-t.ResponseStart, 0),
-				tools.MaxInt64(now-t.Start, 0),
+				max(t.ConnEnd-t.ConnStart, 0),
+				max(t.DNSEnd-t.DNSStart, 0),
+				max(t.TLSEnd-t.TLSStart, 0),
+				max(now-t.ResponseStart, 0),
+				max(now-t.Start, 0),
 			))
 	}
 }

--- a/tasklog/log.go
+++ b/tasklog/log.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/git-lfs/git-lfs/v3/tools"
 	isatty "github.com/mattn/go-isatty"
 	"github.com/olekukonko/ts"
 )
@@ -254,7 +253,7 @@ func (l *Logger) logTask(task Task) {
 // It returns the number of bytes "n" written to the sink and the error "err",
 // if one was encountered.
 func (l *Logger) logLine(str string) (n int, err error) {
-	padding := strings.Repeat(" ", tools.MaxInt(0, l.widthFn()-len(str)))
+	padding := strings.Repeat(" ", max(0, l.widthFn()-len(str)))
 
 	return l.log(str + padding + "\r")
 }

--- a/tools/math.go
+++ b/tools/math.go
@@ -1,42 +1,6 @@
 package tools
 
-// MinInt returns the smaller of two `int`s, "a", or "b".
-func MinInt(a, b int) int {
-	if a < b {
-		return a
-	}
-
-	return b
-}
-
-// MaxInt returns the greater of two `int`s, "a", or "b".
-func MaxInt(a, b int) int {
-	if a > b {
-		return a
-	}
-
-	return b
-}
-
-// ClampInt returns the integer "n" bounded between "min" and "max".
-func ClampInt(n, min, max int) int {
-	return MinInt(max, MaxInt(min, n))
-}
-
-// MinInt64 returns the smaller of two `int`s, "a", or "b".
-func MinInt64(a, b int64) int64 {
-	if a < b {
-		return a
-	}
-
-	return b
-}
-
-// MaxInt64 returns the greater of two `int`s, "a", or "b".
-func MaxInt64(a, b int64) int64 {
-	if a > b {
-		return a
-	}
-
-	return b
+// ClampInt returns the integer "n" bounded between "low" and "high".
+func ClampInt(n, low, high int) int {
+	return min(high, max(low, n))
 }

--- a/tools/math_test.go
+++ b/tools/math_test.go
@@ -6,14 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMinIntPicksTheSmallerInt(t *testing.T) {
-	assert.Equal(t, -1, MinInt(-1, 1))
-}
-
-func TestMaxIntPicksTheBiggertInt(t *testing.T) {
-	assert.Equal(t, 1, MaxInt(-1, 1))
-}
-
 func TestClampDiscardsIntsLowerThanMin(t *testing.T) {
 	assert.Equal(t, 0, ClampInt(-1, 0, 1))
 }

--- a/tools/ordered_set.go
+++ b/tools/ordered_set.go
@@ -109,7 +109,7 @@ func (s *OrderedSet) Union(other *OrderedSet) *OrderedSet {
 // Intersect returns the elements that are in both this set and then given
 // "ordered" set. It is an O(min(n, m)) (in other words, O(n)) operation.
 func (s *OrderedSet) Intersect(other *OrderedSet) *OrderedSet {
-	intersection := NewOrderedSetWithCapacity(MinInt(
+	intersection := NewOrderedSetWithCapacity(min(
 		s.Cardinality(), other.Cardinality()))
 
 	if s.Cardinality() < other.Cardinality() {
@@ -163,7 +163,7 @@ func (s *OrderedSet) Remove(i string) {
 		return
 	}
 
-	rest := MinInt(idx+1, len(s.s)-1)
+	rest := min(idx+1, len(s.s)-1)
 
 	s.s = append(s.s[:idx], s.s[rest:]...)
 	for _, e := range s.s[rest:] {

--- a/tools/str_tools.go
+++ b/tools/str_tools.go
@@ -57,7 +57,7 @@ func Ljust(strs []string) []string {
 	copy(dup, strs)
 
 	for i, str := range strs {
-		width := MaxInt(0, llen-len(str))
+		width := max(0, llen-len(str))
 		padding := strings.Repeat(" ", width)
 
 		dup[i] = str + padding
@@ -75,7 +75,7 @@ func Rjust(strs []string) []string {
 	copy(dup, strs)
 
 	for i, str := range strs {
-		width := MaxInt(0, llen-len(str))
+		width := max(0, llen-len(str))
 		padding := strings.Repeat(" ", width)
 
 		dup[i] = padding + str

--- a/tq/meter.go
+++ b/tq/meter.go
@@ -241,26 +241,16 @@ func (m *Meter) str() string {
 		percentage,
 		m.finishedFiles, m.estimatedFiles,
 		humanize.FormatBytes(clamp(m.currentBytes)),
-		humanize.FormatByteRate(clampf(m.avgBytes), time.Second))
+		humanize.FormatByteRate(clamp(m.avgBytes), time.Second))
 }
 
 // clamp clamps the given "x" within the acceptable domain of the uint64 integer
 // type, so as to prevent over- and underflow.
-func clamp(x int64) uint64 {
+func clamp[T int64 | float64](x T) uint64 {
 	if x < 0 {
 		return 0
 	}
 	if x > math.MaxInt64 {
-		return math.MaxUint64
-	}
-	return uint64(x)
-}
-
-func clampf(x float64) uint64 {
-	if x < 0 {
-		return 0
-	}
-	if x > math.MaxUint64 {
 		return math.MaxUint64
 	}
 	return uint64(x)

--- a/tq/meter.go
+++ b/tq/meter.go
@@ -241,16 +241,26 @@ func (m *Meter) str() string {
 		percentage,
 		m.finishedFiles, m.estimatedFiles,
 		humanize.FormatBytes(clamp(m.currentBytes)),
-		humanize.FormatByteRate(clamp(m.avgBytes), time.Second))
+		humanize.FormatByteRate(clampf(m.avgBytes), time.Second))
 }
 
 // clamp clamps the given "x" within the acceptable domain of the uint64 integer
 // type, so as to prevent over- and underflow.
-func clamp[T int64 | float64](x T) uint64 {
+func clamp(x int64) uint64 {
 	if x < 0 {
 		return 0
 	}
 	if x > math.MaxInt64 {
+		return math.MaxUint64
+	}
+	return uint64(x)
+}
+
+func clampf(x float64) uint64 {
+	if x < 0 {
+		return 0
+	}
+	if x > math.MaxUint64 {
 		return math.MaxUint64
 	}
 	return uint64(x)

--- a/tq/verify.go
+++ b/tq/verify.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	"github.com/git-lfs/git-lfs/v3/lfsapi"
-	"github.com/git-lfs/git-lfs/v3/tools"
 	"github.com/rubyist/tracerx"
 )
 
@@ -42,7 +41,7 @@ func verifyUpload(c *lfsapi.Client, remote string, t *Transfer) error {
 	}
 
 	mv := c.GitEnv().Int(maxVerifiesConfigKey, defaultMaxVerifyAttempts)
-	mv = tools.MaxInt(defaultMaxVerifyAttempts, mv)
+	mv = max(defaultMaxVerifyAttempts, mv)
 	req = c.LogRequest(req, "lfs.verify")
 
 	for i := 1; i <= mv; i++ {


### PR DESCRIPTION
We can use the built-in `min` and `max` functions since Go 1.21.

Reference: https://go.dev/ref/spec#Min_and_max