### PR TITLE
doc: Add missing "--to" argument in git-lfs-checkout example

### DIFF
--- a/docs/man/git-lfs-checkout.adoc
+++ b/docs/man/git-lfs-checkout.adoc
@@ -69,8 +69,8 @@ $ git merge conflicting-branch
 CONFLICT (content): Merge conflict in path/to/conflicting/file.dat
 
 # Checkout versions of the conflicting file into temp files
-$ git lfs checkout ours.dat --ours path/to/conflicting/file.dat
-$ git lfs checkout theirs.dat --theirs path/to/conflicting/file.dat
+$ git lfs checkout --to ours.dat --ours path/to/conflicting/file.dat
+$ git lfs checkout --to theirs.dat --theirs path/to/conflicting/file.dat
 
 # Compare conflicting versions in ours.dat and theirs.dat,
 # then resolve conflict (e.g., by choosing one version over


### PR DESCRIPTION
While looking into coding a solution for #5990, I stumbled upon an issue in the docs for the `checkout` command.

If you try to run the commands for the `--ours` and `--theirs` examples, it will error out complaining about missing the `--to` flag. So I added it to the doc example.