### PR TITLE
Fix infinite loop in LFS requests rejected with 401

### DIFF
--- a/lfsapi/auth.go
+++ b/lfsapi/auth.go
@@ -25,21 +25,31 @@ var (
 // supporting basic authentication.
 func (c *Client) DoWithAuth(remote string, access creds.Access, req *http.Request) (*http.Response, error) {
 	count := 0
-	res, err := c.doWithAuth(remote, &count, access, req, nil)
+	for {
+		oldCount := count
+		res, err := c.doWithAuth(remote, &count, access, req, nil)
 
-	if errors.IsAuthError(err) {
-		if len(req.Header.Get("Authorization")) == 0 {
-			// This case represents a rejected request that
-			// should have been authenticated but wasn't. Do
-			// not count this against our redirection
-			// maximum.
-			newAccess := c.Endpoints.AccessFor(access.URL())
-			tracerx.Printf("api: http response indicates %q authentication. Resubmitting...", newAccess.Mode())
-			return c.DoWithAuth(remote, newAccess, req)
+		if errors.IsAuthError(err) {
+			if len(req.Header.Get("Authorization")) == 0 {
+				// This case represents a rejected request that
+				// should have been authenticated but wasn't. Do
+				// not count this against our redirection
+				// maximum.
+				newAccess := c.Endpoints.AccessFor(access.URL())
+				if count == oldCount && newAccess.Mode() == access.Mode() {
+					count++
+				}
+
+				if count < defaultMaxAuthAttempts {
+					access = newAccess
+					tracerx.Printf("api: http response indicates %q authentication. Resubmitting...", access.Mode())
+					continue
+				}
+			}
 		}
-	}
 
-	return res, err
+		return res, err
+	}
 }
 
 // DoWithAuthNoRetry sends an HTTP request to get an HTTP response. It works in

--- a/lfsapi/auth_test.go
+++ b/lfsapi/auth_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/git-lfs/git-lfs/v3/creds"
 	"github.com/git-lfs/git-lfs/v3/errors"
@@ -768,4 +769,50 @@ func TestClientRedirectReauthenticate(t *testing.T) {
 	// called1 is 2 since LFS tries an unauthenticated request first
 	assert.EqualValues(t, 2, called1)
 	assert.EqualValues(t, 1, called2)
+}
+
+func TestDoWithAuthInfiniteLoop(t *testing.T) {
+	var called uint32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		atomic.AddUint32(&called, 1)
+		w.Header().Set("Lfs-Authenticate", "Basic")
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	cred := newMockCredentialHelper()
+	c, err := NewClient(lfshttp.NewContext(git.NewReadOnlyConfig("", ""),
+		nil, map[string]string{
+			"lfs.url": srv.URL,
+		},
+	))
+	require.Nil(t, err)
+	c.Credentials = cred
+
+	req, err := http.NewRequest("POST", srv.URL, nil)
+	require.Nil(t, err)
+
+	// Use a channel to timeout the test if it loops
+	done := make(chan bool)
+	go func() {
+		_, _ = c.DoAPIRequestWithAuth("", req)
+		done <- true
+	}()
+
+	select {
+	case <-done:
+	// Success: it didn't loop forever
+	case <-time.After(2 * time.Second):
+		t.Errorf("Test timed out, likely infinite loop. Called %d times", atomic.LoadUint32(&called))
+	}
+
+	// We expect:
+	// 1. Unauthenticated request (returns 401)
+	// 2. Authenticated request with "user:pass" (returns 401)
+	// 3. (Optional) Retry again if first auth attempt failed.
+	// 4. (Limit) Stop after defaultMaxAuthAttempts.
+	//
+	// Without the bug, it should stop after a few attempts, not loop thousands of times.
+	assert.LessOrEqual(t, atomic.LoadUint32(&called), uint32(4))
 }


### PR DESCRIPTION
The infinite loop was caused by a recursive call in lfsapi/auth.go:DoWithAuth. When an LFS request was rejected with a 401 but didn't have an Authorization header, the function would call itself recursively. Because the count variable was local to the function, it was reset to 0 on every recursion, effectively bypassing the defaultMaxAuthAttempts limit. In cases where the user lacked permissions (401 response despite valid credentials), git-lfs would continuously "resubmit" the request.

Fix:
 1. Converted the recursion in DoWithAuth into a for loop.
 2. Persisted the count variable across retry attempts.
 3. Added logic to increment the counter if a retry is attempted with the same access mode, ensuring the process terminates after defaultMaxAuthAttempts (3 attempts) even if the server continues to challenge.