### PR TITLE
Scale default concurrent transfers by CPU count

### DIFF
--- a/docs/man/git-lfs-config.adoc
+++ b/docs/man/git-lfs-config.adoc
@@ -137,7 +137,8 @@ occurs.
 
 * `lfs.concurrenttransfers`
 +
-The number of concurrent uploads/downloads. Default 8.
+The number of concurrent uploads/downloads. Default is 3x the number of
+logical CPUs, with a minimum of 8.
 * `lfs.basictransfersonly`
 +
 If set to true, only basic HTTP upload/download transfers will be used,

--- a/lfshttp/client.go
+++ b/lfshttp/client.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -29,6 +30,21 @@ import (
 
 const MediaType = "application/vnd.git-lfs+json"
 const RequestContentType = MediaType + "; charset=utf-8"
+
+const (
+	MinConcurrentTransfers = 8
+)
+
+// DefaultConcurrentTransfers scales with CPU count. Downloads are
+// I/O-bound (network + disk) so we use 3× NCPU to keep many connections
+// saturated while a few are stalled on TLS handshakes or server latency.
+func DefaultConcurrentTransfers() int {
+	n := runtime.NumCPU() * 3
+	if n < MinConcurrentTransfers {
+		return MinConcurrentTransfers
+	}
+	return n
+}
 
 var (
 	UserAgent = "git-lfs"
@@ -86,7 +102,7 @@ func NewClient(ctx Context) (*Client, error) {
 		DialTimeout:         gitEnv.Int("lfs.dialtimeout", 0),
 		KeepaliveTimeout:    gitEnv.Int("lfs.keepalive", 0),
 		TLSTimeout:          gitEnv.Int("lfs.tlstimeout", 0),
-		ConcurrentTransfers: gitEnv.Int("lfs.concurrenttransfers", 8),
+		ConcurrentTransfers: gitEnv.Int("lfs.concurrenttransfers", DefaultConcurrentTransfers()),
 		SkipSSLVerify:       !gitEnv.Bool("http.sslverify", true) || osEnv.Bool("GIT_SSL_NO_VERIFY", false),
 		Verbose:             osEnv.Bool("GIT_CURL_VERBOSE", false),
 		DebuggingVerbose:    osEnv.Bool("LFS_DEBUG_HTTP", false),
@@ -411,7 +427,7 @@ func (c *Client) Transport(u *url.URL, access creds.AccessMode) (http.RoundTripp
 
 	concurrentTransfers := c.ConcurrentTransfers
 	if concurrentTransfers < 1 {
-		concurrentTransfers = 8
+		concurrentTransfers = DefaultConcurrentTransfers()
 	}
 
 	dialtime := c.DialTimeout

--- a/t/Makefile
+++ b/t/Makefile
@@ -28,6 +28,7 @@ TEST_CMDS += ../bin/lfstest-caseinverterextension$X
 TEST_CMDS += ../bin/lfstest-count-tests$X
 TEST_CMDS += ../bin/lfstest-customadapter$X
 TEST_CMDS += ../bin/lfstest-genrandom$X
+TEST_CMDS += ../bin/lfstest-getnumcpu$X
 TEST_CMDS += ../bin/lfstest-gitserver$X
 TEST_CMDS += ../bin/lfstest-nanomtime$X
 TEST_CMDS += ../bin/lfstest-realpath$X

--- a/t/cmd/lfstest-getnumcpu.go
+++ b/t/cmd/lfstest-getnumcpu.go
@@ -1,0 +1,13 @@
+//go:build testtools
+// +build testtools
+
+package main
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func main() {
+	fmt.Print(runtime.NumCPU())
+}

--- a/t/t-env.sh
+++ b/t/t-env.sh
@@ -14,6 +14,8 @@ fi
 # despite the "GIT_" strings in its name and value.
 export TEST_GIT_EXAMPLE="GIT_EXAMPLE"
 
+setup_expected_concurrent_transfers
+
 begin_test "env with no remote"
 (
   set -e
@@ -39,7 +41,7 @@ LocalGitStorageDir=%s
 LocalMediaDir=%s
 LocalReferenceDirs=
 TempDir=%s
-ConcurrentTransfers=8
+ConcurrentTransfers=%d
 TusTransfers=false
 BasicTransfersOnly=false
 SkipDownloadErrors=false
@@ -58,7 +60,7 @@ DownloadTransfers=basic,lfs-standalone-file,ssh
 UploadTransfers=basic,lfs-standalone-file,ssh
 %s
 %s
-' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")
+' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$expectedConcurrentTransfers" "$lfsstorage" "$envVars" "$envInitConfig")
   actual=$(git lfs env | grep -v "^GIT_EXEC_PATH=")
 
   contains_same_elements "$expected" "$actual"
@@ -92,7 +94,7 @@ LocalGitStorageDir=%s
 LocalMediaDir=%s
 LocalReferenceDirs=
 TempDir=%s
-ConcurrentTransfers=8
+ConcurrentTransfers=%d
 TusTransfers=false
 BasicTransfersOnly=false
 SkipDownloadErrors=false
@@ -111,7 +113,7 @@ DownloadTransfers=basic,lfs-standalone-file,ssh
 UploadTransfers=basic,lfs-standalone-file,ssh
 %s
 %s
-' "$(git lfs version)" "$(git version)" "$endpoint" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")
+' "$(git lfs version)" "$(git version)" "$endpoint" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$expectedConcurrentTransfers" "$lfsstorage" "$envVars" "$envInitConfig")
   actual=$(git lfs env | grep -v "^GIT_EXEC_PATH=")
   contains_same_elements "$expected" "$actual"
 
@@ -152,7 +154,7 @@ LocalGitStorageDir=%s
 LocalMediaDir=%s
 LocalReferenceDirs=
 TempDir=%s
-ConcurrentTransfers=8
+ConcurrentTransfers=%d
 TusTransfers=false
 BasicTransfersOnly=false
 SkipDownloadErrors=false
@@ -171,7 +173,7 @@ DownloadTransfers=basic,lfs-standalone-file,ssh
 UploadTransfers=basic,lfs-standalone-file,ssh
 %s
 %s
-' "$(git lfs version)" "$(git version)" "$endpoint" "$endpoint2" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")
+' "$(git lfs version)" "$(git version)" "$endpoint" "$endpoint2" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$expectedConcurrentTransfers" "$lfsstorage" "$envVars" "$envInitConfig")
   actual=$(git lfs env | grep -v "^GIT_EXEC_PATH=")
   contains_same_elements "$expected" "$actual"
 
@@ -210,7 +212,7 @@ LocalGitStorageDir=%s
 LocalMediaDir=%s
 LocalReferenceDirs=
 TempDir=%s
-ConcurrentTransfers=8
+ConcurrentTransfers=%d
 TusTransfers=false
 BasicTransfersOnly=false
 SkipDownloadErrors=false
@@ -229,7 +231,7 @@ DownloadTransfers=basic,lfs-standalone-file,ssh
 UploadTransfers=basic,lfs-standalone-file,ssh
 %s
 %s
-' "$(git lfs version)" "$(git version)" "$endpoint" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")
+' "$(git lfs version)" "$(git version)" "$endpoint" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$expectedConcurrentTransfers" "$lfsstorage" "$envVars" "$envInitConfig")
   actual=$(git lfs env | grep -v "^GIT_EXEC_PATH=")
   contains_same_elements "$expected" "$actual"
 
@@ -269,7 +271,7 @@ LocalGitStorageDir=%s
 LocalMediaDir=%s
 LocalReferenceDirs=
 TempDir=%s
-ConcurrentTransfers=8
+ConcurrentTransfers=%d
 TusTransfers=false
 BasicTransfersOnly=false
 SkipDownloadErrors=false
@@ -288,7 +290,7 @@ DownloadTransfers=basic,lfs-standalone-file,ssh
 UploadTransfers=basic,lfs-standalone-file,ssh
 %s
 %s
-' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")
+' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$expectedConcurrentTransfers" "$lfsstorage" "$envVars" "$envInitConfig")
   actual=$(git lfs env | grep -v "^GIT_EXEC_PATH=")
   contains_same_elements "$expected" "$actual"
 
@@ -330,7 +332,7 @@ LocalGitStorageDir=%s
 LocalMediaDir=%s
 LocalReferenceDirs=
 TempDir=%s
-ConcurrentTransfers=8
+ConcurrentTransfers=%d
 TusTransfers=false
 BasicTransfersOnly=false
 SkipDownloadErrors=false
@@ -349,7 +351,7 @@ DownloadTransfers=basic,lfs-standalone-file,ssh
 UploadTransfers=basic,lfs-standalone-file,ssh
 %s
 %s
-' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")
+' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$expectedConcurrentTransfers" "$lfsstorage" "$envVars" "$envInitConfig")
   actual=$(git lfs env | grep -v "^GIT_EXEC_PATH=")
   contains_same_elements "$expected" "$actual"
 
@@ -459,7 +461,7 @@ LocalGitStorageDir=%s
 LocalMediaDir=%s
 LocalReferenceDirs=
 TempDir=%s
-ConcurrentTransfers=8
+ConcurrentTransfers=%d
 TusTransfers=false
 BasicTransfersOnly=false
 SkipDownloadErrors=false
@@ -478,7 +480,7 @@ DownloadTransfers=basic,lfs-standalone-file,ssh
 UploadTransfers=basic,lfs-standalone-file,ssh
 %s
 %s
-' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")
+' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$expectedConcurrentTransfers" "$lfsstorage" "$envVars" "$envInitConfig")
   actual=$(git lfs env | grep -v "^GIT_EXEC_PATH=")
   contains_same_elements "$expected" "$actual"
 
@@ -515,7 +517,7 @@ LocalGitStorageDir=%s
 LocalMediaDir=%s
 LocalReferenceDirs=
 TempDir=%s
-ConcurrentTransfers=8
+ConcurrentTransfers=%d
 TusTransfers=false
 BasicTransfersOnly=false
 SkipDownloadErrors=false
@@ -534,7 +536,7 @@ DownloadTransfers=basic,lfs-standalone-file,ssh
 UploadTransfers=basic,lfs-standalone-file,ssh
 %s
 %s
-' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")
+' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$expectedConcurrentTransfers" "$lfsstorage" "$envVars" "$envInitConfig")
 
   actual=$(GIT_DIR=$gitDir GIT_WORK_TREE=$workTree git lfs env \
             | grep -v "^GIT_EXEC_PATH=")
@@ -570,7 +572,7 @@ LocalGitStorageDir=
 LocalMediaDir=%s
 LocalReferenceDirs=
 TempDir=%s
-ConcurrentTransfers=8
+ConcurrentTransfers=%d
 TusTransfers=false
 BasicTransfersOnly=false
 SkipDownloadErrors=false
@@ -591,7 +593,7 @@ UploadTransfers=basic,lfs-standalone-file,ssh
 git config filter.lfs.process = ""
 git config filter.lfs.smudge = ""
 git config filter.lfs.clean = ""
-' "$(git lfs version)" "$(git version)" "$mediaDir5" "$tempDir5" "$envVars")
+' "$(git lfs version)" "$(git version)" "$mediaDir5" "$tempDir5" "$expectedConcurrentTransfers" "$envVars")
   actual5=$(GIT_DIR=$gitDir GIT_WORK_TREE=a/b git lfs env \
             | grep -v "^GIT_EXEC_PATH=")
   contains_same_elements "$expected5" "$actual5"
@@ -607,7 +609,7 @@ LocalGitStorageDir=%s
 LocalMediaDir=%s
 LocalReferenceDirs=
 TempDir=%s
-ConcurrentTransfers=8
+ConcurrentTransfers=%d
 TusTransfers=false
 BasicTransfersOnly=false
 SkipDownloadErrors=false
@@ -626,7 +628,7 @@ DownloadTransfers=basic,lfs-standalone-file,ssh
 UploadTransfers=basic,lfs-standalone-file,ssh
 %s
 %s
-' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")
+' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$expectedConcurrentTransfers" "$lfsstorage" "$envVars" "$envInitConfig")
   actual7=$(GIT_DIR=$gitDir git lfs env | grep -v "^GIT_EXEC_PATH=")
   contains_same_elements "$expected7" "$actual7"
 
@@ -641,7 +643,7 @@ LocalGitStorageDir=%s
 LocalMediaDir=%s
 LocalReferenceDirs=
 TempDir=%s
-ConcurrentTransfers=8
+ConcurrentTransfers=%d
 TusTransfers=false
 BasicTransfersOnly=false
 SkipDownloadErrors=false
@@ -660,7 +662,7 @@ DownloadTransfers=basic,lfs-standalone-file,ssh
 UploadTransfers=basic,lfs-standalone-file,ssh
 %s
 %s
-' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")
+' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$expectedConcurrentTransfers" "$lfsstorage" "$envVars" "$envInitConfig")
   actual8=$(GIT_WORK_TREE=$workTree git lfs env | grep -v "^GIT_EXEC_PATH=")
   contains_same_elements "$expected8" "$actual8"
 )
@@ -687,7 +689,7 @@ LocalGitStorageDir=%s
 LocalMediaDir=%s
 LocalReferenceDirs=
 TempDir=%s
-ConcurrentTransfers=8
+ConcurrentTransfers=%d
 TusTransfers=false
 BasicTransfersOnly=false
 SkipDownloadErrors=false
@@ -706,7 +708,7 @@ DownloadTransfers=basic,lfs-standalone-file,ssh
 UploadTransfers=basic,lfs-standalone-file,ssh
 %s
 %s
-" "$(git lfs version)" "$(git version)" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")
+" "$(git lfs version)" "$(git version)" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$expectedConcurrentTransfers" "$lfsstorage" "$envVars" "$envInitConfig")
   actual=$(git lfs env | grep -v "^GIT_EXEC_PATH=")
   contains_same_elements "$expected" "$actual"
 
@@ -767,7 +769,7 @@ LocalGitStorageDir=%s
 LocalMediaDir=%s
 LocalReferenceDirs=
 TempDir=%s
-ConcurrentTransfers=8
+ConcurrentTransfers=%d
 TusTransfers=false
 BasicTransfersOnly=false
 SkipDownloadErrors=true
@@ -786,7 +788,7 @@ DownloadTransfers=basic,lfs-standalone-file,ssh
 UploadTransfers=basic,lfs-standalone-file,ssh
 %s
 %s
-' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")
+' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$expectedConcurrentTransfers" "$lfsstorage" "$envVars" "$envInitConfig")
   actual=$(git lfs env | grep -v "^GIT_EXEC_PATH=")
   contains_same_elements "$expectedenabled" "$actual"
 
@@ -801,7 +803,7 @@ LocalGitStorageDir=%s
 LocalMediaDir=%s
 LocalReferenceDirs=
 TempDir=%s
-ConcurrentTransfers=8
+ConcurrentTransfers=%d
 TusTransfers=false
 BasicTransfersOnly=false
 SkipDownloadErrors=false
@@ -820,7 +822,7 @@ DownloadTransfers=basic,lfs-standalone-file,ssh
 UploadTransfers=basic,lfs-standalone-file,ssh
 %s
 %s
-' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")
+' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$expectedConcurrentTransfers" "$lfsstorage" "$envVars" "$envInitConfig")
   actual=$(git lfs env | grep -v "^GIT_EXEC_PATH=")
   contains_same_elements "$expecteddisabled" "$actual"
 
@@ -835,7 +837,7 @@ LocalGitStorageDir=%s
 LocalMediaDir=%s
 LocalReferenceDirs=
 TempDir=%s
-ConcurrentTransfers=8
+ConcurrentTransfers=%d
 TusTransfers=false
 BasicTransfersOnly=false
 SkipDownloadErrors=true
@@ -854,7 +856,7 @@ DownloadTransfers=basic,lfs-standalone-file,ssh
 UploadTransfers=basic,lfs-standalone-file,ssh
 %s
 %s
-' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVarsEnabled" "$envInitConfig")
+' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$expectedConcurrentTransfers" "$lfsstorage" "$envVarsEnabled" "$envInitConfig")
   actual=$(GIT_LFS_SKIP_DOWNLOAD_ERRORS=1 git lfs env | grep -v "^GIT_EXEC_PATH=")
   contains_same_elements "$expectedenabled2" "$actual"
 
@@ -898,7 +900,7 @@ LocalGitStorageDir=%s
 LocalMediaDir=%s
 LocalReferenceDirs=
 TempDir=%s
-ConcurrentTransfers=8
+ConcurrentTransfers=%d
 TusTransfers=true
 BasicTransfersOnly=false
 SkipDownloadErrors=false
@@ -917,7 +919,7 @@ DownloadTransfers=basic,lfs-standalone-file,ssh,supertransfer
 UploadTransfers=basic,lfs-standalone-file,ssh,supertransfer,tus
 %s
 %s
-' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")
+' "$(git lfs version)" "$(git version)" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$expectedConcurrentTransfers" "$lfsstorage" "$envVars" "$envInitConfig")
   actual=$(git lfs env | grep -v "^GIT_EXEC_PATH=")
   contains_same_elements "$expectedenabled" "$actual"
 
@@ -958,7 +960,7 @@ LocalGitStorageDir=%s
 LocalMediaDir=%s
 LocalReferenceDirs=
 TempDir=%s
-ConcurrentTransfers=8
+ConcurrentTransfers=%d
 TusTransfers=false
 BasicTransfersOnly=false
 SkipDownloadErrors=false
@@ -977,7 +979,7 @@ DownloadTransfers=basic,lfs-standalone-file,ssh
 UploadTransfers=basic,lfs-standalone-file,ssh
 %s
 %s
-' "$(git lfs version)" "$(git version)" "$endpoint" "$endpoint2" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")
+' "$(git lfs version)" "$(git version)" "$endpoint" "$endpoint2" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$expectedConcurrentTransfers" "$lfsstorage" "$envVars" "$envInitConfig")
   actual=$(git lfs env | grep -v "^GIT_EXEC_PATH=")
   contains_same_elements "$expected" "$actual"
 )
@@ -1023,7 +1025,7 @@ LocalGitStorageDir=%s
 LocalMediaDir=%s
 LocalReferenceDirs=
 TempDir=%s
-ConcurrentTransfers=8
+ConcurrentTransfers=%d
 TusTransfers=false
 BasicTransfersOnly=false
 SkipDownloadErrors=false
@@ -1042,7 +1044,7 @@ DownloadTransfers=basic,lfs-standalone-file,ssh
 UploadTransfers=basic,lfs-standalone-file,ssh
 %s
 %s
-' "$(git lfs version)" "$(git version)" "$endpoint" "$endpoint2" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")
+' "$(git lfs version)" "$(git version)" "$endpoint" "$endpoint2" "$localwd" "$localgit" "$localgitstore" "$localmedia" "$tempdir" "$expectedConcurrentTransfers" "$lfsstorage" "$envVars" "$envInitConfig")
   actual=$(git lfs env | grep -v "^GIT_EXEC_PATH=")
   contains_same_elements "$expected" "$actual"
 )
