### PR TITLE
transform DoWithAuth from recurrent to loop approach to prevent endless authentication attepmpts

### DIFF
--- a/lfsapi/auth.go
+++ b/lfsapi/auth.go
@@ -25,21 +25,20 @@ var (
 // supporting basic authentication.
 func (c *Client) DoWithAuth(remote string, access creds.Access, req *http.Request) (*http.Response, error) {
 	count := 0
-	res, err := c.doWithAuth(remote, &count, access, req, nil)
-
-	if errors.IsAuthError(err) {
-		if len(req.Header.Get("Authorization")) == 0 {
-			// This case represents a rejected request that
-			// should have been authenticated but wasn't. Do
-			// not count this against our redirection
-			// maximum.
-			newAccess := c.Endpoints.AccessFor(access.URL())
-			tracerx.Printf("api: http response indicates %q authentication. Resubmitting...", newAccess.Mode())
-			return c.DoWithAuth(remote, newAccess, req)
+	for {
+		res, err := c.doWithAuth(remote, &count, access, req, nil)
+		if !errors.IsAuthError(err) || len(req.Header.Get("Authorization")) != 0 || count == defaultMaxAuthAttempts {
+			return res, err
 		}
-	}
 
-	return res, err
+		// This case represents a rejected request that
+		// should have been authenticated but wasn't. Do
+		// not count this against our redirection
+		// maximum.
+		newAccess := c.Endpoints.AccessFor(access.URL())
+		tracerx.Printf("api: http response indicates %q authentication. Resubmitting...", newAccess.Mode())
+		count++
+	}
 }
 
 // DoWithAuthNoRetry sends an HTTP request to get an HTTP response. It works in
@@ -86,9 +85,7 @@ func (c *Client) doWithAuth(remote string, count *int, access creds.Access, req 
 
 			if credWrapper.Creds != nil {
 				req.Header.Del("Authorization")
-				if multistage && *count < defaultMaxAuthAttempts && res != nil && res.StatusCode == 401 {
-					*count++
-				} else {
+				if !multistage || *count >= defaultMaxAuthAttempts || res == nil || res.StatusCode != 401 {
 					credWrapper.CredentialHelper.Reject(credWrapper.Creds)
 				}
 			}


### PR DESCRIPTION
In case of wrong credentials, the method DoWithAuth is executed recursively without termination. This is not such a big problem when users interact with LFS via the command line, but it may cause the process to hang when the command is called automatically (e.g. by CI tool) with credential.helper and core.askpass arguments