### PR TITLE
Honour 429 object transfer response `Retry-After` headers

### DIFF
--- a/t/cmd/lfstest-gitserver.go
+++ b/t/cmd/lfstest-gitserver.go
@@ -276,13 +276,18 @@ var (
 	laterRetriesMu  sync.Mutex
 )
 
+func getResourceKey(api, direction, repo, oid string) string {
+	return strings.Join([]string{api, direction, repo, oid}, ":")
+}
+
 // checkRateLimit tracks the various requests to the git-server. If it is the first
 // request of its kind, then a times is started, that when it is finished, a certain
 // number of requests become available.
 func checkRateLimit(api, direction, repo, oid string) (seconds int, isWait bool) {
 	laterRetriesMu.Lock()
 	defer laterRetriesMu.Unlock()
-	key := strings.Join([]string{direction, repo, oid}, ":")
+
+	key := getResourceKey(api, direction, repo, oid)
 	if requestsRemaining, ok := requestTokens[key]; !ok || requestsRemaining == 0 {
 		if retryStartTimes[key] == (time.Time{}) {
 			// If time is not initialized, set it to now
@@ -331,7 +336,7 @@ func incrementRetriesFor(api, direction, repo, oid string, check bool) (after ui
 	retriesMu.Lock()
 	defer retriesMu.Unlock()
 
-	retryKey := strings.Join([]string{direction, repo, oid}, ":")
+	retryKey := getResourceKey(api, direction, repo, oid)
 
 	retries[retryKey]++
 	retries := retries[retryKey]

--- a/t/t-batch-retries-ratelimit.sh
+++ b/t/t-batch-retries-ratelimit.sh
@@ -24,6 +24,8 @@ begin_test "batch upload causes retries"
     exit 1
   fi
 
+  [ 1 -eq $(grep -c "tq: enqueue retry" push.log) ]
+
   assert_server_object "$reponame" "$oid"
 )
 end_test
@@ -53,6 +55,9 @@ begin_test "batch upload with multiple files causes retries"
     echo >&2 "fatal: expected \`git push origin main\` to succeed ..."
     exit 1
   fi
+
+  [ 2 -eq $(grep -c "tq: enqueue retry" push.log) ]
+  [ 2 -eq $(grep -c "tq: enqueue retry #1" push.log) ]
 
   assert_server_object "$reponame" "$oid1"
   assert_server_object "$reponame" "$oid2"
@@ -152,6 +157,10 @@ begin_test "batch upload causes retries (missing header)"
     echo >&2 "fatal: expected \`git push origin main\` to succeed ..."
     exit 1
   fi
+
+  [ 1 -lt $(grep -c "tq: enqueue retry" push.log) ]
+  [ 1 -eq $(grep -c "tq: enqueue retry #1" push.log) ]
+  [ 1 -eq $(grep -c "tq: enqueue retry #2" push.log) ]
 
   assert_server_object "$reponame" "$oid"
 )

--- a/t/t-batch-retries-ratelimit.sh
+++ b/t/t-batch-retries-ratelimit.sh
@@ -80,15 +80,28 @@ begin_test "batch clone causes retries"
   git add .gitattributes a.dat
   git commit -m "initial commit"
 
+  # Note that the server would apply the default rate limit delay only
+  # to this push operation, not the subsequent clone whose handling of
+  # 429 responses we want to test.  To avoid this, we first set the
+  # available non-rate-limited requests for the repository to the maximum
+  # allowed, which allows the push to proceed without delay.  Then we
+  # reset the available requests to zero afterwards so the clone will
+  # receive a 429 response.
+  set_server_rate_limit "batch" "" "$reponame" "" "max"
+
   git push origin main
   assert_server_object "$reponame" "$oid"
 
+  set_server_rate_limit "batch" "" "$reponame" "" 0
+
   pushd ..
-    git lfs clone "$GITSERVER/$reponame" "$reponame-assert"
-    if [ "0" -ne "$?" ]; then
+    GIT_TRACE=1 git lfs clone "$GITSERVER/$reponame" "$reponame-assert" 2>&1 | tee clone.log
+    if [ "0" -ne "${PIPESTATUS[0]}" ]; then
       echo >&2 "fatal: expected \`git lfs clone \"$GITSERVER/$reponame\" \"$reponame-assert\"\` to succeed ..."
       exit 1
     fi
+
+    [ 1 -eq $(grep -c "tq: enqueue retry" clone.log) ]
 
     cd "$reponame-assert"
 
@@ -117,16 +130,30 @@ begin_test "batch clone with multiple files causes retries"
   git add .gitattributes a.dat b.dat
   git commit -m "initial commit"
 
+  # Note that the server would apply the default rate limit delay only
+  # to this push operation, not the subsequent clone whose handling of
+  # 429 responses we want to test.  To avoid this, we first set the
+  # available non-rate-limited requests for the repository to the maximum
+  # allowed, which allows the push to proceed without delay.  Then we
+  # reset the available requests to zero afterwards so the clone will
+  # receive a 429 response.
+  set_server_rate_limit "batch" "" "$reponame" "" "max"
+
   git push origin main
   assert_server_object "$reponame" "$oid1"
   assert_server_object "$reponame" "$oid2"
 
+  set_server_rate_limit "batch" "" "$reponame" "" 0
+
   pushd ..
-    git lfs clone "$GITSERVER/$reponame" "$reponame-assert"
-    if [ "0" -ne "$?" ]; then
+    GIT_TRACE=1 git lfs clone "$GITSERVER/$reponame" "$reponame-assert" 2>&1 | tee clone.log
+    if [ "0" -ne "${PIPESTATUS[0]}" ]; then
       echo >&2 "fatal: expected \`git lfs clone \"$GITSERVER/$reponame\" \"$reponame-assert\"\` to succeed ..."
       exit 1
     fi
+
+    [ 2 -eq $(grep -c "tq: enqueue retry" clone.log) ]
+    [ 2 -eq $(grep -c "tq: enqueue retry #1" clone.log) ]
 
     cd "$reponame-assert"
 

--- a/t/t-batch-retries-ratelimit.sh
+++ b/t/t-batch-retries-ratelimit.sh
@@ -81,9 +81,9 @@ begin_test "batch clone causes retries"
   pushd ..
     git lfs clone "$GITSERVER/$reponame" "$reponame-assert"
     if [ "0" -ne "$?" ]; then
-	  echo >&2 "fatal: expected \`git lfs clone \"$GITSERVER/$reponame\" \"$reponame-assert\"\` to su``"
-	  exit 1
-	fi
+      echo >&2 "fatal: expected \`git lfs clone \"$GITSERVER/$reponame\" \"$reponame-assert\"\` to succeed ..."
+      exit 1
+    fi
 
     cd "$reponame-assert"
 
@@ -119,9 +119,9 @@ begin_test "batch clone with multiple files causes retries"
   pushd ..
     git lfs clone "$GITSERVER/$reponame" "$reponame-assert"
     if [ "0" -ne "$?" ]; then
-	  echo >&2 "fatal: expected \`git lfs clone \"$GITSERVER/$reponame\" \"$reponame-assert\"\` to su``"
-	  exit 1
-	fi
+      echo >&2 "fatal: expected \`git lfs clone \"$GITSERVER/$reponame\" \"$reponame-assert\"\` to succeed ..."
+      exit 1
+    fi
 
     cd "$reponame-assert"
 

--- a/t/t-batch-storage-retries-ratelimit.sh
+++ b/t/t-batch-storage-retries-ratelimit.sh
@@ -64,7 +64,7 @@ begin_test "batch storage download causes retries"
       exit 1
     fi
 
-	assert_local_object "$oid" "${#contents}"
+    assert_local_object "$oid" "${#contents}"
   popd
 )
 end_test
@@ -91,9 +91,9 @@ begin_test "batch clone causes retries"
   pushd ..
     git lfs clone "$GITSERVER/$reponame" "$reponame-assert"
     if [ "0" -ne "$?" ]; then
-	  echo >&2 "fatal: expected \`git lfs clone \"$GITSERVER/$reponame\" \"$reponame-assert\"\` to su``"
-	  exit 1
-	fi
+      echo >&2 "fatal: expected \`git lfs clone \"$GITSERVER/$reponame\" \"$reponame-assert\"\` to succeed ..."
+      exit 1
+    fi
 
     cd "$reponame-assert"
 

--- a/t/t-batch-storage-retries-ratelimit.sh
+++ b/t/t-batch-storage-retries-ratelimit.sh
@@ -24,6 +24,9 @@ begin_test "batch storage upload causes retries"
     exit 1
   fi
 
+  [ 1 -eq $(grep -c "tq: retrying object" push.log) ]
+  [ 1 -eq $(grep -c "tq: enqueue retry" push.log) ]
+
   assert_server_object "$reponame" "$oid"
 )
 end_test
