### PR TITLE
Use single-target `Makefile` patterns for manual pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -717,16 +717,28 @@ MAN_HTML_TARGETS = man/html/git-lfs-checkout.1.html \
   man/html/git-lfs-update.1.html \
   man/html/git-lfs.1.html
 
-# man generates all ROFF- and HTML-style manpage targets.
+# man generates all ROFF- and HTML-style man page targets.
 .PHONY : man
 man : $(MAN_ROFF_TARGETS) $(MAN_HTML_TARGETS)
 
-# man/% generates ROFF-style man pages from the corresponding .ronn file.
-man/man1/%.1 man/man5/%.5 man/man7/%.7 : docs/man/%.adoc
-	@mkdir -p man/man1 man/man5
-	$(ASCIIDOCTOR) $(ASCIIDOCTOR_EXTRA_ARGS) -b manpage -o $@ $^
+# Generate ROFF-style man pages from the corresponding .adoc files.
+man/man1/%.1 : docs/man/%.adoc
+	@mkdir -p man/man1
+	$(ASCIIDOCTOR) $(ASCIIDOCTOR_EXTRA_ARGS) -b manpage -o $@ $<
+man/man5/%.5 : docs/man/%.adoc
+	@mkdir -p man/man5
+	$(ASCIIDOCTOR) $(ASCIIDOCTOR_EXTRA_ARGS) -b manpage -o $@ $<
+man/man7/%.7 : docs/man/%.adoc
+	@mkdir -p man/man7
+	$(ASCIIDOCTOR) $(ASCIIDOCTOR_EXTRA_ARGS) -b manpage -o $@ $<
 
-# man/%.html generates HTML-style man pages from the corresponding .ronn file.
-man/html/%.1.html man/html/%.5.html man/html/%.7.html : docs/man/%.adoc
+# Generate HTML-style man pages from the corresponding .adoc files.
+man/html/%.1.html : docs/man/%.adoc
 	@mkdir -p man/html
-	$(ASCIIDOCTOR) $(ASCIIDOCTOR_EXTRA_ARGS) -b html5 -o $@ $^
+	$(ASCIIDOCTOR) $(ASCIIDOCTOR_EXTRA_ARGS) -b html5 -o $@ $<
+man/html/%.5.html : docs/man/%.adoc
+	@mkdir -p man/html
+	$(ASCIIDOCTOR) $(ASCIIDOCTOR_EXTRA_ARGS) -b html5 -o $@ $<
+man/html/%.7.html : docs/man/%.adoc
+	@mkdir -p man/html
+	$(ASCIIDOCTOR) $(ASCIIDOCTOR_EXTRA_ARGS) -b html5 -o $@ $<


### PR DESCRIPTION
Beginning with version 4.4 of the GNU `make(1)` command, the warning message `pattern recipe did not update peer target` is output if a recipe does not build all of its assigned targets.  The next release of GNU `make(1)` will treat this condition as an error, per the v4.4 [release notes](https://lists.gnu.org/archive/html/info-gnu/2022-10/msg00008.html).

Our Makefile contains several pattern [rules](https://github.com/git-lfs/git-lfs/blob/d5db3c873ed3cf90b667d796a2c39b0dc7674578/Makefile#L724-L732) which generate roff and HTML manual pages from our AsciiDoc source files, and these specify multiple targets because the AsciiDoc source files lack a manual section number (e.g., `1` or `5`), while the target files must contain those numbers (e.g., `man/man1/git-lfs.1`).

With the latest versions of GNU `make(1)`, these rules cause the command to output its warning message, because they do not generate all the specified targets.  For instance, only the `man/man1/git-lfs.1` file will be [generated](https://github.com/git-lfs/git-lfs/blob/d5db3c873ed3cf90b667d796a2c39b0dc7674578/docs/man/git-lfs.adoc?plain=1#L1) from the `git-lfs.adoc` source file; no `man/man5/git-lfs.5` or `man/man7/git-lfs.7` files will be created.

To avoid problems in the future, we rewrite the rules which generate our finished man pages so they only specify the targets that will be created by the given recipe.

We also adjust our use of the `$^` automatic variable to `$<` because we only define a single prerequisite (i.e., source file) for each recipe, and so can reference it explicitly with `$<`, per the [documentation](https://www.gnu.org/software/make/manual/html_node/Automatic-Variables.html).