### PR TITLE
Detect and react to potential conflict markers in pointer files

### DIFF
--- a/commands/command_clean.go
+++ b/commands/command_clean.go
@@ -61,6 +61,14 @@ func clean(gf *lfs.GitFilter, to io.Writer, from io.Reader, fileName string, fil
 
 		_, err = to.Write(errors.GetContext(err, "bytes").([]byte))
 		return nil, err
+	} else if errors.IsPointerConflictMarkerError(err) {
+		// If the contents read from the working directory are the
+		// result of a merge conflict between two pointers, we'll get
+		// a `PointerConflictMarkerError` with the context containing
+		// the data that we should write back out to Git.
+
+		_, err = io.Copy(to, errors.GetContext(err, "reader").(io.Reader))
+		return nil, err
 	}
 
 	if err != nil {

--- a/commands/pull.go
+++ b/commands/pull.go
@@ -103,7 +103,7 @@ func (c *singleCheckout) Run(p *lfs.WrappedPointer) {
 				return
 			}
 		} else {
-			if errors.IsNotAPointerError(err) || errors.IsBadPointerKeyError(err) {
+			if errors.IsNotAPointerError(err) || errors.IsBadPointerKeyError(err) || errors.IsPointerConflictMarkerError(err) {
 				// File has non-pointer content, leave it alone
 				return
 			}

--- a/commands/pull.go
+++ b/commands/pull.go
@@ -103,7 +103,7 @@ func (c *singleCheckout) Run(p *lfs.WrappedPointer) {
 				return
 			}
 		} else {
-			if errors.IsNotAPointerError(err) || errors.IsBadPointerKeyError(err) || errors.IsPointerConflictMarkerError(err) {
+			if errors.IsNotAPointerError(err) || errors.IsPointerConflictMarkerError(err) {
 				// File has non-pointer content, leave it alone
 				return
 			}

--- a/errors/types.go
+++ b/errors/types.go
@@ -94,6 +94,19 @@ func IsNotAPointerError(err error) bool {
 	return false
 }
 
+// IsPointerConflictMarkerError indicates that there are conflict markers in the LFS pointer file.
+func IsPointerConflictMarkerError(err error) bool {
+	if e, ok := err.(interface {
+		PointerConflictMarkerError() bool
+	}); ok {
+		return e.PointerConflictMarkerError()
+	}
+	if parent := parentOf(err); parent != nil {
+		return IsPointerConflictMarkerError(parent)
+	}
+	return false
+}
+
 // IsNotAPointerError indicates the parsed data is not an LFS pointer.
 func IsPointerScanError(err error) bool {
 	if e, ok := err.(interface {
@@ -347,6 +360,20 @@ func (e notAPointerError) NotAPointerError() bool {
 
 func NewNotAPointerError(err error) error {
 	return notAPointerError{newWrappedError(err, tr.Tr.Get("Pointer file error"))}
+}
+
+// Definitions for IsPointerConflictMarkerError()
+
+type pointerConflictMarkerError struct {
+	*wrappedError
+}
+
+func (e pointerConflictMarkerError) PointerConflictMarkerError() bool {
+	return true
+}
+
+func NewPointerConflictMarkerError(err error) error {
+	return pointerConflictMarkerError{newWrappedError(err, tr.Tr.Get("Pointer file conflict marker error"))}
 }
 
 // Definitions for IsPointerScanError()

--- a/lfs/gitfilter_clean.go
+++ b/lfs/gitfilter_clean.go
@@ -80,7 +80,7 @@ func (f *GitFilter) copyToTemp(reader io.Reader, fileSize int64, cb tools.CopyCa
 	n, rerr := buf.Read(by)
 	by = by[:n]
 
-	if rerr != nil || (err == nil && len(by) < blobSizeCutoff) {
+	if rerr != nil || errors.IsPointerConflictMarkerError(err) || (err == nil && len(by) < blobSizeCutoff) {
 		err = errors.NewCleanPointerError(ptr, by)
 		return
 	}

--- a/lfs/gitfilter_clean.go
+++ b/lfs/gitfilter_clean.go
@@ -80,7 +80,7 @@ func (f *GitFilter) copyToTemp(reader io.Reader, fileSize int64, cb tools.CopyCa
 	n, rerr := buf.Read(by)
 	by = by[:n]
 
-	if rerr != nil || errors.IsPointerConflictMarkerError(err) || (err == nil && len(by) < blobSizeCutoff) {
+	if rerr != nil || (err == nil && len(by) < blobSizeCutoff) {
 		err = errors.NewCleanPointerError(ptr, by)
 		return
 	}
@@ -90,6 +90,11 @@ func (f *GitFilter) copyToTemp(reader io.Reader, fileSize int64, cb tools.CopyCa
 		// If there is still more data to be read from the file, tack on
 		// the original reader and continue the read from there.
 		from = io.MultiReader(from, reader)
+	}
+
+	if errors.IsPointerConflictMarkerError(err) {
+		errors.SetContext(err, "reader", from)
+		return
 	}
 
 	size, err = tools.CopyWithCallback(writer, from, fileSize, cb)

--- a/lfs/pointer.go
+++ b/lfs/pointer.go
@@ -276,6 +276,16 @@ func decodeKVData(data []byte) (kvps map[string]string, exts map[string]string, 
 			continue
 		}
 
+		if strings.HasPrefix(text, "<") {
+			err = verifyVersion(kvps["version"])
+			if err == nil {
+				err = errors.NewPointerConflictMarkerError(errors.New(tr.Tr.Get("found potential conflict marker on line %d: %s", line, text)))
+				return
+			}
+			err = errors.NewNotAPointerError(errors.New(tr.Tr.Get("error reading line %d: %s", line, text)))
+			return
+		}
+
 		parts := strings.SplitN(text, " ", 2)
 		if len(parts) < 2 {
 			err = errors.NewNotAPointerError(errors.New(tr.Tr.Get("error reading line %d: %s", line, text)))

--- a/lfs/pointer.go
+++ b/lfs/pointer.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -268,24 +269,35 @@ func decodeKVData(data []byte) (kvps map[string]string, exts map[string]string, 
 	}
 
 	scanner := bufio.NewScanner(bytes.NewBuffer(data))
-	line := 0
-	numKeys := len(pointerKeys)
+	foundConflictMarker := false
+
+	var text_lines []string
 	for scanner.Scan() {
 		text := scanner.Text()
 		if len(text) == 0 {
 			continue
 		}
 
-		if strings.HasPrefix(text, "<") {
-			err = verifyVersion(kvps["version"])
-			if err == nil {
-				err = errors.NewPointerConflictMarkerError(errors.New(tr.Tr.Get("found potential conflict marker on line %d: %s", line, text)))
-				return
-			}
-			err = errors.NewNotAPointerError(errors.New(tr.Tr.Get("error reading line %d: %s", line, text)))
-			return
+		// Check for any potential confilct markers. ('|' marker can appear if changing merge.conflictStyle to "diff3").
+		// We only check the first character as the length of the conflict markers can be changed.
+		// We do not return early to make sure that the file actually seems to be a pointer file first.
+		switch text[0] {
+		case '<', '>', '=', '|':
+			foundConflictMarker = true
+			continue
 		}
 
+		text_lines = append(text_lines, text)
+	}
+
+	err = scanner.Err()
+	if err != nil {
+		return
+	}
+
+	line := 0
+	numKeys := len(pointerKeys)
+	for _, text := range text_lines {
 		parts := strings.SplitN(text, " ", 2)
 		if len(parts) < 2 {
 			err = errors.NewNotAPointerError(errors.New(tr.Tr.Get("error reading line %d: %s", line, text)))
@@ -294,6 +306,15 @@ func decodeKVData(data []byte) (kvps map[string]string, exts map[string]string, 
 
 		key := parts[0]
 		value := parts[1]
+
+		if foundConflictMarker {
+			if slices.Contains(pointerKeys, key) {
+				kvps[key] = value
+				continue
+			}
+			err = errors.NewNotAPointerError(errors.New(tr.Tr.Get("not a git-lfs pointer key on line %d: %s", line, text)))
+			return
+		}
 
 		if numKeys <= line {
 			err = errors.NewNotAPointerError(errors.New(tr.Tr.Get("extra line: %s", text)))
@@ -316,6 +337,15 @@ func decodeKVData(data []byte) (kvps map[string]string, exts map[string]string, 
 		kvps[key] = value
 	}
 
-	err = scanner.Err()
+	if foundConflictMarker {
+		if len(kvps) != numKeys {
+			// Not all pointer keys were present, not a pointer file.
+			err = errors.NewNotAPointerError(errors.New(tr.Tr.Get("Not all required pointer keys were present.")))
+			return
+		}
+		err = errors.NewPointerConflictMarkerError(errors.New(tr.Tr.Get("found potential conflict markers in pointer file.")))
+		return
+	}
+
 	return
 }

--- a/lfs/pointer.go
+++ b/lfs/pointer.go
@@ -312,6 +312,12 @@ func decodeKVData(data []byte) (kvps map[string]string, exts map[string]string, 
 				kvps[key] = value
 				continue
 			}
+			if extRE.MatchString(key) {
+				// The pointer file can contain custom extention entries.
+				// However we do not record if these are present or not as
+				// we only care if all standard keys as these are optional.
+				continue
+			}
 			err = errors.NewNotAPointerError(errors.New(tr.Tr.Get("not a git-lfs pointer key on line %d: %s", line, text)))
 			return
 		}

--- a/lfs/pointer.go
+++ b/lfs/pointer.go
@@ -278,7 +278,7 @@ func decodeKVData(data []byte) (kvps map[string]string, exts map[string]string, 
 			continue
 		}
 
-		// Check for any potential confilct markers. ('|' marker can appear if changing merge.conflictStyle to "diff3").
+		// Check for any potential conflict markers. ('|' marker can appear if changing merge.conflictStyle to "diff3").
 		// We only check the first character as the length of the conflict markers can be changed.
 		// We do not return early to make sure that the file actually seems to be a pointer file first.
 		switch text[0] {

--- a/lfs/pointer_test.go
+++ b/lfs/pointer_test.go
@@ -344,6 +344,149 @@ size 177735`,
 	}
 }
 
+func TestDecodeConflictMarkers(t *testing.T) {
+	// NOTE: The conflict markers examples are mostly single character examples here because of the configurable length.
+	examples := []string{
+		// Real work example
+		`version https://git-lfs.github.com/spec/v1
+<<<<<<< Updated upstream
+oid sha256:7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730
+=======
+oid sha256:bf07a7fbb825fc0aae7bf4a1177b2b31fcf8a3feeaf7092761e18c859ee52a9c
+>>>>>>> Stashed changes
+size 4`,
+
+		// very short conflict markers
+		`version https://git-lfs.github.com/spec/v1
+< Updated upstream
+oid sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+=
+oid sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+> Stashed changes
+size 4`,
+
+		// No conflict comments/hint strings
+		`version https://git-lfs.github.com/spec/v1
+<
+oid sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+=
+oid sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+>
+size 4`,
+
+		// Partially removed conflict markers
+		`version https://git-lfs.github.com/spec/v1
+oid sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+=
+oid sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+>
+size 4`,
+
+		`version https://git-lfs.github.com/spec/v1
+oid sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+oid sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+>
+size 4`,
+
+		`version https://git-lfs.github.com/spec/v1
+<
+oid sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+oid sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+size 4`,
+
+		`version https://git-lfs.github.com/spec/v1
+oid sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+=
+oid sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+size 4`,
+
+		// Test that multiple conflict markers and git-lfs entries can exist
+		// (For compounding merge conflicts)
+		`<
+version https://git-lfs.github.com/spec/v1
+=
+version https://git-lfs.github.com/spec/v2
+<
+>
+oid sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+=
+oid sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+>
+<
+size 10
+=
+size 4
+<`,
+
+		// Test "diff3" style conflict markers
+		`version https://git-lfs.github.com/spec/v1
+<
+oid sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+|
+oid sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+=
+oid sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+>
+size 4`,
+
+		`version https://git-lfs.github.com/spec/v1
+oid sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+|
+oid sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+size 4`,
+	}
+
+	for _, ex := range examples {
+		_, err := DecodePointer(bytes.NewBufferString(ex))
+		if err == nil || !errors.IsPointerConflictMarkerError(err) {
+			t.Errorf("No conflict marker detected. From:\n%s", strings.TrimSpace(ex))
+		}
+	}
+}
+
+func TestDecodeConflictMarkersInvalid(t *testing.T) {
+	// NOTE: The conflict markers examples are mostly single character examples here because of the configurable length.
+	examples := []string{
+		// No git-lfs version string
+		`<
+oid sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+=
+oid sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+>
+size 4`,
+
+		// No size
+		`version https://git-lfs.github.com/spec/v1
+<
+oid sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+=
+oid sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+>`,
+
+		// No oid
+		`version https://git-lfs.github.com/spec/v1
+<
+=
+>
+size 4`,
+
+		// Only markers
+		`<
+|
+=
+>`,
+	}
+
+	for _, ex := range examples {
+		_, err := DecodePointer(bytes.NewBufferString(ex))
+		if err == nil {
+			t.Errorf("No error detected from:\n%s", strings.TrimSpace(ex))
+		} else if errors.IsPointerConflictMarkerError(err) {
+			t.Errorf("Erroneous conflict marker error was detected from:\n%s", strings.TrimSpace(ex))
+		}
+	}
+}
+
 func assertEqualWithExample(t *testing.T, example string, expected, actual interface{}) {
 	assert.Equal(t, expected, actual, "Example:\n%s", strings.TrimSpace(example))
 }

--- a/t/t-clean.sh
+++ b/t/t-clean.sh
@@ -108,3 +108,16 @@ begin_test "clean stdin"
   fi
 )
 end_test
+
+begin_test "clean: pointer merge conflict detected and not converted"
+(
+  set -e
+
+  setup_local_repo_with_merge_conflict "clean-merge-conflict" \
+    "test.bin" "other" "other" "main"
+
+  # Check that an unresolved merge conflict is not converted
+  # to a Git LFS object.
+  diff -u "test.bin" <(git lfs clean <"test.bin")
+)
+end_test

--- a/t/t-filter-process.sh
+++ b/t/t-filter-process.sh
@@ -317,3 +317,74 @@ begin_test "filter process: git archive does not invoke SSH"
   true
 )
 end_test
+
+begin_test "filter process: pointer merge conflict detected and not converted"
+(
+  set -e
+
+  setup_local_repo_with_merge_conflict "filter-process-merge-conflict" \
+    "test.bin" "other" "other" "main"
+
+  # Git will choose "filter.lfs.process" over "filter.lfs.clean".
+  git config --global --unset filter.lfs.clean
+
+  # Check that conflicts are detected by Git correctly.
+  git diff --check 2>&1 | tee diff.log
+  [ 2 -eq "${PIPESTATUS[0]}" ]
+
+  [ 3 -eq "$(grep -c "leftover conflict marker" diff.log)" ]
+
+  contents_oid="$(calc_oid_file "test.bin")"
+
+  # Check that an unresolved merge conflict is not converted
+  # to a Git LFS object.
+  git add test.bin
+  git commit -m "commit with merge conflict"
+
+  refute_local_object "$contents_oid"
+)
+end_test
+
+begin_test "filter process: partially fixed merge conflict is still detected"
+(
+  set -e
+
+  setup_local_repo_with_merge_conflict "filter-process-partially-fixed-merge-conflict" \
+    "test.bin" "other" "other" "main"
+
+  cp test.bin test.bin_bak
+
+  # Define conflict marker removal patterns for us to try
+  patterns=(
+  '^[<]'
+  '^[=]'
+  '^[>]'
+  '^[<=]'
+  '^[<>]'
+  '^[=>]'
+  '^[<=>]'
+  )
+
+  i=1
+  for pattern in "${patterns[@]}"; do
+      echo "Partially removing conflict markers with: $pattern"
+      sed -e "/$pattern/d" test.bin_bak > test.bin
+      if [ $i -lt ${#patterns[@]} ]; then
+        # Check that the remaining conflict markers are still detected by git
+        git diff --check 2>&1 | tee diff.log
+        [ 2 -eq "${PIPESTATUS[0]}" ]
+
+        # There should be three conflict markers in the file to start with.
+        # We can calculate how many should be left with the pattern string length.
+        # There a three characters in the pattern besides the conflict markers,
+        conflict_markers_left=$((3 + 3 - ${#pattern}))
+        [ $conflict_markers_left -eq "$(grep -c "leftover conflict marker" diff.log)" ]
+      else
+        # All conflict markers should have been removed so check that none are detected
+        git diff --check 2>&1 | tee diff.log
+        [ 0 -eq "${PIPESTATUS[0]}" ]
+      fi
+      ((i++))
+  done
+)
+end_test

--- a/t/t-pointer.sh
+++ b/t/t-pointer.sh
@@ -688,3 +688,26 @@ begin_test "pointer: incorrectly resolved merge conflict results in invalid poin
   true
 )
 end_test
+
+begin_test "pointer: merge conflict detected with lfs extension"
+(
+  set -e
+
+  # Setup custom extentions so the the pointer file contains additional "ext-0-" entries
+  git init pointer-merge-conflict-with-ext
+  cd pointer-merge-conflict-with-ext
+  setup_case_inverter_extension
+  cd ..
+
+  setup_local_repo_with_merge_conflict "pointer-merge-conflict-with-ext" \
+    "test.bin" "other" "other" "main"
+
+  git lfs pointer --check --file test.bin && exit 1
+
+  git lfs pointer --no-extensions --file test.bin 2>&1 | tee pointer.log
+  [ 0 -ne "${PIPESTATUS[0]}" ]
+
+  grep "Pointer file conflict marker error" pointer.log
+  grep "found potential conflict markers in pointer file" pointer.log
+)
+end_test

--- a/t/t-pointer.sh
+++ b/t/t-pointer.sh
@@ -654,3 +654,37 @@ begin_test "pointer: extension with multiple files"
   [ $(grep -c "clean:" "$LFSTEST_EXT_LOG") -eq 3 ]
 )
 end_test
+
+begin_test "pointer: merge conflict detected"
+(
+  set -e
+
+  setup_local_repo_with_merge_conflict "pointer-merge-conflict" \
+    "test.bin" "other" "other" "main"
+
+  git lfs pointer --check --file test.bin && exit 1
+
+  git lfs pointer --file test.bin 2>&1 | tee pointer.log
+  [ 0 -ne "${PIPESTATUS[0]}" ]
+
+  grep "Pointer file conflict marker error" pointer.log
+  grep "found potential conflict markers in pointer file" pointer.log
+)
+end_test
+
+begin_test "pointer: incorrectly resolved merge conflict results in invalid pointer"
+(
+  set -e
+
+  setup_local_repo_with_merge_conflict "pointer-merge-conflict-bad-solution" \
+    "test.bin" "other" "other" "main"
+
+  # Remove all conflict markers from the file
+  sed -i -e "/^[<=>]/d" test.bin
+
+  # Ensure that git lfs does not treat the file as a valid pointer file
+  git lfs pointer --check --file test.bin && exit 1
+  # Make the result of the subshell a success.
+  true
+)
+end_test

--- a/t/t-pull.sh
+++ b/t/t-pull.sh
@@ -1044,6 +1044,59 @@ begin_test "pull with merge conflict"
 
   set -e
   [ "$res" = "2" ]
+
+  # Ensure that git lfs does not treat the file as a valid pointer file
+  git lfs pointer --check --file abc.bin && exit 1
+  # Make the result of the subshell a success.
+  true
+)
+end_test
+
+begin_test "pull with partially fixed merge conflict"
+(
+  set -e
+  cd pull-merge-conflict
+
+  cp abc.bin abc.bin_bak
+
+  # Define conflict marker removal patterns for us to try
+  patterns=(
+  '^[<]'
+  '^[=]'
+  '^[>]'
+  '^[<=]'
+  '^[<>]'
+  '^[=>]'
+  '^[<=>]'
+  )
+
+  i=1
+  for pattern in "${patterns[@]}"; do
+      echo "Partially removing conflict markers with: $pattern"
+      sed -i "/$pattern/d" abc.bin
+      if [ $i -lt 7 ]; then
+        # Check that the remaining confict markers are still detected by git
+        set +e
+        git diff --check > conficts.log 2>&1
+        res=$?
+
+        set -e
+        [ "$res" = "2" ]
+      else
+        # All conflict markers should have been removed so check that none are detected
+        set +e
+        git diff --check > conficts.log 2>&1
+        res=$?
+
+        set -e
+        [ "$res" = "0" ]
+
+        # Ensure that git lfs does not treat the file as a valid pointer file
+        git lfs pointer --check --file abc.bin && exit 1
+      fi
+      cp abc.bin_bak abc.bin
+      ((i++))
+  done
 )
 end_test
 

--- a/t/t-pull.sh
+++ b/t/t-pull.sh
@@ -1073,7 +1073,7 @@ begin_test "pull with partially fixed merge conflict"
   i=1
   for pattern in "${patterns[@]}"; do
       echo "Partially removing conflict markers with: $pattern"
-      sed -i "/$pattern/d" abc.bin
+      sed -e "/$pattern/d" abc.bin_bak > abc.bin
       if [ $i -lt 7 ]; then
         # Check that the remaining confict markers are still detected by git
         set +e
@@ -1094,7 +1094,6 @@ begin_test "pull with partially fixed merge conflict"
         # Ensure that git lfs does not treat the file as a valid pointer file
         git lfs pointer --check --file abc.bin && exit 1
       fi
-      cp abc.bin_bak abc.bin
       ((i++))
   done
 )

--- a/t/t-pull.sh
+++ b/t/t-pull.sh
@@ -1035,7 +1035,16 @@ begin_test "pull with merge conflict"
   # This will exit nonzero because of the merge conflict.
   GIT_LFS_SKIP_SMUDGE=1 git merge def || true
   git lfs pull > pull.log 2>&1
-  [ ! -s pull.log ]
+  # LFS should have caught the confict markers in the file
+  [ -s pull.log ]
+
+  # Check that conficts are detected by git correctly
+  set +e
+  git diff --check > conficts.log 2>&1
+  res=$?
+
+  set -e
+  [ "$res" = "2" ]
 )
 end_test
 

--- a/t/t-pull.sh
+++ b/t/t-pull.sh
@@ -1035,8 +1035,7 @@ begin_test "pull with merge conflict"
   # This will exit nonzero because of the merge conflict.
   GIT_LFS_SKIP_SMUDGE=1 git merge def || true
   git lfs pull > pull.log 2>&1
-  # LFS should have caught the confict markers in the file
-  [ -s pull.log ]
+  [ ! -s pull.log ]
 
   # Check that conficts are detected by git correctly
   set +e

--- a/t/t-pull.sh
+++ b/t/t-pull.sh
@@ -1012,90 +1012,12 @@ end_test
 begin_test "pull with merge conflict"
 (
   set -e
-  git init pull-merge-conflict
-  cd pull-merge-conflict
 
-  git lfs track "*.bin"
-  git add .
-  git commit -m 'gitattributes'
-  printf abc > abc.bin
-  git add .
-  git commit -m 'abc'
+  setup_local_repo_with_merge_conflict "pull-merge-conflict" \
+  "abc.bin" "other" "def" "ghi"
 
-  git checkout -b def
-  printf def > abc.bin
-  git add .
-  git commit -m 'def'
-
-  git checkout main
-  printf ghi > abc.bin
-  git add .
-  git commit -m 'ghi'
-
-  # This will exit nonzero because of the merge conflict.
-  GIT_LFS_SKIP_SMUDGE=1 git merge def || true
   git lfs pull > pull.log 2>&1
   [ ! -s pull.log ]
-
-  # Check that conficts are detected by git correctly
-  set +e
-  git diff --check > conficts.log 2>&1
-  res=$?
-
-  set -e
-  [ "$res" = "2" ]
-
-  # Ensure that git lfs does not treat the file as a valid pointer file
-  git lfs pointer --check --file abc.bin && exit 1
-  # Make the result of the subshell a success.
-  true
-)
-end_test
-
-begin_test "pull with partially fixed merge conflict"
-(
-  set -e
-  cd pull-merge-conflict
-
-  cp abc.bin abc.bin_bak
-
-  # Define conflict marker removal patterns for us to try
-  patterns=(
-  '^[<]'
-  '^[=]'
-  '^[>]'
-  '^[<=]'
-  '^[<>]'
-  '^[=>]'
-  '^[<=>]'
-  )
-
-  i=1
-  for pattern in "${patterns[@]}"; do
-      echo "Partially removing conflict markers with: $pattern"
-      sed -e "/$pattern/d" abc.bin_bak > abc.bin
-      if [ $i -lt 7 ]; then
-        # Check that the remaining confict markers are still detected by git
-        set +e
-        git diff --check > conficts.log 2>&1
-        res=$?
-
-        set -e
-        [ "$res" = "2" ]
-      else
-        # All conflict markers should have been removed so check that none are detected
-        set +e
-        git diff --check > conficts.log 2>&1
-        res=$?
-
-        set -e
-        [ "$res" = "0" ]
-
-        # Ensure that git lfs does not treat the file as a valid pointer file
-        git lfs pointer --check --file abc.bin && exit 1
-      fi
-      ((i++))
-  done
 )
 end_test
 

--- a/t/testhelpers.sh
+++ b/t/testhelpers.sh
@@ -1084,3 +1084,46 @@ pktize_delim() {
 pktize_flush() {
   printf '0000'
 }
+
+# setup_local_repo_with_merge_conflict initializes a Git repository that has
+# a merge conflict in it. The `pwd` is set to the repository's directory.
+#
+# The function requires 5 arguments:
+#
+# reponame: The name of the git repo we should create.
+# filename: The filename of the file that will be create with a merge conflict in it.
+# branch: The branch where the incomming merge conflict will come from
+# branch_contents: The text string contents of that will generate the merge conflict
+# main_contents: The text string that will be in conflict. This can not be the same
+#                as branch_contents, otherwise not conflict will be generated.
+#
+setup_local_repo_with_merge_conflict() {
+  local reponame="$1"
+  local filename="$2"
+  local branch="$3"
+  local branch_contents="$4"
+  local main_contents="$5"
+
+  git init "$reponame"
+  cd "$reponame"
+
+  git lfs track "$filename"
+  printf "%s" "$filename" >"$filename"
+  git add .gitattributes "$filename"
+  git commit -m "add $filename"
+
+  git checkout -b "$branch"
+
+  printf "%s" "$branch_contents" >"$filename"
+  git add "$filename"
+  git commit -m "$branch_contents"
+
+  git checkout main
+
+  printf "%s" "$main_contents" >"$filename"
+  git add "$filename"
+  git commit -m "$main_contents"
+
+  # This will exit nonzero because of the merge conflict.
+  git merge "$branch" || true
+}


### PR DESCRIPTION
Before, we would create new hashes for pointer files that contained conflict markers. Now we do not do any extra processing for these kinds of files.

This also makes it so `git diff --check` return the correct result when we have conflicts in pointer files.

Note that I'm very unsure if my changes are safe and doesn't introduce any unintended side effects. `make test` seems to pass, but I'm not sure how exhaustive the test suite is.

Before I started working on this, I created a ticket about the problem here: https://github.com/git-lfs/git-lfs/issues/5990

In that issue, @chrisd8088 pointed out that detecting conflict markers might be very hard as the length of them are configurable. However from my point of view, I think that if we have detected a valid LFS header, then if we detect a "start conflict" marker symbol of any length, we can be quite certain that there are conflict markers in the file.

False positives in this case would mean that the pointer file has been corrupted in some other way and the end result should be the same in that case I think. IE we don't create a new LFS object for the corrupted file and instead just return/save the actual content of the pointer file to git.

In this change I explicitly did not make git lfs error our and return an error to git in the filter process.

This is because I don't think we should stray from how conflicts are handled in regular git for the following reasons:

1. Git GUI programs like VScode and SourceGIT etc, will have to adopt special workarounds for conflict resolution in LFS files as a lot of git commands will in that case error out. For example, they can't use regular git commands like `git diff --check` to check for conflicts anymore. (It also means regular terminal users have to modify their workflow when dealing with LFS conflict resolution)
2. I've personally been (and continue to be) in projects where not everyone on the team knows how to properly resolve a conflict. With git I've multiple times had scenarios where the easiest solution was for someone (that could potentially be on the other side of the world) to create a branch and commit all they have including files with conflict markers and then someone else resolves the conflicts in the branch. LFS erroring out would make this impossible.

On the basic level, I feel that conflict markers is a feature of git itself. If we can detect them, then I think that we should simply treat them as warnings and not errors, just like regular git does.

While this of course means that you can commit broken pointer files, I don't feel that this is a big issue because there is no data loss (I think). If someone needs to prevent people from doing this, I feel like the git server and client hooks should be enough. (IE the hook looks for conflicts markers and denies pushes or commits with them).

Perhaps we could have some example hooks that people could deploy if they wanted to? 