@@ -64,6 +67,9 @@ begin_test "batch storage download causes retries"
       exit 1
     fi
 
+    [ 1 -eq $(grep -c "tq: retrying object" pull.log) ]
+    [ 1 -eq $(grep -c "tq: enqueue retry" pull.log) ]
+
     assert_local_object "$oid" "${#contents}"
   popd
 )
@@ -89,11 +95,14 @@ begin_test "batch clone causes retries"
   assert_server_object "$reponame" "$oid"
 
   pushd ..
-    git lfs clone "$GITSERVER/$reponame" "$reponame-assert"
-    if [ "0" -ne "$?" ]; then
+    GIT_TRACE=1 git lfs clone "$GITSERVER/$reponame" "$reponame-assert" 2>&1 | tee clone.log
+    if [ "0" -ne "${PIPESTATUS[0]}" ]; then
       echo >&2 "fatal: expected \`git lfs clone \"$GITSERVER/$reponame\" \"$reponame-assert\"\` to succeed ..."
       exit 1
     fi
+
+    [ 1 -eq $(grep -c "tq: retrying object" clone.log) ]
+    [ 1 -eq $(grep -c "tq: enqueue retry" clone.log) ]
 
     cd "$reponame-assert"
 

--- a/t/t-batch-storage-retries-ratelimit.sh
+++ b/t/t-batch-storage-retries-ratelimit.sh
@@ -124,6 +124,11 @@ begin_test "batch storage upload causes retries (missing header)"
     exit 1
   fi
 
