### PR TITLE
commands: fix format string type mismatch in lockverifier

### DIFF
--- a/commands/lockverifier.go
+++ b/commands/lockverifier.go
@@ -90,7 +90,7 @@ func (lv *lockVerifier) addLocks(ref *git.Ref, locks []locking.Lock, set map[str
 	for _, l := range locks {
 		if rl, ok := set[l.Path]; ok {
 			if err := rl.Add(ref, l); err != nil {
-				Error(tr.Tr.Get("warning: error adding %q lock for ref %q: %+v", l.Path, ref, err))
+				Error(tr.Tr.Get("warning: error adding %q lock for ref %q: %+v", l.Path, ref.Refspec(), err))
 			}
 		} else {
 			set[l.Path] = lv.newRefLocks(ref, l)


### PR DESCRIPTION
The addLocks() method passes a *git.Ref value to a %q format verb in a tr.Tr.Get() call, but %q expects a string. Newer versions of Go recognize tr.Tr.Get() as a printf-like function and flag this as an error during go vet.

Pass ref.Refspec() instead, which returns the reference name as a string.