### PR TITLE
Update Linux distribution package list for v3.8.0 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,5 +185,5 @@ jobs:
         persist-credentials: false
         ref: ${{ github.ref }}
     - run: git clone https://github.com/git-lfs/build-dockers.git "$HOME/build-dockers"
-    - run: (cd "$HOME/build-dockers" && ./build_dockers.bsh --arch=arm64 debian_11 debian_12)
-    - run: ./docker/run_dockers.bsh --prune --arch=arm64 debian_11 debian_12
+    - run: (cd "$HOME/build-dockers" && ./build_dockers.bsh --arch=arm64 debian_11 debian_12 debian_13)
+    - run: ./docker/run_dockers.bsh --prune --arch=arm64 debian_11 debian_12 debian_13

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,8 +205,8 @@ jobs:
         ref: ${{ github.ref }}
     - run: sudo gem install packagecloud-ruby
     - run: git clone https://github.com/git-lfs/build-dockers.git "$HOME/build-dockers"
-    - run: (cd "$HOME/build-dockers" && ./build_dockers.bsh --arch=arm64 debian_11 debian_12)
-    - run: ./docker/run_dockers.bsh --prune --arch=arm64 debian_11 debian_12
+    - run: (cd "$HOME/build-dockers" && ./build_dockers.bsh --arch=arm64 debian_11 debian_12 debian_13)
+    - run: ./docker/run_dockers.bsh --prune --arch=arm64 debian_11 debian_12 debian_13
     # If this is a pre-release tag, don't upload anything to packagecloud.
     - run: '[ -z "${GITHUB_REF%%refs/tags/*-pre*}" ] || ./script/packagecloud.rb'
       env:

--- a/script/lib/distro.rb
+++ b/script/lib/distro.rb
@@ -45,8 +45,6 @@ class DistroMap
         package_tag: "-1.el9",
         equivalent: [
           "el/9",                      # EOL May 2032
-          "fedora/41",                 # EOL November 2025
-          "fedora/42",                 # EOL May 2026
           "opensuse/15.6",             # EOL December 2025
           "sles/15.6",                 # Current
         ],
@@ -59,6 +57,9 @@ class DistroMap
         package_tag: "-1.el10",
         equivalent: [
           "el/10",                     # EOL May 2035
+          "fedora/42",                 # EOL May 2026
+          "fedora/43",                 # EOL December 2026
+          "fedora/44",                 # EOL May 2027
         ],
       },
       # Debian EOL https://wiki.debian.org/LTS/

--- a/script/lib/distro.rb
+++ b/script/lib/distro.rb
@@ -90,12 +90,22 @@ class DistroMap
         package_tag: "",
         equivalent: [
           "debian/bookworm",           # EOL June 2028
-          "debian/trixie",             # Current testing (Debian 13)
           "linuxmint/wilma",           # EOL April 2029
           "linuxmint/xia",             # EOL April 2029
           "ubuntu/noble",              # EOL June 2029
           "ubuntu/oracular",           # EOL July 2025
           "ubuntu/plucky",             # EOL January 2026
+        ]
+      },
+      "debian/13" => {
+        name: "Debian 13",
+        component: "debian/trixie",
+        image: "debian_13",
+        package_type: "deb",
+        package_tag: "",
+        equivalent: [
+          "debian/trixie",             # EOL June 2030
+          "debian/forky",              # Current testing (Debian 14)
         ]
       },
     }

--- a/script/lib/distro.rb
+++ b/script/lib/distro.rb
@@ -45,8 +45,8 @@ class DistroMap
         package_tag: "-1.el9",
         equivalent: [
           "el/9",                      # EOL May 2032
-          "opensuse/15.6",             # EOL December 2025
-          "sles/15.6",                 # Current
+          "opensuse/15.6",             # EOL April 2026
+          "sles/15.7",                 # EOL July 2031
         ],
       },
       "rocky/10" => {
@@ -60,6 +60,8 @@ class DistroMap
           "fedora/42",                 # EOL May 2026
           "fedora/43",                 # EOL December 2026
           "fedora/44",                 # EOL May 2027
+          "opensuse/16.0",             # EOL October 2027
+          "sles/16.0",                 # EOL November 2027
         ],
       },
       # Debian EOL https://wiki.debian.org/LTS/

--- a/script/lib/distro.rb
+++ b/script/lib/distro.rb
@@ -90,8 +90,11 @@ class DistroMap
         package_tag: "",
         equivalent: [
           "debian/bookworm",           # EOL June 2028
+          "linuxmint/faye",            # LMDE LTS release based on Debian 12
           "linuxmint/wilma",           # EOL April 2029
           "linuxmint/xia",             # EOL April 2029
+          "linuxmint/zara",            # EOL April 2029
+          "linuxmint/zena",            # EOL April 2029
           "ubuntu/noble",              # EOL June 2029
         ]
       },
@@ -104,6 +107,7 @@ class DistroMap
         equivalent: [
           "debian/trixie",             # EOL June 2030
           "debian/forky",              # Current testing (Debian 14)
+          "linuxmint/gigi",            # LMDE LTS release based on Debian 13
           "ubuntu/questing",           # EOL July 2026
           "ubuntu/resolute",           # EOL July 2031
         ]

--- a/script/lib/distro.rb
+++ b/script/lib/distro.rb
@@ -93,8 +93,6 @@ class DistroMap
           "linuxmint/wilma",           # EOL April 2029
           "linuxmint/xia",             # EOL April 2029
           "ubuntu/noble",              # EOL June 2029
-          "ubuntu/oracular",           # EOL July 2025
-          "ubuntu/plucky",             # EOL January 2026
         ]
       },
       "debian/13" => {
@@ -106,6 +104,8 @@ class DistroMap
         equivalent: [
           "debian/trixie",             # EOL June 2030
           "debian/forky",              # Current testing (Debian 14)
+          "ubuntu/questing",           # EOL July 2026
+          "ubuntu/resolute",           # EOL July 2031
         ]
       },
     }


### PR DESCRIPTION
As we anticipate releasing Git LFS version 3.8.0 in the near future, we first update our list of the Linux distributions and versions for which our scripts will publish RPM and Debian packages.

Most significantly, we add support for Debian 13 ("trixie") along with several other distribution versions based on that platform.

We will also now build RPM packages for version 16.0 of the SUSE Enterprise Linux (SLES) and openSUSE Leap distributions, and will build Debian packages for versions 6 and 7 of the Linux Mint Debian Edition (LMDE) distribution.

This PR will be most easily reviewed on a commit-by-commit basis.