@@ -1069,7 +1071,7 @@ LocalGitStorageDir=
 LocalMediaDir=%s
 LocalReferenceDirs=
 TempDir=%s
-ConcurrentTransfers=8
+ConcurrentTransfers=%d
 TusTransfers=false
 BasicTransfersOnly=false
 SkipDownloadErrors=false
@@ -1088,7 +1090,7 @@ DownloadTransfers=basic,lfs-standalone-file,ssh
 UploadTransfers=basic,lfs-standalone-file,ssh
 %s
 %s
-' "$(git lfs version)" "$(git version)" "$localmedia" "$tempdir" "$lfsstorage" "$envVars" "$envInitConfig")
+' "$(git lfs version)" "$(git version)" "$localmedia" "$tempdir" "$expectedConcurrentTransfers" "$lfsstorage" "$envVars" "$envInitConfig")
   # We redirect the standard error here because we should not get any error
   # messages, and if we do, we want to fail.
   actual=$(git lfs env 2>&1 | grep -v "^GIT_EXEC_PATH=")

--- a/t/t-worktree.sh
+++ b/t/t-worktree.sh
@@ -15,6 +15,8 @@ fi
 # despite the "GIT_" strings in its name and value.
 export TEST_GIT_EXAMPLE="GIT_EXAMPLE"
 
