### PR TITLE
feat: git lfs pointer support extensions

### DIFF
--- a/docs/man/git-lfs-pointer.adoc
+++ b/docs/man/git-lfs-pointer.adoc
@@ -37,6 +37,8 @@ consistency between different Git LFS implementations.
   canonical; that is, it would be the one created by Git LFS. If it is not,
   exits 2. The default, for backwards compatibility, is `--no-strict`, but this
   may change in a future version.
+`--no-extensions`::
+  Don't print the extensions of the pointer.
 
 == SEE ALSO
 


### PR DESCRIPTION
`git-lfs pointer` support `--extensions` parameter to print extended information.

Resolves https://github.com/git-lfs/git-lfs/issues/4047