### PR TITLE
commands: use Exit() function to exit with a warning message

### DIFF
--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -103,8 +103,7 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 
 	if fetchUseStdin {
 		if len(args) > 1 {
-			Print(tr.Tr.Get("Further command line arguments are ignored with --stdin"))
-			os.Exit(1)
+			Exit(tr.Tr.Get("Further command line arguments are ignored with --stdin"))
 		}
 
 		scanner := bufio.NewScanner(os.Stdin) // line-delimited

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -36,8 +36,7 @@ var (
 // of commits between the local and remote git servers.
 func pushCommand(cmd *cobra.Command, args []string) {
 	if len(args) == 0 {
-		Print(tr.Tr.Get("Specify a remote and a remote branch name (`git lfs push origin main`)"))
-		os.Exit(1)
+		Exit(tr.Tr.Get("Specify a remote and a remote branch name (`git lfs push origin main`)"))
 	}
 
 	requireGitVersion()
@@ -52,8 +51,7 @@ func pushCommand(cmd *cobra.Command, args []string) {
 	var argList []string
 	if useStdin {
 		if len(args) > 1 {
-			Print(tr.Tr.Get("Further command line arguments are ignored with --stdin"))
-			os.Exit(1)
+			Exit(tr.Tr.Get("Further command line arguments are ignored with --stdin"))
 		}
 
 		scanner := bufio.NewScanner(os.Stdin) // line-delimited


### PR DESCRIPTION
Replace the remaining `os.Exit()` calls with our `Exit()` wrapper for consistency. This change also alters the exit code for these exits from `1` to `2`. This is irrelevant for the `fetch` code as it was not released, yet. The push code was shipped some time ago (https://github.com/git-lfs/git-lfs/pull/5086) and therefore we need to mention this change in the release notes.