### PR TITLE
Fix concurrent map/struct races in sshCache and lazyManifest

### DIFF
--- a/lfshttp/ssh.go
+++ b/lfshttp/ssh.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/git-lfs/git-lfs/v3/config"
@@ -18,14 +19,11 @@ type SSHResolver interface {
 }
 
 func withSSHCache(ssh SSHResolver) SSHResolver {
-	return &sshCache{
-		endpoints: make(map[string]*sshAuthResponse),
-		ssh:       ssh,
-	}
+	return &sshCache{ssh: ssh}
 }
 
 type sshCache struct {
-	endpoints map[string]*sshAuthResponse
+	endpoints sync.Map // map[string]*sshAuthResponse
 	ssh       SSHResolver
 }
 
@@ -35,7 +33,8 @@ func (c *sshCache) Resolve(e Endpoint, method string) (sshAuthResponse, error) {
 	}
 
 	key := strings.Join([]string{e.SSHMetadata.UserAndHost, e.SSHMetadata.Port, e.SSHMetadata.Path, method}, "//")
-	if res, ok := c.endpoints[key]; ok {
+	if val, ok := c.endpoints.Load(key); ok {
+		res := val.(*sshAuthResponse)
 		if _, expired := res.IsExpiredWithin(5 * time.Second); !expired {
 			tracerx.Printf("ssh cache: %s git-lfs-authenticate %s %s",
 				e.SSHMetadata.UserAndHost, e.SSHMetadata.Path, endpointOperation(e, method))
@@ -48,7 +47,7 @@ func (c *sshCache) Resolve(e Endpoint, method string) (sshAuthResponse, error) {
 
 	res, err := c.ssh.Resolve(e, method)
 	if err == nil {
-		c.endpoints[key] = &res
+		c.endpoints.Store(key, &res)
 	}
 	return res, err
 }

--- a/lfshttp/ssh_test.go
+++ b/lfshttp/ssh_test.go
@@ -1,6 +1,7 @@
 package lfshttp
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -12,10 +13,10 @@ import (
 func TestSSHCacheResolveFromCache(t *testing.T) {
 	ssh := newFakeResolver()
 	cache := withSSHCache(ssh).(*sshCache)
-	cache.endpoints["userandhost//1//path//post"] = &sshAuthResponse{
+	cache.endpoints.Store("userandhost//1//path//post", &sshAuthResponse{
 		Href:      "cache",
 		createdAt: time.Now(),
-	}
+	})
 	ssh.responses["userandhost"] = sshAuthResponse{Href: "real"}
 
 	e := Endpoint{
@@ -34,11 +35,11 @@ func TestSSHCacheResolveFromCache(t *testing.T) {
 func TestSSHCacheResolveFromCacheWithFutureExpiresAt(t *testing.T) {
 	ssh := newFakeResolver()
 	cache := withSSHCache(ssh).(*sshCache)
-	cache.endpoints["userandhost//1//path//post"] = &sshAuthResponse{
+	cache.endpoints.Store("userandhost//1//path//post", &sshAuthResponse{
 		Href:      "cache",
 		ExpiresAt: time.Now().Add(time.Duration(1) * time.Hour),
 		createdAt: time.Now(),
-	}
+	})
 	ssh.responses["userandhost"] = sshAuthResponse{Href: "real"}
 
 	e := Endpoint{
@@ -57,11 +58,11 @@ func TestSSHCacheResolveFromCacheWithFutureExpiresAt(t *testing.T) {
 func TestSSHCacheResolveFromCacheWithFutureExpiresIn(t *testing.T) {
 	ssh := newFakeResolver()
 	cache := withSSHCache(ssh).(*sshCache)
-	cache.endpoints["userandhost//1//path//post"] = &sshAuthResponse{
+	cache.endpoints.Store("userandhost//1//path//post", &sshAuthResponse{
 		Href:      "cache",
 		ExpiresIn: 60 * 60,
 		createdAt: time.Now(),
-	}
+	})
 	ssh.responses["userandhost"] = sshAuthResponse{Href: "real"}
 
 	e := Endpoint{
@@ -80,11 +81,11 @@ func TestSSHCacheResolveFromCacheWithFutureExpiresIn(t *testing.T) {
 func TestSSHCacheResolveFromCacheWithPastExpiresAt(t *testing.T) {
 	ssh := newFakeResolver()
 	cache := withSSHCache(ssh).(*sshCache)
-	cache.endpoints["userandhost//1//path//post"] = &sshAuthResponse{
+	cache.endpoints.Store("userandhost//1//path//post", &sshAuthResponse{
 		Href:      "cache",
 		ExpiresAt: time.Now().Add(time.Duration(-1) * time.Hour),
 		createdAt: time.Now(),
-	}
+	})
 	ssh.responses["userandhost"] = sshAuthResponse{Href: "real"}
 
 	e := Endpoint{
@@ -103,11 +104,11 @@ func TestSSHCacheResolveFromCacheWithPastExpiresAt(t *testing.T) {
 func TestSSHCacheResolveFromCacheWithPastExpiresIn(t *testing.T) {
 	ssh := newFakeResolver()
 	cache := withSSHCache(ssh).(*sshCache)
-	cache.endpoints["userandhost//1//path//post"] = &sshAuthResponse{
+	cache.endpoints.Store("userandhost//1//path//post", &sshAuthResponse{
 		Href:      "cache",
 		ExpiresIn: -60 * 60,
 		createdAt: time.Now(),
-	}
+	})
 	ssh.responses["userandhost"] = sshAuthResponse{Href: "real"}
 
 	e := Endpoint{
@@ -126,12 +127,12 @@ func TestSSHCacheResolveFromCacheWithPastExpiresIn(t *testing.T) {
 func TestSSHCacheResolveFromCacheWithAmbiguousExpirationInfo(t *testing.T) {
 	ssh := newFakeResolver()
 	cache := withSSHCache(ssh).(*sshCache)
-	cache.endpoints["userandhost//1//path//post"] = &sshAuthResponse{
+	cache.endpoints.Store("userandhost//1//path//post", &sshAuthResponse{
 		Href:      "cache",
 		ExpiresIn: 60 * 60,
 		ExpiresAt: time.Now().Add(-1 * time.Hour),
 		createdAt: time.Now(),
-	}
+	})
 	ssh.responses["userandhost"] = sshAuthResponse{Href: "real"}
 
 	e := Endpoint{
@@ -151,7 +152,7 @@ func TestSSHCacheResolveWithoutError(t *testing.T) {
 	ssh := newFakeResolver()
 	cache := withSSHCache(ssh).(*sshCache)
 
-	assert.Equal(t, 0, len(cache.endpoints))
+	assertCacheLen(t, cache, 0)
 
 	ssh.responses["userandhost"] = sshAuthResponse{Href: "real"}
 
@@ -167,11 +168,11 @@ func TestSSHCacheResolveWithoutError(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "real", res.Href)
 
-	assert.Equal(t, 1, len(cache.endpoints))
-	cacheres, ok := cache.endpoints["userandhost//1//path//post"]
+	assertCacheLen(t, cache, 1)
+	val, ok := cache.endpoints.Load("userandhost//1//path//post")
 	assert.True(t, ok)
-	assert.NotNil(t, cacheres)
-	assert.Equal(t, "real", cacheres.Href)
+	assert.NotNil(t, val)
+	assert.Equal(t, "real", val.(*sshAuthResponse).Href)
 
 	delete(ssh.responses, "userandhost")
 	res2, err := cache.Resolve(e, "post")
@@ -183,7 +184,7 @@ func TestSSHCacheResolveWithError(t *testing.T) {
 	ssh := newFakeResolver()
 	cache := withSSHCache(ssh).(*sshCache)
 
-	assert.Equal(t, 0, len(cache.endpoints))
+	assertCacheLen(t, cache, 0)
 
 	ssh.responses["userandhost"] = sshAuthResponse{Message: "resolve error", Href: "real"}
 
@@ -199,11 +200,50 @@ func TestSSHCacheResolveWithError(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, "real", res.Href)
 
-	assert.Equal(t, 0, len(cache.endpoints))
+	assertCacheLen(t, cache, 0)
 	delete(ssh.responses, "userandhost")
 	res2, err := cache.Resolve(e, "post")
 	assert.Nil(t, err)
 	assert.Equal(t, "", res2.Href)
+}
+
+func assertCacheLen(t *testing.T, cache *sshCache, expected int) {
+	t.Helper()
+	n := 0
+	cache.endpoints.Range(func(_, _ any) bool { n++; return true })
+	assert.Equal(t, expected, n)
+}
+
+func TestSSHCacheConcurrentResolve(t *testing.T) {
+	ssh := newFakeResolver()
+	cache := withSSHCache(ssh)
+
+	ssh.responses["userandhost"] = sshAuthResponse{Href: "real"}
+
+	e := Endpoint{
+		SSHMetadata: sshp.SSHMetadata{
+			UserAndHost: "userandhost",
+			Port:        "1",
+			Path:        "path",
+		},
+	}
+
+	// Two goroutines resolving the same endpoint concurrently is enough
+	// for `go test -race` to detect an unprotected map access.
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			res, err := cache.Resolve(e, "post")
+			assert.Nil(t, err)
+			assert.Equal(t, "real", res.Href)
+		}()
+	}
+	close(start)
+	wg.Wait()
 }
 
 func newFakeResolver() *fakeResolver {

--- a/tq/manifest.go
+++ b/tq/manifest.go
@@ -42,6 +42,7 @@ type lazyManifest struct {
 	apiClient *lfsapi.Client
 	operation string
 	remote    string
+	mu        sync.Mutex
 	m         *concreteManifest
 }
 
@@ -116,6 +117,8 @@ func (m *lazyManifest) NewUploadAdapter(name string) Adapter {
 }
 
 func (m *lazyManifest) Upgrade() *concreteManifest {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.m == nil {
 		m.m = newConcreteManifest(m.f, m.apiClient, m.operation, m.remote)
 	}
@@ -123,6 +126,8 @@ func (m *lazyManifest) Upgrade() *concreteManifest {
 }
 
 func (m *lazyManifest) Upgraded() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return m.m != nil
 }
 

--- a/tq/manifest_test.go
+++ b/tq/manifest_test.go
@@ -1,6 +1,7 @@
 package tq
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/git-lfs/git-lfs/v3/lfsapi"
@@ -27,6 +28,31 @@ func TestManifestClampsValidValues(t *testing.T) {
 
 	m := NewManifest(nil, cli, "", "")
 	assert.Equal(t, 8, m.MaxRetries())
+}
+
+func TestLazyManifestConcurrentUpgrade(t *testing.T) {
+	cli, err := lfsapi.NewClient(lfshttp.NewContext(nil, nil, nil))
+	require.Nil(t, err)
+
+	m := NewManifest(nil, cli, "", "")
+
+	// Concurrent Upgrade calls must return the same concreteManifest
+	// instance and not race on the nil check.
+	start := make(chan struct{})
+	results := make([]*concreteManifest, 2)
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			results[idx] = m.Upgrade()
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	assert.Same(t, results[0], results[1], "concurrent Upgrade returned different instances")
 }
 
 func TestManifestIgnoresNonInts(t *testing.T) {


### PR DESCRIPTION
In #6234 `sshCache.endpoints` is accessed from multiple goroutines when parallel batch API workers resolve SSH credentials simultaneously. Replace the plain map with `sync.Map` to prevent the "concurrent map writes" panic.

`lazyManifest.Upgrade()` can be called concurrently, causing multiple concreteManifest instances to be created. Add a mutex to ensure only one is created.