### PR TITLE
Log additional HTTP request headers when tracing

### DIFF
--- a/lfshttp/verbose.go
+++ b/lfshttp/verbose.go
@@ -18,7 +18,7 @@ func (c *Client) traceRequest(req *http.Request) (*tracedRequest, error) {
 	tracerx.Printf("HTTP: %s", traceReq(req))
 
 	if c.Verbose {
-		if dump, err := httputil.DumpRequest(req, false); err == nil {
+		if dump, err := httputil.DumpRequestOut(req, false); err == nil {
 			c.traceHTTPDump(">", dump)
 		}
 	}

--- a/lfshttp/verbose_test.go
+++ b/lfshttp/verbose_test.go
@@ -61,6 +61,7 @@ func TestVerboseEnabled(t *testing.T) {
 		"> Host: 127.0.0.1:",
 		"\n> Authorization: Basic * * * * *\n",
 		"\n> Content-Type: application/json\n",
+		"\n> Accept-Encoding: gzip\n",
 		"\n> \n" + `{"Test":"Verbose"}` + "\n\n",
 
 		"\n< HTTP/1.1 200 OK\n",
@@ -117,6 +118,7 @@ func TestVerboseWithBinaryBody(t *testing.T) {
 		"> Host: 127.0.0.1:",
 		"\n> Authorization: Basic * * * * *\n",
 		"\n> Content-Type: application/octet-stream\n",
+		"\n> Accept-Encoding: gzip\n",
 
 		"\n< HTTP/1.1 200 OK\n",
 		"\n< Content-Type: application/octet-stream\n",
@@ -175,6 +177,7 @@ func TestVerboseEnabledWithDebugging(t *testing.T) {
 		"> Host: 127.0.0.1:",
 		"\n> Authorization: Basic ABC\n",
 		"\n> Content-Type: application/json\n",
+		"\n> Accept-Encoding: gzip\n",
 		"\n> \n" + `{"Test":"Verbose"}` + "\n\n",
 
 		"\n< HTTP/1.1 200 OK\n",


### PR DESCRIPTION
This PR updates our trace logging so that we capture and report additional HTTP request headers, beyond the limited set we currently log.

Specifically, by replacing our [use](https://github.com/git-lfs/git-lfs/blob/ba2ada74a9a173a5581d1af5645998fc82a7b4d2/lfshttp/verbose.go#L21) of the `DumpRequest()` [function](https://pkg.go.dev/net/http/httputil#DumpRequest) from Go's `net/http/httputil` package with the `DumpRequestOut()` [function](https://pkg.go.dev/net/http/httputil#DumpRequestOut), our trace logs will now capture request headers such as the `Accept-Encoding` header that are automatically added by Go's `net/http` library to all of our HTTP client requests.  The absence of this header from our trace logs was noted recently in #6193.

#### Background

At present, when the `GIT_CURL_VERBOSE` environment variable is set to a value such as `1` or `true`, the Git LFS client outputs some of the details of each HTTP request and response it makes to its standard error stream.

We gather the HTTP request headers to be logged in the `traceRequest()` method of the Client structure from our `lfshttp` package.  To gather the headers, the `traceRequest()` method [uses](https://github.com/git-lfs/git-lfs/blob/ba2ada74a9a173a5581d1af5645998fc82a7b4d2/lfshttp/verbose.go#L21) the `DumpRequest()` function from the from the `net/http/httputil` package in the Go standard library.

Our use of the `DumpRequest()` function for this purpose dates back to commit 6fafade7529e91301f2fc99f53ab03af6fc691de of PR #366 in 2015, when it was first [introduced](https://github.com/git-lfs/git-lfs/blob/257f90939e0b4ecc1a2acb796b04cc89e52d08b1/lfs/http.go#L164) into what was then the `traceHttpRequest()` function in our `lfs` package.  This function gradually evolved into the current `traceRequest()` method through a series of PRs.  First, portions of the `lfs` package were migrated into a new `httputil` package in PR #1226.  That package was later removed in PR #1846 after a new `lfsapi` package was added in PR #1794 with a version of the `traceRequest()` method very similar to the current one.  Finally, in PR #3244 we moved the method into the current `lfshttp` package.

Throughout these changes, however, our use of the `DumpRequest()` function has remained the same.  However, since the Git LFS client only acts as an HTTP client and not an HTTP server, we should instead be using the `DumpRequestOut()` function from the standard `httputil` package to gather the headers of an HTTP request for logging purposes.

Since Go version 1.6, the `httputil` package's documentation has [stated](https://pkg.go.dev/net/http/httputil@go1.6#DumpRequest) that the `DumpRequest()` function "should only be used by servers to debug client requests", and that the `DumpRequestOut()` function "is like DumpRequest but for outgoing client requests."

However, at the time we first adopted the use of the `DumpRequest()` function, the Go documentation did not include these directives, and merely [noted](https://pkg.go.dev/net/http/httputil@go1.4#DumpRequest) that "DumpRequest returns the as-received wire representation of req, optionally including the request body, for debugging" and that "DumpRequestOut is like DumpRequest but includes headers that the standard http.Transport adds, such as User-Agent."

It is reasonable to assume, therefore, that when PR #366 was written its authors simply assumed that the `DumpRequest()` function was sufficient, given the state of the Go documentation at that time.

#### Change Details

As we would prefer to log a more complete set of client HTTP request headers, though, particularly the `Accept-Encoding` header which the Go `net/http` package [automatically](https://github.com/golang/go/blob/a8291eb61402d4549b69803fc8f834ded45b1f6c/src/net/http/transport.go#L195-L198) [adds](https://github.com/golang/go/blob/a8291eb61402d4549b69803fc8f834ded45b1f6c/src/net/http/transport.go#L2858) to outgoing requests, we now update our `traceRequest()` method to use the `DumpRequestOut()` function.

We then also update some of our Go language `TestVerbose*()` test [functions](https://github.com/git-lfs/git-lfs/blob/ba2ada74a9a173a5581d1af5645998fc82a7b4d2/lfshttp/verbose_test.go#L21-L190) to confirm that the `Accept-Encoding` request header is now captured and reported when verbose logging is enabled.  Note that without the change in this PR to the use of the `DumpRequestOut()` function, these revised tests would fail, since the `Accept-Encoding` header would not appear in headers returned by the `DumpRequest()` function.

/cc @mzr as reporter in #6193