### PR TITLE
locking: ignore missing files after unlock

### DIFF
--- a/locking/locks.go
+++ b/locking/locks.go
@@ -185,7 +185,7 @@ func (c *Client) UnlockFileById(id string, force bool) error {
 		}
 
 		// Make non-writeable if required
-		if c.SetLockableFilesReadOnly && c.IsFileLockable(unlockRes.Lock.Path) {
+		if c.SetLockableFilesReadOnly && c.IsFileLockable(unlockRes.Lock.Path) && tools.FileExists(abs) {
 			return tools.SetFileWriteFlag(abs, false)
 		}
 	}

--- a/t/t-unlock.sh
+++ b/t/t-unlock.sh
@@ -508,27 +508,24 @@ begin_test "unlocking a missing lockable file (--json)"
 
   reponame="unlock_missing_lockable_path_json"
   setup_remote_repo "$reponame"
-  clone_repo "$reponame" seed
+  clone_repo "$reponame" "$reponame"
 
-  cd "$TRASHDIR/seed"
   git lfs track --lockable "*.dat"
   git add .gitattributes
   git commit -m "Add lockable pattern"
   git push origin main
 
-  cd "$TRASHDIR"
-  clone_repo "$reponame" cloneA
-  clone_repo "$reponame" cloneB
-
-  cd "$TRASHDIR/cloneA"
   echo "file1.dat" > file1.dat
   git lfs lock --json "file1.dat" | tee lock.log
 
   id=$(assert_lock lock.log file1.dat)
   assert_server_lock "$reponame" "$id"
 
-  cd "$TRASHDIR/cloneB"
-  git lfs unlock --json "file1.dat" 2>&1 | tee unlock.log
+  rm file1.dat
+
+  git lfs unlock --json "file1.dat" | tee unlock.log
+  [ 0 -eq "${PIPESTATUS[0]}" ]
+
   grep -F '[{"path":"file1.dat","unlocked":true}]' unlock.log
 
   refute_server_lock "$reponame" "$id"

--- a/t/t-unlock.sh
+++ b/t/t-unlock.sh
@@ -378,6 +378,39 @@ begin_test "unlocking a lock (--json)"
 )
 end_test
 
+begin_test "unlocking a missing lockable file (--json)"
+(
+  set -e
+
+  reponame="unlock_missing_lockable_path_json"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" seed
+
+  cd "$TRASHDIR/seed"
+  git lfs track --lockable "*.dat"
+  git add .gitattributes
+  git commit -m "Add lockable pattern"
+  git push origin main
+
+  cd "$TRASHDIR"
+  clone_repo "$reponame" cloneA
+  clone_repo "$reponame" cloneB
+
+  cd "$TRASHDIR/cloneA"
+  echo "file1.dat" > file1.dat
+  git lfs lock --json "file1.dat" | tee lock.log
+
+  id=$(assert_lock lock.log file1.dat)
+  assert_server_lock "$reponame" "$id"
+
+  cd "$TRASHDIR/cloneB"
+  git lfs unlock --json "file1.dat" 2>&1 | tee unlock.log
+  grep -F '[{"path":"file1.dat","unlocked":true}]' unlock.log
+
+  refute_server_lock "$reponame" "$id"
+)
+end_test
+
 begin_test "unlocking a lock by id"
 (
   set -e


### PR DESCRIPTION
Fixes #6167

When one clone has the lockable pattern but not the newly locked file, `git lfs unlock --json <path>` can remove the server lock and then turn that successful unlock into a local failure while trying to make the missing path read-only.

Before this change, the unlock POST succeeded but the command exited with `unlocked:false` and a local `stat ... no such file or directory` reason.

After this change, a successful unlock stays successful, and the post-unlock chmod step is skipped when the file is not present in the current worktree.

I also added a regression in `t/t-unlock.sh` that reproduces the two-clone lockable-pattern case from the issue.

Validation:
- `make -C t t-unlock.sh`
- `go test ./locking`