+  [ 1 -lt $(grep -c "tq: retrying object" push.log) ]
+  [ 1 -lt $(grep -c "tq: enqueue retry" push.log) ]
+  [ 1 -eq $(grep -c "tq: enqueue retry #1" push.log) ]
+  [ 1 -eq $(grep -c "tq: enqueue retry #2" push.log) ]
+
   assert_server_object "$reponame" "$oid"
 )
 end_test
@@ -163,6 +168,11 @@ begin_test "batch storage download causes retries (missing header)"
       echo >&2 "fatal: expected \`git lfs pull origin main\` to succeed ..."
       exit 1
     fi
+
+    [ 1 -lt $(grep -c "tq: retrying object" pull.log) ]
+    [ 1 -lt $(grep -c "tq: enqueue retry" pull.log) ]
+    [ 1 -eq $(grep -c "tq: enqueue retry #1" pull.log) ]
+    [ 1 -eq $(grep -c "tq: enqueue retry #2" pull.log) ]
 
     assert_local_object "$oid" "${#contents}"
   popd

--- a/t/testhelpers.sh
+++ b/t/testhelpers.sh
@@ -194,6 +194,23 @@ assert_remote_object() {
   popd
 }
 
+# Set rate limit counts on the LFS server. HTTP log is written to http.log.
+#
+#   $ reset_server_rate_limit "api" "direction" "reponame" "oid" "num-tokens"
+set_server_rate_limit() {
+  local api="$1"
+  local direction="$2"
+  local reponame="$3"
+  local oid="$4"
+  local tokens="$5"
+
+  local query="api=$api&direction=$direction&repo=$reponame&oid=$oid&tokens=$tokens"
+
+  curl -v "$GITSERVER/limits/?$query" 2>&1 | tee http.log
+
+  grep "200 OK" http.log
+}
+
 check_server_lock_ssh() {
   local reponame="$1"
   local id="$2"

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -806,7 +806,7 @@ func (q *TransferQueue) handleTransferResult(
 			// If the object can't be retried now, but can be
 			// after a certain period of time, send it to
 			// the retry channel with a time when it's ready.
-			tracerx.Printf("tq: retrying object %s after %s seconds.", oid, time.Until(readyTime).Seconds())
+			tracerx.Printf("tq: retrying object %s after %.2fs", oid, time.Until(readyTime).Seconds())
 			q.trMutex.Lock()
 			objects, ok := q.transfers[oid]
 			q.trMutex.Unlock()


### PR DESCRIPTION
This PR resolves the problem reported in #6007 regarding the Git LFS client's failure to honour the delay interval or fixed retry time specified in `Retry-After` headers, if the headers are sent with 429 HTTP response status codes in reply to individual Git LFS object transfer requests.

In addition, we revise a number of related tests so they now check the number of retry attempts made after 429 status code responses to both Batch API requests and individual object transfer requests, and then add the same type of checks to the appropriate [tests](https://github.com/git-lfs/git-lfs/blob/41999a064abfc4c30ff6864da6bab8fad32d3536/t/t-batch-storage-retries-ratelimit.sh#L5-L103) to verify that the bug fix in this PR is effective.

As well, we fix [several](https://github.com/git-lfs/git-lfs/blob/41999a064abfc4c30ff6864da6bab8fad32d3536/t/t-batch-retries-ratelimit.sh#L62-L132) [tests](https://github.com/git-lfs/git-lfs/blob/41999a064abfc4c30ff6864da6bab8fad32d3536/t/t-batch-storage-retries-ratelimit.sh#L72-L103) of our 429 status code response handling during `git lfs clone` operations.  At present, these tests only receive responses from our test server with 429 status codes and `Retry-After` headers when pushing objects to establish the test conditions, and not when performing the subsequent clone operations the tests are intended to validate.

This PR will be most easily reviewed on a commit-by-commit basis.

Resolves #6007.
/cc @max-wittig as reporter.