### PR TITLE
Report missing objects consistently when pushing

### DIFF
--- a/t/t-pre-push.sh
+++ b/t/t-pre-push.sh
@@ -307,11 +307,14 @@ begin_test "pre-push with missing pointer not on server"
   git commit -m "add new pointer"
 
   # assert that push fails
-  set +e
   echo "refs/heads/main main refs/heads/main 0000000000000000000000000000000000000000" |
     git lfs pre-push origin "$GITSERVER/$reponame" 2>&1 |
     tee push.log
-  set -e
+
+  if [ "2" -ne "${PIPESTATUS[1]}" ]; then
+    echo >&2 "fatal: expected 'git lfs pre-push origin $GITSERVER/$reponame' to fail ..."
+    exit 1
+  fi
 
   grep "  (missing) new.dat ($oid)" push.log
 )
@@ -352,9 +355,9 @@ begin_test "pre-push with missing pointer which is on server"
   echo "refs/heads/main main refs/heads/main 0000000000000000000000000000000000000000" |
     git lfs pre-push origin "$GITSERVER/$reponame" 2>&1 |
     tee push.log
+
   # make sure there were no errors reported
   [ -z "$(grep -i 'Error' push.log)" ]
-
 )
 end_test
 
@@ -397,7 +400,7 @@ begin_test "pre-push with missing and present pointers (lfs.allowincompletepush 
     tee push.log
 
   if [ "0" -ne "${PIPESTATUS[1]}" ]; then
-    echo >&2 "fatal: expected \`git lfs pre-push origin $GITSERVER/$reponame\` to succeed..."
+    echo >&2 "fatal: expected 'git lfs pre-push origin $GITSERVER/$reponame' to succeed ..."
     exit 1
   fi
 
@@ -446,7 +449,7 @@ begin_test "pre-push reject missing pointers (lfs.allowincompletepush default)"
     tee push.log
 
   if [ "2" -ne "${PIPESTATUS[1]}" ]; then
-    echo >&2 "fatal: expected \`git lfs pre-push origin $GITSERVER/$reponame\` to fail..."
+    echo >&2 "fatal: expected 'git lfs pre-push origin $GITSERVER/$reponame' to fail ..."
     exit 1
   fi
 

--- a/t/t-pre-push.sh
+++ b/t/t-pre-push.sh
@@ -390,9 +390,6 @@ begin_test "pre-push allow missing object (lfs.allowincompletepush true)"
   git add present.dat missing.dat
   git commit -m "add objects"
 
-  git rm missing.dat
-  git commit -m "remove missing"
-
   delete_local_object "$missing_oid"
 
   git config lfs.allowincompletepush true

--- a/t/t-pre-push.sh
+++ b/t/t-pre-push.sh
@@ -451,7 +451,7 @@ begin_test "pre-push reject missing object (lfs.allowincompletepush default)"
     exit 1
   fi
 
-  grep 'Unable to find source' push.log
+  grep "Unable to find source for object $missing_oid" push.log
 
   refute_server_object "$reponame" "$present_oid"
   refute_server_object "$reponame" "$missing_oid"

--- a/t/t-pre-push.sh
+++ b/t/t-pre-push.sh
@@ -449,7 +449,8 @@ begin_test "pre-push reject missing object (lfs.allowincompletepush default)"
   fi
 
   grep "tq: stopping batched queue, object \"$missing_oid\" missing locally and on remote" push.log
-  grep "Unable to find source for object $missing_oid" push.log
+  grep "LFS upload failed:" push.log
+  grep "  (missing) missing.dat ($missing_oid)" push.log
 
   refute_server_object "$reponame" "$present_oid"
   refute_server_object "$reponame" "$missing_oid"

--- a/t/t-pre-push.sh
+++ b/t/t-pre-push.sh
@@ -387,11 +387,7 @@ begin_test "pre-push with missing and present pointers (lfs.allowincompletepush 
   git rm missing.dat
   git commit -m "remove missing"
 
-  # :fire: the "missing" object
-  missing_oid_part_1="$(echo "$missing_oid" | cut -b 1-2)"
-  missing_oid_part_2="$(echo "$missing_oid" | cut -b 3-4)"
-  missing_oid_path=".git/lfs/objects/$missing_oid_part_1/$missing_oid_part_2/$missing_oid"
-  rm "$missing_oid_path"
+  delete_local_object "$missing_oid"
 
   git config lfs.allowincompletepush true
 
@@ -438,11 +434,7 @@ begin_test "pre-push reject missing pointers (lfs.allowincompletepush default)"
   git rm missing.dat
   git commit -m "remove missing"
 
-  # :fire: the "missing" object
-  missing_oid_part_1="$(echo "$missing_oid" | cut -b 1-2)"
-  missing_oid_part_2="$(echo "$missing_oid" | cut -b 3-4)"
-  missing_oid_path=".git/lfs/objects/$missing_oid_part_1/$missing_oid_part_2/$missing_oid"
-  rm "$missing_oid_path"
+  delete_local_object "$missing_oid"
 
   echo "refs/heads/main main refs/heads/main 0000000000000000000000000000000000000000" |
     git lfs pre-push origin "$GITSERVER/$reponame" 2>&1 |

--- a/t/t-pre-push.sh
+++ b/t/t-pre-push.sh
@@ -382,7 +382,7 @@ begin_test "pre-push with missing and present pointers (lfs.allowincompletepush 
   printf "%s" "$missing" > missing.dat
 
   git add present.dat missing.dat
