### PR TITLE
lfshttp/certs_darwin: filter CA certs that are only fuzzy matches of CN

### DIFF
--- a/lfshttp/certs_darwin_test.go
+++ b/lfshttp/certs_darwin_test.go
@@ -1,0 +1,138 @@
+//go:build darwin
+// +build darwin
+
+package lfshttp
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestAppendMatchingCertsByCN tests that our function correctly filters certificates
+// based on hostname matches in the CN field.
+func TestAppendMatchingCertsByCN(t *testing.T) {
+	// Create certificates with different CNs for testing
+	problematicCert := generateCACert(t, "example.org JSS Built-in Certificate Authority", true)
+	exactMatchCert := generateCACert(t, "example.org", true)
+	regularCert := generateCACert(t, "git-lfs.local", false)
+
+	// Export the certs to PEM format
+	problematicPEM := exportCertToPEM(t, problematicCert)
+	exactMatchPEM := exportCertToPEM(t, exactMatchCert)
+	regularPEM := exportCertToPEM(t, regularCert)
+
+	// Combine all certs into a bundle
+	certBundle := append(problematicPEM, exactMatchPEM...)
+	certBundle = append(certBundle, regularPEM...)
+
+	// Create test cases
+	tests := []struct {
+		name          string
+		hostname      string
+		certBundle    []byte
+		expectedCount int // How many certs we expect to be added to the pool
+		description   string
+	}{
+		{
+			name:          "Problematic cert filtered for exact hostname",
+			hostname:      "example.org",
+			certBundle:    certBundle,
+			expectedCount: 2, // Should only include exactMatchCert + regularCert (problematic is filtered)
+			description:   "Should filter out the problematic cert with hostname as substring",
+		},
+		{
+			name:          "All certs included for different hostname",
+			hostname:      "github.com",
+			certBundle:    certBundle,
+			expectedCount: 3, // Should include all 3 certs
+			description:   "Should include all certs when hostname doesn't match as substring",
+		},
+		{
+			name:          "Only matching cert included",
+			hostname:      "git-lfs.local",
+			certBundle:    certBundle,
+			expectedCount: 3, // Should only include all 3 certs
+			description:   "Should only include the cert with exact hostname match",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Start with an empty pool
+			pool := x509.NewCertPool()
+
+			// Create a pool with all certificates (to check initial count)
+			allCertsPool := x509.NewCertPool()
+			ok := allCertsPool.AppendCertsFromPEM(certBundle)
+			assert.True(t, ok, "Should be able to parse certificate bundle")
+
+			// Call the function we're testing with the corrected parameter order
+			updatedPool := appendMatchingCertsByCN(pool, tt.certBundle, tt.hostname)
+
+			// Count the certificates using the deprecated Subjects() method
+			filteredCount := len(updatedPool.Subjects())
+
+			// Verify the count matches our expectation
+			assert.Equal(t, tt.expectedCount, filteredCount, tt.description)
+		})
+	}
+}
+
+// generateCACert creates a test certificate with the specified common name
+func generateCACert(t *testing.T, commonName string, isCA bool) *x509.Certificate {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("Failed to generate private key: %v", err)
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		t.Fatalf("Failed to generate serial number: %v", err)
+	}
+
+	notBefore := time.Now()
+	notAfter := notBefore.Add(10 * 365 * 24 * time.Hour)
+
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName: commonName,
+		},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  isCA,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, template, template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		t.Fatalf("Failed to create certificate: %v", err)
+	}
+
+	cert, err := x509.ParseCertificate(derBytes)
+	if err != nil {
+		t.Fatalf("Failed to parse generated certificate: %v", err)
+	}
+
+	return cert
+}
+
+// exportCertToPEM converts an x509 certificate to PEM format
+func exportCertToPEM(t *testing.T, cert *x509.Certificate) []byte {
+	pemBlock := &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: cert.Raw,
+	}
+
+	return pem.EncodeToMemory(pemBlock)
+}


### PR DESCRIPTION
In our organization (`example.org`), we use the Jamf endpoint, which adds a self-signed SSL certificate with the CN:

```
CN=example.org JSS Built-in Certificate Authority
```

This causes SSL validation to fail when accessing Git LFS on `example.org`:

```
Post "https://example.org/group/project/info/lfs/locks/verify": x509: certificate signed by unknown authority
```

This is happening because:

1. When accessing `example.org` endpoints, Git LFS checks if there are any custom certificates to trust for that host.
2. It calls `appendRootCAsForHostFromKeychain` with the hostname `example.org`.
3. This function executes `/usr/bin/security find-certificate -a -p -c example.org <keychain>`, which performs a substring match on the Common Name.
4. If the System keychain contains a certificate with CN `example.org JSS Built-in Certificate Authority`, this gets returned by the fuzzy match.
5. Git LFS then adds this CA certificate to the trust store for connections to `example.org`.
6. When connecting to the real `example.org`, Git LFS is now trying to validate the official TLS certificate against this self-signed JAMF CA certificate, which will always fail.

Because `/usr/bin/security find-certificate` does not support exact matches, this commit filters out non-matching CNs to avoid using the wrong cert for the given domain.

Resolves #6036.