### PR TITLE
Use `core.ignorecase` to determine case sensitivity

### DIFF
--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -85,7 +85,7 @@ func checkoutCommand(cmd *cobra.Command, args []string) {
 		pointers = append(pointers, p)
 	})
 
-	chgitscanner.Filter = filepathfilter.New(rootedPathPatterns, nil, filepathfilter.GitIgnore)
+	chgitscanner.Filter = filepathfilter.New(rootedPathPatterns, nil, filepathfilter.GitIgnore, cfg.Git)
 
 	if err := chgitscanner.ScanLFSFiles(ref.Sha, nil); err != nil {
 		ExitWithError(err)

--- a/commands/command_filter_process.go
+++ b/commands/command_filter_process.go
@@ -61,7 +61,7 @@ func filterCommand(cmd *cobra.Command, args []string) {
 	}
 
 	skip := filterSmudgeSkip || cfg.Os.Bool("GIT_LFS_SKIP_SMUDGE", false)
-	filter := filepathfilter.New(cfg.FetchIncludePaths(), cfg.FetchExcludePaths(), filepathfilter.GitIgnore)
+	filter := filepathfilter.New(cfg.FetchIncludePaths(), cfg.FetchExcludePaths(), filepathfilter.GitIgnore, cfg.Git)
 
 	ptrs := make(map[string]*lfs.Pointer)
 

--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -145,7 +145,7 @@ func doFsckObjects(include, exclude string, useIndex bool) []string {
 	// objects), the "missing" ones will fail the fsck.
 	//
 	// Attach a filepathfilter to avoid _only_ the excluded paths.
-	gitscanner.Filter = filepathfilter.New(nil, cfg.FetchExcludePaths(), filepathfilter.GitIgnore)
+	gitscanner.Filter = filepathfilter.New(nil, cfg.FetchExcludePaths(), filepathfilter.GitIgnore, cfg.Git)
 
 	if exclude == "" {
 		if err := gitscanner.ScanRef(include, nil); err != nil {

--- a/commands/command_migrate_import.go
+++ b/commands/command_migrate_import.go
@@ -64,7 +64,7 @@ func migrateImportCommand(cmd *cobra.Command, args []string) {
 
 		root := commit.TreeID
 
-		filter := gitattr.GetAttributeFilter(cfg.LocalWorkingDir(), cfg.LocalGitDir())
+		filter := gitattr.GetAttributeFilter(cfg.Git, cfg.LocalWorkingDir(), cfg.LocalGitDir())
 		if len(filter.Include()) == 0 {
 			ExitWithError(errors.New(tr.Tr.Get("No Git LFS filters found in '.gitattributes'")))
 		}

--- a/commands/command_prune.go
+++ b/commands/command_prune.go
@@ -114,7 +114,7 @@ func prune(fetchPruneConfig lfs.FetchPruneConfig, verifyRemote, verifyUnreachabl
 	retainChan := make(chan string, 100)
 
 	gitscanner := lfs.NewGitScanner(cfg, nil)
-	gitscanner.Filter = filepathfilter.New(nil, cfg.FetchExcludePaths(), filepathfilter.GitIgnore)
+	gitscanner.Filter = filepathfilter.New(nil, cfg.FetchExcludePaths(), filepathfilter.GitIgnore, cfg.Git)
 
 	sem := semaphore.NewWeighted(int64(runtime.NumCPU() * 2))
 

--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -154,7 +154,7 @@ func smudgeCommand(cmd *cobra.Command, args []string) {
 	if !smudgeSkip && cfg.Os.Bool("GIT_LFS_SKIP_SMUDGE", false) {
 		smudgeSkip = true
 	}
-	filter := filepathfilter.New(cfg.FetchIncludePaths(), cfg.FetchExcludePaths(), filepathfilter.GitIgnore)
+	filter := filepathfilter.New(cfg.FetchIncludePaths(), cfg.FetchExcludePaths(), filepathfilter.GitIgnore, cfg.Git)
 	gitfilter := lfs.NewGitFilter(cfg)
 
 	if n, err := smudge(gitfilter, os.Stdout, os.Stdin, smudgeFilename(args), smudgeSkip, filter); err != nil {

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -139,7 +139,7 @@ func buildFilepathFilter(config *config.Configuration, includeArg, excludeArg *s
 
 func buildFilepathFilterWithPatternType(config *config.Configuration, includeArg, excludeArg *string, useFetchOptions bool, patternType filepathfilter.PatternType) *filepathfilter.Filter {
 	inc, exc := determineIncludeExcludePaths(config, includeArg, excludeArg, useFetchOptions)
-	return filepathfilter.New(inc, exc, patternType, determineFilepathFilterCache(config))
+	return filepathfilter.New(inc, exc, patternType, config.Git, determineFilepathFilterCache(config))
 }
 
 func downloadTransfer(p *lfs.WrappedPointer) (name, path, oid string, size int64, missing bool, err error) {

--- a/filepathfilter/filepathfilter.go
+++ b/filepathfilter/filepathfilter.go
@@ -83,10 +83,10 @@ func NewFromPatterns(include, exclude []Pattern, setters ...Option) *Filter {
 	return f
 }
 
-func New(include, exclude []string, ptype PatternType, setters ...Option) *Filter {
+func New(include, exclude []string, ptype PatternType, gitEnv Environment, setters ...Option) *Filter {
 	return NewFromPatterns(
-		convertToWildmatch(include, ptype),
-		convertToWildmatch(exclude, ptype), setters...)
+		convertToWildmatch(include, ptype, gitEnv),
+		convertToWildmatch(exclude, ptype, gitEnv), setters...)
 }
 
 // Include returns the result of calling String() on each Pattern in the
@@ -184,7 +184,7 @@ const (
 	sep byte = '/'
 )
 
-func NewPattern(p string, ptype PatternType) Pattern {
+func NewPattern(p string, ptype PatternType, gitEnv Environment) Pattern {
 	tracerx.Printf("filepathfilter: creating pattern %q of type %v", p, ptype)
 
 	switch ptype {
@@ -193,7 +193,7 @@ func NewPattern(p string, ptype PatternType) Pattern {
 			p: p,
 			w: wildmatch.NewWildmatch(
 				p,
-				wildmatch.SystemCase,
+				caseFromConfig(gitEnv),
 				wildmatch.Contents,
 			),
 		}
@@ -202,7 +202,7 @@ func NewPattern(p string, ptype PatternType) Pattern {
 			p: p,
 			w: wildmatch.NewWildmatch(
 				p,
-				wildmatch.SystemCase,
+				caseFromConfig(gitEnv),
 				wildmatch.Basename,
 				wildmatch.GitAttributes,
 			),
@@ -228,10 +228,10 @@ func join(paths ...string) string {
 	return joined
 }
 
-func convertToWildmatch(rawpatterns []string, ptype PatternType) []Pattern {
+func convertToWildmatch(rawpatterns []string, ptype PatternType, gitEnv Environment) []Pattern {
 	patterns := make([]Pattern, len(rawpatterns))
 	for i, raw := range rawpatterns {
-		patterns[i] = NewPattern(raw, ptype)
+		patterns[i] = NewPattern(raw, ptype, gitEnv)
 	}
 	return patterns
 }

--- a/filepathfilter/filepathfilter_test.go
+++ b/filepathfilter/filepathfilter_test.go
@@ -107,28 +107,28 @@ func TestPatternMatch(t *testing.T) {
 }
 
 func assertPatternMatch(t *testing.T, pattern string, filenames ...string) {
-	p := NewPattern(pattern, GitAttributes)
+	p := NewPattern(pattern, GitAttributes, nil)
 	for _, filename := range filenames {
 		assert.True(t, p.Match(filename), "%q should match pattern %q", filename, pattern)
 	}
 }
 
 func assertPatternMatchIgnore(t *testing.T, pattern string, filenames ...string) {
-	p := NewPattern(pattern, GitIgnore)
+	p := NewPattern(pattern, GitIgnore, nil)
 	for _, filename := range filenames {
 		assert.True(t, p.Match(filename), "%q should match pattern %q", filename, pattern)
 	}
 }
 
 func refutePatternMatch(t *testing.T, pattern string, filenames ...string) {
-	p := NewPattern(pattern, GitAttributes)
+	p := NewPattern(pattern, GitAttributes, nil)
 	for _, filename := range filenames {
 		assert.False(t, p.Match(filename), "%q should not match pattern %q", filename, pattern)
 	}
 }
 
 func refutePatternMatchIgnore(t *testing.T, pattern string, filenames ...string) {
-	p := NewPattern(pattern, GitIgnore)
+	p := NewPattern(pattern, GitIgnore, nil)
 	for _, filename := range filenames {
 		assert.False(t, p.Match(filename), "%q should not match pattern %q", filename, pattern)
 	}
@@ -142,13 +142,13 @@ type filterTest struct {
 }
 
 func TestFilterReportsIncludePatterns(t *testing.T) {
-	filter := New([]string{"*.foo", "*.bar"}, nil, GitAttributes)
+	filter := New([]string{"*.foo", "*.bar"}, nil, GitAttributes, nil)
 
 	assert.Equal(t, []string{"*.foo", "*.bar"}, filter.Include())
 }
 
 func TestFilterReportsExcludePatterns(t *testing.T) {
-	filter := New(nil, []string{"*.baz", "*.quux"}, GitAttributes)
+	filter := New(nil, []string{"*.baz", "*.quux"}, GitAttributes, nil)
 
 	assert.Equal(t, []string{"*.baz", "*.quux"}, filter.Exclude())
 }

--- a/git/gitattr/files.go
+++ b/git/gitattr/files.go
@@ -219,14 +219,14 @@ func AttrPathsFromReader(mp *MacroProcessor, fpath, workingDir string, rdr io.Re
 // file paths can be matched against
 // workingDir is the root of the working copy
 // gitDir is the root of the git repo
-func GetAttributeFilter(workingDir, gitDir string) *filepathfilter.Filter {
+func GetAttributeFilter(gitEnv filepathfilter.Environment, workingDir, gitDir string) *filepathfilter.Filter {
 	paths := GetAttributePaths(NewMacroProcessor(), workingDir, gitDir)
 	patterns := make([]filepathfilter.Pattern, 0, len(paths))
 
 	for _, path := range paths {
 		// Convert all separators to `/` before creating a pattern to
 		// avoid characters being escaped in situations like `subtree\*.md`
-		patterns = append(patterns, filepathfilter.NewPattern(filepath.ToSlash(path.Path), filepathfilter.GitAttributes))
+		patterns = append(patterns, filepathfilter.NewPattern(filepath.ToSlash(path.Path), filepathfilter.GitAttributes, gitEnv))
 	}
 
 	return filepathfilter.NewFromPatterns(patterns, nil)

--- a/git/githistory/rewriter_test.go
+++ b/git/githistory/rewriter_test.go
@@ -204,7 +204,7 @@ func TestRewriterIgnoresPathsThatDontMatchFilter(t *testing.T) {
 	include := []string{"*.txt"}
 	exclude := []string{"subdir/*.txt"}
 
-	filter := filepathfilter.New(include, exclude, filepathfilter.GitIgnore)
+	filter := filepathfilter.New(include, exclude, filepathfilter.GitIgnore, nil)
 
 	db := DatabaseFromFixture(t, "non-repeated-subtrees.git")
 	r := NewRewriter(db, WithFilter(filter))
@@ -228,7 +228,7 @@ func TestRewriterIgnoresPathsThatDontMatchFilterWithResultCaching(t *testing.T) 
 	include := []string{"*.txt"}
 	exclude := []string{"subdir/*.txt"}
 
-	filter := filepathfilter.New(include, exclude, filepathfilter.GitIgnore, filepathfilter.EnableCache(10))
+	filter := filepathfilter.New(include, exclude, filepathfilter.GitIgnore, nil, filepathfilter.EnableCache(10))
 
 	db := DatabaseFromFixture(t, "non-repeated-subtrees.git")
 	r := NewRewriter(db, WithFilter(filter))
@@ -487,7 +487,7 @@ func TestHistoryRewriterUpdatesRefs(t *testing.T) {
 }
 
 func TestHistoryRewriterReturnsFilter(t *testing.T) {
-	f := filepathfilter.New([]string{"a"}, []string{"b"}, filepathfilter.GitIgnore)
+	f := filepathfilter.New([]string{"a"}, []string{"b"}, filepathfilter.GitIgnore, nil)
 	r := NewRewriter(nil, WithFilter(f))
 
 	expected := reflect.ValueOf(f).Elem().Addr().Pointer()

--- a/lfs/gitscanner_tree.go
+++ b/lfs/gitscanner_tree.go
@@ -256,7 +256,7 @@ func catFileBatchTreeForPointers(treeblobs *TreeBlobChannelWrapper, gitEnv, osEn
 	for _, path := range paths {
 		// Convert all separators to `/` before creating a pattern to
 		// avoid characters being escaped in situations like `subtree\*.md`
-		pattern := filepathfilter.NewPattern(filepath.ToSlash(path.Path), filepathfilter.GitAttributes)
+		pattern := filepathfilter.NewPattern(filepath.ToSlash(path.Path), filepathfilter.GitAttributes, gitEnv)
 		if path.Tracked {
 			includes = append(includes, pattern)
 		} else {

--- a/lfs/scanner_test.go
+++ b/lfs/scanner_test.go
@@ -152,7 +152,7 @@ func TestLogScannerAdditionsNoFiltering(t *testing.T) {
 func TestLogScannerAdditionsFilterInclude(t *testing.T) {
 	r := strings.NewReader(pointerParseLogOutput)
 	scanner := newLogScanner(LogDiffAdditions, r)
-	scanner.Filter = filepathfilter.New([]string{"wave*"}, nil, filepathfilter.GitAttributes)
+	scanner.Filter = filepathfilter.New([]string{"wave*"}, nil, filepathfilter.GitAttributes, nil)
 
 	// addition, + side
 	assertNextScan(t, scanner)
@@ -169,7 +169,7 @@ func TestLogScannerAdditionsFilterInclude(t *testing.T) {
 func TestLogScannerAdditionsFilterIncludeOctals(t *testing.T) {
 	r := strings.NewReader(pointerParseLogOutput)
 	scanner := newLogScanner(LogDiffAdditions, r)
-	scanner.Filter = filepathfilter.New([]string{"*ç*"}, nil, filepathfilter.GitAttributes)
+	scanner.Filter = filepathfilter.New([]string{"*ç*"}, nil, filepathfilter.GitAttributes, nil)
 
 	// modification, + side with extensions
 	assertNextScan(t, scanner)
@@ -186,7 +186,7 @@ func TestLogScannerAdditionsFilterIncludeOctals(t *testing.T) {
 func TestLogScannerAdditionsFilterExclude(t *testing.T) {
 	r := strings.NewReader(pointerParseLogOutput)
 	scanner := newLogScanner(LogDiffAdditions, r)
-	scanner.Filter = filepathfilter.New(nil, []string{"wave*"}, filepathfilter.GitAttributes)
+	scanner.Filter = filepathfilter.New(nil, []string{"wave*"}, filepathfilter.GitAttributes, nil)
 
 	// modification, + side
 	assertNextScan(t, scanner)
@@ -274,7 +274,7 @@ func TestLogScannerDeletionsNoFiltering(t *testing.T) {
 func TestLogScannerDeletionsFilterInclude(t *testing.T) {
 	r := strings.NewReader(pointerParseLogOutput)
 	scanner := newLogScanner(LogDiffDeletions, r)
-	scanner.Filter = filepathfilter.New([]string{"flare*"}, nil, filepathfilter.GitAttributes)
+	scanner.Filter = filepathfilter.New([]string{"flare*"}, nil, filepathfilter.GitAttributes, nil)
 
 	// deletion, - side with extensions
 	assertNextScan(t, scanner)
@@ -291,7 +291,7 @@ func TestLogScannerDeletionsFilterInclude(t *testing.T) {
 func TestLogScannerDeletionsFilterIncludeOctals(t *testing.T) {
 	r := strings.NewReader(pointerParseLogOutput)
 	scanner := newLogScanner(LogDiffDeletions, r)
-	scanner.Filter = filepathfilter.New([]string{"*ç*"}, nil, filepathfilter.GitAttributes)
+	scanner.Filter = filepathfilter.New([]string{"*ç*"}, nil, filepathfilter.GitAttributes, nil)
 
 	// modification, - side with extensions
 	assertNextScan(t, scanner)
@@ -308,7 +308,7 @@ func TestLogScannerDeletionsFilterIncludeOctals(t *testing.T) {
 func TestLogScannerDeletionsFilterExclude(t *testing.T) {
 	r := strings.NewReader(pointerParseLogOutput)
 	scanner := newLogScanner(LogDiffDeletions, r)
-	scanner.Filter = filepathfilter.New(nil, []string{"flare*"}, filepathfilter.GitAttributes)
+	scanner.Filter = filepathfilter.New(nil, []string{"flare*"}, filepathfilter.GitAttributes, nil)
 
 	// deletion, - side
 	assertNextScan(t, scanner)

--- a/locking/lockable.go
+++ b/locking/lockable.go
@@ -47,7 +47,7 @@ func (c *Client) refreshLockablePatterns() {
 			c.lockablePatterns = append(c.lockablePatterns, filepath.ToSlash(p.Path))
 		}
 	}
-	c.lockableFilter = filepathfilter.New(c.lockablePatterns, nil, filepathfilter.GitAttributes, filepathfilter.DefaultValue(false))
+	c.lockableFilter = filepathfilter.New(c.lockablePatterns, nil, filepathfilter.GitAttributes, c.cfg.Git, filepathfilter.DefaultValue(false))
 }
 
 // IsFileLockable returns whether a specific file path is marked as Lockable,
@@ -100,10 +100,10 @@ func (c *Client) FixFileWriteFlagsInDir(dir string, lockablePatterns, unlockable
 	var lockableFilter *filepathfilter.Filter
 	var unlockableFilter *filepathfilter.Filter
 	if lockablePatterns != nil {
-		lockableFilter = filepathfilter.New(lockablePatterns, nil, filepathfilter.GitAttributes)
+		lockableFilter = filepathfilter.New(lockablePatterns, nil, filepathfilter.GitAttributes, c.cfg.Git)
 	}
 	if unlockablePatterns != nil {
-		unlockableFilter = filepathfilter.New(unlockablePatterns, nil, filepathfilter.GitAttributes)
+		unlockableFilter = filepathfilter.New(unlockablePatterns, nil, filepathfilter.GitAttributes, c.cfg.Git)
 	}
 
 	return c.fixFileWriteFlags(absPath, c.LocalWorkingDir, lockableFilter, unlockableFilter)

--- a/t/t-ls-files.sh
+++ b/t/t-ls-files.sh
@@ -291,6 +291,36 @@ begin_test "ls-files: --size"
 )
 end_test
 
+begin_test "ls-files: correctly reflects case sensitivity"
+(
+  set -e
+
+  reponame="ls-files-case-sensitive"
+  git init "$reponame"
+  cd "$reponame"
+  ignorecase="$(git config core.ignorecase || true)"
+  ignorecase="${ignorecase:-false}"
+
+  git lfs track '*.DAT'
+  git add .gitattributes
+
+  contents="a"
+  oid="$(calc_oid "$contents")"
+  printf "%s" "$contents" > a.dat
+
+  [ "" = "$(git lfs ls-files)" ]
+
+  git add a.dat
+
+  if [ "$ignorecase" = true ]
+  then
+    [ "${oid:0:10} * a.dat" = "$(git lfs ls-files)" ]
+  else
+    [ "" = "$(git lfs ls-files)" ]
+  fi
+)
+end_test
+
 begin_test "ls-files: indexed files without tree"
 (
   set -e


### PR DESCRIPTION
Right now, we always determine the case sensitivity of the repository based on the operating system default: case insensitive on Windows and macOS and case sensitive on other Unix systems.  This works in most cases, but it is possible to have case sensitive file systems on macOS, case sensitive directories on Windows, and case insensitive file systems (e.g., JFS) on Linux, in which case we do not function correctly.

Add a function which uses the `core.ignorecase` setting in Git to properly detect whether our repository is case sensitive or not.

This PR contains independent, logical, bisectable commits each with their own commit message, and as such is best reviewed commit by commit.