### PR TITLE
Use relative paths exclusively for internal checkout and pull operations

### DIFF
--- a/lfs/gitfilter_smudge.go
+++ b/lfs/gitfilter_smudge.go
@@ -15,13 +15,13 @@ import (
 	"github.com/rubyist/tracerx"
 )
 
-func (f *GitFilter) SmudgeToFile(filename string, ptr *WrappedPointer, download bool, manifest tq.Manifest, cb tools.CopyCallback) error {
+func (f *GitFilter) SmudgeToFile(path string, ptr *WrappedPointer, download bool, manifest tq.Manifest, cb tools.CopyCallback) error {
 	// When no pointer file exists on disk, we should use the permissions
 	// defined for the file in Git, since the executable mode may be set.
 	// However, to conform with our legacy behaviour, we do not do this
 	// at present.
 	var mode os.FileMode = 0666
-	if stat, _ := os.Lstat(filename); stat != nil && stat.Mode().IsRegular() {
+	if stat, _ := os.Lstat(path); stat != nil && stat.Mode().IsRegular() {
 		if ptr.Size == 0 && stat.Size() == 0 {
 			return nil
 		}
@@ -29,13 +29,13 @@ func (f *GitFilter) SmudgeToFile(filename string, ptr *WrappedPointer, download 
 		mode = stat.Mode().Perm()
 	}
 
-	if err := os.Remove(filename); err != nil && !os.IsNotExist(err) {
-		return errors.Wrap(err, tr.Tr.Get("could not remove working directory file %q", filename))
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return errors.Wrap(err, tr.Tr.Get("could not remove working directory file %q", path))
 	}
 
-	file, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode)
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode)
 	if err != nil {
-		return errors.Wrap(err, tr.Tr.Get("could not create working directory file %q", filename))
+		return errors.Wrap(err, tr.Tr.Get("could not create working directory file %q", path))
 	}
 	defer file.Close()
 	if _, err := f.Smudge(file, ptr.Pointer, ptr.Name, download, manifest, cb); err != nil {


### PR DESCRIPTION
As a result of improvements in the `os` package of Go's standard library in Go v1.23.0, file paths longer than the Windows `MAX_PATH` limit are now always converted into a format which allows them to exceed the limit.

We can therefore simplify the internal file path handling of our `git lfs checkout` and `git lfs pull` commands as we no longer need to convert relative file paths into absolute ones before passing them to functions from the `os` package.

Previously we performed this step because Go's `os` package would only convert absolute paths into the Windows format that allowed them to exceed the `MAX_PATH` limit; relative paths would not be converted into that format, but they are now.

This PR will be most easily reviewed on a commit-by-commit basis.

#### Background

At present, during `git lfs checkout` and `git lfs pull` commands, we [construct](https://github.com/git-lfs/git-lfs/blob/66c84c30834855cbc58aa86f5f89fbae09b17849/lfs/gitfilter_smudge.go#L32-L44) an absolute path to the files we intend to create, although we don't use those absolute paths consistently for all filesystem operations.  For instance, we do not use the absolute path when [checking](https://github.com/git-lfs/git-lfs/blob/66c84c30834855cbc58aa86f5f89fbae09b17849/lfs/gitfilter_smudge.go#L24-L30) the permissions of existing files at the same locations.

The extra conversion from relative paths to absolute paths was introduced in PR #3780 with the goal of resolving the problem reported in #3772 regarding Windows systems where the maximum length of a file path is often [restricted](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation) to the `MAX_PATH` limit of 260 characters, unless it is provided in the form of a "root local" DOS device path [beginning](https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#win32-file-namespaces) with the `\\?\` prefix.

At the time of our change in PR #3780, we were using Go v1.11.1 to build the Git LFS client, and by changing our `SmudgeToFile()` method to construct an absolute path we took advantage of the fact that when we passed the resultant path to the `Create()` function of the `os` package, it would translate that path into one beginning with `\\?\` and thus the final file path could exceed the `MAX_PATH` length limit.  The `Create()` function, like others in the `os` package, [invoked](https://github.com/golang/go/blob/go1.11.1/src/os/file.go#L274) a chain of [internal](https://github.com/golang/go/blob/go1.11.1/src/os/file.go#L284) [functions](https://github.com/golang/go/blob/go1.11.1/src/os/file_windows.go#L158) which ultimately [passed](https://github.com/golang/go/blob/go1.11.1/src/os/file_windows.go#L97) the input path to the `fixLongPath()` [function](https://github.com/golang/go/blob/go1.11.1/src/os/path_windows.go#L131-L209), which converted any absolute path into one beginning with `\\?\`.

However, while the changes in PR #3780 resolved some instances where a long relative path caused errors on Windows when running `git lfs checkout` or `git lfs pull` commands, they were likely insufficient to resolve all such cases, because the `SmudgeToFile()` method continued to [pass](https://github.com/git-lfs/git-lfs/blob/719e1aaf78344c552e47ffc50b2b071798141b2d/lfs/gitfilter_smudge.go#L18) relative paths to the `MkdirAll()` function in our `tools` package, which in turn [calls](https://github.com/git-lfs/git-lfs/blob/66c84c30834855cbc58aa86f5f89fbae09b17849/tools/filetools.go#L138) the `MkdirAll()` function in the `os` package of the standard Go library.  If the relative path provided to the `SmudgeToFile()` method was longer than the `MAX_PATH` limit even with the trailing file name removed, and some of the directories named in that path did not exist, then the `MkdirAll()` method would have failed on Windows, at least with versions of Go prior to v1.23.0.

#### Current State

Fortunately, ever since PR #5997, when we upgraded the version of Go we use to build the Git LFS client to Go v1.23.0, this problem and any similar issues should now be effectively eliminated.  Go v1.23.0 includes the revisions to its internal `fixLongPath()` function from CLs (Change Lists) [570995](https://go.dev/cl/570995) and [574695](https://go.dev/cl/574695), particularly commits golang/go@2e8d84f148c69404b8eec86d9149785a3f4e3e92 and golang/go@7c89ad6a80020e3654129183c528054921899650, which ensure that the [function](https://github.com/golang/go/blob/go1.23.0/src/os/path_windows.go#L41-L152) now correctly handles both UNC paths and, most importantly for our purposes here, relative paths.

These improvements in the Go standard library therefore apply to our [use](https://github.com/git-lfs/git-lfs/blob/66c84c30834855cbc58aa86f5f89fbae09b17849/lfs/gitfilter_smudge.go#L37-L44) of the `Remove()` and `OpenFile()` functions from the `os` package in our `SmudgeToFile()` method.  Further, they also apply to our use of the `os` package's `Mkdir()` function to create any missing directories between the root of the current Git working tree and the file path provided to the `SmudgeToFile()` method.  We no longer call the `MkdirAll()` function since commits 0cffe93176b870055c9dadbb3cc9a4a440e98396 and 2902e9d2dec816f1f7d76b0a6b7177f66a65c374; instead, the `walk()` method of the new `DirWalker` structure in our `tools` package [invokes](https://github.com/git-lfs/git-lfs/blob/66c84c30834855cbc58aa86f5f89fbae09b17849/tools/dir_walker.go#L85) the `Mkdir()` function in the same package for each missing directory, and this helper function then [calls](https://github.com/git-lfs/git-lfs/blob/66c84c30834855cbc58aa86f5f89fbae09b17849/tools/filetools.go#L129) the `os` package's `Mkdir()` function.

As a consequence, we can simply remove the call to the `Abs()` function from our `SmudgeToFile()` method and use the relative path provided in its `filename` parameter without any adjustment.

#### Parameter Names

We also take the opportunity to rename the `SmudgeToFile()` method's `filename` parameter to `path`, which matches the `path` parameter of the method's sole caller, the `RunToPath()` [method](https://github.com/git-lfs/git-lfs/blob/66c84c30834855cbc58aa86f5f89fbae09b17849/commands/pull.go#L147-L150) of the `singleCheckout` structure in our `commands` package.  This should help clarify the relationship between these two parameters and somewhat more accurately describes their expected contents, since they are often not plain filenames but a relative paths with both directory and filename components. 