### PR TITLE
Update minimum required Git version checks

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -532,7 +532,7 @@ func buildProgressMeter(dryRun bool, d tq.Direction) *tq.Meter {
 }
 
 func requireGitVersion() {
-	minimumGit := "1.8.2"
+	minimumGit := "2.0.0"
 
 	if !git.IsGitVersionAtLeast(minimumGit) {
 		gitver, err := git.Version()


### PR DESCRIPTION
Since commit a343a11ddb8e3d3755590d1a3786831ccc18888b of PR #1461, a number of our commands, including `git lfs pull`, `git lfs push`, and `git lfs track`, have [checked](https://github.com/git-lfs/git-lfs/blob/97f47b9cd2102273287066e0225a6c10457c401a/commands/command_track.go#L38) the version of the currently available Git program and [reported](https://github.com/git-lfs/git-lfs/blob/97f47b9cd2102273287066e0225a6c10457c401a/commands/commands.go#L542) an error if it was not at least version 1.8.2.

However, when we added support for the `git lfs migrate` command in PR #2353, the actual minimum supported version of Git was changed from 1.8.x to 1.9.0 (in commit 1d0e834489913d05eaa2ae36f7c22d1901e5f845) and then to 2.0.0 (in commit 5aea841bb167e51592646e0c703ac37180623292).

These changes were made to the Travis CI configuration in use at the time, and later migrated to our current GitHub Actions CI workflow in commit c32820806229c3f42364d989f7a8597f73cb107ba of PR #3808.  This workflow continues to run our Git LFS test suite using Git 2.0.0.

More recently, in commit 15012658e6cbef04139eb22705c7f0352e2ec488 of PR #5921, we updated our `README` file to [document](https://github.com/git-lfs/git-lfs/blob/97f47b9cd2102273287066e0225a6c10457c401a/README.md?plain=1#L164-L165) that the current minimum supported version of Git we require is v2.0.0.

We therefore now update the minimum Git version required by the Git LFS client to 2.0.0 by adjusting the version string [defined](https://github.com/git-lfs/git-lfs/blob/97f47b9cd2102273287066e0225a6c10457c401a/commands/commands.go#L535) in the `requireGitVersion()` function of our `commands` package.