### PR TITLE
use direct value nil for error

### DIFF
--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -60,7 +60,7 @@ func delayedSmudge(gf *lfs.GitFilter, s *git.FilterProcessScanner, to io.Writer,
 
 	if !skip && filter.Allows(filename) {
 		if _, statErr := os.Stat(path); statErr != nil && ptr.Size != 0 {
-			q.Add(filename, path, ptr.Oid, ptr.Size, false, err)
+			q.Add(filename, path, ptr.Oid, ptr.Size, false, nil)
 			return 0, true, ptr, nil
 		}
 


### PR DESCRIPTION
the code logic I think, 

if file not exists( statErr != nil ) it will be delay write to path use the `ptr`,  so it should call with a direct nil value.