-  git commit -m "add present.dat and missing.dat"
+  git commit -m "add objects"
 
   git rm missing.dat
   git commit -m "remove missing"
@@ -429,7 +429,7 @@ begin_test "pre-push reject missing pointers (lfs.allowincompletepush default)"
   printf "%s" "$missing" > missing.dat
 
   git add present.dat missing.dat
-  git commit -m "add present.dat and missing.dat"
+  git commit -m "add objects"
 
   git rm missing.dat
   git commit -m "remove missing"

--- a/t/t-pre-push.sh
+++ b/t/t-pre-push.sh
@@ -241,11 +241,11 @@ begin_test "pre-push 307 redirects"
 )
 end_test
 
-begin_test "pre-push with existing file"
+begin_test "pre-push with existing object"
 (
   set -e
 
-  reponame="pre-push-existing-file"
+  reponame="pre-push-existing-object"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"
 
@@ -270,11 +270,11 @@ begin_test "pre-push with existing file"
 )
 end_test
 
-begin_test "pre-push with existing pointer"
+begin_test "pre-push with existing object (untracked)"
 (
   set -e
 
-  reponame="pre-push-existing-pointer"
+  reponame="pre-push-existing-object-untracked"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"
 
@@ -295,11 +295,11 @@ begin_test "pre-push with existing pointer"
 )
 end_test
 
-begin_test "pre-push with missing pointer not on server"
+begin_test "pre-push reject missing object"
 (
   set -e
 
-  reponame="pre-push-missing-pointer"
+  reponame="pre-push-reject-missing-object"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"
 
@@ -326,13 +326,13 @@ begin_test "pre-push with missing pointer not on server"
 )
 end_test
 
-begin_test "pre-push with missing pointer which is on server"
+begin_test "pre-push allow missing object (found on server)"
 (
   # should permit push if files missing locally but are on server, shouldn't
   # require client to have every file (prune)
   set -e
 
-  reponame="pre-push-missing-but-on-server"
+  reponame="pre-push-allow-missing-object-found-on-server"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"
 
@@ -367,11 +367,11 @@ begin_test "pre-push with missing pointer which is on server"
 )
 end_test
 
-begin_test "pre-push with missing and present pointers (lfs.allowincompletepush true)"
+begin_test "pre-push allow missing object (lfs.allowincompletepush true)"
 (
   set -e
 
-  reponame="pre-push-missing-and-present"
+  reponame="pre-push-allow-missing-object"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"
 
@@ -414,11 +414,11 @@ begin_test "pre-push with missing and present pointers (lfs.allowincompletepush 
 )
 end_test
 