+setup_expected_concurrent_transfers
+
 begin_test "git worktree"
 (
     set -e
@@ -35,7 +37,7 @@ LocalGitStorageDir=$(canonical_path_escaped "$TRASHDIR/$reponame/.git")
 LocalMediaDir=$(canonical_path_escaped "$TRASHDIR/$reponame/.git/lfs/objects")
 LocalReferenceDirs=
 TempDir=$(canonical_path_escaped "$TRASHDIR/$reponame/.git/lfs/tmp")
-ConcurrentTransfers=8
+ConcurrentTransfers=%d
 TusTransfers=false
 BasicTransfersOnly=false
 SkipDownloadErrors=false
@@ -54,7 +56,7 @@ DownloadTransfers=basic,lfs-standalone-file,ssh
 UploadTransfers=basic,lfs-standalone-file,ssh
 $(escape_path "$(env | grep "^GIT_")")
 %s
-" "$(git lfs version)" "$(git version)" "$envInitConfig")
+" "$(git lfs version)" "$(git version)" "$expectedConcurrentTransfers" "$envInitConfig")
     actual=$(git lfs env | grep -v "^GIT_EXEC_PATH=")
     contains_same_elements "$expected" "$actual"
 
@@ -72,7 +74,7 @@ LocalGitStorageDir=$(canonical_path_escaped "$TRASHDIR/$reponame/.git")
 LocalMediaDir=$(canonical_path_escaped "$TRASHDIR/$reponame/.git/lfs/objects")
 LocalReferenceDirs=
 TempDir=$(canonical_path_escaped "$TRASHDIR/$reponame/.git/lfs/tmp")
-ConcurrentTransfers=8
+ConcurrentTransfers=%d
 TusTransfers=false
 BasicTransfersOnly=false
 SkipDownloadErrors=false
@@ -91,7 +93,7 @@ DownloadTransfers=basic,lfs-standalone-file,ssh
 UploadTransfers=basic,lfs-standalone-file,ssh
 $(escape_path "$(env | grep "^GIT_")")
 %s
-" "$(git lfs version)" "$(git version)" "$envInitConfig")
+" "$(git lfs version)" "$(git version)" "$expectedConcurrentTransfers" "$envInitConfig")
     actual=$(git lfs env | grep -v "^GIT_EXEC_PATH=")
     contains_same_elements "$expected" "$actual"
 )

