### PR TITLE
Fix language in code snippets in API docs

### DIFF
--- a/docs/api/basic-transfers.md
+++ b/docs/api/basic-transfers.md
@@ -27,7 +27,7 @@ response that looks like this:
           "header": {
             "Authorization": "Basic ..."
           },
-          "expires_in": 86400,
+          "expires_in": 86400
         }
       }
     }

--- a/docs/api/batch.md
+++ b/docs/api/batch.md
@@ -47,7 +47,7 @@ property was added for future compatibility with some experimental transfer
 adapters. See the [API README](./README.md) for a list of the documented
 transfer adapters.
 
-```js
+```json5
 // POST https://lfs-server.com/objects/batch
 // Accept: application/vnd.git-lfs+json
 // Content-Type: application/vnd.git-lfs+json
@@ -76,7 +76,7 @@ Some examples will illustrate how the `ref` property can be used.
 * User `owner` has full access to the repository.
 * User `contrib` has readonly access to the repository, and write access to `refs/heads/contrib`.
 
-```js
+```json5
 {
   "operation": "download",
   "transfers": [ "basic" ],
@@ -91,7 +91,7 @@ Some examples will illustrate how the `ref` property can be used.
 
 With this payload, both `owner` and `contrib` can download the requested object, since they both have read access.
 
-```js
+```json5
 {
   "operation": "upload",
   "transfers": [ "basic" ],
@@ -106,7 +106,7 @@ With this payload, both `owner` and `contrib` can download the requested object,
 
 With this payload, only `owner` can upload the requested object.
 
-```js
+```json5
 {
   "operation": "upload",
   "transfers": [ "basic" ],
@@ -167,7 +167,7 @@ for extra verification, if needed. If a client requests to upload an object that
 the server already has, the server should omit the `actions` property
 completely. The client will then assume the server already has it.
 
-```js
+```json5
 // HTTP/1.1 200 Ok
 // Content-Type: application/vnd.git-lfs+json
 {
@@ -195,7 +195,7 @@ completely. The client will then assume the server already has it.
 If there are problems accessing individual objects, servers should continue to
 return a 200 status code, and provide per-object errors. Here is an example:
 
-```js
+```json5
 // HTTP/1.1 200 Ok
 // Content-Type: application/vnd.git-lfs+json
 {
@@ -242,7 +242,7 @@ debugging.
 * `documentation_url` - Optional String to give the user a place to report
 errors.
 
-```js
+```json5
 // HTTP/1.1 404 Not Found
 // Content-Type: application/vnd.git-lfs+json
 
@@ -258,7 +258,7 @@ client what form of authentication it requires. If omitted, Git LFS will assume
 Basic Authentication. This mirrors the standard `WWW-Authenticate` header with
 a custom header key so it does not trigger password prompts in browsers.
 
-```js
+```json5
 // HTTP/1.1 401 Unauthorized
 // Content-Type: application/vnd.git-lfs+json
 // LFS-Authenticate: Basic realm="Git LFS"

--- a/docs/api/locking.md
+++ b/docs/api/locking.md
@@ -43,7 +43,7 @@ relative to the root of the repository working directory.
 * `ref` - Optional object describing the server ref that the locks belong to. Note: Added in v2.4.
   * `name` - Fully-qualified server refspec.
 
-```js
+```json5
 // POST https://lfs-server.com/locks
 // Accept: application/vnd.git-lfs+json
 // Content-Type: application/vnd.git-lfs+json
@@ -69,7 +69,7 @@ RFC 3339-formatted string with second precision.
 * `owner` - Optional name of the user that created the Lock. This should be set from
 the user credentials posted when creating the lock.
 
-```js
+```json5
 // HTTP/1.1 201 Created
 // Content-Type: application/vnd.git-lfs+json
 {
@@ -96,7 +96,7 @@ debugging.
 * `documentation_url` - Optional String to give the user a place to report
 errors.
 
-```js
+```json5
 // HTTP/1.1 409 Conflict
 // Content-Type: application/vnd.git-lfs+json
 {
@@ -120,7 +120,7 @@ debugging.
 * `documentation_url` - Optional String to give the user a place to report
 errors.
 
-```js
+```json5
 // HTTP/1.1 403 Forbidden
 // Content-Type: application/vnd.git-lfs+json
 {
@@ -138,7 +138,7 @@ debugging.
 * `documentation_url` - Optional String to give the user a place to report
 errors.
 
-```js
+```json5
 // HTTP/1.1 500 Internal server error
 // Content-Type: application/vnd.git-lfs+json
 {
@@ -165,7 +165,7 @@ should have its own upper and lower bounds on the supported limits.
 * `refspec` - Optional fully qualified server refspec
 from which to search for locks.
 
-```js
+```json5
 // GET https://lfs-server.com/locks?path=&id=&cursor=&limit=&refspec=
 // Accept: application/vnd.git-lfs+json
 // Authorization: Basic ... (if needed)
@@ -183,7 +183,7 @@ setting the `?cursor` query value with this `next_cursor` value.
 
 Note: If the server has no locks, it must return an empty `locks` array.
 
-```js
+```json5
 // HTTP/1.1 200 Ok
 // Content-Type: application/vnd.git-lfs+json
 {
@@ -212,7 +212,7 @@ debugging.
 * `documentation_url` - Optional String to give the user a place to report
 errors.
 
-```js
+```json5
 // HTTP/1.1 403 Forbidden
 // Content-Type: application/vnd.git-lfs+json
 {
@@ -230,7 +230,7 @@ debugging.
 * `documentation_url` - Optional String to give the user a place to report
 errors.
 
-```js
+```json5
 // HTTP/1.1 500 Internal server error
 // Content-Type: application/vnd.git-lfs+json
 {
@@ -262,7 +262,7 @@ to `/locks/verify` (appended to the LFS server url, as described above):
 * `limit` - Optional limit to how many locks to
 return.
 
-```js
+```json5
 // POST https://lfs-server.com/locks/verify
 // Accept: application/vnd.git-lfs+json
 // Content-Type: application/vnd.git-lfs+json
@@ -299,7 +299,7 @@ their team.
 Note: If the server has no locks, it must return an empty array in the `ours` or
 `theirs` properties.
 
-```js
+```json5
 // HTTP/1.1 200 Ok
 // Content-Type: application/vnd.git-lfs+json
 {
@@ -332,7 +332,7 @@ debugging.
 * `documentation_url` - Optional String to give the user a place to report
 errors.
 
-```js
+```json5
 // HTTP/1.1 404 Not found
 // Content-Type: application/vnd.git-lfs+json
 {
@@ -353,7 +353,7 @@ debugging.
 * `documentation_url` - Optional String to give the user a place to report
 errors.
 
-```js
+```json5
 // HTTP/1.1 403 Forbidden
 // Content-Type: application/vnd.git-lfs+json
 {
@@ -371,7 +371,7 @@ debugging.
 * `documentation_url` - Optional String to give the user a place to report
 errors.
 
-```js
+```json5
 // HTTP/1.1 500 Internal server error
 // Content-Type: application/vnd.git-lfs+json
 {
@@ -396,7 +396,7 @@ lock.
 * `ref` - Optional object describing the server ref that the locks belong to. Note: Added in v2.4.
   * `name` - Fully-qualified server refspec.
 
-```js
+```json5
 // POST https://lfs-server.com/locks/:id/unlock
 // Accept: application/vnd.git-lfs+json
 // Content-Type: application/vnd.git-lfs+json
@@ -415,7 +415,7 @@ lock.
 Successful deletions return the deleted lock. See the "Create Lock" successful
 response section to see what Lock properties are possible.
 
-```js
+```json5
 // HTTP/1.1 200 Ok
 // Content-Type: application/vnd.git-lfs+json
 {
@@ -442,7 +442,7 @@ debugging.
 * `documentation_url` - Optional String to give the user a place to report
 errors.
 
-```js
+```json5
 // HTTP/1.1 403 Forbidden
 // Content-Type: application/vnd.git-lfs+json
 {
@@ -460,7 +460,7 @@ debugging.
 * `documentation_url` - Optional String to give the user a place to report
 errors.
 
-```js
+```json5
 // HTTP/1.1 500 Internal server error
 // Content-Type: application/vnd.git-lfs+json
 {


### PR DESCRIPTION
These snippets are not `js` (JavaScript), they are JSON. Since many snippets also include comments, I marked them as JSON5 because raw JSON doesn't support comments.