-begin_test "pre-push reject missing pointers (lfs.allowincompletepush default)"
+begin_test "pre-push reject missing object (lfs.allowincompletepush default)"
 (
   set -e
 
-  reponame="pre-push-reject-missing-and-present"
+  reponame="pre-push-reject-missing-object-default"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"
 

--- a/t/t-pre-push.sh
+++ b/t/t-pre-push.sh
@@ -440,7 +440,7 @@ begin_test "pre-push reject missing object (lfs.allowincompletepush default)"
   delete_local_object "$missing_oid"
 
   echo "refs/heads/main main refs/heads/main 0000000000000000000000000000000000000000" |
-    git lfs pre-push origin "$GITSERVER/$reponame" 2>&1 |
+    GIT_TRACE=1 git lfs pre-push origin "$GITSERVER/$reponame" 2>&1 |
     tee push.log
 
   if [ "2" -ne "${PIPESTATUS[1]}" ]; then
@@ -448,6 +448,7 @@ begin_test "pre-push reject missing object (lfs.allowincompletepush default)"
     exit 1
   fi
 
+  grep "tq: stopping batched queue, object \"$missing_oid\" missing locally and on remote" push.log
   grep "Unable to find source for object $missing_oid" push.log
 
   refute_server_object "$reponame" "$present_oid"

--- a/t/t-pre-push.sh
+++ b/t/t-pre-push.sh
@@ -434,9 +434,6 @@ begin_test "pre-push reject missing object (lfs.allowincompletepush default)"
   git add present.dat missing.dat
   git commit -m "add objects"
 
-  git rm missing.dat
-  git commit -m "remove missing"
-
   delete_local_object "$missing_oid"
 
   echo "refs/heads/main main refs/heads/main 0000000000000000000000000000000000000000" |

--- a/t/t-pre-push.sh
+++ b/t/t-pre-push.sh
@@ -245,10 +245,10 @@ begin_test "pre-push with existing file"
 (
   set -e
 
-  reponame="$(basename "$0" ".sh")-existing-file"
+  reponame="pre-push-existing-file"
   setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
 
-  clone_repo "$reponame" existing-file
   echo "existing" > existing.dat
   git add existing.dat
   git commit -m "add existing dat"
@@ -274,9 +274,9 @@ begin_test "pre-push with existing pointer"
 (
   set -e
 
-  reponame="$(basename "$0" ".sh")-existing-pointer"
+  reponame="pre-push-existing-pointer"
   setup_remote_repo "$reponame"
-  clone_repo "$reponame" existing-pointer
+  clone_repo "$reponame" "$reponame"
 
   echo "$(pointer "7aa7a5359173d05b63cfd682e3c38487f3cb4f7f1d60659fe59fab1505977d4c" 4)" > new.dat
   git add new.dat
@@ -299,9 +299,9 @@ begin_test "pre-push with missing pointer not on server"
 (
   set -e
 
-  reponame="$(basename "$0" ".sh")-missing-pointer"
+  reponame="pre-push-missing-pointer"
   setup_remote_repo "$reponame"
-  clone_repo "$reponame" missing-pointer
+  clone_repo "$reponame" "$reponame"
 
   oid="7aa7a5359173d05b63cfd682e3c38487f3cb4f7f1d60659fe59fab1505977d4c"
 
@@ -332,9 +332,9 @@ begin_test "pre-push with missing pointer which is on server"
   # require client to have every file (prune)
   set -e
 
-  reponame="$(basename "$0" ".sh")-missing-but-on-server"
+  reponame="pre-push-missing-but-on-server"
   setup_remote_repo "$reponame"
-  clone_repo "$reponame" missing-but-on-server
+  clone_repo "$reponame" "$reponame"
 
   contents="common data"
   contents_oid=$(calc_oid "$contents")

--- a/t/t-pre-push.sh
+++ b/t/t-pre-push.sh
@@ -289,6 +289,9 @@ begin_test "pre-push with existing pointer"
     git lfs pre-push origin "$GITSERVER/$reponame" 2>&1 |
     tee push.log
   grep "Uploading LFS objects: 100% (1/1), 4 B" push.log
+
+  # now the file exists
+  assert_server_object "$reponame" 7aa7a5359173d05b63cfd682e3c38487f3cb4f7f1d60659fe59fab1505977d4c
 )
 end_test
 
@@ -316,7 +319,10 @@ begin_test "pre-push with missing pointer not on server"
     exit 1
   fi
 
+  grep "LFS upload failed:" push.log
   grep "  (missing) new.dat ($oid)" push.log
+
+  refute_server_object "$reponame" "$oid"
 )
 end_test
 

--- a/t/t-push-failures-local.sh
+++ b/t/t-push-failures-local.sh
@@ -43,6 +43,54 @@ begin_test "push allow missing object (lfs.allowincompletepush true)"
 )
 end_test
 
+begin_test "push allow missing object (lfs.allowincompletepush true) (git-lfs-transfer)"
+(
+  set -e
+
+  setup_pure_ssh
+
+  reponame="push-ssh-allow-missing-object"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  sshurl=$(ssh_remote "$reponame")
+  git config lfs.url "$sshurl"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  present="present"
+  present_oid="$(calc_oid "$present")"
+  printf "%s" "$present" > present.dat
+
+  missing="missing"
+  missing_oid="$(calc_oid "$missing")"
+  printf "%s" "$missing" > missing.dat
+
+  git add present.dat missing.dat
+  git commit -m "add objects"
+
+  delete_local_object "$missing_oid"
+
+  git config lfs.allowincompletepush true
+
+  GIT_TRACE=1 git push origin main 2>&1 | tee push.log
+  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected 'git push origin main' to succeed ..."
+    exit 1
+  fi
+
+  grep "pure SSH connection successful" push.log
+
+  grep "LFS upload missing objects" push.log
+  grep "  (missing) missing.dat ($missing_oid)" push.log
+
+  assert_remote_object "$reponame" "$present_oid" "${#present}"
+  refute_remote_object "$reponame" "$missing_oid"
+)
+end_test
+
 begin_test "push reject missing object (lfs.allowincompletepush false)"
 (
   set -e
@@ -86,6 +134,56 @@ begin_test "push reject missing object (lfs.allowincompletepush false)"
 )
 end_test
 
+begin_test "push reject missing object (lfs.allowincompletepush false) (git-lfs-transfer)"
+(
+  set -e
+
+  setup_pure_ssh
+
+  reponame="push-ssh-reject-missing-object"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  sshurl=$(ssh_remote "$reponame")
+  git config lfs.url "$sshurl"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  present="present"
+  present_oid="$(calc_oid "$present")"
+  printf "%s" "$present" > present.dat
+
+  missing="missing"
+  missing_oid="$(calc_oid "$missing")"
+  printf "%s" "$missing" > missing.dat
+
+  git add present.dat missing.dat
+  git commit -m "add objects"
+
+  git rm missing.dat
+  git commit -m "remove missing"
+
+  delete_local_object "$missing_oid"
+
+  git config lfs.allowincompletepush false
+
+  GIT_TRACE=1 git push origin main 2>&1 | tee push.log
+  if [ "1" -ne "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected 'git push origin main' to fail ..."
+    exit 1
+  fi
+
+  grep "pure SSH connection successful" push.log
+
+  grep "Unable to find source for object $missing_oid" push.log
+
+  refute_remote_object "$reponame" "$present_oid"
+  refute_remote_object "$reponame" "$missing_oid"
+)
+end_test
+
 begin_test "push reject missing object (lfs.allowincompletepush default)"
 (
   set -e
@@ -125,6 +223,52 @@ begin_test "push reject missing object (lfs.allowincompletepush default)"
 )
 end_test
 
+begin_test "push reject missing object (lfs.allowincompletepush default) (git-lfs-transfer)"
+(
+  set -e
+
+  setup_pure_ssh
+
+  reponame="push-ssh-reject-missing-object-default"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  sshurl=$(ssh_remote "$reponame")
+  git config lfs.url "$sshurl"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  present="present"
+  present_oid="$(calc_oid "$present")"
+  printf "%s" "$present" > present.dat
+
+  missing="missing"
+  missing_oid="$(calc_oid "$missing")"
+  printf "%s" "$missing" > missing.dat
+
+  git add present.dat missing.dat
+  git commit -m "add objects"
+
+  delete_local_object "$missing_oid"
+
+  GIT_TRACE=1 git push origin main 2>&1 | tee push.log
+  if [ "1" -ne "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected 'git push origin main' to fail ..."
+    exit 1
+  fi
+
+  grep "pure SSH connection successful" push.log
+
+  grep "LFS upload failed:" push.log
+  grep "  (missing) missing.dat ($missing_oid)" push.log
+
+  assert_remote_object "$reponame" "$present_oid" "${#present}"
+  refute_remote_object "$reponame" "$missing_oid"
+)
+end_test
+
 begin_test "push reject corrupt object (lfs.allowincompletepush default)"
 (
   set -e
@@ -161,5 +305,51 @@ begin_test "push reject corrupt object (lfs.allowincompletepush default)"
 
   assert_server_object "$reponame" "$present_oid"
   refute_server_object "$reponame" "$corrupt_oid"
+)
+end_test
+
+begin_test "push reject corrupt object (lfs.allowincompletepush default) (git-lfs-transfer)"
+(
+  set -e
+
+  setup_pure_ssh
+
+  reponame="push-ssh-reject-corrupt-object-default"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  sshurl=$(ssh_remote "$reponame")
+  git config lfs.url "$sshurl"
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  present="present"
+  present_oid="$(calc_oid "$present")"
+  printf "%s" "$present" > present.dat
+
+  corrupt="corrupt"
+  corrupt_oid="$(calc_oid "$corrupt")"
+  printf "%s" "$corrupt" > corrupt.dat
+
+  git add present.dat corrupt.dat
+  git commit -m "add objects"
+
+  corrupt_local_object "$corrupt_oid"
+
+  GIT_TRACE=1 git push origin main 2>&1 | tee push.log
+  if [ "1" -ne "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected 'git push origin main' to fail ..."
+    exit 1
+  fi
+
+  grep "pure SSH connection successful" push.log
+
+  grep "LFS upload failed:" push.log
+  grep "  (corrupt) corrupt.dat ($corrupt_oid)" push.log
+
+  assert_remote_object "$reponame" "$present_oid" "${#present}"
+  refute_remote_object "$reponame" "$corrupt_oid"
 )
 end_test

--- a/t/t-push-failures-local.sh
+++ b/t/t-push-failures-local.sh
@@ -121,12 +121,13 @@ begin_test "push reject missing object (lfs.allowincompletepush false)"
 
   git config lfs.allowincompletepush false
 
-  git push origin main 2>&1 | tee push.log
+  GIT_TRACE=1 git push origin main 2>&1 | tee push.log
   if [ "1" -ne "${PIPESTATUS[0]}" ]; then
     echo >&2 "fatal: expected 'git push origin main' to fail ..."
     exit 1
   fi
 
+  grep "tq: stopping batched queue, object \"$missing_oid\" missing locally and on remote" push.log
   grep "Unable to find source for object $missing_oid" push.log
 
   refute_server_object "$reponame" "$present_oid"
@@ -177,6 +178,7 @@ begin_test "push reject missing object (lfs.allowincompletepush false) (git-lfs-
 
   grep "pure SSH connection successful" push.log
 
+  grep "tq: stopping batched queue, object \"$missing_oid\" missing locally and on remote" push.log
   grep "Unable to find source for object $missing_oid" push.log
 
   refute_remote_object "$reponame" "$present_oid"

--- a/t/t-push-failures-local.sh
+++ b/t/t-push-failures-local.sh
@@ -25,9 +25,6 @@ begin_test "push allow missing object (lfs.allowincompletepush true)"
   git add present.dat missing.dat
   git commit -m "add objects"
 
-  git rm missing.dat
-  git commit -m "remove missing"
-
   delete_local_object "$missing_oid"
 
   git config lfs.allowincompletepush true

--- a/t/t-push-failures-local.sh
+++ b/t/t-push-failures-local.sh
@@ -124,8 +124,8 @@ begin_test "push reject missing objects (lfs.allowincompletepush default)"
   grep "LFS upload failed:" push.log
   grep "  (missing) missing.dat ($missing_oid)" push.log
 
-  refute_server_object "$reponame" "$missing_oid"
   assert_server_object "$reponame" "$present_oid"
+  refute_server_object "$reponame" "$missing_oid"
 )
 end_test
 
@@ -164,7 +164,7 @@ begin_test "push reject corrupt objects (lfs.allowincompletepush default)"
   grep "LFS upload failed:" push.log
   grep "  (corrupt) corrupt.dat ($corrupt_oid)" push.log
 
-  refute_server_object "$reponame" "$corrupt_oid"
   assert_server_object "$reponame" "$present_oid"
+  refute_server_object "$reponame" "$corrupt_oid"
 )
 end_test

--- a/t/t-push-failures-local.sh
+++ b/t/t-push-failures-local.sh
@@ -103,25 +103,17 @@ begin_test "push reject missing objects (lfs.allowincompletepush default)"
 
   missing="missing"
   missing_oid="$(calc_oid "$missing")"
-  missing_len="$(printf "%s" "$missing" | wc -c | awk '{ print $1 }')"
   printf "%s" "$missing" > missing.dat
   git add missing.dat
   git commit -m "add missing.dat"
 
   present="present"
   present_oid="$(calc_oid "$present")"
-  present_len="$(printf "%s" "$present" | wc -c | awk '{ print $1 }')"
   printf "%s" "$present" > present.dat
   git add present.dat
   git commit -m "add present.dat"
 
-  assert_local_object "$missing_oid" "$missing_len"
-  assert_local_object "$present_oid" "$present_len"
-
   delete_local_object "$missing_oid"
-
-  refute_local_object "$missing_oid"
-  assert_local_object "$present_oid" "$present_len"
 
   git push origin main 2>&1 | tee push.log
   if [ "1" -ne "${PIPESTATUS[0]}" ]; then
@@ -151,25 +143,17 @@ begin_test "push reject corrupt objects (lfs.allowincompletepush default)"
 
   corrupt="corrupt"
   corrupt_oid="$(calc_oid "$corrupt")"
-  corrupt_len="$(printf "%s" "$corrupt" | wc -c | awk '{ print $1 }')"
   printf "%s" "$corrupt" > corrupt.dat
   git add corrupt.dat
   git commit -m "add corrupt.dat"
 
   present="present"
   present_oid="$(calc_oid "$present")"
-  present_len="$(printf "%s" "$present" | wc -c | awk '{ print $1 }')"
   printf "%s" "$present" > present.dat
   git add present.dat
   git commit -m "add present.dat"
 
-  assert_local_object "$corrupt_oid" "$corrupt_len"
-  assert_local_object "$present_oid" "$present_len"
-
   corrupt_local_object "$corrupt_oid"
-
-  refute_local_object "$corrupt_oid" "$corrupt_len"
-  assert_local_object "$present_oid" "$present_len"
 
   git push origin main 2>&1 | tee push.log
   if [ "1" -ne "${PIPESTATUS[0]}" ]; then

--- a/t/t-push-failures-local.sh
+++ b/t/t-push-failures-local.sh
@@ -38,7 +38,7 @@ begin_test "push with missing objects (lfs.allowincompletepush true)"
 
   git push origin main 2>&1 | tee push.log
   if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected \`git push origin main\` to succeed ..."
+    echo >&2 "fatal: expected 'git push origin main' to succeed ..."
     exit 1
   fi
 
@@ -86,7 +86,7 @@ begin_test "push reject missing objects (lfs.allowincompletepush false)"
 
   git push origin main 2>&1 | tee push.log
   if [ "1" -ne "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected \`git push origin main\` to succeed ..."
+    echo >&2 "fatal: expected 'git push origin main' to fail ..."
     exit 1
   fi
 
@@ -132,9 +132,8 @@ begin_test "push reject missing objects (lfs.allowincompletepush default)"
   assert_local_object "$present_oid" "$present_len"
 
   git push origin main 2>&1 | tee push.log
-
-  if [ "0" -eq "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected 'git push origin main' to exit with non-zero code"
+  if [ "1" -ne "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected 'git push origin main' to fail ..."
     exit 1
   fi
 
@@ -181,9 +180,8 @@ begin_test "push reject corrupt objects (lfs.allowincompletepush default)"
   assert_local_object "$present_oid" "$present_len"
 
   git push origin main 2>&1 | tee push.log
-
-  if [ "0" -eq "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected 'git push origin main' to exit with non-zero code"
+  if [ "1" -ne "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected 'git push origin main' to fail ..."
     exit 1
   fi
 

--- a/t/t-push-failures-local.sh
+++ b/t/t-push-failures-local.sh
@@ -2,11 +2,11 @@
 
 . "$(dirname "$0")/testlib.sh"
 
-begin_test "push with missing objects (lfs.allowincompletepush true)"
+begin_test "push allow missing object (lfs.allowincompletepush true)"
 (
   set -e
 
-  reponame="push-with-missing-objects"
+  reponame="push-allow-missing-object"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"
 
@@ -46,11 +46,11 @@ begin_test "push with missing objects (lfs.allowincompletepush true)"
 )
 end_test
 
-begin_test "push reject missing objects (lfs.allowincompletepush false)"
+begin_test "push reject missing object (lfs.allowincompletepush false)"
 (
   set -e
 
-  reponame="push-reject-missing-objects"
+  reponame="push-reject-missing-object"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"
 
@@ -89,11 +89,11 @@ begin_test "push reject missing objects (lfs.allowincompletepush false)"
 )
 end_test
 
-begin_test "push reject missing objects (lfs.allowincompletepush default)"
+begin_test "push reject missing object (lfs.allowincompletepush default)"
 (
   set -e
 
-  reponame="push-missing-objects"
+  reponame="push-reject-missing-object-default"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"
 
@@ -128,11 +128,11 @@ begin_test "push reject missing objects (lfs.allowincompletepush default)"
 )
 end_test
 
-begin_test "push reject corrupt objects (lfs.allowincompletepush default)"
+begin_test "push reject corrupt object (lfs.allowincompletepush default)"
 (
   set -e
 
-  reponame="push-corrupt-objects"
+  reponame="push-reject-corrupt-object"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"
 

--- a/t/t-push-failures-local.sh
+++ b/t/t-push-failures-local.sh
@@ -22,7 +22,7 @@ begin_test "push with missing objects (lfs.allowincompletepush true)"
   missing_oid="$(calc_oid "$missing")"
   printf "%s" "$missing" > missing.dat
 
-  git add missing.dat present.dat
+  git add present.dat missing.dat
   git commit -m "add objects"
 
   git rm missing.dat
@@ -66,7 +66,7 @@ begin_test "push reject missing objects (lfs.allowincompletepush false)"
   missing_oid="$(calc_oid "$missing")"
   printf "%s" "$missing" > missing.dat
 
-  git add missing.dat present.dat
+  git add present.dat missing.dat
   git commit -m "add objects"
 
   git rm missing.dat
@@ -101,17 +101,16 @@ begin_test "push reject missing objects (lfs.allowincompletepush default)"
   git add .gitattributes
   git commit -m "initial commit"
 
-  missing="missing"
-  missing_oid="$(calc_oid "$missing")"
-  printf "%s" "$missing" > missing.dat
-  git add missing.dat
-  git commit -m "add missing.dat"
-
   present="present"
   present_oid="$(calc_oid "$present")"
   printf "%s" "$present" > present.dat
-  git add present.dat
-  git commit -m "add present.dat"
+
+  missing="missing"
+  missing_oid="$(calc_oid "$missing")"
+  printf "%s" "$missing" > missing.dat
+
+  git add present.dat missing.dat
+  git commit -m "add objects"
 
   delete_local_object "$missing_oid"
 
@@ -141,17 +140,16 @@ begin_test "push reject corrupt objects (lfs.allowincompletepush default)"
   git add .gitattributes
   git commit -m "initial commit"
 
-  corrupt="corrupt"
-  corrupt_oid="$(calc_oid "$corrupt")"
-  printf "%s" "$corrupt" > corrupt.dat
-  git add corrupt.dat
-  git commit -m "add corrupt.dat"
-
   present="present"
   present_oid="$(calc_oid "$present")"
   printf "%s" "$present" > present.dat
-  git add present.dat
-  git commit -m "add present.dat"
+
+  corrupt="corrupt"
+  corrupt_oid="$(calc_oid "$corrupt")"
+  printf "%s" "$corrupt" > corrupt.dat
+
+  git add present.dat corrupt.dat
+  git commit -m "add objects"
 
   corrupt_local_object "$corrupt_oid"
 

--- a/t/t-push-failures-local.sh
+++ b/t/t-push-failures-local.sh
@@ -82,7 +82,7 @@ begin_test "push reject missing object (lfs.allowincompletepush false)"
     exit 1
   fi
 
-  grep 'Unable to find source' push.log
+  grep "Unable to find source for object $missing_oid" push.log
 
   refute_server_object "$reponame" "$present_oid"
   refute_server_object "$reponame" "$missing_oid"

--- a/t/t-push-failures-local.sh
+++ b/t/t-push-failures-local.sh
@@ -28,11 +28,7 @@ begin_test "push with missing objects (lfs.allowincompletepush true)"
   git rm missing.dat
   git commit -m "remove missing"
 
-  # :fire: the "missing" object
-  missing_oid_part_1="$(echo "$missing_oid" | cut -b 1-2)"
-  missing_oid_part_2="$(echo "$missing_oid" | cut -b 3-4)"
-  missing_oid_path=".git/lfs/objects/$missing_oid_part_1/$missing_oid_part_2/$missing_oid"
-  rm "$missing_oid_path"
+  delete_local_object "$missing_oid"
 
   git config lfs.allowincompletepush true
 
@@ -76,11 +72,7 @@ begin_test "push reject missing objects (lfs.allowincompletepush false)"
   git rm missing.dat
   git commit -m "remove missing"
 
-  # :fire: the "missing" object
-  missing_oid_part_1="$(echo "$missing_oid" | cut -b 1-2)"
-  missing_oid_part_2="$(echo "$missing_oid" | cut -b 3-4)"
-  missing_oid_path=".git/lfs/objects/$missing_oid_part_1/$missing_oid_part_2/$missing_oid"
-  rm "$missing_oid_path"
+  delete_local_object "$missing_oid"
 
   git config lfs.allowincompletepush false
 

--- a/t/t-push-failures-local.sh
+++ b/t/t-push-failures-local.sh
@@ -128,7 +128,8 @@ begin_test "push reject missing object (lfs.allowincompletepush false)"
   fi
 
   grep "tq: stopping batched queue, object \"$missing_oid\" missing locally and on remote" push.log
-  grep "Unable to find source for object $missing_oid" push.log
+  grep "LFS upload failed:" push.log
+  grep "  (missing) missing.dat ($missing_oid)" push.log
 
   refute_server_object "$reponame" "$present_oid"
   refute_server_object "$reponame" "$missing_oid"
@@ -179,7 +180,8 @@ begin_test "push reject missing object (lfs.allowincompletepush false) (git-lfs-
   grep "pure SSH connection successful" push.log
 
   grep "tq: stopping batched queue, object \"$missing_oid\" missing locally and on remote" push.log
-  grep "Unable to find source for object $missing_oid" push.log
+  grep "LFS upload failed:" push.log
+  grep "  (missing) missing.dat ($missing_oid)" push.log
 
   refute_remote_object "$reponame" "$present_oid"
   refute_remote_object "$reponame" "$missing_oid"

--- a/t/testhelpers.sh
+++ b/t/testhelpers.sh
@@ -194,6 +194,21 @@ assert_remote_object() {
   popd
 }
 
+# refute_remote_object() confirms that an object file with the given OID
+# is not stored in the "remote" copy of a repository
+refute_remote_object() {
+  local reponame="$1"
+  local oid="$2"
+  local destination="$(canonical_path "$REMOTEDIR/$reponame.git")"
+
+  pushd "$destination"
+    local f="$(local_object_path "$oid")"
+    if [ -e $f ]; then
+      exit 1
+    fi
+  popd
+}
+
 # Set rate limit counts on the LFS server. HTTP log is written to http.log.
 #
 #   $ reset_server_rate_limit "api" "direction" "reponame" "oid" "num-tokens"

--- a/tq/api.go
+++ b/tq/api.go
@@ -75,11 +75,6 @@ func (c *tqClient) Batch(remote string, bReq *batchRequest) (*BatchResponse, err
 		bReq.TransferAdapterNames = nil
 	}
 
-	missing := make(map[string]bool)
-	for _, obj := range bReq.Objects {
-		missing[obj.Oid] = obj.Missing
-	}
-
 	bRes.endpoint = c.Endpoints.Endpoint(bReq.Operation, remote)
 	requestedAt := time.Now()
 
@@ -110,7 +105,6 @@ func (c *tqClient) Batch(remote string, bReq *batchRequest) (*BatchResponse, err
 	}
 
 	for _, obj := range bRes.Objects {
-		obj.Missing = missing[obj.Oid]
 		for _, a := range obj.Actions {
 			a.createdAt = requestedAt
 		}

--- a/tq/ssh.go
+++ b/tq/ssh.go
@@ -49,10 +49,8 @@ func (a *SSHBatchClient) Batch(remote string, bReq *batchRequest) (*BatchRespons
 		return bRes, nil
 	}
 
-	missing := make(map[string]bool)
 	batchLines := make([]string, 0, len(bReq.Objects))
 	for _, obj := range bReq.Objects {
-		missing[obj.Oid] = obj.Missing
 		batchLines = append(batchLines, fmt.Sprintf("%s %d", obj.Oid, obj.Size))
 	}
 
@@ -131,7 +129,6 @@ func (a *SSHBatchClient) Batch(remote string, bReq *batchRequest) (*BatchRespons
 	}
 
 	for _, obj := range bRes.Objects {
-		obj.Missing = missing[obj.Oid]
 		for _, a := range obj.Actions {
 			a.createdAt = requestedAt
 		}

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -625,6 +625,7 @@ func (q *TransferQueue) enqueueAndCollectRetriesFor(batch batch) (batch, error) 
 			// missing in that case, since we don't need to upload
 			// it.
 			if o.Missing && len(o.Actions) != 0 {
+				tracerx.Printf("tq: stopping batched queue, object %q missing locally and on remote", o.Oid)
 				return nil, errors.New(tr.Tr.Get("Unable to find source for object %v (try running `git lfs fetch --all`)", o.Oid))
 			}
 		}

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -634,7 +634,7 @@ func (q *TransferQueue) enqueueAndCollectRetriesFor(batch batch) (batch, error) 
 				// transfer queue.
 				if ok && objects.First().Missing {
 					tracerx.Printf("tq: stopping batched queue, object %q missing locally and on remote", o.Oid)
-					return nil, errors.New(tr.Tr.Get("Unable to find source for object %v (try running `git lfs fetch --all`)", o.Oid))
+					return nil, newObjectMissingError(objects.First().Name, o.Oid)
 				}
 			}
 		}


### PR DESCRIPTION
This PR simplifies and makes consistent the messages reported by the Git LFS client during push operations when a Git LFS object is missing from local internal Git LFS storage and is also not present on the remote server, and the `lfs.allowIncompletePush` Git configuration option is set to its default value of `false`.

At present, the client outputs different messages under these conditions, depending on whether or not a file exists in the working tree at the same path as that of the Git LFS pointer which references the missing object.  We can demonstrate this variable behaviour of the client as follows:

```
$ git clone https://github.com/chrisd8088/test
$ cd test
$ git lfs track "*.bin"
$ echo foo >foo.bin
$ git add .gitattributes foo.bin
$ git commit -m test

$ rm -rf .git/lfs/objects
$ git push origin main
Git LFS upload failed:   0% (0/1), 0 B | 0 B/s                                  
Uploading LFS objects:   0% (0/1), 0 B | 0 B/s, done.
  (missing) foo.bin (b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c)
hint: Your push was rejected due to missing or corrupt local objects.
hint: You can disable this check with: `git config lfs.allowincompletepush true`

$ rm foo.bin 
$ git push origin main
Unable to find source for object b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c (try running `git lfs fetch --all`)
Uploading LFS objects:   0% (0/1), 0 B | 0 B/s, done.
```

Note that in neither case is the push operation successful, but the error messages are different depending on whether or not `foo.bin` exists in the working tree.

Further, the contents of the file in the working tree do not matter, as shown below in a continuation of the example above:
```
$ echo bar >foo.bin
$ git push origin main
Git LFS upload failed:   0% (0/1), 0 B | 0 B/s                                  
  (missing) foo.bin (b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c)
Uploading LFS objects:   0% (0/1), 0 B | 0 B/s, done.
hint: Your push was rejected due to missing or corrupt local objects.
hint: You can disable this check with: `git config lfs.allowincompletepush true`
```

(Note that when pushing to a remote on a local filesystem using the `git-lfs-standalone-file(1)` adapter, rather than either the of HTTP-based or SSH-based Git LFS object transfer protocols, the client always reports the error message shown above.)

This variable behaviour is the consequence of an incomplete implementation of the `ensureFile()` [method](https://github.com/git-lfs/git-lfs/blob/97f47b9cd2102273287066e0225a6c10457c401a/commands/uploader.go#L363-L392) of the `uploadContext` structure in our `commands` package, dating from its introduction in PR #176.  In that PR's description, the method's purpose was explained as follows (using the original pre-release name for the Git LFS project):

> If the `.git/hawser/objects` directory gets into a weird state (for example, if the user manually removed some files in there), this attempts to re-clean the objects based on the git repository file path.

The code comments preceding the method describe it in the same way, as do several subsequent references to the method in later PRs, such as PR #2574 and #3398.  However, the `ensureFile()` method has never actually replaced missing object files under any circumstances.

This PR removes the `ensureFile()` method and as a consequence, missing object files should always produce the same error messages regardless of whether a file exists in the working tree at the path associated with an object's Git LFS pointer.  For example:

```
$ git clone https://github.com/chrisd8088/test
$ cd test
$ git lfs track "*.bin"
$ echo foo >foo.bin
$ git add .gitattributes foo.bin
$ git commit -m test

$ rm -rf .git/lfs/objects
$ rm foo.bin
$ git push origin main
Git LFS upload failed:   0% (0/1), 0 B | 0 B/s                                  
Uploading LFS objects:   0% (0/1), 0 B | 0 B/s, done.
  (missing) foo.bin (b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c)
hint: Your push was rejected due to missing or corrupt local objects.
hint: You can disable this check with: `git config lfs.allowincompletepush true`
```

In addition to making these error messages consistent, this PR also removes some [unnecessary](https://github.com/git-lfs/git-lfs/blob/97f47b9cd2102273287066e0225a6c10457c401a/tq/api.go#L78-L81) [mapping](https://github.com/git-lfs/git-lfs/blob/97f47b9cd2102273287066e0225a6c10457c401a/tq/api.go#L113) of the `Missing` fields in per-object data structures during upload operations, and refactors and expands the tests that validate our handling of missing and corrupt object files in `git lfs pre-push` and `git push` commands.

This PR will be most easily reviewed on a commit-by-commit basis, as each commit contains a detailed description of its changes.

#### Background

The `ensureFile()` method [checks](https://github.com/git-lfs/git-lfs/blob/97f47b9cd2102273287066e0225a6c10457c401a/commands/uploader.go#L366-L368) whether an object file is missing from the local storage directories, and if not, [tests](https://github.com/git-lfs/git-lfs/blob/97f47b9cd2102273287066e0225a6c10457c401a/commands/uploader.go#L370-L374) whether a file exists in the current working tree at the path of the Git LFS pointer associated with the object.  If such a file exists, the method proceeds to [run](https://github.com/git-lfs/git-lfs/blob/97f47b9cd2102273287066e0225a6c10457c401a/commands/uploader.go#L383) the `Clean()` method of the `GitFilter` structure in our `lfs` package on the file's contents.

The `Clean()` method [calls](https://github.com/git-lfs/git-lfs/blob/97f47b9cd2102273287066e0225a6c10457c401a/lfs/gitfilter_clean.go#L52) the `copyToTemp()` method, which writes a "cleaned" version of the contents of the file from the working tree into a temporary file in the `.git/lfs/tmp` directory.  It does not, though, move this file into the appropriate location under the `.git/lfs/objects` directory hierarchy.  That has always been the responsibility of the `clean()` function in the `commands` package, which [renames](https://github.com/git-lfs/git-lfs/blob/97f47b9cd2102273287066e0225a6c10457c401a/commands/command_clean.go#L82-L84) the temporary file into its final location, unless the file in the working tree was [found](https://github.com/git-lfs/git-lfs/blob/97f47b9cd2102273287066e0225a6c10457c401a/commands/command_clean.go#L57-L68) to contain a raw Git LFS pointer, or an error occurred.

While we could try to revise the `ensureFile()` method to operate as was originally intended, the advantages of such a change are relatively slim, and the disadvantages are several.  Most obviously, it requires modifications to our `clean()` function to guard against the replacement of object files with incorrect data, something the other callers of the function do not need to be concerned about because they only run within the context of our `clean` filter code, and so receive the input data from Git itself.
    
That this is a concern at all is in turn due to the reasonable chance that a file found in the current working tree at a given path does not contain the identical data as that of an Git LFS object generated from another file previously located at the same path.
    
As well, the fact that the `ensureFile()` method has never worked as designed, despite being repeatedly refactored and enhanced over ten years, suggests that its purpose is somewhat obscure and that the requisite logic is less intelligible than would be ideal.  Users and developers expect push operations to involve the transfer of data but not the creation (or re-creation) of local data files, so the use of our `clean` filter code in such a context is not particularly intuitive.
    
For all these reasons, we just remove the `ensureFile()` method entirely, which simplifies our handling of missing objects during upload transfer operations, and makes them more consistent, whether a missing file is detected before beginning batch transfer requests, or while [preparing](https://github.com/git-lfs/git-lfs/blob/97f47b9cd2102273287066e0225a6c10457c401a/tq/transfer_queue.go#L753-L762) a set of objects to be uploaded following a server's batch API response.