### PR TITLE
feature: bulk transfer adapters

### DIFF
--- a/docs/api/batch.md
+++ b/docs/api/batch.md
@@ -41,6 +41,12 @@ be assumed by the server.
   * `size` - Integer byte size of the LFS object. Must be at least zero.
 * `hash_algo` - The hash algorithm used to name Git LFS objects.  Optional;
   defaults to `sha256` if not specified.
+* `supported_transfer_concurrency_modes` - Optional Array of String identifiers for 
+  transfer concurrency modes that the client supports. If omitted, the server MUST
+  assume that only the `basic` transfer concurrency mode is supported.
+* `preferred_transfer_concurrency_mode` - Optional String identifier for the transfer
+  concurrency mode that the client prefers. If omitted, the server MUST assume the
+  `basic` transfer concurrency mode is preferred.
 
 Note: Git LFS currently only supports the `basic` transfer adapter. This
 property was added for future compatibility with some experimental transfer
@@ -62,7 +68,9 @@ transfer adapters.
       "size": 123
     }
   ],
-  "hash_algo": "sha256"
+  "hash_algo": "sha256",
+  "supported_transfer_concurrency_modes": [ "batch", "basic" ],
+  "preferred_transfer_concurrency_mode": "basic"
 }
 ```
 
@@ -188,7 +196,8 @@ completely. The client will then assume the server already has it.
       }
     }
   ],
-  "hash_algo": "sha256"
+  "hash_algo": "sha256",
+  "transfer_concurrency_mode": "basic"
 }
 ```
 
@@ -217,7 +226,7 @@ return a 200 status code, and provide per-object errors. Here is an example:
 LFS object error codes should match HTTP status codes where possible:
 
 * 404 - The object does not exist on the server.
-* 409 - The specified hash algorithm disagrees with the server's acceptable options.
+* 409 - The specified hash algorithm disagrees with the server's acceptable options or no transfer concurrency mode is supported.
 * 410 - The object was removed by the owner.
 * 422 - Validation error.
 

