### PR TITLE
Upgrade to Go 1.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        go: ['1.23.x']
+        go: ['1.24.x']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -45,7 +45,7 @@ jobs:
     name: Build with specific Go
     strategy:
       matrix:
-        go: ['1.22.x']
+        go: ['1.23.x']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -69,7 +69,7 @@ jobs:
     - run: gem install asciidoctor
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.23.x'
+        go-version: '1.24.x'
     - run: mkdir -p "$HOME/go/bin"
       shell: bash
     - run: set GOPATH=%HOME%\go
@@ -129,7 +129,7 @@ jobs:
         ref: ${{ github.ref }}
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.23.x'
+        go-version: '1.24.x'
     - run: git clone -b master https://github.com/git/git.git "$HOME/git"
     - run: |
         echo "GIT_INSTALL_DIR=$HOME/git" >> "$GITHUB_ENV"
@@ -153,7 +153,7 @@ jobs:
         ref: ${{ github.ref }}
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.23.x'
+        go-version: '1.24.x'
     - run: git clone -b v2.0.0 https://github.com/git/git.git "$HOME/git"
     - run: |
         echo "GIT_INSTALL_DIR=$HOME/git" >> "$GITHUB_ENV"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        go: ['1.23.x']
+        go: ['1.24.x']
     steps:
     - uses: actions/checkout@v4
       with:
@@ -100,7 +100,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        go: ['1.23.x']
+        go: ['1.24.x']
     steps:
     - uses: actions/checkout@v4
       with:
@@ -137,7 +137,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.23.x']
+        go: ['1.24.x']
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Go version 1.24 has been released, and because we aim to build and test Git LFS against only supported versions of Go, we upgrade our GitHub Actions CI workflows to test against Go versions 1.24 and 1.23.

This resolves a problem now seen in our `Build with specific Go` CI job, where we install the latest version of the `goimports` package and it fails because the `x/tools` module requires Go 1.23 as of commit golang/tools@94db7107945332a789135d458a0f0de1d7c00ddb, and we are still using Go 1.22 for that CI job.

After this PR is merged, we will revise the required set of jobs in our CI test suite, and also upgrade the version of Go used in the scripts and Dockerfiles in our `github/build-dockers` project.