### PR TITLE
Fix remote ref resolution for download operations

### DIFF
--- a/commands/command_filter_process.go
+++ b/commands/command_filter_process.go
@@ -107,7 +107,7 @@ func filterCommand(cmd *cobra.Command, args []string) {
 					tq.Download,
 					getTransferManifestOperationRemote("download", cfg.Remote()),
 					cfg.Remote(),
-					tq.RemoteRef(currentRemoteRef()),
+					tq.RemoteRef(fetchRemoteRef()),
 					tq.WithBatchSize(cfg.TransferBatchSize()),
 				)
 				go infiniteTransferBuffer(q, available)

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -121,7 +121,7 @@ func uploadsWithObjectIDs(ctx *uploadContext, oids []string) {
 		}
 	}
 
-	q := ctx.NewQueue(tq.RemoteRef(currentRemoteRef()))
+	q := ctx.NewQueue(tq.RemoteRef(pushRemoteRef()))
 	ctx.UploadPointers(q, pointers...)
 	ctx.CollectErrors(q)
 	ctx.ReportErrors()

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -124,12 +124,19 @@ func newDownloadCheckQueue(manifest tq.Manifest, remote string, options ...tq.Op
 // newDownloadQueue builds a DownloadQueue, allowing concurrent downloads.
 func newDownloadQueue(manifest tq.Manifest, remote string, options ...tq.Option) *tq.TransferQueue {
 	return tq.NewTransferQueue(tq.Download, manifest, remote, append(options,
-		tq.RemoteRef(currentRemoteRef()),
+		tq.RemoteRef(fetchRemoteRef()),
 		tq.WithBatchSize(cfg.TransferBatchSize()),
 	)...)
 }
 
-func currentRemoteRef() *git.Ref {
+// fetchRemoteRef returns the remote ref for download operations by looking up
+// the upstream tracking branch for the current local ref. Unlike pushRemoteRef,
+// this does not use push.default logic, which is not meaningful for fetches.
+func fetchRemoteRef() *git.Ref {
+	return git.TrackingRef(cfg.Git, cfg.CurrentRef())
+}
+
+func pushRemoteRef() *git.Ref {
 	return git.NewRefUpdate(cfg.Git, cfg.PushRemote(), cfg.CurrentRef(), nil).RemoteRef()
 }
 

--- a/git/refs.go
+++ b/git/refs.go
@@ -50,7 +50,7 @@ func defaultRemoteRef(g Env, remote string, localRef *Ref) *Ref {
 			// in centralized workflow, work like 'upstream' with an added safety to
 			// refuse to push if the upstream branch’s name is different from the
 			// local one.
-			return trackingRef(g, localRef)
+			return TrackingRef(g, localRef)
 		}
 
 		// When pushing to a remote that is different from the remote you normally
@@ -59,7 +59,7 @@ func defaultRemoteRef(g Env, remote string, localRef *Ref) *Ref {
 	case "upstream", "tracking":
 		// push the current branch back to the branch whose changes are usually
 		// integrated into the current branch
-		return trackingRef(g, localRef)
+		return TrackingRef(g, localRef)
 	case "current":
 		// push the current branch to update a branch with the same name on the
 		// receiving end.
@@ -70,7 +70,9 @@ func defaultRemoteRef(g Env, remote string, localRef *Ref) *Ref {
 	}
 }
 
-func trackingRef(g Env, localRef *Ref) *Ref {
+// TrackingRef returns the upstream tracking ref for the given local ref, or the
+// local ref itself if no tracking is configured.
+func TrackingRef(g Env, localRef *Ref) *Ref {
 	if merge, ok := g.Get(fmt.Sprintf("branch.%s.merge", localRef.Name)); ok {
 		return ParseRef(merge, "")
 	}

--- a/t/t-fetch-refspec.sh
+++ b/t/t-fetch-refspec.sh
@@ -56,6 +56,39 @@ begin_test "fetch with tracked ref"
 )
 end_test
 
+begin_test "fetch with pushRemote configured"
+(
+  set -e
+
+  reponame="fetch-tracked-with-push-remote-tracked-branch-required"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.dat"
+  echo "a" > a.dat
+  git add .gitattributes a.dat
+  git commit -m "add a.dat"
+
+  git push origin main:tracked
+
+  # $ echo "a" | shasum -a 256
+  oid="87428fc522803d31065e7bce3cf03fe475096631e5e07bbd7a0fde60c4cf25c7"
+  assert_local_object "$oid" 2
+  assert_server_object "$reponame" "$oid" "refs/heads/tracked"
+
+  # Configure tracking to "tracked" and set a separate push remote.
+  # The fetch should send refs/heads/tracked (the tracking ref) to the server,
+  # not a ref derived from push.default logic using the push remote.
+  git remote add push-only "$GITSERVER/$reponame"
+  git config remote.pushDefault push-only
+  git config branch.main.merge refs/heads/tracked
+
+  rm -rf .git/lfs/objects
+  git lfs fetch origin --all
+  assert_local_object "$oid" 2
+)
+end_test
+
 begin_test "fetch with bad ref"
 (
   set -e


### PR DESCRIPTION
## Summary

Fix download operations to resolve the remote ref using the upstream tracking branch instead of `push.default` logic.

## Problem

`currentRemoteRef()` resolved the remote ref sent in LFS batch API requests using `push.default` rules via `cfg.PushRemote()`. This is semantically correct for pushes but wrong for downloads: a download needs to tell the LFS server which remote branch the client is *fetching from* (for authorization), not which branch a *push* would target.

When `remote.pushDefault` pointed to a different remote than the fetch remote, the download path could resolve to the wrong ref.

## Changes

Split `currentRemoteRef()` into two purpose-specific functions:

- **`pushRemoteRef()`** -- resolves the remote ref using `push.default` rules and the configured push remote (used by push operations)
- **`fetchRemoteRef()`** -- resolves the upstream tracking ref for the current local branch (used by download operations)

Export `TrackingRef` in `git/refs.go` so `fetchRemoteRef` can look up the tracking branch directly without going through push-oriented `defaultRemoteRef` logic.

## Testing

Added integration test "fetch with pushRemote configured" that:
1. Pushes to a `tracked` branch on origin
2. Configures `remote.pushDefault` to a separate push-only remote
3. Sets `branch.main.merge` to `refs/heads/tracked`
4. Verifies `git lfs fetch` sends the correct tracking ref

The test fails without the fix (server rejects the wrong ref) and passes with it.
