### PR TITLE
Improve throughput by pipelining batch API calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ lfstest-*
 !lfstest-*.go
 
 vendor/
+.idea/

--- a/docs/man/git-lfs-config.adoc
+++ b/docs/man/git-lfs-config.adoc
@@ -139,6 +139,12 @@ occurs.
 +
 The number of concurrent uploads/downloads. Default is 3x the number of
 logical CPUs, with a minimum of 8.
+* `lfs.concurrentbatchrequests`
++
+The number of concurrent batch API requests to make when fetching download
+URLs from the server. Higher values keep download workers saturated when
+there are many objects to transfer. Default scales with `lfs.concurrenttransfers`
+(1 per 12 concurrent transfers, minimum 4).
 * `lfs.basictransfersonly`
 +
 If set to true, only basic HTTP upload/download transfers will be used,

--- a/tq/adapterbase.go
+++ b/tq/adapterbase.go
@@ -104,24 +104,29 @@ type job struct {
 
 	results chan<- TransferResult
 	wg      *sync.WaitGroup
+	done    *sync.WaitGroup
 }
 
 func (j *job) Done(err error) {
 	j.results <- TransferResult{j.T, err}
 	j.wg.Done()
+	j.done.Done()
 }
 
 func (a *adapterBase) Add(transfers ...*Transfer) <-chan TransferResult {
 	results := make(chan TransferResult, len(transfers))
 
+	// done tracks when this batch's jobs complete, independent of
+	// other batches. jobWait tracks all jobs globally for End().
+	var done sync.WaitGroup
+	done.Add(len(transfers))
 	a.jobWait.Add(len(transfers))
 
 	go func() {
 		for _, t := range transfers {
-			a.jobChan <- &job{t, results, a.jobWait}
+			a.jobChan <- &job{T: t, results: results, wg: a.jobWait, done: &done}
 		}
-		a.jobWait.Wait()
-
+		done.Wait()
 		close(results)
 	}()
 

--- a/tq/manifest.go
+++ b/tq/manifest.go
@@ -22,6 +22,7 @@ type Manifest interface {
 	MaxRetries() int
 	MaxRetryDelay() int
 	ConcurrentTransfers() int
+	ConcurrentBatchRequests() int
 	IsStandaloneTransfer() bool
 	batchClient() BatchClient
 	GetAdapterNames(dir Direction) []string
@@ -70,6 +71,10 @@ func (m *lazyManifest) MaxRetryDelay() int {
 
 func (m *lazyManifest) ConcurrentTransfers() int {
 	return m.Upgrade().ConcurrentTransfers()
+}
+
+func (m *lazyManifest) ConcurrentBatchRequests() int {
+	return m.Upgrade().ConcurrentBatchRequests()
 }
 
 func (m *lazyManifest) IsStandaloneTransfer() bool {
@@ -138,6 +143,7 @@ type concreteManifest struct {
 	maxRetries              int
 	maxRetryDelay           int
 	concurrentTransfers     int
+	concurrentBatchRequests int
 	basicTransfersOnly      bool
 	standaloneTransferAgent string
 	tusTransfersAllowed     bool
@@ -164,6 +170,10 @@ func (m *concreteManifest) MaxRetryDelay() int {
 
 func (m *concreteManifest) ConcurrentTransfers() int {
 	return m.concurrentTransfers
+}
+
+func (m *concreteManifest) ConcurrentBatchRequests() int {
+	return m.concurrentBatchRequests
 }
 
 func (m *concreteManifest) IsStandaloneTransfer() bool {
@@ -225,6 +235,9 @@ func newConcreteManifest(f *fs.Filesystem, apiClient *lfsapi.Client, operation, 
 		if v := git.Int("lfs.concurrenttransfers", 0); v > 0 {
 			m.concurrentTransfers = v
 		}
+		if v := git.Int("lfs.concurrentbatchrequests", 0); v > 0 {
+			m.concurrentBatchRequests = v
+		}
 		m.basicTransfersOnly = git.Bool("lfs.basictransfersonly", false)
 		m.standaloneTransferAgent = findStandaloneTransfer(
 			apiClient, operation, remote,
@@ -243,7 +256,6 @@ func newConcreteManifest(f *fs.Filesystem, apiClient *lfsapi.Client, operation, 
 	if m.concurrentTransfers < 1 {
 		m.concurrentTransfers = lfshttp.DefaultConcurrentTransfers()
 	}
-
 	if sshTransfer != nil {
 		if !useSSHMultiplexing {
 			m.concurrentTransfers = 1
@@ -253,6 +265,22 @@ func newConcreteManifest(f *fs.Filesystem, apiClient *lfsapi.Client, operation, 
 		m.batchClientAdapter = &SSHBatchClient{
 			maxRetries: m.maxRetries,
 			transfer:   sshTransfer,
+		}
+		// SSH batch requests are serialized through a single
+		// connection, so parallel batch API workers don't help.
+		m.concurrentBatchRequests = 1
+	}
+
+	if m.concurrentBatchRequests < 1 {
+		// Scale batch API workers with transfer concurrency so the
+		// download pipeline stays saturated. This ratio was benchmarked
+		// across large cloud workers and local laptops.
+		m.concurrentBatchRequests = (m.concurrentTransfers + 11) / 12
+		if m.concurrentBatchRequests < 4 && m.concurrentTransfers >= 4 {
+			m.concurrentBatchRequests = 4
+		}
+		if m.concurrentBatchRequests < 1 {
+			m.concurrentBatchRequests = 1
 		}
 	}
 

--- a/tq/transfer.go
+++ b/tq/transfer.go
@@ -244,7 +244,7 @@ type Adapter interface {
 	// or more Add calls. The passed in callback will receive updates on progress.
 	Begin(cfg AdapterConfig, cb ProgressCallback) error
 	// Add queues a download/upload, which will complete asynchronously and
-	// notify the callbacks given to Begin()
+	// whose results will be sent on the returned channel.
 	Add(transfers ...*Transfer) (results <-chan TransferResult)
 	// Indicate that all transfers have been scheduled and resources can be released
 	// once the queued items have completed.

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -252,6 +252,7 @@ type objectTuple struct {
 	Missing         bool
 	ReadyTime       time.Time
 	retryLaterTime  time.Time
+	lastErr         error
 }
 
 func (o *objectTuple) ToTransfer() *Transfer {
@@ -413,35 +414,116 @@ func (q *TransferQueue) remember(t *objectTuple) objects {
 	return *q.transfers[t.Oid]
 }
 
-// collectBatches collects batches in a loop, prioritizing failed items from the
-// previous before adding new items. The process works as follows:
+// collectBatches collects batches in a loop and dispatches them to parallel
+// batch API workers. It prioritizes retries from previous batches before
+// accepting new items. The process works as follows:
 //
-//  1. Create a new batch, of size `q.batchSize`, and containing no items
-//  2. While the batch contains less items than `q.batchSize` AND the channel
-//     is open, read one item from the `q.incoming` channel.
-//     a. If the read was a channel close, go to step 4.
-//     b. If the read was a transferable item, go to step 3.
-//  3. Append the item to the batch.
-//  4. Sort the batch by descending object size, make a batch API call, send
-//     the items to the `*adapterBase`.
-//  5. In a separate goroutine, process the worker results, incrementing and
-//     appending retries if possible. On the main goroutine, accept new items
-//     into "pending".
-//  6. Concat() the "next" and "pending" batches such that no more items than
-//     the maximum allowed per batch are in next, and the rest are in pending.
-//  7. If the `q.incoming` channel is open, go to step 2.
-//  8. If the next batch is empty AND the `q.incoming` channel is closed,
-//     terminate immediately.
+//  1. Block until the first item arrives on q.incoming, then lazily
+//     initialize channels and spin up parallel batch API workers. This
+//     avoids creating SSH connections when no transfers are needed.
+//  2. Drain any retries from retryCh into the next batch.
+//  3. Read items from q.incoming until the batch is full or the channel
+//     closes.
+//  4. Use Concat() to separate rate-limited items (whose ReadyTime has
+//     not passed) into a pending batch. If all items are rate-limited,
+//     sleep until the earliest ReadyTime.
+//  5. Sort the ready batch by descending size and send it to batchCh,
+//     where a parallel worker makes the batch API call and submits
+//     objects to the transfer adapter. Retries flow back via retryCh.
+//  6. If q.incoming is still open, go to step 2.
+//  7. Once q.incoming closes, wait for all in-flight batches to finish,
+//     drain final retries, and loop back to step 4 if any remain.
+//  8. When no retries remain, close batchCh and wait for workers to exit.
 //
 // collectBatches runs in its own goroutine.
 func (q *TransferQueue) collectBatches() {
 	defer q.collectorWait.Done()
 
+	first, ok := <-q.incoming
+	if !ok {
+		return
+	}
+
+	batchCh := make(chan batch, q.manifest.ConcurrentTransfers())
+	retryCh := make(chan *objectTuple, q.batchSize)
+	var retryWg sync.WaitGroup
+
+	maxBatchWorkers := q.manifest.ConcurrentBatchRequests()
+	batchDone := make(chan struct{}, maxBatchWorkers)
+
+	collectRetriesFrom := func(ch <-chan *objectTuple) {
+		if ch == nil {
+			return
+		}
+		retryWg.Add(1)
+		go func() {
+			defer retryWg.Done()
+			for t := range ch {
+				retryCh <- t
+			}
+		}()
+	}
+
+	var batchWg sync.WaitGroup
+	batchWg.Add(maxBatchWorkers)
+	for i := 0; i < maxBatchWorkers; i++ {
+		go func() {
+			defer batchWg.Done()
+			for b := range batchCh {
+				retries, newRetries, err := q.enqueueAndCollectRetriesFor(b)
+				if err != nil {
+					q.errorc <- err
+					if !errors.IsRetriableError(err) {
+						q.wait.Abort()
+						batchDone <- struct{}{}
+						return
+					}
+				}
+				collectRetriesFrom(newRetries)
+				for _, t := range retries {
+					retryCh <- t
+				}
+				batchDone <- struct{}{}
+			}
+		}()
+	}
+
+	enqueueRetryItem := func(t *objectTuple) {
+		count := q.rc.Increment(t.Oid)
+		if t.retryLaterTime.IsZero() {
+			t.ReadyTime = q.rc.ReadyTime(t.Oid)
+		} else {
+			t.ReadyTime = t.retryLaterTime
+			t.retryLaterTime = time.Time{}
+		}
+		delay := time.Until(t.ReadyTime).Seconds()
+		var errMsg string
+		if t.lastErr != nil {
+			errMsg = fmt.Sprintf(": %s", t.lastErr)
+			t.lastErr = nil
+		}
+		tracerx.Printf("tq: enqueue retry #%d after %.2fs for %q (size: %d)%s", count, delay, t.Oid, t.Size, errMsg)
+	}
+
 	var closing bool
+	var inFlight int
 	next := q.makeBatch()
-	pending := q.makeBatch()
+	next = append(next, first)
 
 	for {
+	drainRetries:
+		for {
+			select {
+			case t := <-retryCh:
+				enqueueRetryItem(t)
+				next = append(next, t)
+			case <-batchDone:
+				inFlight--
+			default:
+				break drainRetries
+			}
+		}
+
 		for !closing && (len(next) < q.batchSize) {
 			t, ok := <-q.incoming
 			if !ok {
@@ -452,116 +534,92 @@ func (q *TransferQueue) collectBatches() {
 			next = append(next, t)
 		}
 
-		// Before enqueuing the next batch, sort by descending object
-		// size.
-		sort.Sort(sort.Reverse(next))
+		if len(next) > 0 {
+			var pending batch
+			var minWait time.Duration
+			next, pending, minWait = next.Concat(nil, q.batchSize)
 
-		done := make(chan struct{})
-
-		var retries batch
-		var err error
-
-		go func() {
-			defer close(done)
-
-			if len(next) == 0 {
-				return
+			if len(next) > 0 {
+				sort.Sort(sort.Reverse(next))
+				inFlight++
+				batchCh <- next
+				next = pending
+			} else if len(pending) > 0 {
+				// All items are rate-limited; wait for
+				// the earliest Retry-After to elapse.
+				time.Sleep(minWait)
+				next = pending
+				continue
 			}
-
-			retries, err = q.enqueueAndCollectRetriesFor(next)
-			if err != nil {
-				q.errorc <- err
-			}
-		}()
-
-		var collected batch
-		collected, closing = q.collectPendingUntil(done)
-
-		// If we've encountered a serious error here, abort immediately;
-		// don't process further batches.  Abort the wait queue so that
-		// we don't deadlock waiting for objects to complete when they
-		// never will.
-		if err != nil && !errors.IsRetriableError(err) {
-			q.wait.Abort()
-			break
 		}
 
-		// Ensure the next batch is filled with, in order:
-		//
-		// - retries from the previous batch,
-		// - new additions that were enqueued behind retries, &
-		// - items collected while the batch was processing.
-		var minWaitTime time.Duration
-		next, pending, minWaitTime = retries.Concat(append(pending, collected...), q.batchSize)
-		if len(next) == 0 && len(pending) != 0 {
-			// There are some pending that could not be queued.
-			// Wait the requested time before resuming loop.
-			time.Sleep(minWaitTime)
-		} else if len(next) == 0 && len(pending) == 0 && closing {
-			// There are no items remaining, it is safe to break
+		if !closing {
+			continue
+		}
+
+		// q.incoming is closed. Wait for in-flight batches to
+		// complete, then collect any retries they produced.
+		for inFlight > 0 {
+			select {
+			case <-batchDone:
+				inFlight--
+			case t := <-retryCh:
+				// Keep draining retries while waiting, to
+				// prevent deadlock on retryCh sends.
+				enqueueRetryItem(t)
+				next = append(next, t)
+			}
+		}
+
+		// All batches complete. Wait for retry collector goroutines
+		// to finish forwarding, then do a final non-blocking drain.
+		retryWg.Wait()
+	drainFinal:
+		for {
+			select {
+			case t := <-retryCh:
+				enqueueRetryItem(t)
+				next = append(next, t)
+			default:
+				break drainFinal
+			}
+		}
+
+		// If retries were collected, loop to send them as a new
+		// batch through the parallel workers. Otherwise we're done.
+		if len(next) == 0 {
 			break
 		}
 	}
+
+	close(batchCh)
+	batchWg.Wait()
 }
 
-// collectPendingUntil collects items from q.incoming into a "pending" batch
-// until the given "done" channel is written to, or is closed.
+// enqueueAndCollectRetriesFor makes a Batch API call, submits objects to the
+// transfer adapter, and returns:
+//   - a batch of objects that failed the batch API call and can be retried
+//   - a channel that yields retries from individual transfer failures
+//   - any non-retriable error
 //
-// A "pending" batch is returned, along with whether or not "q.incoming" is
-// closed.
-func (q *TransferQueue) collectPendingUntil(done <-chan struct{}) (pending batch, closing bool) {
-	q.Upgrade()
-
-	for {
-		select {
-		case t, ok := <-q.incoming:
-			if !ok {
-				closing = true
-				<-done
-				return
-			}
-
-			pending = append(pending, t)
-		case <-done:
-			return
-		}
-	}
-}
-
-// enqueueAndCollectRetriesFor makes a Batch API call and returns a "next" batch
-// containing all of the objects that failed from the previous batch and had
-// retries available to them.
-//
-// If an error was encountered while making the API request, _all_ of the items
-// from the previous batch (that have retries available to them) will be
-// returned immediately, along with the error that was encountered.
-//
-// enqueueAndCollectRetriesFor blocks until the entire Batch "batch" has been
-// processed.
-func (q *TransferQueue) enqueueAndCollectRetriesFor(batch batch) (batch, error) {
+// It does NOT block on download completion; the returned retries channel
+// is read asynchronously by the caller, allowing the next batch API call
+// to proceed while downloads from this batch are still in flight.
+func (q *TransferQueue) enqueueAndCollectRetriesFor(batch batch) (batch, <-chan *objectTuple, error) {
 	q.Upgrade()
 
 	next := q.makeBatch()
 	tracerx.Printf("tq: sending batch of size %d", len(batch))
 
+	// enqueueRetry marks an object for retry by the collectBatches loop.
+	// It does NOT increment the retry counter or log; that is handled
+	// by enqueueRetryItem in collectBatches when the object is dequeued
+	// from retryCh.
 	enqueueRetry := func(t *objectTuple, err error, readyTime *time.Time) {
-		count := q.rc.Increment(t.Oid)
-
-		if !t.retryLaterTime.IsZero() {
-			t.ReadyTime = t.retryLaterTime
-			t.retryLaterTime = time.Time{}
-		} else if readyTime == nil {
-			t.ReadyTime = q.rc.ReadyTime(t.Oid)
-		} else {
-			t.ReadyTime = *readyTime
+		if readyTime != nil {
+			t.retryLaterTime = *readyTime
 		}
-		delay := time.Until(t.ReadyTime).Seconds()
-
-		var errMsg string
-		if err != nil {
-			errMsg = fmt.Sprintf(": %s", err)
-		}
-		tracerx.Printf("tq: enqueue retry #%d after %.2fs for %q (size: %d)%s", count, delay, t.Oid, t.Size, errMsg)
+		t.lastErr = err
 		next = append(next, t)
 	}
 
@@ -603,15 +661,15 @@ func (q *TransferQueue) enqueueAndCollectRetriesFor(batch batch) (batch, error) 
 			// was not enqueued for retrial at a later point.
 			// Make sure to return an error which causes all other objects to be retried.
 			if hasNonRetriableObjects {
-				return next, errors.NewRetriableError(err)
+				return next, nil, errors.NewRetriableError(err)
 			} else {
-				return next, nil
+				return next, nil, nil
 			}
 		}
 	}
 
 	if len(bRes.Objects) == 0 {
-		return next, nil
+		return next, nil, nil
 	}
 
 	// We check first that all of the objects we want to upload are present,
@@ -634,7 +692,7 @@ func (q *TransferQueue) enqueueAndCollectRetriesFor(batch batch) (batch, error) 
 				// transfer queue.
 				if ok && objects.First().Missing {
 					tracerx.Printf("tq: stopping batched queue, object %q missing locally and on remote", o.Oid)
-					return nil, newObjectMissingError(objects.First().Name, o.Oid)
+					return nil, nil, newObjectMissingError(objects.First().Name, o.Oid)
 				}
 			}
 		}
@@ -690,12 +748,11 @@ func (q *TransferQueue) enqueueAndCollectRetriesFor(batch batch) (batch, error) 
 		}
 	}
 
+	// Submit transfers to the adapter without blocking. The returned
+	// channel will yield retries as individual transfers complete or fail.
 	retries := q.addToAdapter(bRes.endpoint, toTransfer)
-	for t := range retries {
-		enqueueRetry(t, nil, nil)
-	}
 
-	return next, nil
+	return next, retries, nil
 }
 
 // makeBatch returns a new, empty batch, with a capacity equal to the maximum
@@ -824,6 +881,7 @@ func (q *TransferQueue) handleTransferResult(
 			if ok {
 				t := objects.First()
 				t.retryLaterTime = readyTime
+				t.lastErr = res.Error
 				retries <- t
 			} else {
 				q.errorc <- res.Error
@@ -839,7 +897,9 @@ func (q *TransferQueue) handleTransferResult(
 			q.trMutex.Unlock()
 
 			if ok {
-				retries <- objects.First()
+				t := objects.First()
+				t.lastErr = res.Error
+				retries <- t
 			} else {
 				q.errorc <- res.Error
 			}

--- a/tq/transfer_queue_test.go
+++ b/tq/transfer_queue_test.go
@@ -1,6 +1,8 @@
 package tq
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -139,4 +141,122 @@ func TestUseAdapterSwitchesWhenNameDiffers(t *testing.T) {
 	assert.NotNil(t, q.adapter)
 	assert.NotSame(t, first, q.adapter, "expected a new adapter when name differs")
 	assert.Equal(t, "ssh", q.adapter.Name())
+}
+
+// TestPipelineBatchDoneNotStarved verifies that the collectBatches loop
+// drains batchDone signals while still accepting new work. Without this,
+// batch workers block sending to batchDone (which was only drained
+// during shutdown), preventing them from reading the next batch and
+// deadlocking the collector's send to batchCh.
+func TestPipelineBatchDoneNotStarved(t *testing.T) {
+	const (
+		numObjects      = 300
+		concurrentXfers = 4
+		batchWorkers    = 4
+		batchSize       = 20
+	)
+
+	adapter := &fakeSlowAdapter{jobs: make(chan *job, 100)}
+
+	m := &concreteManifest{
+		maxRetries:              1,
+		maxRetryDelay:           1,
+		concurrentTransfers:     concurrentXfers,
+		concurrentBatchRequests: batchWorkers,
+		standaloneTransferAgent: "fake",
+		downloadAdapterFuncs:    map[string]NewAdapterFunc{},
+		uploadAdapterFuncs:      map[string]NewAdapterFunc{},
+	}
+	m.RegisterNewAdapterFunc("fake", Download, func(string, Direction) Adapter {
+		return adapter
+	})
+
+	q := NewTransferQueue(Download, m, "origin", WithBatchSize(batchSize))
+	watch := q.Watch()
+
+	var received int
+	watchDone := make(chan struct{})
+	go func() {
+		for range watch {
+			received++
+		}
+		close(watchDone)
+	}()
+
+	addDone := make(chan struct{})
+	go func() {
+		for i := 0; i < numObjects; i++ {
+			q.Add(fmt.Sprintf("file-%d", i), "", fmt.Sprintf("%064x", i), int64(i+1), false, nil)
+		}
+		close(addDone)
+	}()
+
+	select {
+	case <-addDone:
+	case <-time.After(time.Second):
+		t.Fatal("deadlock: Add() blocked")
+	}
+
+	waitDone := make(chan struct{})
+	go func() {
+		q.Wait()
+		close(waitDone)
+	}()
+
+	select {
+	case <-waitDone:
+	case <-time.After(time.Second):
+		t.Fatal("deadlock: queue did not finish")
+	}
+
+	<-watchDone
+	assert.Equal(t, numObjects, received)
+	assert.Empty(t, q.Errors())
+}
+
+// fakeSlowAdapter is a minimal Adapter for testing the transfer pipeline.
+type fakeSlowAdapter struct {
+	jobs    chan *job
+	workers sync.WaitGroup
+	jobWait sync.WaitGroup
+}
+
+func (a *fakeSlowAdapter) Name() string         { return "fake" }
+func (a *fakeSlowAdapter) Direction() Direction { return Download }
+
+func (a *fakeSlowAdapter) Begin(cfg AdapterConfig, cb ProgressCallback) error {
+	n := cfg.ConcurrentTransfers()
+	a.workers.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer a.workers.Done()
+			for j := range a.jobs {
+				j.results <- TransferResult{Transfer: j.T}
+				j.wg.Done()
+				j.done.Done()
+			}
+		}()
+	}
+	return nil
+}
+
+func (a *fakeSlowAdapter) Add(transfers ...*Transfer) <-chan TransferResult {
+	results := make(chan TransferResult, len(transfers))
+	var done sync.WaitGroup
+	done.Add(len(transfers))
+	a.jobWait.Add(len(transfers))
+	go func() {
+		for _, t := range transfers {
+			a.jobs <- &job{T: t, results: results, wg: &a.jobWait, done: &done}
+		}
+		done.Wait()
+		close(results)
+	}()
+	return results
+}
+
+func (a *fakeSlowAdapter) End() {
+	a.jobWait.Wait()
+	close(a.jobs)
+	a.workers.Wait()
 }


### PR DESCRIPTION
Previously, each batch of LFS objects had to fully download before the next batch API call was made (`lfs.transfer.batchSize` let users increase the number of objects per batch. but GitHub has a hard cap of 100). I measured ~400ms of time per batch API call, and download workers spent significant time idle waiting for the next batch response. This PR pipelines batch API calls using a pool of parallel workers so that downloads from previous batches run concurrently with new API requests.

Additionally, the default concurrent transfers is now scaled to `3 * NCPU` (min 8) instead of the hardcoded default of 8 from 2017. A bug is also fixed where an empty `"transfer"` field in the batch API response (which per spec means "use default") was treated as a name mismatch, causing all download workers to be torn down and recreated every batch cycle.

Tested on a repo with ~19,400 LFS objects (~20KB avg, ~900MB total, GitHub hosted) on a 16-core M3 macbook pro: network throughput increased from ~1.8 MB/s to ~18 MB/s (~10x) and wall time dropped from 6m 4s to 48s (~7.5x) for `git lfs pull` after nuking `.git/lfs/objects/*`.

I added `lfs.concurrentbatchrequests` (default 4) to control the number of parallel batch API workers. In testing, 3-4 was the sweet spot for my laptop and kept the download workers busy, though I needed 8 in a server environment.

## Download Benchmark Results

  ### android repo — 26,810 objects, 905 MB

  #### Cloud worker (192 CPUs)

  I did a benchmark sweep of git-lfs v3.7.1 and this patch with various settings on a large cloud worker.

  ##### Current git-lfs v3.7.1 (serial batch API)

  | concurrenttransfers |   Time | vs default |
  |--------------------:|-------:|-----------:|
  |          8 (default)| 511.6s |   baseline |
  |                  32 | 245.5s |      2.1x  |
  |                  96 | 191.0s |      2.7x  |
  |                 192 | 179.0s |      2.9x  |

  Bumping transfer concurrency alone hits diminishing returns fast, the serial batch API calls are the bottleneck, not the download workers.

  ##### This PR (pipelined batch API)

  | transfers | batch workers |   Time | vs v3.7.1 default | vs best v3.7.1 |
  |----------:|--------------:|-------:|-------------------:|---------------:|
  |         8 |             1 | 346.3s |              1.5x  |          0.5x  |
  |         8 |             4 | 323.8s |              1.6x  |          0.6x  |
  |        32 |             4 |  79.1s |              6.5x  |          2.3x  |
  |        96 |             4 |  27.3s |             18.7x  |          6.6x  |
  |        96 |             8 |  26.8s |             19.1x  |          6.7x  |
  |       192 |             4 |  25.3s |             20.2x  |          7.1x  |
  |       192 |             8 |  14.6s |             35.0x  |         12.3x  |
  |       288 |             8 |  14.3s |             35.8x  |         12.5x  |
  |       384 |             8 |  14.0s |             36.5x  |         12.8x  |
  |       384 |            12 |  11.7s |             43.7x  |         15.3x  |
  |       384 |            16 |   9.0s |             56.8x  |         19.9x  |
  |       576 |      4 (def.) |  26.8s |             19.1x  |          6.7x  |
  |       576 |             8 |  15.0s |             34.1x  |         11.9x  |
  |       576 |            16 |   9.5s |             53.9x  |         18.8x  |

  Best: **9.0s** at transfers=384, batch=16, **56.8x** faster than stock.
  Transfer concurrency plateaus above ~192; batch workers scale nearly linearly.

  #### Local machine (M3 MacBook Pro, 16 CPUs, baseline 364s with v3.7.1)

  | transfers | batch workers |  Time | vs v3.7.1 |
  |----------:|--------------:|------:|-------------------:|
  |         8 |             1 |  331s |              1.1x  |
  |         8 |             4 |  306s |              1.2x  |
  |        16 |             4 |  147s |              2.5x  |
  |        32 |             4 |   70s |              5.2x  |
  |        48 |             4 |   48s |              7.6x  |
  |        48 |             8 |   50s |              7.3x  |
  |        64 |             4 |   36s |             10.1x  |
  |        64 |             8 |   37s |              9.8x  |
  |        96 |             4 |   29s |             12.6x  |
  |        96 |             8 |   29s |             12.6x  |
  |        96 |            16 |   33s |             11.0x  |

  Best: **29s** at transfers=96, batch=4 or 8, **12.6x** faster than v3.7.1.
  Batch workers beyond 4 show no benefit.

  ---

  ### ios repo — 65,387 objects, 7.3 GB

  #### Cloud worker (192 CPUs)

  I also tested this PR against our larger iOS repo, using batch worker concurrency of 1 to somewhat mimic the current state.

  | transfers | batch workers |    Time | vs baseline |
  |----------:|--------------:|--------:|------------:|
  |         8 |             1 | 1139.8s |    baseline |
  |         8 |             4 |  996.7s |       1.1x  |
  |        32 |             4 |  214.4s |       5.3x  |
  |        96 |             4 |   71.5s |      15.9x  |
  |       192 |             4 |   57.3s |      19.9x  |
  |       576 |      4 (def.) |  157.9s |       7.2x  |
  |       576 |             1 |  206.7s |       5.5x  |
  |       576 |             8 |  113.9s |      10.0x  |

  Best: **57.3s** at transfers=192, batch=4, **19.9x** faster than baseline.