--- a/t/testhelpers.sh
+++ b/t/testhelpers.sh
@@ -1084,3 +1084,14 @@ pktize_delim() {
 pktize_flush() {
   printf '0000'
 }
+
+# Compute the expected default ConcurrentTransfers value (3 × NCPU,
+# min 8) so tests stay correct on any machine.  We use a small Go
+# helper to get runtime.NumCPU() so the value always matches what the
+# git-lfs binary sees, even inside containers with cgroup limits.
+setup_expected_concurrent_transfers() {
+  _ncpu=$(lfstest-getnumcpu)
+  _ct=$(( _ncpu * 3 ))
+  [ "$_ct" -lt 8 ] && _ct=8
+  expectedConcurrentTransfers=$_ct
+}

--- a/tq/manifest.go
+++ b/tq/manifest.go
@@ -7,14 +7,14 @@ import (
 	"github.com/git-lfs/git-lfs/v3/config"
 	"github.com/git-lfs/git-lfs/v3/fs"
 	"github.com/git-lfs/git-lfs/v3/lfsapi"
+	"github.com/git-lfs/git-lfs/v3/lfshttp"
 	"github.com/git-lfs/git-lfs/v3/ssh"
 	"github.com/rubyist/tracerx"
 )
 
 const (
-	defaultMaxRetries          = 8
-	defaultMaxRetryDelay       = 10
-	defaultConcurrentTransfers = 8
+	defaultMaxRetries    = 8
+	defaultMaxRetryDelay = 10
 )
 
 type Manifest interface {
@@ -236,7 +236,7 @@ func newConcreteManifest(f *fs.Filesystem, apiClient *lfsapi.Client, operation, 
 	}
 
 	if m.concurrentTransfers < 1 {
-		m.concurrentTransfers = defaultConcurrentTransfers
+		m.concurrentTransfers = lfshttp.DefaultConcurrentTransfers()
 	}
 
 	if sshTransfer != nil {


### PR DESCRIPTION
Default to 6× logical CPUs (min 8) instead of a hard-coded 8, better utilizing available I/O parallelism. (See previous benchmarks in #6234)