### PR TITLE
Add `--add-i386` option to RPM build script

### DIFF
--- a/rpm/build_rpms.bsh
+++ b/rpm/build_rpms.bsh
@@ -73,6 +73,9 @@ echo "Build git-lfs RPMs..."
 
 #--no-deps added for now so you can compile without official rpms installed
 "${RPMBUILD[@]}" --nodeps -ba "$SPEC"
-"${RPMBUILD[@]}" --nodeps --target=i686 -bb "$SPEC"
+
+if [ "$#" -eq 1 ] && [ "$1" = "--add-i386" ]; then
+  "${RPMBUILD[@]}" --nodeps --target=i686 -bb "$SPEC"
+fi
 
 echo "All Done!"


### PR DESCRIPTION
This PR updates the `rpm/build_rpms.bsh` script we use to generate RPM packages for Git LFS releases so that the script will only build a 32-bit binary when the new `--add-i386` option is provided.

In conjunction with the changes from PR git-lfs/build-dockers#76, this PR should ensure we only publish 64-bit RPM packages for platforms based on Red Hat Enterprise Linux (RHEL) 10.0 and the distributions we consider equivalent to it.

This PR's changes have been tested with our GitHub Actions CI and release workflows using a private repository.

#### Details

In commit git-lfs/build-dockers@cc16329409175a2120e7306499b30304689b07f8 of PR git-lfs/build-dockers#71 we added a `Dockerfile` to build RPM packages of Git LFS for the Red Hat Enterprise Linux (RHEL) 10.0 and Rocky Linux 10.0 platforms.  This `Dockerfile` originally followed the same set of steps as our `Dockerfile`s for the earlier RHEL/CentOS 8 and RHEL/Rocky Linux 9 platforms, and so was intended to build both 32-bit and 64-bit binaries in two separate RPM packages.

However, the RHEL 10.0 and Rocky Linux 10.0 platforms only provide support for 64-bit systems, as noted in their [release](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10/html-single/10.0_release_notes/index) [announcements](https://rockylinux.org/news/rocky-linux-10-0-ga-release), which means we should only be building 64-bit RPM packages of Git LFS for them.

To help resolve this issue, in commit git-lfs/build-dockers@1caa5b338abdf6f7ce9fc8847f84a3b13379ff0c of PR git-lfs/build-dockers#76 we updated the `Dockerfile`s for the RHEL/CentOS 8 and RHEL/Rocky Linux 9 platforms so they [now](https://github.com/git-lfs/build-dockers/blob/7093bc50c5f3236082416c1c604264dccbb3e81f/centos_8.Dockerfile#L27) [pass](https://github.com/git-lfs/build-dockers/blob/7093bc50c5f3236082416c1c604264dccbb3e81f/rocky_9.Dockerfile#L27) an explicit `--add-i386` option to the `centos_script.bsh` shell [script](https://github.com/git-lfs/build-dockers/blob/7093bc50c5f3236082416c1c604264dccbb3e81f/centos_script.bsh) in that repository.  At the same time, we also revised the script so that it passes its command-line arguments through to the `rpm/build_rpms.bsh` [script](https://github.com/git-lfs/git-lfs/blob/4f71871c143dc9898addeb6fc1c0969bbf073fac/rpm/build_rpms.bsh) in this repository.

To fully resolve the issue, we now update the `rpm/build_rpms.bsh` script so that it only builds a package with a 32-bit binary if the `--add-i386` option is provided.

Because our `Dockerfile` for the RHEL/Rocky Linux 10 platforms does not pass the `--add-i386` option to the `centos_script.bsh` script, the `rpm/build_rpms.bsh` script will now build only one package for these platforms, containing a 64-bit Git LFS binary.  For the earlier RHEL-based platforms, though, the `rpm/build_rpms.bsh` script will receive the `--add-i386` option, and will build both 32-bit and 64-bit packages.