### PR TITLE
Prevent conflicting curl macros in early Git version CI jobs

### DIFF
--- a/script/build-git
+++ b/script/build-git
@@ -22,6 +22,29 @@ esac
 GIT_INSTALL_PATH="${GIT_INSTALL_DIR:-"/usr/local"}"
 
 cd "$DIR"
+
+# Hide macros defined in Git v2.33.x and earlier which now conflict with
+# macros defined by curl since v8.13.0.
+if grep -q "CURLOPT_USE_SSL" http.h; then
+  cat <<EOF | patch -p1
+--- a/http.h
++++ b/http.h
+@@ -45,10 +45,12 @@
+  * CURLOPT_USE_SSL was known as CURLOPT_FTP_SSL up to 7.16.4,
+  * and the constants were known as CURLFTPSSL_*
+ */
++/*
+ #if !defined(CURLOPT_USE_SSL) && defined(CURLOPT_FTP_SSL)
+ #define CURLOPT_USE_SSL CURLOPT_FTP_SSL
+ #define CURLUSESSL_TRY CURLFTPSSL_TRY
+ #endif
++*/
+
+ struct slot_results {
+	CURLcode curl_result;
+EOF
+fi
+
 printf "%s\n" \
   "NO_GETTEXT=YesPlease" \
   "NO_OPENSSL=YesPlease" \


### PR DESCRIPTION
This PR resolves a problem which has recently caused our `build-earliest` CI [job](https://github.com/git-lfs/git-lfs/blob/9b9bccb9a559f9e3e76807a00ff908b3e414ded9/.github/workflows/ci.yml#L142-L165) to [fail](https://github.com/git-lfs/git-lfs/actions/runs/14646748015/job/41123628361) on macOS GitHubActions runners when we try to compile Git v2.0.0.

Specifically, the compiler reports `error: use of undeclared identifier 'CURLUSESSL_TRY'` in the [call](https://github.com/git/git/blob/v2.0.0/http.c#L363) to the `curl_easy_setopt()` function in Git's `get_curl_handle()` function, where `CURLUSESSL_TRY` is passed as the final argument.

As described below, and explicated in further detail in the description of this PR's sole commit, the error occurs because older versions of Git contain a macro whose [definition](https://github.com/git/git/blob/v2.0.0/http.h#L50) of `CURLUSESSL_TRY` overrides the [definition](https://github.com/curl/curl/blob/curl-8_13_0/include/curl/curl.h#L931) now provided by the curl library, and the result is that the macro expands back to the same name, which is nowhere defined as an actual C identifier and not as a preprocessor macro.

To resolve the compiler error we update our `script/build-git` script to patch older versions of Git's `http.h` source file and comment out the conditional [block](https://github.com/git/git/blob/v2.0.0/http.h#L44-L51) which defined the `CURLOPT_USE_SSL` and `CURLUSESSL_TRY` macros.  Since all modern versions of curl [define](https://github.com/curl/curl/blob/curl-8_13_0/include/curl/curl.h#L1592) these identifiers, there is no need for Git to define them, and Git versions since 2.34.0 do not do so.

(We may in the future consider raising the minimum version of Git we support and test against to v2.34.0 or higher, at which point we will no longer need to patch the `http.h` source file.  However, we still build packages for Linux distributions with versions of Git older than 2.34.0; for instance, Debian 11 [packages](https://packages.debian.org/bullseye/git) Git v2.30.2 with a number of back-ported security patches.  Therefore we should for now continue to test with relatively old versions of Git, and as such, will need to patch the Git source to allow our `build-earliest` CI jobs to succeed.)

#### Background

The error seen in our CI jobs occurs on our macOS runners because the version of the curl library installed by Homebrew has just been upgraded to v8.13.0, and that version includes the changes from commit curl/curl@7b0240c07799c28dc84272f9e38e1092ce4cc498, where the `CURLUSESSL_*` enumerated constants, including `CURLUSESSL_TRY`, were replaced with macro [definitions](https://github.com/curl/curl/blob/curl-8_13_0/include/curl/curl.h#L930-L933), for the reasons outlined in curl/curl#16539 and curl/curl#16482.

With recent versions of Git, this change has no effect.  However, versions of Git between 1.8.3 and 2.33.8 contained a macro definition [block](https://github.com/git/git/blob/v2.0.0/http.h#L44-L51) which defines `CURLUSESSL_TRY` with the value `CURLFTPSSL_TRY`.  (This block was added in commit git/git@4bc444eb64173f770c1d1dba2ed3db393c2a9b18 with the intention that it would allow Git to be compiled against versions of curl prior to v7.17.0, which did not define the `CURLOPT_USE_SSL` and `CURLUSESSL_TRY` identifiers, although that may not ever have actually worked as intended.)

The curl library, meanwhile, provides a macro [definition](https://github.com/curl/curl/blob/curl-8_13_0/include/curl/curl.h#L987) of `CURLFTPSSL_TRY` which expands back to `CURLUSESSL_TRY`.

When our `build-earliest` CI job tries to compile Git v2.0.0 using curl v8.13.0, these duplicate definitions produce some compiler warnings.  They also cause an error, because Git's definition supersedes curl's, so the C preprocessor first expands `CURLUSESSL_TRY` to `CURLFTPSSL_TRY` (per Git's definition) and then expands `CURLFTPSSL_TRY` back to `CURLUSESSL_TRY` (per curl's definition of `CURLFTPSSL_TRY`). At this point, preprocessing stops, at which point the compiler expects to find a C identifier with the name `CURLUSESSL_TRY`.  When it finds none, an error results.

(Note that newer versions of Git do not define the `CURLOPT_USE_SSL` and `CURLUSESSL_TRY` macros at all, so our other CI jobs are not affected by the changes in curl v8.13.0.  The conditional block which defined these macros was removed in commit git/git@5db9d383590c37272a9f16464a66dfbd3a3c8aff of Git v2.34.0.)

The description of this PR's single commit provides additional information and context on the history of these macro definitions in the Git and curl source code, and some speculation as to whether the conditional governing Git's macro definitions ever worked as intended.