### PR TITLE
attempt to fix merge ff with multiple remotes and multiple lfs commits

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -225,7 +225,7 @@ func (c *Configuration) IsDefaultRemote() bool {
 }
 
 func (c *Configuration) AutoDetectRemoteEnabled() bool {
-	return c.Git.Bool("lfs.remote.autodetect", false)
+	return c.Git.Bool("lfs.remote.autodetect", true)
 }
 
 func (c *Configuration) SearchAllRemotesEnabled() bool {


### PR DESCRIPTION
This code is meant to fix the following issue reproducer 

## Clone the same repo just from  two different git instances
```
git clone gitea@src.oss.org:joe/nodejs22 oss-nodejs
git clone gitea@src.iss.org:joe/nodejs22 iss-nodejs
```

## Add new LFS objects to OSS
```
cd oss-nodejs
git checkout main

dd if=/dev/random of=foo.xz count=100
git add foo.xz
git commit -a -m 'test1'

dd if=/dev/random of=foo.xz count=100
git add foo.xz
git commit -a -m 'test2'
```

## Now we have two new commits with 2 LFS objects to push
```
git push origin main
```

## Move to the repo hosted on another instance with a branch in common
```
cd ../iss-nodejs
git checkout main
git remote add oss gitea@src.oss.org
git fetch oss

git merge --ff-only oss/main
Updating f442893..67b6897
Downloading foo.xz (51 KB)
Error downloading object: foo.xz (bbdd1b0): Smudge error: Error downloading foo.xz (bbdd1b0b9131658ad7820176879a65d9a24fde1f2a1d8fffd0b79aa663bd4076): could not get connection for batch request: pure SSH connection unavailable (#0)

Errors logged to '/tmp/node/iss-nodejs22/.git/lfs/logs/20251219T123627.95839924.log'.
Use `git lfs logs last` to view the log.
error: external filter 'git-lfs filter-process' failed
fatal: foo.xz: smudge filter lfs failed
```

lfs.remote.autodetect fixes the issue, why is the default setting not true ?        
```                   
git config lfs.remote.autodetect true                                      
Updating f442893..67b6897
Fast-forward
 foo.xz | 3 +++
 1 file changed, 3 insertions(+)
 create mode 100644 foo.xz
```

## OK, so things look like they merged… Try to push
```
> git push origin main                                               
Locking support detected on remote "origin". Consider enabling it with:
  $ git config lfs.https://src.iss.org/joe/nodejs.git/info/lfs.locksverify true
Git LFS upload failed:   0% (0/1), 0 B | 0 B/s      
Uploading LFS objects:   0% (0/2), 0 B | 0 B/s, done.
  (missing) foo.xz (02b3b4dd03aff81ca43fdd0941ace2ef36de6cd5786559e079cefcab7bcd9fe0)
hint: Your push was rejected due to missing or corrupt local objects.
hint: You can disable this check with: `git config lfs.allowincompletepush true`
```

With a fast forward merge, only the HEAD LFS object is fetched, leaving the LFS objects from intermediate commits unfetched.