### PR TITLE
Run git lfs install as original user when using sudo

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -38,4 +38,8 @@ pushd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null
 popd > /dev/null
 
 PATH+=:"$prefix/bin"
-git lfs install
+if [ -n "${SUDO_USER:-}" ]; then
+  sudo -u "$SUDO_USER" git lfs install
+else
+  git lfs install
+fi


### PR DESCRIPTION
When install.sh runs with sudo on macOS, git lfs install was executing as root and messing up .gitconfig ownership. Fixed by checking for SUDO_USER and running the command as the original user. Fixes #6230.