### PR TITLE
Makefile,script: add vendored source release asset

### DIFF
--- a/script/upload
+++ b/script/upload
@@ -70,6 +70,8 @@ categorize_asset () {
   local arch=$(echo "$file" | ruby -pe '$_.gsub!(/\Agit-lfs-[^-]+-([^-]+)[-.].*/, "\\1")')
 
   case "$file" in
+    git-lfs-vendor-v*.*.*.tar.gz)
+      echo "Source with Vendored Modules";;
     git-lfs-v*.*.*.tar.gz)
       echo "Source";;
     git-lfs-windows-v*.*.*.exe)


### PR DESCRIPTION
This PR adjusts our `Makefile` and release upload script so future feature releases of the Git LFS client will include an additional asset archive file containing the project's source files along with a vendored set of Go module dependencies, as requested in #6071.

The changes in this PR have been tested in a private repository with a successful run of our GitHub Actions release workflow.  The new release asset appears in the release page as shown below:

<img width="925" height="194" alt="Screenshot 2025-12-07 at 9 31 25 AM" src="https://github.com/user-attachments/assets/da321f33-8a86-4c6e-830a-43503ad56687" />

#### Details

As described in #6071, some of the downstream distributors who package Git LFS from our source release asset also run their build processes offline and therefore they cannot run `go mod vendor` to fetch our Go module dependencies.  As a result, these distributors have requested that we also provide a source release asset which includes a fully-populated `vendor` directory.

To fulfill this request, we add a new release asset target to our `Makefile` and include this new asset's archive file in the [list](https://github.com/git-lfs/git-lfs/blob/194116686bb5559bdcfe5cde784ee53e86aa0b16/Makefile#L357-L373) in the `RELEASE_TARGETS` `make(1)` variable.  The new target is named `bin/releases/git-lfs-vendor-$(VERSION).tar.gz`, and contains both our source files and a complete `vendor` directory.

We build this new release asset in several steps.  First, we run `git archive` akin to how it is [used](https://github.com/git-lfs/git-lfs/blob/194116686bb5559bdcfe5cde784ee53e86aa0b16/Makefile#L437) in our regular source release asset target, the `bin/releases/git-lfs-$(VERSION).tar.gz` target, except that we generate a local `tmp.tar` file rather than a final, compressed archive file.

We then add the contents of the `vendor` directory to this temporary archive file, using the appropriate command-line arguments to rewrite the names of the added files so they include our expected versioned package name as a parent directory.  This ensures the `vendor` directory is located alongside our source files in the same directory when the archive file is unpacked.

Note that the `vendor` directory must exist in the current working directory at the time our new `Makefile` target's recipe runs because we specify the `vendor` prerequisite for the target.  Our existing `vendor` target [runs](https://github.com/git-lfs/git-lfs/blob/194116686bb5559bdcfe5cde784ee53e86aa0b16/Makefile#L614) `go mod vendor`, so this will create and populate the `vendor` directory before our new target's recipe executes.

We do, however, ensure that the files in the `vendor` directory have their group permissions set, to match the permissions of the files in the temporary archive files.  The `git archive` command [uses](https://git-scm.com/docs/git-archive#Documentation/git-archive.txt-tarumask) a default octal permissions mask of `0002` when adding files to the archive it outputs, so we adjust our `vendor` directories to align with that default.

Finally, we compress the archive using the `gzip(1)` command to create our final release asset file, and remove the temporary archive file. To invoke the `gzip` command we reference a new `GZIP` variable in our `Makefile` whose default value is `gzip`; this aligns with our use of similar [variables](https://github.com/git-lfs/git-lfs/blob/194116686bb5559bdcfe5cde784ee53e86aa0b16/Makefile#L64-L78) for the `grep(1)`, `tar(1)`, and `xargs(1)` commands.  (We do not consistently reference these `make` variables, however, but we defer addressing that issue to a future PR).

In addition to revising our `Makefile`, we also update our `script/upload` file so that its `categorize_asset()` [function](https://github.com/git-lfs/git-lfs/blob/194116686bb5559bdcfe5cde784ee53e86aa0b16/script/upload#L65-L88) recognizes our new release asset archive file and provides a description for it, to be used in the asset file listings of our GitHub release pages.

Resolves #6071.
/cc @bbhtt as reporter.