--- a/docs/bulk-transfers.md
+++ b/docs/bulk-transfers.md
@@ -1,0 +1,427 @@
+﻿# Bulk Transfer Protocol for Git LFS
+
+## Introduction
+
+The bulk transfer extends the existing custom transfer mechanism to allow 
+processing multiple files simultaneously in bulks. This protocol is designed 
+to improve transfer efficiency when dealing with many files by grouping them 
+into bulks and allowing transfer adapters complete flexibility in how they 
+process these bulks.
+
+The main goal of the protocol is to allow several artifacts to be
+transferred in a single operation, reducing the overhead of multiple
+individual requests. This is particularly useful for large repositories with
+many LFS objects, where transferring in bulk can significantly reduce the 
+time and resources required for the transfer by using modern data 
+deduplication strategies, parallel processing, and optimized transfer protocols.
+
+## Defining a Custom Transfer Type
+
+A custom transfer process is defined under a settings group called
+`lfs.bulk.transfer.<name>`, where `<name>` is an identifier (see
+[Naming](#naming) below).
+
+* `lfs.bulk.transfer.<name>.path`
+
+  `path` should point to the process you wish to invoke. This will be invoked at
+  the start of all transfers (possibly many times, see the `concurrent` option
+  below) and the protocol over stdin/stdout is defined below in the
+  [Protocol](#protocol) section.
+
+* `lfs.bulk.transfer.<name>.args`
+
+  If the custom transfer process requires any arguments, these can be provided
+  here. Typically you would only need this if your process was multi-purpose or
+  particularly flexible, most of the time you won't need it.  Note that this
+  string will be expanded by the shell.
+
+* `lfs.bulk.transfer.<name>.concurrent`
+
+  If true (the default), git-lfs will invoke the custom transfer process
+  multiple times in parallel, according to `lfs.concurrenttransfers`, splitting
+  the transfer workload between the processes.
+
+  If you would prefer that only one instance of the transfer process is invoked,
+  maybe because you want to do your own parallelism internally (e.g. slicing
+  files into parts), set this to false.
+
+* `lfs.bulk.transfer.<name>.direction`
+
+  Specifies which direction the custom transfer process supports, either
+  `download`, `upload`, or `both`. The default if unspecified is `both`.
+*  `lfs.bulk.transfer.<name>.bulkSize`
+
+  Specifies the maximum number of files that can be processed in a single bulk
+  transfer. The default is `100`, but this can be adjusted based on the expected
+  workload and performance characteristics of the transfer process.
+  
+  When the number of remaining files is less than bulkSize, git-lfs will
+  automatically send the incomplete bulk after a 100ms timeout to ensure
+  efficient processing.
+
+## Naming
+
+Each batch transfer must have a name which is unique to the underlying
+mechanism, and the client and the server must agree on that name. The client
+will advertise this name to the server as a supported transfer approach, and if
+the server supports it, it will return relevant object action links. Because
+these may be very different from standard HTTP URLs it's important that the
+client and server agree on the name.
+
+For example, let's say I've implemented a custom transfer process which uses
+NFS. I could call this transfer type `nfs` - although it's not specific to my
+configuration exactly, it is specific to the way NFS works, and the server will
+need to give me different URLs. Assuming I define my transfer like this, and the
+server supports it, I might start getting object action links back like
+`nfs://<host>/path/to/object`
+
+
+## Protocol
+
+The git-lfs client communicates with the bulk transfer process via the stdin
+and stdout streams. No file content is communicated on these streams, only
+request / response metadata. The metadata exchanged is always in JSON format.
+External files will be referenced when actual content is exchanged.
+
+### Line Delimited JSON
+
+Because multiple JSON messages will be exchanged on the same stream it's useful
+to delimit them explicitly rather than have the parser find the closing `}` in
+an arbitrary stream, therefore each JSON structure will be sent and received on
+a **single line** as per [Line Delimited
+JSON](https://en.wikipedia.org/wiki/JSON_Streaming#Line_delimited_JSON_2).
+
+In other words when git-lfs sends a JSON message to the bulk transfer it will
+be on a single line, with a line feed at the end. The transfer process must
+respond the same way by writing a JSON structure back to stdout with a single
+line feed at the end (and flush the output).
+
+### Protocol Stages
+
+The bulk transfer protocol follows these stages:
+1. **Initiation** - Same as custom transfers
+2. **Bulk Transfers** - Announces the start of a bulk with metadata
+6. **Completion/Error** - Final result for the bulk
+
+#### Stage 1: Initiation
+
+Immediately after invoking a bulk transfer process, git-lfs sends initiation
+data to the process over stdin. This tells the process useful information about
+the configuration.
+
+The message will look like this:
+
+```json
+{ "event": "init", "operation": "download", "remote": "origin", "concurrent": true, "concurrenttransfers": 3 }
+```
+
+* `event`: Always `init` to identify this message
+* `operation`: will be `upload` or `download` depending on transfer direction
+* `remote`: The Git remote.  It can be a remote name like `origin` or an URL
+  like `ssh://git.example.com//path/to/repo`.  A standalone transfer agent can
+  use it to determine the location of remote files.
+* `concurrent`: reflects the value of `lfs.bulk.transfer.<name>.concurrent`, in
+  case the process needs to know
+* `concurrenttransfers`: reflects the value of `lfs.concurrenttransfers`, for if
+  the transfer process wants to implement its own concurrency and wants to
+  respect this setting.
+
+The transfer process should use the information it needs from the initiation
+structure, and also perform any one-off setup tasks it needs to do. It should
+then respond on stdout with a simple empty confirmation structure, as follows:
+
+```json
+{ }
+```
+
+Or if there was an error:
+
+```json
+{ "error": { "code": 32, "message": "Some init failure message" } }
+```
+
+#### Stage 2: Bulk Transfer
+After the initiation exchange, git-lfs will send any number of bulk definitions
+to the stdin of the transfer process. Multiple bulk transfers can be processed
+concurrently when the `concurrent` setting is enabled, allowing for efficient
+parallel processing of different bulks across multiple worker processes.
+
+The bulk definition consists of a header, items, and a footer. Each bulk
+definition is sent as a series of JSON messages, each on a single line.
+
+**Important**: If the number of remaining files is less than the configured
+`bulkSize`, git-lfs will automatically flush the pending transfers after a
+100ms timeout to ensure timely processing of incomplete bulks.
+
+
+### 2.1 Bulk Transfer Header
+
+The first message in a bulk transfer is always the bulk header, which defines the
+bulk transfer general bulk data. The header defines the bulk ID and the number of items
+in following bulk transfer. 
+
+It looks like this:
+
+```json
+{ "event": "bulk-header", "oid": "bulk-12345-uuid", "size": 5 }
+```
+
+Fields:
+- `event`: Always "bulk-header" to identify this message
+- `oid`: Unique identifier for this bulk (persistent throughout the bulk transfer)
+- `size`: Number of items that will follow in this bulk
+
+### 2.2 Bulk Transfer Item
+
+Next git-lfs will send the individual items that are part of the bulk transfer.
+The number of items is defined in the bulk header, and each item is sent as a
+separate JSON message. Each item can be an upload or a download, depending on
+the operation defined in the initiation message.
+
+##### Uploads
+
+For uploads the message sent from git-lfs to the transfer process will look
+like this:
+
+```json
+{ "event": "upload", "oid": "bf3e3e2af9366a3b704ae0c31de5afa64193ebabffde2091936ad2e7510bc03a", "size": 346232, "path": "/path/to/file.png", "action": { "href": "nfs://server/path", "header": { "key": "value" } } }
+```
+
+* `event`: Always `upload` to identify this message
+* `oid`: the identifier of the LFS object
+* `size`: the size of the LFS object
+* `path`: the file which the transfer process should read the upload data from
+* `action`: the `upload` action copied from the response from the batch API.
+  This contains `href` and `header` contents, which are named per HTTP
+  conventions, but can be interpreted however the custom transfer agent wishes
+  (this is an NFS example, but it doesn't even have to be an URL). Generally,
+  `href` will give the primary connection details, with `header` containing any
+  miscellaneous information needed.  `action` is `null` for standalone transfer
+  agents.
+
+##### Downloads
+
+For downloads the message sent from git-lfs to the transfer process will look
+like this:
+
+```json
+{ "event": "download", "oid": "22ab5f63670800cc7be06dbed816012b0dc411e774754c7579467d2536a9cf3e", "size": 21245, "action": { "href": "nfs://server/path", "header": { "key": "value" } } }
+```
+
+* `event`: Always `download` to identify this message
+* `oid`: the identifier of the LFS object
+* `size`: the size of the LFS object
+* `action`: the `download` action copied from the response from the batch API.
+  This contains `href` and `header` contents, which are named per HTTP
+  conventions, but can be interpreted however the custom transfer agent wishes
+  (this is an NFS example, but it doesn't even have to be an URL). Generally,
+  `href` will give the primary connection details, with `header` containing any
+  miscellaneous information needed.  `action` is `null` for standalone transfer
+  agents.
+
+Note there is no file path included in the download request; the transfer
+process should create a file itself and return the path in the final response
+after completion (see below).
+
+### Bulk Footer Message
+
+Last git-lfs sends a bulk footer message to indicate the end of the bulk
+transfer definition. This message signals that no more items will be sent for
+this bulk, and it provides the total size of all items in the bulk.
+
+It looks like this:
+
+```json
+{ "event": "bulk-footer", "oid": "bulk-12345-uuid", "size": 3145728 }
+```
+
+Fields:
+- `event`: Always "bulk-footer" to identify this message
+- `oid`: Same bulk ID as used in bulk-header to maintain context
+- `size`: Total size in bytes of all files in the bulk
+
+### Processing Strategies
+
+Once a bulk transfer definition is complete (after receiving the bulk-footer), 
+the transfer adapter has complete freedom in how it processes the items within 
+the bulk. Common strategies include:
+
+1. **Sequential Processing**: Process items one by one in the order received
+2. **Parallel Processing**: Process multiple items simultaneously using threads/workers
+3. **Batch Operations**: Download/upload all items as a single archive or package
+4. **Hybrid Approaches**: Combine strategies based on file sizes, types, or other criteria
+
+The protocol places no restrictions on processing order - completion messages
+can be sent in any order as items finish processing. 
+
+## Response Messages
+
+### Progress Events
+
+After the bulk transfer definition is complete, the transfer process can start
+processing the items. 
+
+The transfer process should post one or more progress events to indicate the
+bulk transfer progress.
+
+It looks like this:
+
+```json
+{ "event": "progress", "oid": "bulk-12345-uuid", "bytesSoFar": 1572864, "bytesSinceLast": 524288 }
+```
+
+Fields:
+- `event`: Always "progress" to identify this message
+- `oid`: The bulk transfer ID
+- `bytesSoFar`: Total bytes transferred for this bulk so far
+- `bytesSinceLast`: Bytes transferred since the last progress event
+
+### Individual Item Completion
+
+When an individual item within a bulk transfer completes, the transfer
+process should send a completion message for that item. 
+
+```json
+{ "event": "complete", "oid": "22ab5f63670800cc7be06dbed816012b0dc411e774754c7579467d2536a9cf3e", "path": "/tmp/downloaded/file.bin" }
+```
+
+Fields:
+- `event`: Always "complete" to identify this message
+- `oid`: The individual file's OID
+- `path`: For downloads, the temporary path where the file was downloaded
+
+Or, if there was a failure transferring this item:
+
+```json
+{ "event": "complete", "oid": "22ab5f63670800cc7be06dbed816012b0dc411e774754c7579467d2536a9cf3e", "error": { "code": 2, "message": "Explain what happened to this transfer" } }
+```
+
+These messages have to be sent for each item in the bulk transfer, and they can 
+be sent in any order. The transfer adapter has complete freedom in how it 
+processes the items within a bulk - they can be processed sequentially, in 
+parallel, or using any other strategy (e.g., downloading all files as a single 
+archive and then extracting them). Git-LFS will track completion of individual 
+items regardless of the order in which completion messages arrive.
+
+Errors for a single transfer request should not terminate the process or bulk 
+transfer. The error should be returned in the response structure instead.
+
+The custom transfer adapter does not need to check the SHA of the file content
+it has downloaded, git-lfs will do that before moving the final content into
+the LFS store.
+
+### Bulk Completion
+
+After all the item completion messages are sent, the entire bulk transfer completion
+message follows. This message indicates that the entire bulk transfer is completed.
+
+For successful completion, it looks like this:
+
+```json
+{ "event": "bulk-complete", "oid": "bulk-12345-uuid" }
+```
+
+Fields:
+- `event`: Always "bulk-complete" to identify this message
+- `oid`: The bulk transfer ID
+
+If there was an error during the bulk transfer, it can be sent as follows:
+
+```json
+{ "event": "bulk-complete", "oid": "bulk-12345-uuid", "error": { "code": 500, "message": "Bulk transfer failed due to network error" } }
+```
+
+Fields:
+- `event`: Always "bulk-complete" to identify this message
+- `oid`: The bulk transfer ID
+- `error`: An object containing error details
+
+The bulk transfer competion error never preceeds the item completion messages, and it
+is sent only once after all items have been processed.
+
+The bulk transfer failure is not considered a fatal error, and the process can continue 
+to handle other bulks or items.
+
+### Stage 3: Finish & Cleanup
+
+When all transfers have been processed, git-lfs will send the following message
+to the stdin of the transfer process:
+
+```json
+{ "event": "terminate" }
+```
+
+On receiving this message the transfer process should clean up and terminate.
+No response is expected.
+
+## Protocol Flow Example
+
+Here's an example flow for downloading 2 files in a bulk:
+
+### Client to Process:
+```json
+{"event": "init", "operation": "download", "remote": "origin", "concurrent": true, "concurrenttransfers": 3}
+{"event": "bulk-header", "oid": "bulk-001", "size": 2 }
+{"event": "download", "oid": "sha256:file1", "size": 1024, "path": "", "action": {"href": "https://example.com/file1"}}
+{"event": "download", "oid": "sha256:file2", "size": 2048, "path": "", "action": {"href": "https://example.com/file2"}}
+{"event": "bulk-footer", "oid": "bulk-001", "size": 3072, "path": "", "action": null}
+```
+
+### Process to Client (Sequential Processing):
+```json
+{ }
+{"event": "progress", "oid": "bulk-001", "bytesSoFar": 0, "bytesSinceLast": 0}
+{"event": "progress", "oid": "bulk-001", "bytesSoFar": 1024, "bytesSinceLast": 1024}
+{"event": "complete", "oid": "sha256:file1", "path": "/tmp/file1" }
+{"event": "progress", "oid": "bulk-001", "bytesSoFar": 3072, "bytesSinceLast": 2048}
+{"event": "complete", "oid": "sha256:file2", "path": "/tmp/file2" }
+{"event": "bulk-complete", "oid": "bulk-001" }
+```
+
+### Process to Client (Parallel Processing):
+```json
+{ }
+{"event": "progress", "oid": "bulk-001", "bytesSoFar": 0, "bytesSinceLast": 0}
+{"event": "progress", "oid": "bulk-001", "bytesSoFar": 2048, "bytesSinceLast": 2048}
+{"event": "complete", "oid": "sha256:file2", "path": "/tmp/file2" }
+{"event": "progress", "oid": "bulk-001", "bytesSoFar": 3072, "bytesSinceLast": 1024}
+{"event": "complete", "oid": "sha256:file1", "path": "/tmp/file1" }
+{"event": "bulk-complete", "oid": "bulk-001" }
+```
+
+Note: In the parallel example, file2 completes before file1, demonstrating that 
+completion order is independent of the order in which items were sent.
+
+### Cleanup:
+```json
+{"event": "terminate"}
+```
+
+## Error handling
+
+Any unexpected fatal errors in the transfer process (not errors specific to a
+transfer request) should set the exit code to non-zero and print information to
+stderr. Otherwise the exit code should be 0 even if some transfers failed.
+
+
+## Implementation Notes
+
+1. **Bulk Size**: The bulk size is configurable via `lfs.bulk.transfer.<name>.bulkSize` and determines how many individual transfers are grouped together. Default is 100.
+
+2. **Concurrency**: When `lfs.bulk.transfer.<name>.concurrent` is true (default), multiple bulks can be processed concurrently by different worker processes. Items within each bulk can be processed in any order and in parallel by the transfer adapter - the protocol places no restrictions on processing order or parallelism within a bulk.
+
+3. **Timer-based Flush**: If the number of pending files is less than the configured bulkSize, git-lfs automatically flushes the incomplete bulk after a fixed 100ms timeout to prevent hanging on partial bulks. This timeout value is currently hardcoded and not configurable.
+
+4. **Worker Management**: Git-LFS manages worker availability and distributes bulks to available workers, ensuring efficient resource utilization and true parallel processing.
+
+5. **Error Recovery**: Individual item failures within a bulk don't necessarily fail the entire bulk unless it's a fatal error. Each item reports its completion status independently.
+
+6. **Progress Reporting**: Progress is reported at the bulk level, aggregating the progress of all items within the bulk.
+
+7. **File Verification**: For downloads, individual files should still be verified against their SHA256 checksums after bulk completion.
+
+8. **Temporary Paths**: Downloaded files are placed in temporary locations and moved to final destinations after verification.
+
+9. **Channel Management**: The implementation uses Go channels for communication between the main process and workers, with proper channel lifecycle management to prevent deadlocks.
+
+10. **Resource Cleanup**: Workers are properly tracked and resources are cleaned up when bulks complete or encounter errors.

--- a/docs/custom-transfers.md
+++ b/docs/custom-transfers.md
@@ -74,14 +74,20 @@ A custom transfer process is defined under a settings group called
   Specifies which direction the custom transfer process supports, either
   `download`, `upload`, or `both`. The default if unspecified is `both`.
 
-* `lfs.customtransfer.<name>.mode
+* `lfs.customtransfer.<name>.protocol`
 
-  Specifies the tranfer operation mode. This setting can be set either to
-  `basic`, `bulk` or `any` for using one of the transfer modes. Theese transfer 
-  modes are explained below. The default if unspecified is `basic`.
-  If set to `any` the tranfer should specify the mode explicitly on the initation 
-  stage, the `basic` assumed otherwise. `any` allows falling back from
-  `bulk` to `basic` in case of bulk transfer failure that cannot be retried. `
+  Specifies which protocol version the custom transfer process supports. The
+  current protocol version is `2`. If unspecified, protocol version `1` is used.
+
+* `lfs.customtransfer.<name>.concurrencyMode`
+
+  Specifies the tranfer concurreny mode. This setting can be set either to
+  `basic`, `batch` or `any` for using one of the transfer concurrency modes. 
+  These transfer concurrency modes are explained below. The default if 
+  unspecified is `basic`.
+  If set to `any` the tranfer should specify the concurrency mode explicitly on the initation stage, the `basic` assumed otherwise. `any` allows falling back 
+  from `batch` to `basic` in case of batch transfer failure that cannot be 
+  retried. `
 
 ## Naming
 
@@ -99,51 +105,59 @@ need to give me different URLs. Assuming I define my transfer like this, and the
 server supports it, I might start getting object action links back like
 `nfs://<host>/path/to/object`
 
-## Transfer modes
+## Transfer concurrency modes
 
-Transfer mode defines the way Git Lfs schedules operations to custom tranfer process
-and the protocol version to be used for communicating between custom transfer and the
-Git Lfs client. 
-There are two modes available for custom transfers: basic and bulk.
+Transfer concurrency mode defines the way Git Lfs schedules operations to 
+custom transfer process and the protocol version to be used for communicating 
+between custom transfer and the Git Lfs client. 
+There are two concurrency modes available for custom transfers: basic and batch.
 
 ### Basic
 
-Basic mode uses single artifact as unit of work for every transfer operation.
-Git Lfs will request every process to transfer a single artifact per time 
-and expect the progress/result report for this single artifact before moving 
-to the next artifact.
+Basic concurrency mode uses single artifact as unit of work for every transfer 
+operation.
+Git Lfs will request every process to transfer a single artifact per time and 
+expect the progress/result report for this single artifact before moving to the 
+next artifact.
 Concurrency in this mode applies per artifact - every single concurrent process
 gets a single unique atrifact to work with per time.
 
-### Bulk
+### Batch
 
-Bulk mode uses group (bulk) of artifacts as unit of work for every transfer operation.
-Git Lfs will request every process to transfer a bulk of artifacts per time and expect 
-the progress/result report for every atrifact in bulk before moving to next bulk.
-Concurrency in this mode applies per bulk - every concurrent process gets a bulk of
-unique artifacts to work with per time.
+Batch concurrency mode uses group (batch) of artifacts as unit of work for every 
+transfer operation. Git Lfs will request every process to transfer a batch of 
+artifacts per time and expect the progress/result report for every atrifact in 
+batch before moving to next batch.
+Concurrency in this mode applies per batch - every concurrent process gets a 
+batch of unique artifacts to work with per time.
 
-### Transfer mode selection and behaviour
+### Transfer concurrency mode selection and behaviour
 
-The effective transfer mode is determined as follows:
-1. If `lfs.customtransfer.<name>.mode` is set to `basic` or is not specified, Git Lfs will
-   use basic mode and the basic protocol for all transfers.
-2. If `lfs.customtransfer.<name>.mode` is set to `bulk`, Git Lfs will attempt to initiate
-   the bulk transfer protocol. The custom transfer process must confirm the bulk mode support
-   on the initiation stage, otherwise the transfer will fail and no fallback will be attempted.
-3. If `lfs.customtransfer.<name>.mode` is set to `any`, Git Lfs will attempt to initiate
-   the bulk transfer protocol. If the custom process confirms the bulk mode support it will be used.
-   Otherwise Git Lfs will fallback to basic mode and continue the transfers using basic protocol.
-   Initiation stage will not be repeated.
-   This mode also allows to fallback from bulk to basic mode due to errors without losing any progress.
-   To trigger the fallback bulk transfer process should report a bulk failure with a non-retriable error
-   on the bulk transfer stages.
+The effective transfer concurrency mode is determined as follows:
+1. If `lfs.customtransfer.<name>.concurrencyMode` is set to `basic` or is not 
+specified, Git Lfs will use basic mode and the basic protocol for all transfers.
+2. If `lfs.customtransfer.<name>.concurrencyMode` is set to `batch`, Git Lfs will 
+attempt to initiate the batch transfer protocol. The custom transfer process must 
+confirm the batch mode support on the initiation stage, otherwise the transfer will 
+fail and no fallback will be attempted.
+3. If `lfs.customtransfer.<name>.concurrencyMode` is set to `any`, Git Lfs will 
+attempt to initiate the batch transfer protocol. If the custom process confirms 
+the batch mode support it will be used.
+Otherwise Git Lfs will fallback to basic mode and continue the transfers using 
+basic protocol. Initiation stage will not be repeated.
+This mode also allows to fallback from batch to basic mode due to errors without 
+losing any progress.
+To trigger the fallback batch transfer process should report a batch failure with 
+a non-retriable error on the batch transfer stages.
 
-While using bulk mode partial bulk failures are allowed. This means that bulk transfer can be reported as successful
-though some items from the bulk are failed with retriable errors. For such bulks the successfully transferred items
-will be used and the rest will be included into the next bulk transfer for retry.
-Failing the bulk with a non-retryable error will trigger the fallback to `basic` mode if allowed by mode
-configurations. Retrying the whole bulk will discard any successfully transferred items and retry the whole bulk again.
+While using batch mode partial batch failures are allowed. This means that batch 
+transfer can be reported as successful though some items from the batch are 
+failed with retriable errors. For such batches the successfully transferred items 
+will be used and the rest will be included into the next batch transfer for 
+retry.
+Failing the batch with a non-retryable error will trigger the fallback to `basic` 
+mode if allowed by mode configurations. Retrying the whole batch will discard any 
+successfully transferred items and retry the whole batch again.
 
 ## Protocol
 
@@ -165,25 +179,61 @@ be on a single line, with a line feed at the end. The transfer process must
 respond the same way by writing a JSON structure back to stdout with a single
 line feed at the end (and flush the output).
 
-The exact protocol is defined via effective transfer mode.
+### Versioning
+Since this protocol is likely to evolve over time, each protocol version is tied to a
+specific version number. The current protocol version is 2. 
+To maintain backward compatibility, git-lfs will negotiate the protocol version with the
+custom transfer first and only behave according to the supported protocol version protocol 
+and features features inside a single custom transfer session. 
+The effective protocol version can differ from current latest version and is determined 
+during the negotiation process.
 
-### Basic Protocol Stages
+Section below describes each protocol version in detail to allow implementing the correct 
+version.
 
-The protocol consists of 3 stages:
+## Protocol Specification
 
-#### Stage 1: Initiation
+This section contains the detailed specification of the protocol stages and versions.
+
+Stage 1 and Stage 3 are common between all protocol versions, while Stage 2 is defined 
+per protocol version.
+
+### Stage 1: Initiation and version negotiation
 
 Immediately after invoking a custom transfer process, git-lfs sends initiation
 data to the process over stdin. This tells the process useful information about
-the configuration.
+the configuration and allows to perform effective protocol version negotiation. 
 
-The message will look like this:
+Effective protocol version negotiation process is arranged according to the following rules:
+1. Git Lfs always starts the negotiation by sending the initiation message with
+    the current configured protocol version. The protocol version is configured 
+    via `lfs.customtransfer.<name>.protocol` setting. If this setting is not
+    specified Git Lfs assumes protocol version `1`.
+2. The custom transfer process should respond with the supported protocol version
+    and features to be used during the session.
+3. If the custom transfer process responds with the same protocol version as
+    the one sent by Git Lfs, Git Lfs will continue the session using the
+    current protocol version features.    
+4. If the custom transfer process responds with a lower protocol version than
+    the one sent by Git Lfs, Git Lfs will switch to the lower protocol version
+    and continue the session using the lower protocol version features.
+5. If the custom transfer process responds with unrecognized protocol version, 
+    Git Lfs will terminate the session with an error.
+6. If the custom transfer process responds with no explicit protocol version,
+    Git Lfs will continue the session using the protocol version 1.
+    This allows backward compatibility with existing custom transfer implementations
+    that don't support the protocol version negotiation.
+
+#### Default behaviour
+
+In case the protocol version is configured to `1` or not specified the initiation message 
+will look like this:
 
 ```json
-{ "event": "init", "operation": "download", "remote": "origin", "concurrent": true, "concurrenttransfers": 3, "mode": "basic" }
+{ "event": "init", "operation": "download", "remote": "origin", "concurrent": true, "concurrenttransfers": 3 }
 ```
 
-* `event`: Always `init` to identify this message
+* `event`: always `init` to identify this message
 * `operation`: will be `upload` or `download` depending on transfer direction
 * `remote`: The Git remote.  It can be a remote name like `origin` or an URL
   like `ssh://git.example.com//path/to/repo`.  A standalone transfer agent can
@@ -193,12 +243,13 @@ The message will look like this:
 * `concurrenttransfers`: reflects the value of `lfs.concurrenttransfers`, for if
   the transfer process wants to implement its own concurrency and wants to
   respect this setting.
-* `mode`: reflects the current effective transfer mode. For basic protocol is always
-  set to `basic` to identify this protocol.
+
+No version negotiation is performed by default to maintain backward compatibility.
 
 The transfer process should use the information it needs from the initiation
 structure, and also perform any one-off setup tasks it needs to do. It should
 then respond on stdout with a simple empty confirmation structure, as follows:
+
 
 ```json
 { }
@@ -210,9 +261,311 @@ Or if there was an error:
 { "error": { "code": 32, "message": "Some init failure message" } }
 ```
 
-In case of any error the initiation step cannot be retried.
+In case of any error the initiation step will not be retried.
 
-#### Stage 2: 0..N Transfers
+#### Versioned behaviour
+
+In case the protocol version is configured to 2 or above the initiation 
+message look like this:
+
+```json
+{ "event": "init", "operation": "download", "remote": "origin", "concurrent": true, "concurrenttransfers": 3, "protocol": 2, "concurrencyMode": "batch" }
+```
+
+* `event`: always `init` to identify this message
+* `operation`: will be `upload` or `download` depending on transfer direction
+* `remote`: the Git remote.  It can be a remote name like `origin` or an URL
+  like `ssh://git.example.com//path/to/repo`.  A standalone transfer agent can
+  use it to determine the location of remote files.
+* `concurrent`: reflects the value of `lfs.customtransfer.<name>.concurrent`, in
+  case the process needs to know
+* `concurrenttransfers`: reflects the value of `lfs.concurrenttransfers`, for if
+  the transfer process wants to implement its own concurrency and wants to
+  respect this setting.
+* `protocol`: the current configured protocol version. This is configured via
+  `lfs.customtransfer.<name>.protocol` setting. 
+* `concurrencyMode`: the current configured transfer concurrency mode. This is 
+  configured via `lfs.customtransfer.<name>.concurrencyMode` setting.
+
+The version negotiation is performed according to the rules defined above.
+The behaviour on this stage is affects the effective protocol version and features.
+
+The transfer process should use the information it needs from the initiation
+structure, and also perform any one-off setup tasks it needs to do. It should
+then respond on stdout with a simple empty confirmation structure, as follows:
+
+```json
+{ "protocol": 2, "concurrencyMode": "batch" }
+```
+
+* `protocol`: the protocol version supported by the custom transfer process.
+  If this version is lower than the one sent by Git Lfs, Git Lfs will switch
+  to this lower protocol version for the session. If it's higher, Git Lfs
+  will terminate the session with an error.
+* `concurrencyMode`: optional value to specify the concurrency mode to use.
+  If this value is set to `batch` - this will confirm the batch concurrency mode
+  support and enable it. All further communications will be performed according to
+  batch protocol. If this value is not specified or set to `basic` - this will 
+  switch the transfer to basic concurrency mode and all further communications will 
+  be performed according to basic protocol.
+
+Or if the transfer is aware about the newer protocol version but does not support it:
+
+```json
+{ "protocol": 1 }
+```
+
+* `protocol`: the protocol version supported by the custom transfer process.
+  In this case Git Lfs will switch to protocol version 1 for the session.
+
+In this case Git Lfs will continue the session using the protocol version `1`.
+
+Or if the transfer process doesn't specify the protocol version:
+
+```json
+{ }
+```
+
+In this case Git Lfs will continue the session using the protocol version `1`.
+
+Or if there was an error:
+
+```json
+{ "error": { "code": 32, "message": "Some init failure message" } }
+```
+
+In case of any error during the initiation step will not be retried and process terminated.
+
+### Stage 2: Transfers (Version 2)
+
+For protocol version 2 transfer stages are defined according to the selected transfer concurrency mode.
+There are two concurrency modes available for protocol version 2: basic and batch.
+
+#### Batch Protocol
+
+After the initiation exchange, git-lfs will send any number of batch definitions
+to the stdin of the transfer process. Multiple batch transfers can be processed
+concurrently when the `concurrent` setting is enabled, allowing for efficient
+parallel processing of different batches across multiple worker processes.
+
+The batch definition consists of a header, items, and a footer. Each batch
+definition is sent as a series of JSON messages, each on a single line.
+
+**Important**: If the number of remaining files is less than the configured
+`lfs.transfer.batchSize`, git-lfs will automatically flush the pending transfers after a
+100ms timeout to ensure timely processing of incomplete batches.
+
+
+##### 2.1 Batch Transfer Header
+
+The first message in a batch transfer is always the batch header, which defines the
+batch transfer general batch data. The header defines the batch ID and the number of items
+in following batch transfer. 
+
+It looks like this:
+
+```json
+{ "event": "batch-header", "bid": "batch-1", "totalSize": 1024, "objectsCount": 5 }
+```
+
+Fields:
+* `event`: always `batch-header` to identify this message
+* `bid`: unique identifier for this batch (persistent throughout the batch transfer)
+* `size`: total size in bytes of all files in the batch
+* `objectsCount`: number of objects that will follow in this batch
+
+##### 2.2 Batch Transfer Item
+
+Next git-lfs will send the individual items that are part of the batch transfer.
+The number of items is defined in the batch header, and each item is sent as a
+separate JSON message. Each item can be an upload or a download, depending on
+the operation defined in the initiation message.
+
+###### Uploads
+
+For uploads the message sent from git-lfs to the transfer process will look
+like this:
+
+```json
+{ "event": "upload", "oid": "bf3e3e2af9366a3b704ae0c31de5afa64193ebabffde2091936ad2e7510bc03a", "bid": "batch-1", "size": 1024, "path": "/path/to/file.png", "action": { "href": "nfs://server/path", "header": { "key": "value" } } }
+```
+
+* `event`: always `upload` to identify this message
+* `oid`: the identifier of the LFS object
+* `bid`: the identifier of the batch as defined in the `batch-header`
+* `size`: the size of the LFS object
+* `path`: the file which the transfer process should read the upload data from
+* `action`: the `upload` action copied from the response from the batch API.
+  This contains `href` and `header` contents, which are named per HTTP
+  conventions, but can be interpreted however the custom transfer agent wishes
+  (this is an NFS example, but it doesn't even have to be an URL). Generally,
+  `href` will give the primary connection details, with `header` containing any
+  miscellaneous information needed.  `action` is `null` for standalone transfer
+  agents.
+
+###### Downloads
+
+For downloads the message sent from git-lfs to the transfer process will look
+like this:
+
+```json
+{ "event": "download", "oid": "22ab5f63670800cc7be06dbed816012b0dc411e774754c7579467d2536a9cf3e", "bid": "batch-1", "size": 1024, "action": { "href": "nfs://server/path", "header": { "key": "value" } } }
+```
+
+* `event`: always `download` to identify this message
+* `oid`: the identifier of the LFS object
+* `bid`: the identifier of the batch as defined in the `batch-header`
+* `size`: the size of the LFS object
+* `action`: the `download` action copied from the response from the batch API.
+  This contains `href` and `header` contents, which are named per HTTP
+  conventions, but can be interpreted however the custom transfer agent wishes
+  (this is an NFS example, but it doesn't even have to be an URL). Generally,
+  `href` will give the primary connection details, with `header` containing any
+  miscellaneous information needed.  `action` is `null` for standalone transfer
+  agents.
+
+Note there is no file path included in the download request; the transfer
+process should create a file itself and return the path in the final response
+after completion (see below).
+
+##### 2.3 Batch Footer Message
+
+Last git-lfs sends a batch footer message to indicate the end of the batch
+transfer definition. This message signals that no more items will be sent for
+this batch, and it provides the total size of all items in the batch.
+It looks like this:
+
+```json
+{ "event": "batch-footer", "bid": "batch-1", "totalSize": 1024, "objectsCount": 5 }
+```
+
+Fields:
+* `event`: always `batch-footer` to identify this message
+* `bid`: same batch ID as used in `batch-header` to maintain context
+* `size`: total size in bytes of all files in the batch (should match the `size` in `batch-header`)
+* `objectsCount`: total number of objects in the batch (should match the `objectsCount` in `batch-header`)
+
+##### 2.4 Processing Strategies
+
+Once a batch transfer definition is complete (after receiving the batch-footer), 
+the transfer adapter has complete freedom in how it processes the items within 
+the batch. Common strategies include:
+
+1. **Sequential Processing**: Process items one by one in the order received
+2. **Parallel Processing**: Process multiple items simultaneously using threads/workers
+3. **Batch Operations**: Download/upload all items as a single archive or package
+4. **Hybrid Approaches**: Combine strategies based on file sizes, types, or other criteria
+
+The protocol places no restrictions on processing order - completion messages
+can be sent in any order as items finish processing. 
+
+##### Progress Events
+
+After the batch transfer definition is complete, the transfer process can start
+processing the items. 
+
+The transfer process should post one or more progress events to indicate the
+batch transfer progress.
+It looks like this:
+
+```json
+{ "event": "progress", "bid": "batch-1", "bytesSoFar": 256, "bytesSinceLast": 122 }
+```
+
+Fields:
+* `event`: always `progress` to identify this message
+* `bid`: the batch transfer identifier
+* `bytesSoFar`: total bytes transferred for this batch so far
+* `bytesSinceLast`: bytes transferred since the last progress event
+
+##### Response Messages
+
+###### Individual Item Completion
+
+When an individual item within a batch transfer completes, the transfer
+process should send a completion message for that item. 
+
+```json
+{ "event": "complete", "oid": "22ab5f63670800cc7be06dbed816012b0dc411e774754c7579467d2536a9cf3e", "bid": "batch-1", "path": "/tmp/downloaded/file.bin" }
+```
+
+Fields:
+* `event`: always `complete` to identify this message
+* `oid`: the identifier of the LFS object
+* `bid`: the identifier of the batch as defined in the `batch-header`
+* `path`: for downloads, the temporary path where the file was downloaded
+
+Or, if there was a failure transferring this item:
+
+```json
+{ "event": "complete", "oid": "22ab5f63670800cc7be06dbed816012b0dc411e774754c7579467d2536a9cf3e", "bid": "batch-1", "error": { "code": 2, "message": "Explain what happened to this transfer", "retry": true } }
+```
+
+* `event`: always `complete` to identify this message
+* `oid`: the identifier of the LFS object
+* `bid`: the identifier of the batch as defined in the `batch-header`
+* `error`: should contain a `code` and `message` explaining the error and 
+  optional `retry` flag indicating whether this object should be retried. 
+  If `retry` is not specified it is assumed to be false.
+
+These messages have to be sent for each item in the batch transfer, and they can 
+be sent in any order. The transfer adapter has complete freedom in how it 
+processes the items within a batch - they can be processed sequentially, in 
+parallel, or using any other strategy (e.g., downloading all files as a single 
+archive and then extracting them). Git-LFS will track completion of individual 
+items regardless of the order in which completion messages arrive.
+
+Errors for a single transfer request should not terminate the process or batch 
+transfer. The error should be returned in the response structure instead.
+
+`retry` flag indicates whether this batch item can be retried later and does not
+have any effect on the batch result. This flag is optional and if not specified
+it is assumed to be false.
+
+The custom transfer adapter does not need to check the SHA of the file content
+it has downloaded, git-lfs will do that before moving the final content into
+the LFS store.
+
+###### Batch Completion
+
+After all the item completion messages are sent, the entire batch transfer completion
+message follows. This message indicates that the entire batch transfer is completed.
+
+For successful completion, it looks like this:
+
+```json
+{ "event": "batch-complete", "bid": "batch-1" }
+```
+
+Fields:
+* `event`: always `batch-complete` to identify this message
+* `bid`: the identifier of the batch as defined in the `batch-header`
+
+If there was an error during the batch transfer, it can be sent as follows:
+
+```json
+{ "event": "batch-complete", "bid": "batch-1", "error": { "code": 500, "message": "Batch transfer failed due to network error", "retry": true } }
+```
+
+Fields:
+* `event`: always `batch-complete` to identify this message
+* `bid`: the identifier of the batch as defined in the `batch-header`
+* `error`: should contain a `code` and `message` explaining the error and 
+  optional `retry` flag indicating whether this batch should be retried. 
+  If `retry` is not specified it is assumed to be false.
+
+`retry` flag in case of batches corresponds to retrying the whole batch regardless of any previous 
+successful results for individual artifacts. A batch can be reported as successful though
+some artifacts can be retried later via the retry flag in the batch item completion messages. 
+
+The batch transfer completion error never precedes the item completion messages, and it
+is sent only once after all items have been processed.
+
+The batch transfer failure is not considered a fatal error, and the process can continue 
+to handle other batches or items.
+
+
+#### Basic Protocol
 
 After the initiation exchange, git-lfs will send any number of transfer
 requests to the stdin of the transfer process, in a serial sequence. Once a
@@ -228,7 +581,7 @@ like this:
 { "event": "upload", "oid": "bf3e3e2af9366a3b704ae0c31de5afa64193ebabffde2091936ad2e7510bc03a", "size": 346232, "path": "/path/to/file.png", "action": { "href": "nfs://server/path", "header": { "key": "value" } } }
 ```
 
-* `event`: Always `upload` to identify this message
+* `event`: always `upload` to identify this message
 * `oid`: the identifier of the LFS object
 * `size`: the size of the LFS object
 * `path`: the file which the transfer process should read the upload data from
@@ -247,18 +600,20 @@ then a final completion message as follows:
 { "event": "complete", "oid": "bf3e3e2af9366a3b704ae0c31de5afa64193ebabffde2091936ad2e7510bc03a" }
 ```
 
-* `event`: Always `complete` to identify this message
+* `event`: always `complete` to identify this message
 * `oid`: the identifier of the LFS object
 
 Or if there was an error in the transfer:
 
 ```json
-{ "event": "complete", "oid": "bf3e3e2af9366a3b704ae0c31de5afa64193ebabffde2091936ad2e7510bc03a", "error": { "code": 2, "message": "Explain what happened to this transfer", "retry": false } }
+{ "event": "complete", "oid": "bf3e3e2af9366a3b704ae0c31de5afa64193ebabffde2091936ad2e7510bc03a", "error": { "code": 2, "message": "Explain what happened to this transfer", "retry": true } }
 ```
 
-* `event`: Always `complete` to identify this message
+* `event`: always `complete` to identify this message
 * `oid`: the identifier of the LFS object
-* `error`: Should contain a `code` and `message` explaining the error and `retry` flag indicating whether this object should be retried
+* `error`: should contain a `code` and `message` explaining the error and 
+  optional `retry` flag indicating whether this object should be retried. 
+  If `retry` is not specified it is assumed to be false.
 
 In case of an error the retry flag indicates whether this transfer should be retried or abort any further transfers.
 
@@ -271,7 +626,7 @@ like this:
 { "event": "download", "oid": "22ab5f63670800cc7be06dbed816012b0dc411e774754c7579467d2536a9cf3e", "size": 21245, "action": { "href": "nfs://server/path", "header": { "key": "value" } } }
 ```
 
-* `event`: Always `download` to identify this message
+* `event`: always `download` to identify this message
 * `oid`: the identifier of the LFS object
 * `size`: the size of the LFS object
 * `action`: the `download` action copied from the response from the batch API.
@@ -293,7 +648,7 @@ then a final completion message as follows:
 { "event": "complete", "oid": "22ab5f63670800cc7be06dbed816012b0dc411e774754c7579467d2536a9cf3e", "path": "/path/to/file.png" }
 ```
 
-* `event`: Always `complete` to identify this message
+* `event`: always `complete` to identify this message
 * `oid`: the identifier of the LFS object
 * `path`: the path to a file containing the downloaded data, which the transfer
   process relinquishes control of to git-lfs. git-lfs will move the file into
@@ -302,14 +657,17 @@ then a final completion message as follows:
 Or, if there was a failure transferring this item:
 
 ```json
-{ "event": "complete", "oid": "22ab5f63670800cc7be06dbed816012b0dc411e774754c7579467d2536a9cf3e", "error": { "code": 2, "message": "Explain what happened to this transfer", "retry": false } }
+{ "event": "complete", "oid": "22ab5f63670800cc7be06dbed816012b0dc411e774754c7579467d2536a9cf3e", "error": { "code": 2, "message": "Explain what happened to this transfer", "retry": true } }
 ```
 
-* `event`: Always `complete` to identify this message
+* `event`: always `complete` to identify this message
 * `oid`: the identifier of the LFS object
-* `error`: Should contain a `code` and `message` explaining the error and `retry` flag indicating whether this object should be retried
+* `error`: should contain a `code` and `message` explaining the error and 
+  optional `retry` flag indicating whether this object should be retried. 
+  If `retry` is not specified it is assumed to be false.
 
-In case of an error the retry flag indicates whether this transfer should be retried or abort any further transfers.
+In case of an error the retry flag indicates whether this transfer should be retried 
+or abort any further transfers.
 
 Errors for a single transfer request should not terminate the process. The error
 should be returned in the response structure instead.
@@ -328,7 +686,7 @@ the final completion message:
 { "event": "progress", "oid": "22ab5f63670800cc7be06dbed816012b0dc411e774754c7579467d2536a9cf3e", "bytesSoFar": 1234, "bytesSinceLast": 64 }
 ```
 
-* `event`: Always `progress` to identify this message
+* `event`: always `progress` to identify this message
 * `oid`: the identifier of the LFS object
 * `bytesSoFar`: the total number of bytes transferred so far
 * `bytesSinceLast`: the number of bytes transferred since the last progress
@@ -337,111 +695,25 @@ the final completion message:
 The transfer process should post these messages such that the last one sent
 has `bytesSoFar` equal to the file size on success.
 
-#### Stage 3: Finish & Cleanup
+##### Response Messages
 
-When all transfers have been processed, git-lfs will send the following message
-to the stdin of the transfer process:
+### Stage 2: Transfers (Version 1)
 
-```json
-{ "event": "terminate" }
-```
-
-On receiving this message the transfer process should clean up and terminate.
-No response is expected.
-
-### Bulk Protocol stages
-
-#### Stage 1: Initiation
-
-Immediately after invoking a bulk transfer process, git-lfs sends initiation
-data to the process over stdin. This tells the process useful information about
-the configuration.
-
-The message will look like this:
-
-```json
-{ "event": "init", "operation": "download", "remote": "origin", "concurrent": true, "concurrenttransfers": 3, "mode": "bulk" }
-```
-
-* `event`: Always `init` to identify this message
-* `operation`: will be `upload` or `download` depending on transfer direction
-* `remote`: The Git remote.  It can be a remote name like `origin` or an URL
-  like `ssh://git.example.com//path/to/repo`.  A standalone transfer agent can
-  use it to determine the location of remote files.
-* `concurrent`: reflects the value of `lfs.bulk.transfer.<name>.concurrent`, in
-  case the process needs to know
-* `concurrenttransfers`: reflects the value of `lfs.concurrenttransfers`, for if
-  the transfer process wants to implement its own concurrency and wants to
-  respect this setting.
-
-The transfer process should use the information it needs from the initiation
-structure, and also perform any one-off setup tasks it needs to do. It should
-then respond on stdout with a confirmation structure, as follows:
-
-```json
-{ "mode": "bulk" }
-```
-
-* `mode`: `bulk` to confirm the bulk mode support. If this value is not
-  specified or set to `basic` - this will switch the transfer to basic mode
-  and all further communications will be performed according to basic protocol.
-
-Or if there was an error:
-
-```json
-{ "error": { "code": 32, "message": "Some init failure message" } }
-```
-
-Responding this way allows to 
-
-#### Stage 2: Bulk Transfer
-After the initiation exchange, git-lfs will send any number of bulk definitions
-to the stdin of the transfer process. Multiple bulk transfers can be processed
-concurrently when the `concurrent` setting is enabled, allowing for efficient
-parallel processing of different bulks across multiple worker processes.
-
-The bulk definition consists of a header, items, and a footer. Each bulk
-definition is sent as a series of JSON messages, each on a single line.
-
-**Important**: If the number of remaining files is less than the configured
-`bulkSize`, git-lfs will automatically flush the pending transfers after a
-100ms timeout to ensure timely processing of incomplete bulks.
-
-
-### 2.1 Bulk Transfer Header
-
-The first message in a bulk transfer is always the bulk header, which defines the
-bulk transfer general bulk data. The header defines the bulk ID and the number of items
-in following bulk transfer. 
-
-It looks like this:
-
-```json
-{ "event": "bulk-header", "oid": "bulk-12345-uuid", "size": 5 }
-```
-
-Fields:
-* `event`: Always "bulk-header" to identify this message
-* `oid`: Unique identifier for this bulk (persistent throughout the bulk transfer)
-* `size`: Number of items that will follow in this bulk
-
-### 2.2 Bulk Transfer Item
-
-Next git-lfs will send the individual items that are part of the bulk transfer.
-The number of items is defined in the bulk header, and each item is sent as a
-separate JSON message. Each item can be an upload or a download, depending on
-the operation defined in the initiation message.
+After the initiation exchange, git-lfs will send any number of transfer
+requests to the stdin of the transfer process, in a serial sequence. Once a
+transfer request is sent to the process, it awaits a completion response before
+sending the next request.
 
 ##### Uploads
 
-For uploads the message sent from git-lfs to the transfer process will look
+For uploads the request sent from git-lfs to the transfer process will look
 like this:
 
 ```json
 { "event": "upload", "oid": "bf3e3e2af9366a3b704ae0c31de5afa64193ebabffde2091936ad2e7510bc03a", "size": 346232, "path": "/path/to/file.png", "action": { "href": "nfs://server/path", "header": { "key": "value" } } }
 ```
 
-* `event`: Always `upload` to identify this message
+* `event`: always `upload` to identify this message
 * `oid`: the identifier of the LFS object
 * `size`: the size of the LFS object
 * `path`: the file which the transfer process should read the upload data from
@@ -453,16 +725,36 @@ like this:
   miscellaneous information needed.  `action` is `null` for standalone transfer
   agents.
 
+The transfer process should post one or more [progress messages](#progress) and
+then a final completion message as follows:
+
+```json
+{ "event": "complete", "oid": "bf3e3e2af9366a3b704ae0c31de5afa64193ebabffde2091936ad2e7510bc03a" }
+```
+
+* `event`: always `complete` to identify this message
+* `oid`: the identifier of the LFS object
+
+Or if there was an error in the transfer:
+
+```json
+{ "event": "complete", "oid": "bf3e3e2af9366a3b704ae0c31de5afa64193ebabffde2091936ad2e7510bc03a", "error": { "code": 2, "message": "Explain what happened to this transfer" } }
+```
+
+* `event`: always `complete` to identify this message
+* `oid`: the identifier of the LFS object
+* `error`: should contain a `code` and `message` explaining the error
+
 ##### Downloads
 
-For downloads the message sent from git-lfs to the transfer process will look
+For downloads the request sent from git-lfs to the transfer process will look
 like this:
 
 ```json
 { "event": "download", "oid": "22ab5f63670800cc7be06dbed816012b0dc411e774754c7579467d2536a9cf3e", "size": 21245, "action": { "href": "nfs://server/path", "header": { "key": "value" } } }
 ```
 
-* `event`: Always `download` to identify this message
+* `event`: always `download` to identify this message
 * `oid`: the identifier of the LFS object
 * `size`: the size of the LFS object
 * `action`: the `download` action copied from the response from the batch API.
@@ -477,135 +769,54 @@ Note there is no file path included in the download request; the transfer
 process should create a file itself and return the path in the final response
 after completion (see below).
 
-### Bulk Footer Message
-
-Last git-lfs sends a bulk footer message to indicate the end of the bulk
-transfer definition. This message signals that no more items will be sent for
-this bulk, and it provides the total size of all items in the bulk.
-
-It looks like this:
+The transfer process should post one or more [progress messages](#progress) and
+then a final completion message as follows:
 
 ```json
-{ "event": "bulk-footer", "oid": "bulk-12345-uuid", "size": 3145728 }
+{ "event": "complete", "oid": "22ab5f63670800cc7be06dbed816012b0dc411e774754c7579467d2536a9cf3e", "path": "/path/to/file.png" }
 ```
 
-Fields:
-* `event`: Always "bulk-footer" to identify this message
-* `oid`: Same bulk ID as used in bulk-header to maintain context
-* `size`: Total size in bytes of all files in the bulk
-
-### Processing Strategies
-
-Once a bulk transfer definition is complete (after receiving the bulk-footer), 
-the transfer adapter has complete freedom in how it processes the items within 
-the bulk. Common strategies include:
-
-1. **Sequential Processing**: Process items one by one in the order received
-2. **Parallel Processing**: Process multiple items simultaneously using threads/workers
-3. **Batch Operations**: Download/upload all items as a single archive or package
-4. **Hybrid Approaches**: Combine strategies based on file sizes, types, or other criteria
-
-The protocol places no restrictions on processing order - completion messages
-can be sent in any order as items finish processing. 
-
-## Response Messages
-
-### Progress Events
-
-After the bulk transfer definition is complete, the transfer process can start
-processing the items. 
-
-The transfer process should post one or more progress events to indicate the
-bulk transfer progress.
-
-It looks like this:
-
-```json
-{ "event": "progress", "oid": "bulk-12345-uuid", "bytesSoFar": 1572864, "bytesSinceLast": 524288 }
-```
-
-Fields:
-* `event`: Always "progress" to identify this message
-* `oid`: The bulk transfer ID
-* `bytesSoFar`: Total bytes transferred for this bulk so far
-* `bytesSinceLast`: Bytes transferred since the last progress event
-
-### Individual Item Completion
-
-When an individual item within a bulk transfer completes, the transfer
-process should send a completion message for that item. 
-
-```json
-{ "event": "complete", "oid": "22ab5f63670800cc7be06dbed816012b0dc411e774754c7579467d2536a9cf3e", "path": "/tmp/downloaded/file.bin" }
-```
-
-Fields:
-* `event`: Always "complete" to identify this message
-* `oid`: The individual file's OID
-* `path`: For downloads, the temporary path where the file was downloaded
+* `event`: always `complete` to identify this message
+* `oid`: the identifier of the LFS object
+* `path`: the path to a file containing the downloaded data, which the transfer
+  process relinquishes control of to git-lfs. git-lfs will move the file into
+  LFS storage.
 
 Or, if there was a failure transferring this item:
 
 ```json
-{ "event": "complete", "oid": "22ab5f63670800cc7be06dbed816012b0dc411e774754c7579467d2536a9cf3e", "error": { "code": 2, "message": "Explain what happened to this transfer", "retry": false } }
+{ "event": "complete", "oid": "22ab5f63670800cc7be06dbed816012b0dc411e774754c7579467d2536a9cf3e", "error": { "code": 2, "message": "Explain what happened to this transfer" } }
 ```
 
-* `event`: Always `complete` to identify this message
+* `event`: always `complete` to identify this message
 * `oid`: the identifier of the LFS object
-* `error`: Should contain a `code` and `message` explaining the error and `retry` flag indicating whether this object should be retried
+* `error`: should contain a `code` and `message` explaining the error
 
-These messages have to be sent for each item in the bulk transfer, and they can 
-be sent in any order. The transfer adapter has complete freedom in how it 
-processes the items within a bulk - they can be processed sequentially, in 
-parallel, or using any other strategy (e.g., downloading all files as a single 
-archive and then extracting them). Git-LFS will track completion of individual 
-items regardless of the order in which completion messages arrive.
-
-Errors for a single transfer request should not terminate the process or bulk 
-transfer. The error should be returned in the response structure instead.
-
-`retry` flag indicates whether this bulk item can be retried later and does not
-have any effect on the bulk result.
+Errors for a single transfer request should not terminate the process. The error
+should be returned in the response structure instead.
 
 The custom transfer adapter does not need to check the SHA of the file content
 it has downloaded, git-lfs will do that before moving the final content into
 the LFS store.
 
-### Bulk Completion
+##### Progress
 
-After all the item completion messages are sent, the entire bulk transfer completion
-message follows. This message indicates that the entire bulk transfer is completed.
-
-For successful completion, it looks like this:
-
-```json
-{ "event": "bulk-complete", "oid": "bulk-12345-uuid" }
-```
-
-Fields:
-* `event`: Always "bulk-complete" to identify this message
-* `oid`: The bulk transfer ID
-
-If there was an error during the bulk transfer, it can be sent as follows:
+In order to support progress reporting while data is uploading / downloading,
+the transfer process should post messages to stdout as follows before sending
+the final completion message:
 
 ```json
-{ "event": "bulk-complete", "oid": "bulk-12345-uuid", "error": { "code": 500, "message": "Bulk transfer failed due to network error", "retry": false } }
+{ "event": "progress", "oid": "22ab5f63670800cc7be06dbed816012b0dc411e774754c7579467d2536a9cf3e", "bytesSoFar": 1234, "bytesSinceLast": 64 }
 ```
 
-Fields:
-* `event`: Always "bulk-complete" to identify this message
-* `oid`: The bulk transfer ID
-* `error`: Should contain a `code` and `message` explaining the error and `retry` flag indicating whether this bulk should be retried
+* `event`: always `progress` to identify this message
+* `oid`: the identifier of the LFS object
+* `bytesSoFar`: the total number of bytes transferred so far
+* `bytesSinceLast`: the number of bytes transferred since the last progress
+  message
 
-`retry` flag in case of bulks corresponds to retrying the whole bulk regardless of any previous 
-successfull results for individual artifacts. A bulk can be reported as sucessfull though
-some artifacts can be retried later via the retry flag in the bulk item completion messages. 
-
-The bulk transfer completion error never preceeds the item completion messages, and it
-is sent only once after all items have been processed.
-
-The bulk transfer failure is not considered a fatal error, and the process can continue 
-to handle other bulks or items.
+The transfer process should post these messages such that the last one sent
+has `bytesSoFar` equal to the file size on success.
 
 ### Stage 3: Finish & Cleanup
 
@@ -619,39 +830,39 @@ to the stdin of the transfer process:
 On receiving this message the transfer process should clean up and terminate.
 No response is expected.
 
-## Protocol Flow Example
+## Protocol Flow Examples
 
-Here's an example flow for downloading 2 files in a bulk:
+Here's an example flow for downloading 2 files in a batch:
 
 ### Client to Process:
 ```json
 {"event": "init", "operation": "download", "remote": "origin", "concurrent": true, "concurrenttransfers": 3}
-{"event": "bulk-header", "oid": "bulk-001", "size": 2 }
-{"event": "download", "oid": "sha256:file1", "size": 1024, "path": "", "action": {"href": "https://example.com/file1"}}
-{"event": "download", "oid": "sha256:file2", "size": 2048, "path": "", "action": {"href": "https://example.com/file2"}}
-{"event": "bulk-footer", "oid": "bulk-001", "size": 3072, "path": "", "action": null}
+{"event": "batch-header", "bid": "batch-1", "totalSize": 3072, "objectsCount": 2}
+{"event": "download", "oid": "22ab5f63670800cc7be06dbed816012b0dc411e774754c7579467d2536a9cf3e", "bid": "batch-1", "size": 1024, "path": "", "action": {"href": "https://example.com/file1"}}
+{"event": "download", "oid": "bf3e3e2af9366a3b704ae0c31de5afa64193ebabffde2091936ad2e7510bc03a", "bid": "batch-1", "size": 2048, "path": "", "action": {"href": "https://example.com/file2"}}
+{"event": "batch-footer", "bid": "batch-1", "totalSize": 3072, "objectsCount": 2}
 ```
 
 ### Process to Client (Sequential Processing):
 ```json
 { }
-{"event": "progress", "oid": "bulk-001", "bytesSoFar": 0, "bytesSinceLast": 0}
-{"event": "progress", "oid": "bulk-001", "bytesSoFar": 1024, "bytesSinceLast": 1024}
-{"event": "complete", "oid": "sha256:file1", "path": "/tmp/file1" }
-{"event": "progress", "oid": "bulk-001", "bytesSoFar": 3072, "bytesSinceLast": 2048}
-{"event": "complete", "oid": "sha256:file2", "path": "/tmp/file2" }
-{"event": "bulk-complete", "oid": "bulk-001" }
+{"event": "progress", "bid": "batch-1", "bytesSoFar": 0, "bytesSinceLast": 0}
+{"event": "progress", "bid": "batch-1", "bytesSoFar": 1024, "bytesSinceLast": 1024}
+{"event": "complete", "oid": "22ab5f63670800cc7be06dbed816012b0dc411e774754c7579467d2536a9cf3e", "bid": "batch-1", "path": "/tmp/file1" }
+{"event": "progress", "bid": "batch-1", "bytesSoFar": 3072, "bytesSinceLast": 2048}
+{"event": "complete", "oid": "bf3e3e2af9366a3b704ae0c31de5afa64193ebabffde2091936ad2e7510bc03a", "bid": "batch-1", "path": "/tmp/file2" }
+{"event": "batch-complete", "bid": "batch-1" }
 ```
 
 ### Process to Client (Parallel Processing):
 ```json
 { }
-{"event": "progress", "oid": "bulk-001", "bytesSoFar": 0, "bytesSinceLast": 0}
-{"event": "progress", "oid": "bulk-001", "bytesSoFar": 2048, "bytesSinceLast": 2048}
-{"event": "complete", "oid": "sha256:file2", "path": "/tmp/file2" }
-{"event": "progress", "oid": "bulk-001", "bytesSoFar": 3072, "bytesSinceLast": 1024}
-{"event": "complete", "oid": "sha256:file1", "path": "/tmp/file1" }
-{"event": "bulk-complete", "oid": "bulk-001" }
+{"event": "progress", "bid": "batch-1", "bytesSoFar": 0, "bytesSinceLast": 0}
+{"event": "progress", "bid": "batch-1", "bytesSoFar": 2048, "bytesSinceLast": 2048}
+{"event": "complete", "oid": "bf3e3e2af9366a3b704ae0c31de5afa64193ebabffde2091936ad2e7510bc03a", "bid": "batch-1", "path": "/tmp/file2" }
+{"event": "progress", "bid": "batch-1", "bytesSoFar": 3072, "bytesSinceLast": 1024}
+{"event": "complete", "oid": "22ab5f63670800cc7be06dbed816012b0dc411e774754c7579467d2536a9cf3e", "bid": "batch-1", "path": "/tmp/file1" }
+{"event": "batch-complete", "bid": "batch-1" }
 ```
 
 Note: In the parallel example, file2 completes before file1, demonstrating that 

--- a/docs/proposals/custom-transfers-bulking.md
+++ b/docs/proposals/custom-transfers-bulking.md
@@ -1,18 +1,19 @@
-# Bulk transfers proposal 
+# Batch artifact transfers concurrency proposal 
 
-I'd like to extend the custom transfers capabilities in Git Lfs.
+I'd like to extend transfers concurrency capabilities in Git Lfs.
 
-Lets extend the way Git Lfs allows custom transfer agents to handle the 
-artifact transfers from single artifact per process to group of artifacts
-per process leaving all the implementation details to the custom transfer agent.
+Lets extend the way Git Lfs allows transfer agents (including custom transfer agents) 
+to handle the artifact transfers from single artifact per process to group of artifacts
+per process.
 
 ## Motivation
 
-Currently custom transfer agent is responsible for transferring single artifact
-between client and server, Git Lfs is responsible for artifact set discovery
-and scheduling the transfers.
+Currently transfer agent is responsible for transferring single artifact between 
+client and server, Git Lfs is responsible for artifact set discovery and scheduling the transfers.
 Transfers are scheduled one by one in a linear manner and are processed in a
-concurrency model "one process per one artifact transfer".
+concurrency mode "one process per one artifact transfer". This is especially true
+for custom transfer agents, where Git Lfs spawns a new process for each artifact
+transfer request.
 Although this implementation is simple and performs well for a whole lot of scenarios,
 it has some limitations:
 - Minimal file size limitation.
@@ -21,7 +22,7 @@ it has some limitations:
   and natural process count limits per system. The exact mileage may vary, but each
   concrete setup will have a magic number that defines the lower bound of file size
   applicable effectively. Going below this magic number will lead to poor overall
-  operation times: download/upload times per artifact will stop lowering along with
+  operation times: download/upload times per artifact will stop decreasing along with
   artifact sizes and total pull/push operation times will go up.
 - Single file data limitation.
   Transferring artifacts one by one limits the opportunity to optimize network traffic
@@ -37,59 +38,140 @@ it has some limitations:
 ### How does the proposal adress the limitations above?
 
 - Minimal file size limitation.
-  By allowing custom transfer agents to handle multiple artifacts per process
-  we allow them to implement their own logic of grouping artifacts into batches
-  that make sense for their specific use cases. This way the custom transfer agent
-  can decide how many artifacts it wants to handle per process based on the artifact
-  sizes and other factors that are relevant for its specific implementation.
+  By allowing transfer agents to handle multiple artifacts per process we allow implementing 
+  any applicable logic of grouping artifacts into transfer batches that make sense for 
+  specific use cases. This way the transfer agent can decide how many artifacts agent wants 
+  to handle per process based on the artifact sizes and other factors that are relevant 
+  for its specific implementation.
 - Single file data limitation.
-  By allowing custom transfer agents to handle multiple artifacts per process
-  we enable them to optimize the transfer of related artifacts together, potentially
-  using more efficient data formats or compression techniques that take advantage
-  of the similarities between the artifacts. This can lead to better overall
-  transfer speeds and reduced bandwidth usage, especially for large text files
-  that can be compressed effectively.
+  By allowing transfer agents to handle multiple artifacts per process we enable them to 
+  optimize the transfer of related artifacts together, potentially using more efficient data 
+  formats or compression techniques that take advantage of the similarities between the 
+  artifacts. This can lead to better overall transfer speeds and reduced bandwidth usage, 
+  especially for large text files that can be compressed effectively.
 
 ## Terms
 
-The best term to describe the proposed feature would be "batching".
+The best term to describe the proposed feature would be "artifact batching".
 Though this term is already taken in Git Lfs context to describe the way
 Git Lfs client and server communicate about the set of artifacts to be transferred.
-So to keep the terminology consistent and avoid confusion, we will use the term
-"bulking" to describe the proposed feature of transferring multiple artifacts
-together in a single process.
+So to keep the terminology consistent and avoid confusion, we will intoduce the term
+"transfer concurrency mode" to describe the proposed feature of transferring multiple 
+artifacts together in a single process.
+We will define two transfer concurrency modes:
+1. Single artifact per process mode - the existing mode where each transfer process
+handles a single artifact transfer. This is the default mode and will be used
+if no other mode is specified or supported. The short term for this mode will be
+"basic" mode.
+2. Multiple artifacts per process mode - the new mode where each transfer process
+handles multiple artifact transfers. This mode allows transfer agents to optimize 
+the transfer of related artifacts together. The short term for this mode will be
+"batch" mode. Cause effectively we are transferring batches of artifacts in each
+transfer process.
 
-## Changes to the API
+This naming schema shows the ties to the existing gil-lfs terminology and 
+configuration parameters, while clearly defining the new feature and its purpose.
 
-To support this proposal, we need to make some changes to the Git Lfs API.
+## Required changes
 
-1. Extend the custom transfers protocol.
-   This includes defining new request and response formats that support 
-   multiple artifacts per transfer operation and handling the results of
-   transferring of single artifacts and the whole bulks.
-2. Update the Git Lfs client to support the new bulk transfer capabilities.
-   This includes implementing the logic for planning bulk transfers, scheduling
-   them, and processing the results.
-3. Error handling, retries and protocol fallbacks.
-   This includes defining how the client and server should handle errors that
-   occur during bulk transfers, and how to fall back to single artifact transfers
-   in case of failures. This also includes implementing retry logic for failed
-   artifact or bulk transfers.
-4. Documentation and examples.
-   This includes updating the Git Lfs documentation to include information about
-   the new bulk transfer capabilities and how to use them effectively.
+To implement the proposed feature, we need to make some changes to the Git Lfs client
+and the Git Lfs API.
 
-## Further reading
+1. Client configuration for transfer concurrency mode.
+We should introduce a new client configuration options to allow users to specify
+the desired transfer concurrency mode. This option will allow users to choose the preferred mode
+and will further be negotiated with the server during the batch api calls. The server will
+confirm the mode to be used for the batch session based on the client preference and the 
+server capabilities. User should see a clear warning message if the requested mode
+is not supported by the server and the client falls back to the default one.
+To maintain backward compatibility, the default mode will be "basic".
+For maintaining backward compatibility with existing transfer implementations,
+we should also introduce the protocol versioning for custom transfer agents
+to allow negotiation of the supported concurrency modes during the initialization phase.
+This will also require to introduce the protocol version config option to allow
+users to specify the desired protocol version to be used with custom transfer agents.
+2. Client and server should agree on the supported transfer concurrency modes. 
+We should modify the batch api to include the negotiation about the used transfer concurrency mode.
+Each batch request should include information about the supported transfer concurrency modes and define 
+the preferred one from the client configuration. Server should confirm the transfer concurrency mode to 
+be used for the current session in the batch response.
+To maintain backward compatibility, the default mode will be "basic".
+3. Custom transfer agents support.
+We should modify the custom transfer agents implementation to support the new batch concurrency mode.
+This requires defining the new protocol flow and request/response formats to support multiple artifacts 
+per transfer operation. Also we should extend the protocol to allow individual and batch error retries.
+This is essential in case of new concurrency batch mode to deduce the fallback cases.
+To maintain backward compatibility, the protocol flow should include the explicit concurrency mode 
+support confirmation for new mode and consider the existing flow as a "basic" mode.
 
-To demonstrate the proposed changes I modified the existing docs/custom-transfers.md
-document to include the bulk transfer capabilities.
+## Implementation details
+Some of the proposed changes have an implementation details that should be considered or dicussed further.
+As a baseline for this discussion this pull request can be read to see a draft implementation of the proposal:
+https://github.com/git-lfs/git-lfs/pull/6119
 
-The important parts are the new request and response formats for the custom transfer
-operations and the retry and fallback mechanisms described.
+This pull request is mainly focused on the custom transfer agents support. 
+I learned several important things during the implementation that should be considered
+when implementing the rest of the proposal.
 
-The main changes are:
-* introducing the `mode` config opption to enable/disable bulking
-* bulk protocol flow and request/response formats
-* retry support for single artifact transfers and bulks, which is also included
-  into the basic custom transfers protocol
-* fallback support from bulking to single artifact transfers
+1. The current version of custom tranfers protocol does not support error retries and always fallbacks in case
+of any error reported from the custom transfer agent. 
+This effectively means that in case of any retriable error the transfer agent is bound to implement all the retry 
+logic on its own. This makes sense in general, but introduce the question: 
+when custom agent retries on its own - user is seeing a weird misleading data about the download/upload progress 
+cause there is no clear way to report the progress of retries to Git Lfs client. Meanwhile reporting the errors 
+means that Git Lfs client will fallback to the default transfer agent which is not desired in any general case.
+2. Current transfer queue implementation keeps secret about the transfer queue state from the transfer agents.
+This leads to the situation when transfer agent has no idea about the overall transfer queue content and to maintain
+the operability it has to rely on assumption: when transfer queue has anything to tranfer - it will be sending the 
+request immediately. If this is not the case - we wait for some time and then just flush ourself. 
+This should be addresed during the implementation of new concurrency mode to allow transfer agents to explicitly 
+know that the current queue is empty and they should flush their state.
+
+## Implementation plan
+To implement the proposed feature, we can follow these steps:
+1. Describe the batch API changes required to support the concurrency modes negotiation and implement them.
+2. Implement the client configuration options to allow users to specify the desired concurrency mode.
+3. Describe and implement the changes required to support the new concurrency mode in custom transfer agents.
+4. Update the tests and documentation to reflect the changes made to support the new concurrency mode.
+
+## Batch API changes
+To support the proposed concurrency mode, we need to make some changes to the batch API.
+Git Lfs client should include the supported concurrency modes and the preferred one into
+every batch api request. Server should confirm the concurrency mode to be used for the current batch api response.
+It seems the most straightforward way to implement this is to add two new fields to the batch api request:
+- "supported_transfer_concurrency_modes": array of strings - list of supported transfer concurrency modes by the client.
+- "preferred_transfer_concurrency_mode": string - the transfer concurrency mode selected for the current batch session.
+As for the response server should only include one new field:
+- "transfer_concurrency_mode": string - the transfer concurrency mode selected for the current batch session.
+This way we allow extensibility for future transfer concurrency modes and maintain backward compatibility
+by considering the absence of these fields as a signal to use the default "basic" mode.
+We should also introduce new error cases to indicate that the none of the requested transfer concurrency modes
+consigured on the client are supported by the server.
+This way client will try to use the configured mode and if server does not support it - client
+will get a clear error message and will be able to fallback to the default mode or inform the user
+about the misconfiguration.
+
+## Custom transfer protocol changes
+To support the proposed concurrency mode in custom transfer agents, we need to make some changes to the custom transfer protocol.
+
+Effectively we should define two different protocol flows:
+1. Single artifact per process flow - the existing protocol flow that supports transferring single artifact per process.
+2. Batch concurrency mode flow - the new protocol flow that supports transferring multiple artifacts per process.
+Also we need to include the error retry mechanism to allow transfer agents to report retriable errors
+without forcing Git Lfs client to fallback to the default transfer agent.
+
+Git Lfs and custom transfer agents should negotiate the supported concurrency strategies during the initialization phase of the 
+custom transfer protocol. After the negotiation is comlete the protocol version should be fixed for the whole session and both 
+sides should follow the agreed concurrency mode.
+
+Basic flow is already defined and implemented. The only requred change here is to implement the optional error retry mechanism 
+to allow transfer agents to report retriable errors without forcing Git Lfs client to fallback to the default transfer agent.
+
+Batch concurrency mode flow requires more changes to the protocol.
+We need to define the new transfer request format that defines a set of artifacts to be transferred.
+Then we need to define the progress tracking mechanism that allows transfer agents to report the progress of each artifact in the batch.
+Finally we need to implement the error retry mechanism to allow transfer agents to report retriable errors for individual artifacts in the batch.
+
+The protocol proposition is described in more details in the draft implementation pull request: 
+https://github.com/git-lfs/git-lfs/pull/6119
+

--- a/docs/proposals/custom-transfers-bulking.md
+++ b/docs/proposals/custom-transfers-bulking.md
@@ -1,0 +1,95 @@
+# Bulk transfers proposal 
+
+I'd like to extend the custom transfers capabilities in Git Lfs.
+
+Lets extend the way Git Lfs allows custom transfer agents to handle the 
+artifact transfers from single artifact per process to group of artifacts
+per process leaving all the implementation details to the custom transfer agent.
+
+## Motivation
+
+Currently custom transfer agent is responsible for transferring single artifact
+between client and server, Git Lfs is responsible for artifact set discovery
+and scheduling the transfers.
+Transfers are scheduled one by one in a linear manner and are processed in a
+concurrency model "one process per one artifact transfer".
+Although this implementation is simple and performs well for a whole lot of scenarios,
+it has some limitations:
+- Minimal file size limitation.
+  Transferring one artifact per process makes little sense for files smaller than
+  some magic number due to the overhead of process creation and management, network overheads
+  and natural process count limits per system. The exact mileage may vary, but each
+  concrete setup will have a magic number that defines the lower bound of file size
+  applicable effectively. Going below this magic number will lead to poor overall
+  operation times: download/upload times per artifact will stop lowering along with
+  artifact sizes and total pull/push operation times will go up.
+- Single file data limitation.
+  Transferring artifacts one by one limits the opportunity to optimize network traffic
+  size by compressing the artifacts or using some binary protocols that are more efficient
+  when transferring multiple artifacts in a single session. This is especially true for
+  large text files that can be compressed well and the compression ratio improves with the
+  size of the data. This might seem as a counterintuitive statement in terms of git, but
+  a lot of modern game engines for example use text based assets (json, yaml, xml, etc)
+  that can reach hundreds of MBs in size when uncompressed. For big project the amount of
+  such files can be in thousands and they typically have no distinct patterns that allow
+  managing them on the configuration level.
+
+### How does the proposal adress the limitations above?
+
+- Minimal file size limitation.
+  By allowing custom transfer agents to handle multiple artifacts per process
+  we allow them to implement their own logic of grouping artifacts into batches
+  that make sense for their specific use cases. This way the custom transfer agent
+  can decide how many artifacts it wants to handle per process based on the artifact
+  sizes and other factors that are relevant for its specific implementation.
+- Single file data limitation.
+  By allowing custom transfer agents to handle multiple artifacts per process
+  we enable them to optimize the transfer of related artifacts together, potentially
+  using more efficient data formats or compression techniques that take advantage
+  of the similarities between the artifacts. This can lead to better overall
+  transfer speeds and reduced bandwidth usage, especially for large text files
+  that can be compressed effectively.
+
+## Terms
+
+The best term to describe the proposed feature would be "batching".
+Though this term is already taken in Git Lfs context to describe the way
+Git Lfs client and server communicate about the set of artifacts to be transferred.
+So to keep the terminology consistent and avoid confusion, we will use the term
+"bulking" to describe the proposed feature of transferring multiple artifacts
+together in a single process.
+
+## Changes to the API
+
+To support this proposal, we need to make some changes to the Git Lfs API.
+
+1. Extend the custom transfers protocol.
+   This includes defining new request and response formats that support 
+   multiple artifacts per transfer operation and handling the results of
+   transferring of single artifacts and the whole bulks.
+2. Update the Git Lfs client to support the new bulk transfer capabilities.
+   This includes implementing the logic for planning bulk transfers, scheduling
+   them, and processing the results.
+3. Error handling, retries and protocol fallbacks.
+   This includes defining how the client and server should handle errors that
+   occur during bulk transfers, and how to fall back to single artifact transfers
+   in case of failures. This also includes implementing retry logic for failed
+   artifact or bulk transfers.
+4. Documentation and examples.
+   This includes updating the Git Lfs documentation to include information about
+   the new bulk transfer capabilities and how to use them effectively.
+
+## Further reading
+
+To demonstrate the proposed changes I modified the existing docs/custom-transfers.md
+document to include the bulk transfer capabilities.
+
+The important parts are the new request and response formats for the custom transfer
+operations and the retry and fallback mechanisms described.
+
+The main changes are:
+* introducing the `mode` config opption to enable/disable bulking
+* bulk protocol flow and request/response formats
+* retry support for single artifact transfers and bulks, which is also included
+  into the basic custom transfers protocol
+* fallback support from bulking to single artifact transfers

--- a/t/Makefile
+++ b/t/Makefile
@@ -24,6 +24,7 @@ TEST_CMDS += ../bin/lfs-askpass$X
 TEST_CMDS += ../bin/lfs-ssh-echo$X
 TEST_CMDS += ../bin/lfs-ssh-proxy-test$X
 TEST_CMDS += ../bin/lfstest-badpathcheck$X
+TEST_CMDS += ../bin/lfstest-bulkadapter$X
 TEST_CMDS += ../bin/lfstest-count-tests$X
 TEST_CMDS += ../bin/lfstest-customadapter$X
 TEST_CMDS += ../bin/lfstest-genrandom$X

--- a/t/cmd/lfstest-bulkadapter.go
+++ b/t/cmd/lfstest-bulkadapter.go
@@ -1,0 +1,409 @@
+//go:build testtools
+// +build testtools
+
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/git-lfs/git-lfs/v3/config"
+	"github.com/git-lfs/git-lfs/v3/lfsapi"
+	"github.com/git-lfs/git-lfs/v3/tools"
+)
+
+var cfg = config.New()
+
+// Global debug log file
+var debugLog *os.File
+
+func initDebugLog() {
+	var err error
+	debugLog, err = os.OpenFile("/tmp/lfstest-bulkadapter-debug.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		// Fall back to stderr if can't create log file
+		debugLog = os.Stderr
+	}
+}
+
+func writeToDebugLog(msg string) {
+	if debugLog == nil {
+		initDebugLog()
+	}
+	if !strings.HasSuffix(msg, "\n") {
+		msg = msg + "\n"
+	}
+	debugLog.WriteString(fmt.Sprintf("[%s] %s", time.Now().Format("15:04:05.000"), msg))
+	debugLog.Sync()
+}
+
+// This test bulk adapter demonstrates the bulk transfer protocol
+// It processes multiple files at once in bulks as defined by the protocol
+func main() {
+	initDebugLog()
+	defer func() {
+		if debugLog != nil && debugLog != os.Stderr {
+			debugLog.Close()
+		}
+	}()
+
+	scanner := bufio.NewScanner(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	errWriter := bufio.NewWriter(os.Stderr)
+	apiClient, err := lfsapi.NewClient(cfg)
+	if err != nil {
+		writeToDebugLog("Error creating api client: " + err.Error())
+		os.Exit(1)
+	}
+
+	// Track current bulk state
+	var currentBulk *bulkState
+
+	// Add timeout for reading from stdin
+	timeout := time.NewTimer(30 * time.Second)
+	defer timeout.Stop()
+
+	for scanner.Scan() {
+		// Reset timeout on each message
+		if !timeout.Stop() {
+			<-timeout.C
+		}
+		timeout.Reset(30 * time.Second)
+
+		line := scanner.Text()
+
+		// Log every incoming message for debugging
+		writeToDebugLog(fmt.Sprintf("RECEIVED: %s", line))
+
+		// Skip empty lines
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		var req request
+		if err := json.Unmarshal([]byte(line), &req); err != nil {
+			writeToDebugLog(fmt.Sprintf("JSON PARSE ERROR: %v for input: %v", err, line))
+			continue
+		}
+
+		writeToDebugLog(fmt.Sprintf("PARSED EVENT: %s", req.Event))
+
+		switch req.Event {
+		case "init":
+			writeToDebugLog(fmt.Sprintf("Initialised test bulk adapter for %s", req.Operation))
+			resp := &initResponse{}
+			sendResponse(resp, writer, errWriter)
+
+		case "bulk-header":
+			writeToDebugLog(fmt.Sprintf("Starting bulk %s with %d items", req.Oid, req.Size))
+			currentBulk = &bulkState{
+				ID:            req.Oid,
+				ItemCount:     int(req.Size),
+				Items:         make([]*transferItem, 0, req.Size),
+				TotalSize:     0,
+				ProcessedSize: 0,
+			}
+
+		case "upload", "download":
+			if currentBulk == nil {
+				writeToDebugLog("Received transfer request outside of bulk context")
+				continue
+			}
+			writeToDebugLog(fmt.Sprintf("Adding %s request for %s to bulk %s", req.Event, req.Oid, currentBulk.ID))
+
+			item := &transferItem{
+				Event:  req.Event,
+				Oid:    req.Oid,
+				Size:   req.Size,
+				Path:   req.Path,
+				Action: req.Action,
+			}
+			currentBulk.Items = append(currentBulk.Items, item)
+			currentBulk.TotalSize += req.Size
+
+		case "bulk-footer":
+			if currentBulk == nil {
+				writeToDebugLog("Received bulk footer without header")
+				continue
+			}
+			writeToDebugLog(fmt.Sprintf("Processing bulk %s with %d items, total size %d",
+				currentBulk.ID, len(currentBulk.Items), currentBulk.TotalSize))
+
+			processBulk(apiClient, currentBulk, writer, errWriter)
+			currentBulk = nil
+
+		case "terminate":
+			writeToDebugLog("Terminating test bulk adapter gracefully.")
+			return
+		default:
+			writeToDebugLog(fmt.Sprintf("Unknown event: %s", req.Event))
+		}
+	}
+
+	// Check if we exited due to timeout
+	select {
+	case <-timeout.C:
+		writeToDebugLog("Adapter timed out waiting for input")
+	default:
+		// Handle scanner error or EOF
+		if err := scanner.Err(); err != nil {
+			writeToDebugLog(fmt.Sprintf("Scanner error: %v", err))
+		} else {
+			writeToDebugLog("Input stream closed, terminating adapter.")
+		}
+	}
+}
+
+type bulkState struct {
+	ID            string
+	ItemCount     int
+	Items         []*transferItem
+	TotalSize     int64
+	ProcessedSize int64
+}
+
+type transferItem struct {
+	Event  string
+	Oid    string
+	Size   int64
+	Path   string
+	Action *action
+}
+
+func processBulk(apiClient *lfsapi.Client, bulk *bulkState, writer, errWriter *bufio.Writer) {
+	writeToDebugLog(fmt.Sprintf("Starting bulk processing for %s", bulk.ID))
+
+	// Send initial progress
+	sendBulkProgress(bulk.ID, 0, 0, writer, errWriter)
+
+	// Process each item in the bulk
+	for i, item := range bulk.Items {
+		writeToDebugLog(fmt.Sprintf("Processing item %d/%d: %s (%s)",
+			i+1, len(bulk.Items), item.Oid, item.Event))
+
+		var err error
+		var tempPath string
+
+		if item.Event == "download" {
+			tempPath, err = performBulkDownload(apiClient, item, writer, errWriter)
+		} else if item.Event == "upload" {
+			err = performBulkUpload(apiClient, item, writer, errWriter)
+		}
+
+		// Send item completion
+		if err != nil {
+			sendItemComplete(item.Oid, "", &transferError{Code: 1, Message: err.Error()}, writer, errWriter)
+		} else {
+			sendItemComplete(item.Oid, tempPath, nil, writer, errWriter)
+		}
+
+		// Update bulk progress
+		bulk.ProcessedSize += item.Size
+		progressIncrement := int(item.Size)
+		sendBulkProgress(bulk.ID, bulk.ProcessedSize, progressIncrement, writer, errWriter)
+	}
+
+	// Send bulk completion
+	sendBulkComplete(bulk.ID, nil, writer, errWriter)
+	writeToDebugLog(fmt.Sprintf("Bulk %s completed successfully", bulk.ID))
+}
+
+func performBulkDownload(apiClient *lfsapi.Client, item *transferItem, writer, errWriter *bufio.Writer) (string, error) {
+	writeToDebugLog(fmt.Sprintf("Downloading %s", item.Oid))
+
+	// Create temp file
+	dlFile, err := os.CreateTemp("", "lfs-bulk-download-*.tmp")
+	if err != nil {
+		return "", fmt.Errorf("Error creating temp file: %v", err)
+	}
+	defer dlFile.Close()
+
+	dlfilename := dlFile.Name()
+
+	// Make download request
+	req, err := http.NewRequest("GET", item.Action.Href, nil)
+	if err != nil {
+		return "", fmt.Errorf("Error creating request: %v", err)
+	}
+
+	for k := range item.Action.Header {
+		req.Header.Set(k, item.Action.Header[k])
+	}
+
+	res, err := apiClient.DoAPIRequestWithAuth("origin", req)
+	if err != nil {
+		return "", fmt.Errorf("Error downloading: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode > 299 {
+		return "", fmt.Errorf("Invalid status: %d", res.StatusCode)
+	}
+
+	// Copy with progress tracking
+	written, err := tools.CopyWithCallback(dlFile, res.Body, res.ContentLength, func(totalSize int64, readSoFar int64, readSinceLast int) error {
+		// Progress for individual items could be sent here if needed
+		return nil
+	})
+
+	if err != nil {
+		return "", fmt.Errorf("Error writing download: %v", err)
+	}
+
+	if written != item.Size {
+		return "", fmt.Errorf("Downloaded size mismatch: expected %d, got %d", item.Size, written)
+	}
+
+	return dlfilename, nil
+}
+
+func performBulkUpload(apiClient *lfsapi.Client, item *transferItem, writer, errWriter *bufio.Writer) error {
+	writeToDebugLog(fmt.Sprintf("Uploading %s from %s", item.Oid, item.Path))
+
+	req, err := http.NewRequest("PUT", item.Action.Href, nil)
+	if err != nil {
+		return fmt.Errorf("Error creating request: %v", err)
+	}
+
+	for k := range item.Action.Header {
+		req.Header.Set(k, item.Action.Header[k])
+	}
+
+	if len(req.Header.Get("Content-Type")) == 0 {
+		req.Header.Set("Content-Type", "application/octet-stream")
+	}
+
+	if req.Header.Get("Transfer-Encoding") == "chunked" {
+		req.TransferEncoding = []string{"chunked"}
+	} else {
+		req.Header.Set("Content-Length", strconv.FormatInt(item.Size, 10))
+	}
+
+	req.ContentLength = item.Size
+
+	f, err := os.OpenFile(item.Path, os.O_RDONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("Cannot read data from %q: %v", item.Path, err)
+	}
+	defer f.Close()
+
+	// Progress callback for individual upload (simplified for bulk)
+	cb := func(totalSize int64, readSoFar int64, readSinceLast int) error {
+		return nil
+	}
+	req.Body = tools.NewBodyWithCallback(f, item.Size, cb)
+
+	res, err := apiClient.DoAPIRequestWithAuth("origin", req)
+	if err != nil {
+		return fmt.Errorf("Error uploading: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode > 299 {
+		return fmt.Errorf("Invalid status: %d", res.StatusCode)
+	}
+
+	io.Copy(io.Discard, res.Body)
+	return nil
+}
+
+func sendResponse(r interface{}, writer, errWriter *bufio.Writer) error {
+	b, err := json.Marshal(r)
+	if err != nil {
+		return err
+	}
+	// Line oriented JSON
+	b = append(b, '\n')
+	_, err = writer.Write(b)
+	if err != nil {
+		return err
+	}
+	writer.Flush()
+	writeToDebugLog(fmt.Sprintf("Sent message %v", string(b)))
+	return nil
+}
+
+func sendBulkProgress(bulkId string, bytesSoFar int64, bytesSinceLast int, writer, errWriter *bufio.Writer) {
+	resp := &progressResponse{"progress", bulkId, bytesSoFar, bytesSinceLast}
+	err := sendResponse(resp, writer, errWriter)
+	if err != nil {
+		writeToDebugLog(fmt.Sprintf("Unable to send bulk progress: %v", err))
+	}
+}
+
+func sendItemComplete(oid string, path string, transferErr *transferError, writer, errWriter *bufio.Writer) {
+	resp := &transferResponse{"complete", oid, path, transferErr}
+	err := sendResponse(resp, writer, errWriter)
+	if err != nil {
+		writeToDebugLog(fmt.Sprintf("Unable to send item completion: %v", err))
+	}
+}
+
+func sendBulkComplete(bulkId string, transferErr *transferError, writer, errWriter *bufio.Writer) {
+	resp := &bulkCompleteResponse{"bulk-complete", bulkId, transferErr}
+	err := sendResponse(resp, writer, errWriter)
+	if err != nil {
+		writeToDebugLog(fmt.Sprintf("Unable to send bulk completion: %v", err))
+	}
+}
+
+// Struct definitions
+type header struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type action struct {
+	Href      string            `json:"href"`
+	Header    map[string]string `json:"header,omitempty"`
+	ExpiresAt time.Time         `json:"expires_at,omitempty"`
+}
+
+type transferError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// Combined request struct which can accept anything
+type request struct {
+	Event               string  `json:"event"`
+	Operation           string  `json:"operation"`
+	Remote              string  `json:"remote"`
+	Concurrent          bool    `json:"concurrent"`
+	ConcurrentTransfers int     `json:"concurrenttransfers"`
+	Oid                 string  `json:"oid"`
+	Size                int64   `json:"size"`
+	Path                string  `json:"path"`
+	Action              *action `json:"action"`
+}
+
+type initResponse struct {
+	Error *transferError `json:"error,omitempty"`
+}
+
+type transferResponse struct {
+	Event string         `json:"event"`
+	Oid   string         `json:"oid"`
+	Path  string         `json:"path,omitempty"`
+	Error *transferError `json:"error,omitempty"`
+}
+
+type progressResponse struct {
+	Event          string `json:"event"`
+	Oid            string `json:"oid"`
+	BytesSoFar     int64  `json:"bytesSoFar"`
+	BytesSinceLast int    `json:"bytesSinceLast"`
+}
+
+type bulkCompleteResponse struct {
+	Event string         `json:"event"`
+	Oid   string         `json:"oid"`
+	Error *transferError `json:"error,omitempty"`
+}

--- a/t/cmd/lfstest-gitserver.go
+++ b/t/cmd/lfstest-gitserver.go
@@ -463,6 +463,8 @@ func lfsBatchHandler(w http.ResponseWriter, r *http.Request, id, repo string) {
 	testingTus := testingTusUploadInBatchReq(r)
 	testingTusInterrupt := testingTusUploadInterruptedInBatchReq(r)
 	testingCustomTransfer := testingCustomTransfer(r)
+	testingBulkTransfer := testingBulkTransfer(r)
+	debug(id, "testingBulkTransfer: %v", testingBulkTransfer)
 	var transferChoice string
 	var searchForTransfer string
 	hashAlgo := "sha256"
@@ -470,8 +472,13 @@ func lfsBatchHandler(w http.ResponseWriter, r *http.Request, id, repo string) {
 		searchForTransfer = "tus"
 	} else if testingCustomTransfer {
 		searchForTransfer = "testcustom"
+	} else if testingBulkTransfer {
+		searchForTransfer = "testbulk"
+		// Force bulk transfer for bulk transfer test repositories
+		transferChoice = "testbulk"
+		debug(id, "Forcing bulk transfer, transferChoice: %s", transferChoice)
 	}
-	if len(searchForTransfer) > 0 {
+	if len(searchForTransfer) > 0 && transferChoice == "" {
 		for _, t := range objs.Transfers {
 			if t == searchForTransfer {
 				transferChoice = searchForTransfer
@@ -1524,6 +1531,10 @@ func testingTusUploadInterruptedInBatchReq(r *http.Request) bool {
 }
 func testingCustomTransfer(r *http.Request) bool {
 	return strings.HasPrefix(r.URL.String(), "/test-custom-transfer")
+}
+
+func testingBulkTransfer(r *http.Request) bool {
+	return strings.HasPrefix(r.URL.String(), "/test-bulk-transfer")
 }
 
 var lfsUrlRE = regexp.MustCompile(`\A/?([^/]+)/info/lfs`)

--- a/t/t-bulk-transfers.sh
+++ b/t/t-bulk-transfers.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+
+. "$(dirname "$0")/testlib.sh"
+
+begin_test "bulk transfer basic upload download"
+(
+  set -e
+
+  # this repo name is the indicator to the server to support bulk transfer
+  reponame="test-bulk-transfer-upload-download"
+  setup_remote_repo "$reponame"
+
+  # Clone the repo
+  clone_repo "$reponame" $reponame
+
+  # Set up bulk transfer adapter configuration for this repo
+  git config lfs.bulk.transfer.testbulk.path lfstest-bulkadapter
+  git config lfs.bulk.transfer.testbulk.concurrent true
+  git config lfs.bulk.transfer.testbulk.bulkSize 3
+  git config lfs.bulk.transfer.testbulk.direction both
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "Tracking"
+
+  # Create simple test files
+  echo "bulk test data 1" > bulk1.dat
+  echo "bulk test data 2 with more content" > bulk2.dat  
+  echo "bulk test data 3" > bulk3.dat
+  
+  git add *.dat
+  git commit -m "Add bulk test files"
+
+  # Test upload with bulk transfer
+  git push origin main
+
+  # Create a fresh clone to test download
+  cd ..
+  clone_repo "$reponame" "${reponame}-download-test"
+
+  # Test download with bulk transfer
+  git lfs fetch --all
+
+  # Verify the files are present
+  objectlist=`find .git/lfs/objects -type f`
+  [ "$(echo "$objectlist" | wc -l)" -eq 3 ]
+)
+end_test
+
+begin_test "bulk transfer multiple bulks upload with concurrency"
+(
+  set -e
+
+  reponame="test-bulk-transfer-sizes"
+  setup_remote_repo "$reponame"
+
+  clone_repo "$reponame" $reponame
+
+  # Set up bulk transfer adapter configuration for this repo
+  git config lfs.bulk.transfer.testbulk.path lfstest-bulkadapter
+  git config lfs.bulk.transfer.testbulk.concurrent true
+  git config lfs.bulk.transfer.testbulk.bulkSize 2
+  git config lfs.bulk.transfer.testbulk.direction both
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "Tracking"
+
+  # Create exactly 5 files to test bulk grouping (2+2+1)
+  echo "size test data 1" > size1.dat
+  echo "size test data 2 with more content" > size2.dat  
+  echo "size test data 3 even more content here" > size3.dat
+  echo "size test data 4 with lots of additional content to make it bigger" > size4.dat
+  echo "size test data 5 with the most content of all files to test different sizes" > size5.dat
+  
+  git add *.dat
+  git commit -m "Add size test files"
+
+  git push origin main
+)
+end_test
+
+begin_test "bulk transfer multiple bulks upload no concurrency"
+(
+  set -e
+
+  reponame="test-bulk-transfer-errors"
+  setup_remote_repo "$reponame"
+
+  clone_repo "$reponame" $reponame
+
+  git config lfs.bulk.transfer.testbulk.path lfstest-bulkadapter
+  git config lfs.bulk.transfer.testbulk.bulkSize 2
+  git config lfs.bulk.transfer.testbulk.concurrent false
+  git config lfs.bulk.transfer.testbulk.direction upload
+
+  git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "Tracking"
+
+  echo "error test data 1" > error1.dat
+  echo "error test data 2 with some content" > error2.dat
+  echo "error test data 3 with even more content" > error3.dat
+  echo "error test data 4 with lots of additional content to make it bigger" > error4.dat
+  
+  git add *.dat
+  git commit -m "Add error test files"
+
+  git push origin main
+)
+end_test

--- a/tq/bulk.go
+++ b/tq/bulk.go
@@ -1,0 +1,865 @@
+﻿package tq
+
+import (
+	"bufio"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/git-lfs/git-lfs/v3/errors"
+	"github.com/git-lfs/git-lfs/v3/fs"
+	"github.com/git-lfs/git-lfs/v3/lfsapi"
+	"github.com/git-lfs/git-lfs/v3/subprocess"
+	"github.com/git-lfs/git-lfs/v3/tools"
+	"github.com/git-lfs/git-lfs/v3/tr"
+	"github.com/rubyist/tracerx"
+)
+
+// Bulk transfer adapter that processes multiple files in batches
+type customBulkAdapter struct {
+	fs         *fs.Filesystem
+	name       string
+	direction  Direction
+	apiClient  *lfsapi.Client
+	remote     string
+	path       string
+	args       string
+	concurrent bool
+	bulkSize   int
+	debugging  bool
+
+	// transferChan is a buffered channel used to queue transfer requests (*Transfer objects)
+	// for processing by the bulk adapter. Workers consume items from this channel to handle
+	// transfers in batches, ensuring efficient and concurrent processing.
+	transferChan chan *Transfer
+
+	// resultChan is a buffered channel used to send the results of transfer operations.
+	// Each worker writes the outcome of a transfer (success or failure) to this channel,
+	// which is then consumed by the bulk adapter to handle and report transfer results.
+	resultChan chan TransferResult
+
+	// done is a channel used to signal the termination of the bulk adapter's operations.
+	// It is closed when the adapter is shutting down, allowing goroutines to detect
+	// and respond to the shutdown event.
+	done chan struct{}
+
+	// workerWait is a WaitGroup used to manage the lifecycle of worker goroutines.
+	// It ensures that all worker processes complete their tasks before the bulk adapter
+	// shuts down, preventing premature termination.
+	workerWait sync.WaitGroup
+
+	// Worker management
+	workers             []*customBulkAdapterWorkerContext
+	originalConcurrency int
+	workerBusy          []bool // Track which workers are busy
+
+	// Result routing for multiple concurrent Add calls
+	resultRoutingMu sync.RWMutex
+	pendingAddCalls map[string]chan TransferResult // Maps OID to result channel
+	pendingCounts   map[chan TransferResult]int    // Maps result channel to expected count
+}
+
+type customBulkAdapterWorkerContext struct {
+	workerNum   int
+	cmd         *subprocess.Cmd
+	stdout      io.ReadCloser
+	bufferedOut *bufio.Reader
+	stdin       io.WriteCloser
+	errTracer   *traceWriter
+}
+
+// Bulk-specific message types
+type bulkAdapterHeaderRequest struct {
+	Event string `json:"event"`
+	Oid   string `json:"oid"`
+	Size  int64  `json:"size"`
+}
+
+type bulkAdapterTransferRequest struct {
+	// common between upload/download
+	Event  string  `json:"event"`
+	Oid    string  `json:"oid"`
+	Size   int64   `json:"size"`
+	Path   string  `json:"path,omitempty"`
+	Action *Action `json:"action"`
+}
+
+type bulkAdapterFooterRequest struct {
+	Event string `json:"event"`
+	Oid   string `json:"oid"`
+	Size  int64  `json:"size"`
+}
+
+type bulkAdapterBulkResponse struct {
+	Event          string       `json:"event"`
+	Error          *ObjectError `json:"error"`
+	Oid            string       `json:"oid"`
+	Path           string       `json:"path,omitempty"`
+	BytesSoFar     int64        `json:"bytesSoFar"`
+	BytesSinceLast int          `json:"bytesSinceLast"`
+}
+
+// Bulk state tracking
+type bulkState struct {
+	id            string
+	transfers     []*Transfer
+	totalSize     int64
+	completedSize int64
+	itemsComplete int
+	worker        *customBulkAdapterWorkerContext
+}
+
+func NewCustomBulkAdapter(f *fs.Filesystem, name string, dir Direction, path, args string, concurrent bool, bulkSize int) *customBulkAdapter {
+	return &customBulkAdapter{
+		fs:              f,
+		name:            name,
+		direction:       dir,
+		path:            path,
+		args:            args,
+		concurrent:      concurrent,
+		bulkSize:        bulkSize,
+		transferChan:    make(chan *Transfer, bulkSize),
+		resultChan:      make(chan TransferResult, bulkSize),
+		done:            make(chan struct{}),
+		pendingAddCalls: make(map[string]chan TransferResult),
+		pendingCounts:   make(map[chan TransferResult]int),
+	}
+}
+
+func newBulkCustomAdapterUploadRequest(oid string, size int64, path string, action *Action) *bulkAdapterTransferRequest {
+	return &bulkAdapterTransferRequest{"upload", oid, size, path, action}
+}
+func newBulkCustomAdapterDownloadRequest(oid string, size int64, action *Action) *bulkAdapterTransferRequest {
+	return &bulkAdapterTransferRequest{"download", oid, size, "", action}
+}
+
+// Name returns the name of this bulk adapter instance.
+func (a *customBulkAdapter) Name() string {
+	return a.name
+}
+
+// Direction returns the transfer direction (Upload or Download) for this adapter instance.
+func (a *customBulkAdapter) Direction() Direction {
+	return a.direction
+}
+
+// Begin initializes the bulk adapter with the given configuration and progress callback.
+// It starts worker processes and begins the bulk processing goroutine.
+func (a *customBulkAdapter) Begin(cfg AdapterConfig, cb ProgressCallback) error {
+	a.apiClient = cfg.APIClient()
+	a.remote = cfg.Remote()
+	a.debugging = a.apiClient.OSEnv().Bool("GIT_TRANSFER_TRACE", false) ||
+		a.apiClient.OSEnv().Bool("GIT_CURL_VERBOSE", false)
+
+	maxConcurrency := cfg.ConcurrentTransfers()
+	a.originalConcurrency = maxConcurrency
+
+	if !a.concurrent {
+		maxConcurrency = 1
+	}
+
+	a.Trace("xfer: bulk adapter %q Begin() with %d workers, bulk size %d", a.Name(), maxConcurrency, a.bulkSize)
+
+	// Start worker processes
+	a.workers = make([]*customBulkAdapterWorkerContext, maxConcurrency)
+	a.workerBusy = make([]bool, maxConcurrency)
+	for i := 0; i < maxConcurrency; i++ {
+		worker, err := a.startWorker(i)
+		if err != nil {
+			// Clean up already started workers
+			for j := 0; j < i; j++ {
+				a.shutdownWorker(a.workers[j])
+			}
+			return err
+		}
+		a.workers[i] = worker
+	}
+
+	// Start the bulk processor goroutine
+	a.Trace("xfer: bulk adapter starting bulk processor goroutine")
+	a.workerWait.Add(1)
+	go a.bulkProcessor(cb)
+
+	a.Trace("xfer: bulk adapter %q started successfully", a.Name())
+	return nil
+}
+
+// Add queues one or more transfers for bulk processing.
+// Returns a channel that will receive the transfer results.
+func (a *customBulkAdapter) Add(transfers ...*Transfer) <-chan TransferResult {
+	a.Trace("xfer: bulk adapter Add() called with %d transfers", len(transfers))
+	results := make(chan TransferResult, len(transfers))
+
+	// Register this result channel for each transfer OID
+	a.resultRoutingMu.Lock()
+	a.pendingCounts[results] = len(transfers) // Track expected count for this channel
+	for _, t := range transfers {
+		a.Trace("xfer: bulk adapter registering result channel for OID %s", t.Oid)
+		a.pendingAddCalls[t.Oid] = results
+	}
+	a.resultRoutingMu.Unlock()
+
+	// Queue the transfers
+	queued := 0
+	for _, t := range transfers {
+		a.Trace("xfer: bulk adapter attempting to queue transfer %s", t.Oid)
+		select {
+		case a.transferChan <- t:
+			// Transfer queued successfully
+			a.Trace("xfer: bulk adapter successfully queued transfer %s", t.Oid)
+			queued++
+		case <-a.done:
+			// Adapter is shutting down - clean up and send error
+			a.Trace("xfer: bulk adapter shutting down while queuing %s", t.Oid)
+			a.resultRoutingMu.Lock()
+			delete(a.pendingAddCalls, t.Oid)
+			a.resultRoutingMu.Unlock()
+			results <- TransferResult{Transfer: t, Error: errors.New("adapter shutting down")}
+		}
+	}
+
+	a.Trace("xfer: bulk adapter Add() completed, queued %d/%d transfers", queued, len(transfers))
+	return results
+}
+
+// routeResult sends a transfer result to the appropriate Add call's result channel
+func (a *customBulkAdapter) routeResult(result TransferResult) {
+	a.Trace("xfer: routing result for OID %s, error: %v", result.Transfer.Oid, result.Error)
+	a.resultRoutingMu.Lock()
+	resultChan, exists := a.pendingAddCalls[result.Transfer.Oid]
+	if exists {
+		delete(a.pendingAddCalls, result.Transfer.Oid)
+	}
+	a.resultRoutingMu.Unlock()
+
+	if exists {
+		a.Trace("xfer: sending result to registered channel for OID %s", result.Transfer.Oid)
+		// Send to the specific Add call's result channel
+		select {
+		case resultChan <- result:
+			a.Trace("xfer: result sent successfully for OID %s", result.Transfer.Oid)
+
+			// Check if this was the last result for this channel
+			a.resultRoutingMu.Lock()
+			if count, hasCount := a.pendingCounts[resultChan]; hasCount {
+				a.pendingCounts[resultChan] = count - 1
+				if a.pendingCounts[resultChan] <= 0 {
+					// All results sent, close the channel
+					delete(a.pendingCounts, resultChan)
+					close(resultChan)
+					a.Trace("xfer: closed result channel after sending all results")
+				}
+			}
+			a.resultRoutingMu.Unlock()
+		case <-a.done:
+			a.Trace("xfer: adapter shutting down while sending result for OID %s", result.Transfer.Oid)
+		}
+	} else {
+		// No registered Add call for this OID - this shouldn't happen in normal operation
+		a.Trace("xfer: received result for unregistered OID %s", result.Transfer.Oid)
+	}
+}
+
+// End signals that no more transfers will be added and waits for all processing to complete.
+// It gracefully shuts down all worker processes and closes channels.
+func (a *customBulkAdapter) End() {
+	a.Trace("xfer: bulk adapter End() called - closing transfer channel")
+	close(a.transferChan)
+
+	a.Trace("xfer: bulk adapter End() - closing done channel to signal shutdown")
+	close(a.done)
+
+	a.Trace("xfer: bulk adapter End() - waiting for workers to complete")
+	a.workerWait.Wait()
+	a.Trace("xfer: bulk adapter End() - all workers completed")
+
+	a.Trace("xfer: bulk adapter End() - closing result channel")
+	close(a.resultChan)
+
+	// Close any remaining result channels
+	a.resultRoutingMu.Lock()
+	for resultChan := range a.pendingCounts {
+		close(resultChan)
+		a.Trace("xfer: closed remaining result channel during shutdown")
+	}
+	a.pendingCounts = make(map[chan TransferResult]int)
+	a.pendingAddCalls = make(map[string]chan TransferResult)
+	a.resultRoutingMu.Unlock()
+
+	a.Trace("xfer: bulk adapter End() - shutting down %d workers", len(a.workers))
+	// Shutdown all workers
+	for i, worker := range a.workers {
+		if worker != nil {
+			a.Trace("xfer: bulk adapter End() - shutting down worker %d", i)
+			a.shutdownWorker(worker)
+		}
+	}
+	a.Trace("xfer: bulk adapter End() completed")
+}
+
+// startWorker creates and initializes a new worker process for handling bulk transfers.
+// It establishes communication pipes and sends the initialization message.
+func (a *customBulkAdapter) startWorker(workerNum int) (*customBulkAdapterWorkerContext, error) {
+	a.Trace("xfer: starting bulk transfer process %q for worker %d", a.name, workerNum)
+
+	cmdName, cmdArgs := subprocess.FormatForShell(subprocess.ShellQuoteSingle(a.path), a.args)
+	cmd, err := subprocess.ExecCommand(cmdName, cmdArgs...)
+	if err != nil {
+		return nil, errors.New(tr.Tr.Get("failed to find bulk transfer command %q: %v", a.path, err))
+	}
+
+	outp, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, errors.New(tr.Tr.Get("failed to get stdout for bulk transfer command %q: %v", a.path, err))
+	}
+
+	inp, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, errors.New(tr.Tr.Get("failed to get stdin for bulk transfer command %q: %v", a.path, err))
+	}
+
+	// Capture stderr to trace
+	tracer := &traceWriter{}
+	tracer.processName = filepath.Base(a.path)
+	cmd.Stderr = tracer
+
+	err = cmd.Start()
+	if err != nil {
+		return nil, errors.New(tr.Tr.Get("failed to start bulk transfer command %q: %v", a.path, err))
+	}
+
+	worker := &customBulkAdapterWorkerContext{
+		workerNum:   workerNum,
+		cmd:         cmd,
+		stdout:      outp,
+		bufferedOut: bufio.NewReader(outp),
+		stdin:       inp,
+		errTracer:   tracer,
+	}
+
+	// Send initialization message
+	initReq := NewCustomAdapterInitRequest(
+		a.getOperationName(), a.remote, a.concurrent, a.originalConcurrency,
+	)
+	resp, err := a.exchangeMessage(worker, initReq)
+	if err != nil {
+		a.abortWorker(worker)
+		return nil, err
+	}
+	if resp.Error != nil {
+		a.abortWorker(worker)
+		return nil, errors.New(tr.Tr.Get("error initializing bulk adapter %q worker %d: %v", a.name, workerNum, resp.Error))
+	}
+
+	a.Trace("xfer: started bulk adapter process %q for worker %d OK", a.path, workerNum)
+	return worker, nil
+}
+
+// findAvailableWorker returns the index of an available worker, or -1 if none available
+func (a *customBulkAdapter) findAvailableWorker() int {
+	for i, busy := range a.workerBusy {
+		if !busy {
+			return i
+		}
+	}
+	return -1
+}
+
+// markWorkerBusy marks a worker as busy or free
+func (a *customBulkAdapter) markWorkerBusy(workerIndex int, busy bool) {
+	if workerIndex >= 0 && workerIndex < len(a.workerBusy) {
+		a.workerBusy[workerIndex] = busy
+	}
+}
+
+// bulkProcessor is the main goroutine that groups incoming transfers into bulks
+// and distributes them to available workers for processing.
+func (a *customBulkAdapter) bulkProcessor(cb ProgressCallback) {
+	defer a.workerWait.Done()
+	a.Trace("xfer: bulk processor started")
+
+	var pendingTransfers []*Transfer
+
+	// Timer to periodically process pending transfers even if bulk isn't full
+	flushTimer := time.NewTimer(100 * time.Millisecond)
+	defer flushTimer.Stop()
+
+	for {
+		select {
+		case transfer, ok := <-a.transferChan:
+			if !ok {
+				// Channel closed, process remaining transfers
+				a.Trace("xfer: transfer channel closed, processing %d remaining transfers", len(pendingTransfers))
+				if len(pendingTransfers) > 0 {
+					// For shutdown, use any available worker (block if needed)
+					availableWorker := a.findAvailableWorker()
+					if availableWorker >= 0 {
+						a.markWorkerBusy(availableWorker, true)
+						a.processBulk(pendingTransfers, availableWorker, cb)
+					} else {
+						// Wait for a worker to become available
+						a.Trace("xfer: waiting for worker to become available for final bulk")
+						for {
+							availableWorker = a.findAvailableWorker()
+							if availableWorker >= 0 {
+								a.markWorkerBusy(availableWorker, true)
+								a.processBulk(pendingTransfers, availableWorker, cb)
+								break
+							}
+							time.Sleep(10 * time.Millisecond)
+						}
+					}
+				}
+				a.Trace("xfer: bulk processor exiting")
+				return
+			}
+
+			a.Trace("xfer: received transfer %s, pending count: %d", transfer.Oid, len(pendingTransfers)+1)
+			pendingTransfers = append(pendingTransfers, transfer)
+
+			// Process bulk when we reach the bulk size
+			if len(pendingTransfers) >= a.bulkSize {
+				// Find available worker
+				availableWorker := a.findAvailableWorker()
+				if availableWorker >= 0 {
+					a.Trace("xfer: bulk size reached (%d), processing with worker %d", len(pendingTransfers), availableWorker)
+					a.markWorkerBusy(availableWorker, true)
+					a.processBulk(pendingTransfers, availableWorker, cb)
+					pendingTransfers = nil
+					// Reset timer since we just processed
+					if !flushTimer.Stop() {
+						<-flushTimer.C
+					}
+					flushTimer.Reset(100 * time.Millisecond)
+				} else {
+					a.Trace("xfer: bulk size reached but no workers available, waiting...")
+					// Don't reset timer, will try again on next timer tick
+				}
+			} else if len(pendingTransfers) == 1 {
+				// Start/restart timer when we get the first transfer in a new batch
+				if !flushTimer.Stop() {
+					<-flushTimer.C
+				}
+				flushTimer.Reset(100 * time.Millisecond)
+			}
+
+		case <-flushTimer.C:
+			// Timer expired, process any pending transfers
+			if len(pendingTransfers) > 0 {
+				availableWorker := a.findAvailableWorker()
+				if availableWorker >= 0 {
+					a.Trace("xfer: timer expired, processing %d pending transfers with worker %d", len(pendingTransfers), availableWorker)
+					a.markWorkerBusy(availableWorker, true)
+					a.processBulk(pendingTransfers, availableWorker, cb)
+					pendingTransfers = nil
+				} else {
+					a.Trace("xfer: timer expired but no workers available, waiting...")
+				}
+			}
+			// Reset timer for next batch
+			flushTimer.Reset(100 * time.Millisecond)
+
+		case <-a.done:
+			a.Trace("xfer: bulk processor received done signal, processing %d remaining transfers", len(pendingTransfers))
+			if len(pendingTransfers) > 0 {
+				// For shutdown, use any available worker (block if needed)
+				availableWorker := a.findAvailableWorker()
+				if availableWorker >= 0 {
+					a.markWorkerBusy(availableWorker, true)
+					a.processBulk(pendingTransfers, availableWorker, cb)
+				} else {
+					// Wait for a worker to become available
+					a.Trace("xfer: waiting for worker to become available for final bulk")
+					for {
+						availableWorker = a.findAvailableWorker()
+						if availableWorker >= 0 {
+							a.markWorkerBusy(availableWorker, true)
+							a.processBulk(pendingTransfers, availableWorker, cb)
+							break
+						}
+						time.Sleep(10 * time.Millisecond)
+					}
+				}
+			}
+			a.Trace("xfer: bulk processor exiting due to done signal")
+			return
+		}
+	}
+}
+
+// processBulk handles the complete bulk transfer process for a group of transfers.
+// It sends the bulk definition (header, items, footer) and processes all responses.
+func (a *customBulkAdapter) processBulk(transfers []*Transfer, workerIndex int, cb ProgressCallback) {
+	if len(transfers) == 0 {
+		a.Trace("xfer: processBulk called with empty transfers")
+		return
+	}
+
+	a.Trace("xfer: processBulk starting with %d transfers, worker %d", len(transfers), workerIndex)
+	worker := a.workers[workerIndex]
+	bulk := &bulkState{
+		id:        a.generateBulkId(),
+		transfers: transfers,
+		worker:    worker,
+	}
+
+	// Calculate total size
+	for _, t := range transfers {
+		bulk.totalSize += t.Size
+	}
+
+	a.Trace("xfer: processing bulk %s with %d transfers, total size %d", bulk.id, len(transfers), bulk.totalSize)
+
+	// Send bulk header
+	headerReq := &bulkAdapterHeaderRequest{
+		Event: "bulk-header",
+		Oid:   bulk.id,
+		Size:  int64(len(transfers)),
+	}
+
+	if err := a.sendMessage(worker, headerReq); err != nil {
+		a.markWorkerBusy(workerIndex, false)
+		a.failBulk(bulk, err)
+		return
+	}
+
+	// Send individual transfer requests
+	for _, t := range transfers {
+		rel, err := t.Rel(a.getOperationName())
+		if err != nil {
+			a.markWorkerBusy(workerIndex, false)
+			a.failBulk(bulk, err)
+			return
+		}
+
+		var req *bulkAdapterTransferRequest
+		if a.direction == Upload {
+			req = newBulkCustomAdapterUploadRequest(t.Oid, t.Size, t.Path, rel)
+		} else {
+			req = newBulkCustomAdapterDownloadRequest(t.Oid, t.Size, rel)
+		}
+
+		if err := a.sendMessage(worker, req); err != nil {
+			a.markWorkerBusy(workerIndex, false)
+			a.failBulk(bulk, err)
+			return
+		}
+	}
+
+	// Send bulk footer
+	a.Trace("xfer: sending bulk footer for bulk %s", bulk.id)
+	footerReq := &bulkAdapterFooterRequest{
+		Event: "bulk-footer",
+		Oid:   bulk.id,
+		Size:  bulk.totalSize,
+	}
+
+	if err := a.sendMessage(worker, footerReq); err != nil {
+		a.Trace("xfer: failed to send bulk footer: %v", err)
+		a.markWorkerBusy(workerIndex, false)
+		a.failBulk(bulk, err)
+		return
+	}
+
+	// Process responses in parallel - don't block the bulkProcessor
+	a.Trace("xfer: starting to process bulk responses for bulk %s in parallel", bulk.id)
+	a.workerWait.Add(1)
+	go func() {
+		defer a.workerWait.Done()
+		defer a.markWorkerBusy(workerIndex, false) // Free the worker when done
+		a.processBulkResponses(bulk, cb)
+		a.Trace("xfer: processBulk completed for bulk %s", bulk.id)
+	}()
+}
+
+// processBulkResponses handles all response messages from the external process
+// for a bulk transfer, including progress updates, item completions, and bulk completion.
+func (a *customBulkAdapter) processBulkResponses(bulk *bulkState, cb ProgressCallback) {
+	a.Trace("xfer: processBulkResponses starting for bulk %s with %d transfers", bulk.id, len(bulk.transfers))
+	itemsCompleted := make(map[string]*Transfer)
+	var bulkComplete bool
+
+	for !bulkComplete {
+		a.Trace("xfer: waiting for response from bulk adapter...")
+		resp, err := a.readResponse(bulk.worker)
+		if err != nil {
+			a.Trace("xfer: error reading response: %v", err)
+			a.failBulk(bulk, err)
+			return
+		}
+
+		a.Trace("xfer: received response: event=%s, oid=%s, error=%v", resp.Event, resp.Oid, resp.Error)
+		switch resp.Event {
+		case "progress":
+			if resp.Oid == bulk.id {
+				a.Trace("xfer: bulk progress update: %d/%d bytes", resp.BytesSoFar, bulk.totalSize)
+				// Bulk progress
+				if cb != nil {
+					// Report progress for each transfer proportionally
+					for _, t := range bulk.transfers {
+						proportion := float64(t.Size) / float64(bulk.totalSize)
+						transferProgress := int64(float64(resp.BytesSoFar) * proportion)
+						transferIncrement := int(float64(resp.BytesSinceLast) * proportion)
+						cb(t.Name, t.Size, transferProgress, transferIncrement)
+					}
+				}
+				bulk.completedSize = resp.BytesSoFar
+			}
+
+		case "complete":
+			a.Trace("xfer: item completion received for OID %s", resp.Oid)
+			// Individual item completed
+			transfer := a.findTransferByOid(bulk.transfers, resp.Oid)
+			if transfer == nil {
+				a.Trace("xfer: unexpected OID %s in complete event", resp.Oid)
+				a.failBulk(bulk, errors.New(tr.Tr.Get("unexpected OID %q in complete", resp.Oid)))
+				return
+			}
+
+			itemsCompleted[resp.Oid] = transfer
+			bulk.itemsComplete++
+			a.Trace("xfer: marked item %s as complete (%d/%d)", resp.Oid, bulk.itemsComplete, len(bulk.transfers))
+
+			if resp.Error != nil {
+				// Individual item failed
+				a.routeResult(TransferResult{
+					Transfer: transfer,
+					Error:    errors.New(tr.Tr.Get("error transferring %q: %v", transfer.Oid, resp.Error)),
+				})
+			} else {
+				// Individual item succeeded
+				if a.direction == Download {
+					// Verify and move downloaded file
+					if err := tools.VerifyFileHash(transfer.Oid, resp.Path); err != nil {
+						a.routeResult(TransferResult{
+							Transfer: transfer,
+							Error:    errors.New(tr.Tr.Get("downloaded file failed checks: %v", err)),
+						})
+						continue
+					}
+
+					if err := tools.RenameFileCopyPermissions(resp.Path, transfer.Path); err != nil {
+						a.routeResult(TransferResult{
+							Transfer: transfer,
+							Error:    errors.New(tr.Tr.Get("failed to copy downloaded file: %v", err)),
+						})
+						continue
+					}
+				} else if a.direction == Upload {
+					if err := verifyUpload(a.apiClient, a.remote, transfer); err != nil {
+						a.routeResult(TransferResult{
+							Transfer: transfer,
+							Error:    err,
+						})
+						continue
+					}
+				}
+
+				a.routeResult(TransferResult{Transfer: transfer, Error: nil})
+			}
+
+		case "bulk-complete":
+			a.Trace("xfer: bulk completion received for bulk %s", resp.Oid)
+			if resp.Oid != bulk.id {
+				a.Trace("xfer: unexpected bulk ID %s, expected %s", resp.Oid, bulk.id)
+				a.failBulk(bulk, errors.New(tr.Tr.Get("unexpected bulk ID %q in bulk-complete", resp.Oid)))
+				return
+			}
+
+			if resp.Error != nil {
+				a.Trace("xfer: bulk transfer failed: %v", resp.Error)
+				a.failBulk(bulk, errors.New(tr.Tr.Get("bulk transfer failed: %v", resp.Error)))
+				return
+			}
+
+			// Check that all items were completed
+			if bulk.itemsComplete != len(bulk.transfers) {
+				a.Trace("xfer: bulk completed but only %d of %d items finished", bulk.itemsComplete, len(bulk.transfers))
+				a.failBulk(bulk, errors.New(tr.Tr.Get("bulk completed but only %d of %d items finished", bulk.itemsComplete, len(bulk.transfers))))
+				return
+			}
+
+			a.Trace("xfer: bulk %s completed successfully with all %d items", bulk.id, bulk.itemsComplete)
+			bulkComplete = true
+
+		default:
+			a.Trace("xfer: invalid message %s from bulk adapter", resp.Event)
+			a.failBulk(bulk, errors.New(tr.Tr.Get("invalid message %q from bulk adapter", resp.Event)))
+			return
+		}
+	}
+
+	a.Trace("xfer: processBulkResponses completed successfully for bulk %s", bulk.id)
+}
+
+// failBulk marks all transfers in a bulk as failed with the given error.
+// It sends error results for each transfer in the bulk to the result channel.
+func (a *customBulkAdapter) failBulk(bulk *bulkState, err error) {
+	a.Trace("xfer: bulk %s failed: %v", bulk.id, err)
+
+	for _, t := range bulk.transfers {
+		a.routeResult(TransferResult{Transfer: t, Error: err})
+	}
+}
+
+// findTransferByOid searches for a transfer with the given OID within a slice of transfers.
+// Returns the matching transfer or nil if not found.
+func (a *customBulkAdapter) findTransferByOid(transfers []*Transfer, oid string) *Transfer {
+	for _, t := range transfers {
+		if t.Oid == oid {
+			return t
+		}
+	}
+	return nil
+}
+
+// generateBulkId creates a unique identifier for a bulk transfer using random bytes.
+// The ID is used to track the bulk throughout its lifecycle.
+func (a *customBulkAdapter) generateBulkId() string {
+	bytes := make([]byte, 8)
+	rand.Read(bytes)
+	return fmt.Sprintf("bulk-%s", hex.EncodeToString(bytes))
+}
+
+// getOperationName returns the operation name string ("download" or "upload")
+// based on the adapter's direction for use in protocol messages.
+func (a *customBulkAdapter) getOperationName() string {
+	if a.direction == Download {
+		return "download"
+	}
+	return "upload"
+}
+
+// Message handling methods (reuse from custom adapter)
+// sendMessage serializes a message to JSON and sends it to the worker process via stdin.
+// Each message is sent on a single line followed by a newline (line-delimited JSON).
+func (a *customBulkAdapter) sendMessage(worker *customBulkAdapterWorkerContext, req interface{}) error {
+	b, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+	a.Trace("xfer: Bulk adapter worker %d sending message: %v", worker.workerNum, string(b))
+	// Line oriented JSON
+	b = append(b, '\n')
+	_, err = worker.stdin.Write(b)
+	return err
+}
+
+// readResponse reads a single line-delimited JSON response from the worker process stdout
+// and deserializes it into a bulkAdapterBulkResponse struct.
+func (a *customBulkAdapter) readResponse(worker *customBulkAdapterWorkerContext) (*bulkAdapterBulkResponse, error) {
+	line, err := worker.bufferedOut.ReadString('\n')
+	if err != nil {
+		return nil, err
+	}
+	a.Trace("xfer: Bulk adapter worker %d received response: %v", worker.workerNum, strings.TrimSpace(line))
+	resp := &bulkAdapterBulkResponse{}
+	err = json.Unmarshal([]byte(line), resp)
+	return resp, err
+}
+
+// exchangeMessage sends a message to the worker process and waits for a response.
+// This is a convenience method that combines sendMessage and readResponse.
+func (a *customBulkAdapter) exchangeMessage(worker *customBulkAdapterWorkerContext, req interface{}) (*bulkAdapterBulkResponse, error) {
+	err := a.sendMessage(worker, req)
+	if err != nil {
+		return nil, err
+	}
+	return a.readResponse(worker)
+}
+
+// shutdownWorker gracefully terminates a worker process by sending a terminate message
+// and waiting for the process to exit. Returns an error if shutdown fails or times out.
+func (a *customBulkAdapter) shutdownWorker(worker *customBulkAdapterWorkerContext) error {
+	defer worker.errTracer.Flush()
+
+	a.Trace("xfer: Shutting down bulk adapter worker %d", worker.workerNum)
+
+	finishChan := make(chan error, 1)
+	go func() {
+		termReq := NewCustomAdapterTerminateRequest()
+		err := a.sendMessage(worker, termReq)
+		if err != nil {
+			finishChan <- err
+		}
+		worker.stdin.Close()
+		worker.stdout.Close()
+		finishChan <- worker.cmd.Wait()
+	}()
+
+	select {
+	case err := <-finishChan:
+		return err
+	case <-time.After(30 * time.Second):
+		return errors.New(tr.Tr.Get("timeout while shutting down bulk worker process %d", worker.workerNum))
+	}
+}
+
+// abortWorker forcefully terminates a worker process by closing pipes and killing the process.
+// This is used when graceful shutdown fails or when an error occurs during initialization.
+func (a *customBulkAdapter) abortWorker(worker *customBulkAdapterWorkerContext) {
+	a.Trace("xfer: Aborting bulk worker process: %d", worker.workerNum)
+	worker.stdin.Close()
+	worker.stdout.Close()
+	worker.cmd.Process.Kill()
+}
+
+// Trace outputs debug trace messages if debugging is enabled.
+// It uses the same format as fmt.Printf for consistency with other adapters.
+func (a *customBulkAdapter) Trace(format string, args ...interface{}) {
+	if a.debugging {
+		tracerx.Printf(format, args...)
+	}
+}
+
+// Configuration and registration
+// configureBulkAdapters scans the git configuration for bulk transfer adapter definitions
+// and registers them with the manifest. It looks for lfs.bulk.transfer.<name>.* settings.
+func configureBulkAdapters(git Env, m *concreteManifest) {
+	pathRegex := regexp.MustCompile(`lfs\.bulk\.transfer\.([^.]+)\.path`)
+	tracerx.Printf("configureBulkAdapters: scanning git config for bulk adapters")
+	for k, _ := range git.All() {
+		tracerx.Printf("configureBulkAdapters: checking config key: %s", k)
+		match := pathRegex.FindStringSubmatch(k)
+		if match == nil {
+			continue
+		}
+
+		name := match[1]
+		path, _ := git.Get(k)
+		tracerx.Printf("configureBulkAdapters: found bulk adapter '%s' with path '%s'", name, path)
+		// retrieve other values
+		args, _ := git.Get(fmt.Sprintf("lfs.bulk.transfer.%s.args", name))
+		concurrent := git.Bool(fmt.Sprintf("lfs.bulk.transfer.%s.concurrent", name), true)
+		bulkSize := git.Int(fmt.Sprintf("lfs.bulk.transfer.%s.bulkSize", name), 100)
+		direction, _ := git.Get(fmt.Sprintf("lfs.bulk.transfer.%s.direction", name))
+		if len(direction) == 0 {
+			direction = "both"
+		} else {
+			direction = strings.ToLower(direction)
+		}
+		tracerx.Printf("configureBulkAdapters: adapter '%s': concurrent=%t, bulkSize=%d, direction=%s", name, concurrent, bulkSize, direction)
+
+		// Separate closure for each since we need to capture vars above
+		newfunc := func(name string, dir Direction) Adapter {
+			return NewCustomBulkAdapter(m.fs, name, dir, path, args, concurrent, bulkSize)
+		}
+
+		if direction == "download" || direction == "both" {
+			tracerx.Printf("configureBulkAdapters: registering '%s' for Download direction", name)
+			m.RegisterNewAdapterFunc(name, Download, newfunc)
+		}
+		if direction == "upload" || direction == "both" {
+			tracerx.Printf("configureBulkAdapters: registering '%s' for Upload direction", name)
+			m.RegisterNewAdapterFunc(name, Upload, newfunc)
+		}
+	}
+	tracerx.Printf("configureBulkAdapters: completed scanning git config")
+}

--- a/tq/manifest.go
+++ b/tq/manifest.go
@@ -226,6 +226,7 @@ func newConcreteManifest(f *fs.Filesystem, apiClient *lfsapi.Client, operation, 
 		)
 		tusAllowed = git.Bool("lfs.tustransfers", false)
 		configureCustomAdapters(git, m)
+		configureBulkAdapters(git, m)
 	}
 
 	if m.maxRetries < 1 {


### PR DESCRIPTION
Hey git lfs team, hope you're doing great!

This PR introduces a new Bulk Transfer Protocol mechanism that complements the existing custom transfer mechanism to allow processing multiple files simultaneously in bulks. This feature allows different transfer planning strategies (compared to current sequential one artifact per process strategy in custom transfers) for new transfer implementations. 
This is important for repositories with many LFS objects of different file sizes. The new mechanism should allow more advanced transfer techniques like data deduplication per multiple files or multifile packing in a more easy manner compared to custom transfers.

PR contains protocol specification in docs/bulk-transfers.md and the draft implementation in bulk.go. 
Also the test infrastructure:
- test bulk lfs client with basic tests implementation
- test lfs server modification
- some basic tests

I am no good in go programming so while developing this code i used AI help. I am not entirely sure on the quality of this exact request though i tried my best to follow the patterns i saw in custom.go.

Best regards, Alexander Bogomolets.
