### PR TITLE
Fix leaking directories

### DIFF
--- a/ssh/connection.go
+++ b/ssh/connection.go
@@ -2,6 +2,9 @@ package ssh
 
 import (
 	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 
 	"github.com/git-lfs/git-lfs/v3/config"
@@ -171,6 +174,10 @@ func (st *SSHTransfer) setConnectionCount(n int) error {
 				continue
 			}
 			tracerx.Printf("terminating pure SSH connection (#%d) (resetting total from %d to %d)", tn+i, count, n)
+			if st.controlPath != "" {
+				os.RemoveAll(filepath.Join(st.controlPath, ".."))
+				st.controlPath = ""
+			}
 			if err := item.End(); err != nil {
 				return err
 			}
@@ -192,11 +199,14 @@ func (st *SSHTransfer) setConnectionCount(n int) error {
 	}
 	if n == 0 && count > 0 {
 		tracerx.Printf("terminating pure SSH connection (#0) (resetting total from %d to %d)", count, n)
+		if st.controlPath != "" {
+			os.RemoveAll(filepath.Join(st.controlPath, ".."))
+			st.controlPath = ""
+		}
 		if err := st.conn[0].End(); err != nil {
 			return err
 		}
 		st.conn = nil
-		st.controlPath = ""
 	}
 	return nil
 }


### PR DESCRIPTION
Please consider this more a bugreport, then a valid fix. However, it solves the issue for us that our servers run "out of disk space" errors because no available inodes on an ext4 file system. The reason behind is that the /tmp/sock-XXXXX directories of lfs.sock never get cleaned up.

The fix assuming that upper directory of the lfs.sock must be removed is a bit dangerous, but we don't have a handle for the directory itself atm.

It solves the issue, but most likely some refactoring should be done to have a proper handle for cleanup instead.