### PR TITLE
Fix standalone adapter crash and ignore invalid custom adapter names

### DIFF
--- a/commands/command_migrate_export.go
+++ b/commands/command_migrate_export.go
@@ -121,7 +121,7 @@ func migrateExportCommand(cmd *cobra.Command, args []string) {
 
 	// If we have a valid remote, pre-download all objects using the Transfer Queue
 	if remoteURL != "" {
-		q := newDownloadQueue(getTransferManifestOperationRemote("Download", remote), remote)
+		q := newDownloadQueue(getTransferManifestOperationRemote("download", remote), remote)
 		gs := lfs.NewGitScanner(cfg, func(p *lfs.WrappedPointer, err error) {
 			if err != nil {
 				return

--- a/docs/custom-transfers.md
+++ b/docs/custom-transfers.md
@@ -37,7 +37,8 @@ without querying the server, by using the following config option:
   configure a custom transfer agent for individual remotes.
   `lfs.standalonetransferagent` unconditionally configures a custom transfer
   agent for all remotes.  The custom transfer agent must be specified in
-  a `lfs.customtransfer.<name>` settings group.
+  a `lfs.customtransfer.<name>` settings group, or else must be the internal
+  `lfs-standalone-file` transfer adapter.  Other values will be ignored.
 
 ## Defining a Custom Transfer Type
 

--- a/docs/man/git-lfs-config.adoc
+++ b/docs/man/git-lfs-config.adoc
@@ -159,8 +159,13 @@ removed, and tus.io uploads will be available for all clients.
 +
 Allows the specified custom transfer agent to be used directly for
 transferring files, without asking the server how the transfers should
-be made. The custom transfer agent has to be defined in a
-`lfs.customtransfer.<name>` settings group.
+be made. The custom transfer agent must be defined in a
+`lfs.customtransfer.<name>` settings group, or else must be the internal
+`lfs-standalone-file` transfer adapter. Other values will be ignored.
++
+See git-lfs-standalone-file(1) for details of the internal
+`lfs-standalone-file` custom transfer adapter, which is intended for
+use with local `file:///` URLs.
 * `lfs.customtransfer.<name>.path`
 +
 `lfs.customtransfer.<name>` is a settings group which defines a custom
@@ -170,7 +175,10 @@ should point to the process you wish to invoke. The protocol between the
 git-lfs client and the custom transfer process is documented at
 https://github.com/git-lfs/git-lfs/blob/main/docs/custom-transfers.md
 +
-The `<name>` must be a unique identifier that the LFS server understands. When
+The `<name>` must be a unique identifier that the LFS server understands
+and which does not conflict with the name of any pre-defined internal
+transfer adapter in the client such as "basic" or "ssh", as these will
+always override a custom transfer adapter with the same name. When
 calling the LFS API the client will include a list of supported transfer
 types. If the server also supports this named transfer type, it will
 select it and actions returned from the API will be in relation to that
@@ -470,6 +478,6 @@ The set of keys allowed in this file is restricted for security reasons.
 
 == SEE ALSO
 
-git-config(1), git-lfs-install(1), gitattributes(5), gitignore(5).
+git-config(1), git-lfs-install(1), git-lfs-standalone-file(1), gitattributes(5), gitignore(5).
 
 Part of the git-lfs(1) suite.

--- a/docs/man/git-lfs-config.adoc
+++ b/docs/man/git-lfs-config.adoc
@@ -185,6 +185,13 @@ select it and actions returned from the API will be in relation to that
 transfer type (may not be traditional URLs for example). Only if the
 server accepts as a transfer it supports will this custom transfer
 process be invoked.
++
+If multiple `lfs.customtransfer.<name>` settings are defined, they
+must all be contained within the same configuration sub-section,
+meaning that the sub-section portion of their names must be identical.
+For instance, if `lfs.customTransfer.myAdapter.path` is defined,
+then `lfs.customTransfer.myAdapter.args` will be accepted, while
+`lfs.customtransfer.myadapter.args` will not.
 * `lfs.customtransfer.<name>.args`
 +
 If the custom transfer process requires any arguments, these can be

--- a/t/t-custom-transfers.sh
+++ b/t/t-custom-transfers.sh
@@ -285,3 +285,290 @@ begin_test "custom-transfer-standalone-urlmatch"
   git lfs fsck
 )
 end_test
+
+begin_test "standalone agent without custom group (file transfers allowed)"
+(
+  set -e
+
+  reponame="custom-transfer-standalone-valid-file"
+  setup_remote_repo "$reponame"
+
+  # Clone directly, not through lfstest-gitserver.
+  clone_repo_url "$REMOTEDIR/$reponame.git" "$reponame"
+
+  # When the remote has a file:// URL, we permit the standalone transfer
+  # agent to be set to the internal "lfs-standalone-file" adapter without
+  # any "lfs.customtransfer.*" settings.
+  git config lfs.standaloneTransferAgent lfs-standalone-file
+
+  git lfs track "*.bin"
+
+  contents="a"
+  contents_oid="$(calc_oid "$contents")"
+  printf "%s" "$contents" >a.bin
+
+  git add .gitattributes a.bin
+  git commit -m "initial commit"
+
+  GIT_TRACE=1 git push origin main 2>&1 | tee push.log
+  [ 0 -eq "${PIPESTATUS[0]}" ]
+
+  assert_remote_object "$reponame" "$contents_oid" "${#contents}"
+
+  rm -rf .git/lfs/objects
+
+  GIT_TRACE=1 git lfs pull 2>&1 | tee pull.log
+  [ 0 -eq "${PIPESTATUS[0]}" ]
+
+  [ 0 -eq "$(grep -c "not a registered custom transfer adapter" pull.log)" ]
+
+  assert_local_object "$contents_oid" "${#contents}"
+)
+end_test
+
+begin_test "standalone agent without custom group (file transfers disallowed)"
+(
+  set -e
+
+  reponame="custom-transfer-standalone-invalid-file"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.bin"
+
+  contents="a"
+  contents_oid="$(calc_oid "$contents")"
+  printf "%s" "$contents" >a.bin
+
+  git add .gitattributes a.bin
+  git commit -m "initial commit"
+
+  git push origin main
+
+  # When the remote has an HTTP URL, we expect an error if the standalone
+  # transfer agent is set to the internal "lfs-standalone-file" adapter.
+  git config lfs.standaloneTransferAgent lfs-standalone-file
+
+  rm -rf .git/lfs/objects
+
+  GIT_TRACE=1 git lfs pull 2>&1 | tee pull.log
+  [ 0 -ne "${PIPESTATUS[0]}" ]
+
+  grep "error initializing custom adapter \"lfs-standalone-file\"" pull.log
+  grep "error creating handler: no valid file:// URLs found" pull.log
+  grep "Failed to fetch some objects" pull.log
+
+  [ 0 -eq "$(grep -c "not a registered custom transfer adapter" pull.log)" ]
+
+  refute_local_object "$contents_oid"
+)
+end_test
+
+begin_test "standalone agent without custom group ignored (basic transfers)"
+(
+  set -e
+
+  reponame="custom-transfer-standalone-ignored-basic"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  # The standalone transfer agent should be ignored if it is set to the
+  # internal "basic" adapter, regardless of whether that adapter is
+  # actually used for HTTP requests to the Batch API.
+  git config lfs.standaloneTransferAgent basic
+
+  git lfs track "*.bin"
+
+  contents="a"
+  contents_oid="$(calc_oid "$contents")"
+  printf "%s" "$contents" >a.bin
+
+  git add .gitattributes a.bin
+  git commit -m "initial commit"
+
+  GIT_TRACE=1 git push origin main 2>&1 | tee push.log
+  [ 0 -eq "${PIPESTATUS[0]}" ]
+
+  grep "standalone agent \"basic\" is not a registered custom transfer adapter; ignoring" push.log
+
+  assert_server_object "$reponame" "$contents_oid"
+
+  rm -rf .git/lfs/objects
+
+  GIT_TRACE=1 git lfs pull 2>&1 | tee pull.log
+  [ 0 -eq "${PIPESTATUS[0]}" ]
+
+  grep "standalone agent \"basic\" is not a registered custom transfer adapter; ignoring" pull.log
+
+  assert_local_object "$contents_oid" "${#contents}"
+
+  # The standalone transfer agent should still be ignored even when
+  # a custom transfer adapter is registered with the same name as the
+  # internal "basic" adapter.
+  git config lfs.customTransfer.basic.path path-to-nothing
+
+  contents="b"
+  contents_oid="$(calc_oid "$contents")"
+  printf "%s" "$contents" >b.bin
+
+  git add b.bin
+  git commit -m "second commit"
+
+  GIT_TRACE=1 git push origin main 2>&1 | tee push.log
+  [ 0 -eq "${PIPESTATUS[0]}" ]
+
+  grep "standalone agent \"basic\" is not a registered custom transfer adapter; ignoring" push.log
+
+  assert_server_object "$reponame" "$contents_oid"
+
+  rm -rf .git/lfs/objects
+
+  GIT_TRACE=1 git lfs pull 2>&1 | tee pull.log
+  [ 0 -eq "${PIPESTATUS[0]}" ]
+
+  grep "standalone agent \"basic\" is not a registered custom transfer adapter; ignoring" pull.log
+
+  assert_local_object "$contents_oid" "${#contents}"
+)
+end_test
+
+begin_test "standalone agent without custom group ignored (basic transfers not ssh)"
+(
+  set -e
+
+  reponame="custom-transfer-standalone-ignored-basic-ssh"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  # The standalone transfer agent should be ignored if it is set to the
+  # internal "ssh" adapter, regardless of whether the internal "basic"
+  # adapter will actually be used for HTTP requests to the Batch API.
+  git config lfs.standaloneTransferAgent ssh
+
+  git lfs track "*.bin"
+
+  contents="a"
+  contents_oid="$(calc_oid "$contents")"
+  printf "%s" "$contents" >a.bin
+
+  git add .gitattributes a.bin
+  git commit -m "initial commit"
+
+  GIT_TRACE=1 git push origin main 2>&1 | tee push.log
+  [ 0 -eq "${PIPESTATUS[0]}" ]
+
+  grep "standalone agent \"ssh\" is not a registered custom transfer adapter; ignoring" push.log
+
+  assert_server_object "$reponame" "$contents_oid"
+
+  rm -rf .git/lfs/objects
+
+  GIT_TRACE=1 git lfs pull 2>&1 | tee pull.log
+  [ 0 -eq "${PIPESTATUS[0]}" ]
+
+  grep "standalone agent \"ssh\" is not a registered custom transfer adapter; ignoring" pull.log
+
+  assert_local_object "$contents_oid" "${#contents}"
+
+  # The standalone transfer agent should still be ignored even when
+  # a custom transfer adapter is registered with the same name as the
+  # internal "ssh" adapter.
+  git config lfs.customTransfer.ssh.path path-to-nothing
+
+  contents="b"
+  contents_oid="$(calc_oid "$contents")"
+  printf "%s" "$contents" >b.bin
+
+  git add b.bin
+  git commit -m "second commit"
+
+  GIT_TRACE=1 git push origin main 2>&1 | tee push.log
+  [ 0 -eq "${PIPESTATUS[0]}" ]
+
+  grep "standalone agent \"ssh\" is not a registered custom transfer adapter; ignoring" push.log
+
+  assert_server_object "$reponame" "$contents_oid"
+
+  rm -rf .git/lfs/objects
+
+  GIT_TRACE=1 git lfs pull 2>&1 | tee pull.log
+  [ 0 -eq "${PIPESTATUS[0]}" ]
+
+  grep "standalone agent \"ssh\" is not a registered custom transfer adapter; ignoring" pull.log
+
+  assert_local_object "$contents_oid" "${#contents}"
+)
+end_test
+
+begin_test "standalone agent without custom group ignored (ssh transfers)"
+(
+  set -e
+
+  setup_pure_ssh
+
+  reponame="custom-transfer-standalone-ignored-ssh"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  sshurl=$(ssh_remote "$reponame")
+  git config lfs.url "$sshurl"
+
+  # The standalone transfer agent should be ignored if it is set to the
+  # internal "ssh" adapter, regardless of whether that adapter is
+  # actually used for SSH requests to the Batch API.
+  git config lfs.standaloneTransferAgent ssh
+
+  git lfs track "*.bin"
+
+  contents="a"
+  contents_oid="$(calc_oid "$contents")"
+  printf "%s" "$contents" >a.bin
+
+  git add .gitattributes a.bin
+  git commit -m "initial commit"
+
+  GIT_TRACE=1 git push origin main 2>&1 | tee push.log
+  [ 0 -eq "${PIPESTATUS[0]}" ]
+
+  grep "standalone agent \"ssh\" is not a registered custom transfer adapter; ignoring" push.log
+
+  assert_remote_object "$reponame" "$contents_oid" "${#contents}"
+
+  rm -rf .git/lfs/objects
+
+  GIT_TRACE=1 git lfs pull 2>&1 | tee pull.log
+  [ 0 -eq "${PIPESTATUS[0]}" ]
+
+  grep "standalone agent \"ssh\" is not a registered custom transfer adapter; ignoring" pull.log
+
+  assert_local_object "$contents_oid" "${#contents}"
+
+  # The standalone transfer agent should still be ignored even when
+  # a custom transfer adapter is registered with the same name as the
+  # internal "ssh" adapter.
+  git config lfs.customTransfer.ssh.path path-to-nothing
+
+  contents="b"
+  contents_oid="$(calc_oid "$contents")"
+  printf "%s" "$contents" >b.bin
+
+  git add b.bin
+  git commit -m "second commit"
+
+  GIT_TRACE=1 git push origin main 2>&1 | tee push.log
+  [ 0 -eq "${PIPESTATUS[0]}" ]
+
+  grep "standalone agent \"ssh\" is not a registered custom transfer adapter; ignoring" push.log
+
+  assert_remote_object "$reponame" "$contents_oid" "${#contents}"
+
+  rm -rf .git/lfs/objects
+
+  GIT_TRACE=1 git lfs pull 2>&1 | tee pull.log
+  [ 0 -eq "${PIPESTATUS[0]}" ]
+
+  grep "standalone agent \"ssh\" is not a registered custom transfer adapter; ignoring" pull.log
+
+  assert_local_object "$contents_oid" "${#contents}"
+)
+end_test

--- a/t/t-custom-transfers.sh
+++ b/t/t-custom-transfers.sh
@@ -418,6 +418,8 @@ begin_test "standalone agent without custom group ignored (basic transfers)"
   [ 0 -eq "${PIPESTATUS[0]}" ]
 
   grep "standalone agent \"basic\" is not a registered custom transfer adapter; ignoring" push.log
+  grep "custom upload transfer adapter \"basic\" ignored due to conflict with standard adapter" push.log
+  grep "custom download transfer adapter \"basic\" ignored due to conflict with standard adapter" push.log
 
   assert_server_object "$reponame" "$contents_oid"
 
@@ -427,6 +429,8 @@ begin_test "standalone agent without custom group ignored (basic transfers)"
   [ 0 -eq "${PIPESTATUS[0]}" ]
 
   grep "standalone agent \"basic\" is not a registered custom transfer adapter; ignoring" pull.log
+  grep "custom upload transfer adapter \"basic\" ignored due to conflict with standard adapter" pull.log
+  grep "custom download transfer adapter \"basic\" ignored due to conflict with standard adapter" pull.log
 
   assert_local_object "$contents_oid" "${#contents}"
 )
@@ -486,6 +490,8 @@ begin_test "standalone agent without custom group ignored (basic transfers not s
   [ 0 -eq "${PIPESTATUS[0]}" ]
 
   grep "standalone agent \"ssh\" is not a registered custom transfer adapter; ignoring" push.log
+  grep "custom upload transfer adapter \"ssh\" ignored due to conflict with standard adapter" push.log
+  grep "custom download transfer adapter \"ssh\" ignored due to conflict with standard adapter" push.log
 
   assert_server_object "$reponame" "$contents_oid"
 
@@ -495,6 +501,8 @@ begin_test "standalone agent without custom group ignored (basic transfers not s
   [ 0 -eq "${PIPESTATUS[0]}" ]
 
   grep "standalone agent \"ssh\" is not a registered custom transfer adapter; ignoring" pull.log
+  grep "custom upload transfer adapter \"ssh\" ignored due to conflict with standard adapter" pull.log
+  grep "custom download transfer adapter \"ssh\" ignored due to conflict with standard adapter" pull.log
 
   assert_local_object "$contents_oid" "${#contents}"
 )
@@ -559,6 +567,8 @@ begin_test "standalone agent without custom group ignored (ssh transfers)"
   [ 0 -eq "${PIPESTATUS[0]}" ]
 
   grep "standalone agent \"ssh\" is not a registered custom transfer adapter; ignoring" push.log
+  grep "custom upload transfer adapter \"ssh\" ignored due to conflict with standard adapter" push.log
+  grep "custom download transfer adapter \"ssh\" ignored due to conflict with standard adapter" push.log
 
   assert_remote_object "$reponame" "$contents_oid" "${#contents}"
 
@@ -568,6 +578,8 @@ begin_test "standalone agent without custom group ignored (ssh transfers)"
   [ 0 -eq "${PIPESTATUS[0]}" ]
 
   grep "standalone agent \"ssh\" is not a registered custom transfer adapter; ignoring" pull.log
+  grep "custom upload transfer adapter \"ssh\" ignored due to conflict with standard adapter" pull.log
+  grep "custom download transfer adapter \"ssh\" ignored due to conflict with standard adapter" pull.log
 
   assert_local_object "$contents_oid" "${#contents}"
 )

--- a/tq/basic_download.go
+++ b/tq/basic_download.go
@@ -327,7 +327,7 @@ func (a *basicDownloadAdapter) download(context *basicDownloadAdapterWorkerConte
 }
 
 func configureBasicDownloadAdapter(m *concreteManifest) {
-	m.RegisterNewAdapterFunc(BasicAdapterName, Download, func(name string, dir Direction) Adapter {
+	m.RegisterNewAdapterFunc(BasicAdapterName, Download, false, func(name string, dir Direction) Adapter {
 		switch dir {
 		case Download:
 			bd := &basicDownloadAdapter{newAdapterBase(m.fs, name, dir, nil)}

--- a/tq/basic_upload.go
+++ b/tq/basic_upload.go
@@ -211,7 +211,7 @@ func newStartCallbackReader(r lfsapi.ReadSeekCloser, cb func() error) *startCall
 }
 
 func configureBasicUploadAdapter(m *concreteManifest) {
-	m.RegisterNewAdapterFunc(BasicAdapterName, Upload, func(name string, dir Direction) Adapter {
+	m.RegisterNewAdapterFunc(BasicAdapterName, Upload, false, func(name string, dir Direction) Adapter {
 		switch dir {
 		case Upload:
 			bu := &basicUploadAdapter{newAdapterBase(m.fs, name, dir, nil)}

--- a/tq/custom.go
+++ b/tq/custom.go
@@ -356,8 +356,8 @@ func configureDefaultCustomAdapters(git Env, m *concreteManifest) {
 		standalone := m.standaloneTransferAgent != ""
 		return newCustomAdapter(m.fs, standaloneFileName, dir, "git-lfs", "standalone-file", false, standalone)
 	}
-	m.RegisterNewAdapterFunc(standaloneFileName, Download, newfunc)
-	m.RegisterNewAdapterFunc(standaloneFileName, Upload, newfunc)
+	m.RegisterNewAdapterFunc(standaloneFileName, Download, true, newfunc)
+	m.RegisterNewAdapterFunc(standaloneFileName, Upload, true, newfunc)
 }
 
 // Initialise custom adapters based on current config
@@ -390,10 +390,10 @@ func configureCustomAdapters(git Env, m *concreteManifest) {
 		}
 
 		if direction == "download" || direction == "both" {
-			m.RegisterNewAdapterFunc(name, Download, newfunc)
+			m.RegisterNewAdapterFunc(name, Download, true, newfunc)
 		}
 		if direction == "upload" || direction == "both" {
-			m.RegisterNewAdapterFunc(name, Upload, newfunc)
+			m.RegisterNewAdapterFunc(name, Upload, true, newfunc)
 		}
 	}
 }

--- a/tq/custom.go
+++ b/tq/custom.go
@@ -364,19 +364,20 @@ func configureDefaultCustomAdapters(git Env, m *concreteManifest) {
 func configureCustomAdapters(git Env, m *concreteManifest) {
 	configureDefaultCustomAdapters(git, m)
 
-	pathRegex := regexp.MustCompile(`lfs.customtransfer.([^.]+).path`)
+	pathRegex := regexp.MustCompile(`lfs\.((?i)customtransfer\.([^.]+))\.path`)
 	for k, _ := range git.All() {
 		match := pathRegex.FindStringSubmatch(k)
 		if match == nil {
 			continue
 		}
 
-		name := match[1]
+		subSection := match[1]
+		name := match[2]
 		path, _ := git.Get(k)
 		// retrieve other values
-		args, _ := git.Get(fmt.Sprintf("lfs.customtransfer.%s.args", name))
-		concurrent := git.Bool(fmt.Sprintf("lfs.customtransfer.%s.concurrent", name), true)
-		direction, _ := git.Get(fmt.Sprintf("lfs.customtransfer.%s.direction", name))
+		args, _ := git.Get(fmt.Sprintf("lfs.%s.args", subSection))
+		concurrent := git.Bool(fmt.Sprintf("lfs.%s.concurrent", subSection), true)
+		direction, _ := git.Get(fmt.Sprintf("lfs.%s.direction", subSection))
 		if len(direction) == 0 {
 			direction = "both"
 		} else {

--- a/tq/manifest.go
+++ b/tq/manifest.go
@@ -271,6 +271,22 @@ func newConcreteManifest(f *fs.Filesystem, apiClient *lfsapi.Client, operation, 
 		configureTusAdapter(m)
 	}
 	configureSSHAdapter(m)
+
+	if m.IsStandaloneTransfer() {
+		var dir Direction
+		switch operation {
+		case "download":
+			dir = Download
+		case "upload":
+			dir = Upload
+		}
+
+		if !m.isCustomAdapter(m.standaloneTransferAgent, dir) {
+			tracerx.Printf("standalone agent %q is not a registered custom transfer adapter; ignoring", m.standaloneTransferAgent)
+			m.standaloneTransferAgent = ""
+		}
+	}
+
 	return m
 }
 

--- a/tq/manifest.go
+++ b/tq/manifest.go
@@ -28,11 +28,12 @@ type Manifest interface {
 	GetDownloadAdapterNames() []string
 	GetUploadAdapterNames() []string
 	getAdapterNames(adapters map[string]NewAdapterFunc) []string
-	RegisterNewAdapterFunc(name string, dir Direction, f NewAdapterFunc)
+	RegisterNewAdapterFunc(name string, dir Direction, custom bool, f NewAdapterFunc)
 	NewAdapterOrDefault(name string, dir Direction) Adapter
 	NewAdapter(name string, dir Direction) Adapter
 	NewDownloadAdapter(name string) Adapter
 	NewUploadAdapter(name string) Adapter
+	isCustomAdapter(name string, dir Direction) bool
 	Upgrade() *concreteManifest
 	Upgraded() bool
 }
@@ -96,8 +97,8 @@ func (m *lazyManifest) getAdapterNames(adapters map[string]NewAdapterFunc) []str
 	return m.Upgrade().getAdapterNames(adapters)
 }
 
-func (m *lazyManifest) RegisterNewAdapterFunc(name string, dir Direction, f NewAdapterFunc) {
-	m.Upgrade().RegisterNewAdapterFunc(name, dir, f)
+func (m *lazyManifest) RegisterNewAdapterFunc(name string, dir Direction, custom bool, f NewAdapterFunc) {
+	m.Upgrade().RegisterNewAdapterFunc(name, dir, custom, f)
 }
 
 func (m *lazyManifest) NewAdapterOrDefault(name string, dir Direction) Adapter {
@@ -114,6 +115,10 @@ func (m *lazyManifest) NewDownloadAdapter(name string) Adapter {
 
 func (m *lazyManifest) NewUploadAdapter(name string) Adapter {
 	return m.Upgrade().NewUploadAdapter(name)
+}
+
+func (m *lazyManifest) isCustomAdapter(name string, dir Direction) bool {
+	return m.Upgrade().isCustomAdapter(name, dir)
 }
 
 func (m *lazyManifest) Upgrade() *concreteManifest {
@@ -143,6 +148,8 @@ type concreteManifest struct {
 	tusTransfersAllowed     bool
 	downloadAdapterFuncs    map[string]NewAdapterFunc
 	uploadAdapterFuncs      map[string]NewAdapterFunc
+	customDownloadAdapters  map[string]bool
+	customUploadAdapters    map[string]bool
 	fs                      *fs.Filesystem
 	apiClient               *lfsapi.Client
 	sshTransfer             *ssh.SSHTransfer
@@ -206,12 +213,14 @@ func newConcreteManifest(f *fs.Filesystem, apiClient *lfsapi.Client, operation, 
 	}
 
 	m := &concreteManifest{
-		fs:                   f,
-		apiClient:            apiClient,
-		batchClientAdapter:   &tqClient{Client: apiClient},
-		downloadAdapterFuncs: make(map[string]NewAdapterFunc),
-		uploadAdapterFuncs:   make(map[string]NewAdapterFunc),
-		sshTransfer:          sshTransfer,
+		fs:                     f,
+		apiClient:              apiClient,
+		batchClientAdapter:     &tqClient{Client: apiClient},
+		downloadAdapterFuncs:   make(map[string]NewAdapterFunc),
+		uploadAdapterFuncs:     make(map[string]NewAdapterFunc),
+		customDownloadAdapters: make(map[string]bool),
+		customUploadAdapters:   make(map[string]bool),
+		sshTransfer:            sshTransfer,
 	}
 
 	var tusAllowed bool
@@ -328,15 +337,17 @@ func (m *concreteManifest) getAdapterNames(adapters map[string]NewAdapterFunc) [
 // RegisterNewTransferAdapterFunc registers a new function for creating upload
 // or download adapters. If a function with that name & direction is already
 // registered, it is overridden
-func (m *concreteManifest) RegisterNewAdapterFunc(name string, dir Direction, f NewAdapterFunc) {
+func (m *concreteManifest) RegisterNewAdapterFunc(name string, dir Direction, custom bool, f NewAdapterFunc) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	switch dir {
 	case Upload:
 		m.uploadAdapterFuncs[name] = f
+		m.customUploadAdapters[name] = custom
 	case Download:
 		m.downloadAdapterFuncs[name] = f
+		m.customDownloadAdapters[name] = custom
 	}
 }
 
@@ -380,6 +391,16 @@ func (m *concreteManifest) NewDownloadAdapter(name string) Adapter {
 // Create a new upload adapter by name, or BasicAdapterName if doesn't exist
 func (m *concreteManifest) NewUploadAdapter(name string) Adapter {
 	return m.NewAdapterOrDefault(name, Upload)
+}
+
+func (m *concreteManifest) isCustomAdapter(name string, dir Direction) bool {
+	switch dir {
+	case Upload:
+		return m.customUploadAdapters[name]
+	case Download:
+		return m.customDownloadAdapters[name]
+	}
+	return false
 }
 
 // Env is any object with a config.Environment interface.

--- a/tq/manifest.go
+++ b/tq/manifest.go
@@ -36,7 +36,7 @@ type Manifest interface {
 	NewAdapter(name string, dir Direction) Adapter
 	NewDownloadAdapter(name string) Adapter
 	NewUploadAdapter(name string) Adapter
-	isCustomAdapter(name string, dir Direction) bool
+	isCustomAdapter(name, operation string) bool
 	Upgrade() *concreteManifest
 	Upgraded() bool
 }
@@ -120,8 +120,8 @@ func (m *lazyManifest) NewUploadAdapter(name string) Adapter {
 	return m.Upgrade().NewUploadAdapter(name)
 }
 
-func (m *lazyManifest) isCustomAdapter(name string, dir Direction) bool {
-	return m.Upgrade().isCustomAdapter(name, dir)
+func (m *lazyManifest) isCustomAdapter(name, operation string) bool {
+	return m.Upgrade().isCustomAdapter(name, operation)
 }
 
 func (m *lazyManifest) Upgrade() *concreteManifest {
@@ -276,15 +276,7 @@ func newConcreteManifest(f *fs.Filesystem, apiClient *lfsapi.Client, operation, 
 	configureSSHAdapter(m)
 
 	if m.IsStandaloneTransfer() {
-		var dir Direction
-		switch operation {
-		case "download":
-			dir = Download
-		case "upload":
-			dir = Upload
-		}
-
-		if !m.isCustomAdapter(m.standaloneTransferAgent, dir) {
+		if !m.isCustomAdapter(m.standaloneTransferAgent, operation) {
 			tracerx.Printf("standalone agent %q is not a registered custom transfer adapter; ignoring", m.standaloneTransferAgent)
 			m.standaloneTransferAgent = ""
 		}
@@ -421,11 +413,11 @@ func (m *concreteManifest) NewUploadAdapter(name string) Adapter {
 	return m.NewAdapterOrDefault(name, Upload)
 }
 
-func (m *concreteManifest) isCustomAdapter(name string, dir Direction) bool {
-	switch dir {
-	case Upload:
+func (m *concreteManifest) isCustomAdapter(name, operation string) bool {
+	switch operation {
+	case "upload":
 		return m.customUploadAdapters[name]
-	case Download:
+	case "download":
 		return m.customDownloadAdapters[name]
 	}
 	return false

--- a/tq/manifest.go
+++ b/tq/manifest.go
@@ -1,6 +1,8 @@
 package tq
 
 import (
+	"fmt"
+	"os"
 	"strings"
 	"sync"
 
@@ -9,6 +11,7 @@ import (
 	"github.com/git-lfs/git-lfs/v3/lfsapi"
 	"github.com/git-lfs/git-lfs/v3/lfshttp"
 	"github.com/git-lfs/git-lfs/v3/ssh"
+	"github.com/git-lfs/git-lfs/v3/tr"
 	"github.com/rubyist/tracerx"
 )
 
@@ -357,13 +360,22 @@ func (m *concreteManifest) RegisterNewAdapterFunc(name string, dir Direction, cu
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	var wasCustom bool
 	switch dir {
 	case Upload:
+		wasCustom = m.customUploadAdapters[name]
+
 		m.uploadAdapterFuncs[name] = f
 		m.customUploadAdapters[name] = custom
 	case Download:
+		wasCustom = m.customDownloadAdapters[name]
+
 		m.downloadAdapterFuncs[name] = f
 		m.customDownloadAdapters[name] = custom
+	}
+
+	if wasCustom && !custom {
+		fmt.Fprintln(os.Stderr, tr.Tr.Get("warning: custom %s transfer adapter %q ignored due to conflict with standard adapter", dir, name))
 	}
 }
 

--- a/tq/ssh.go
+++ b/tq/ssh.go
@@ -19,6 +19,10 @@ import (
 	"github.com/rubyist/tracerx"
 )
 
+const (
+	SSHAdapterName = "ssh"
+)
+
 type SSHBatchClient struct {
 	maxRetries int
 	transfer   *ssh.SSHTransfer
@@ -44,7 +48,7 @@ func (a *SSHBatchClient) batchInternal(args []string, batchLines []string) (int,
 }
 
 func (a *SSHBatchClient) Batch(remote string, bReq *batchRequest) (*BatchResponse, error) {
-	bRes := &BatchResponse{TransferAdapterName: "ssh"}
+	bRes := &BatchResponse{TransferAdapterName: SSHAdapterName}
 	if len(bReq.Objects) == 0 {
 		return bRes, nil
 	}
@@ -413,12 +417,12 @@ func (a *SSHAdapter) Trace(format string, args ...interface{}) {
 }
 
 func configureSSHAdapter(m *concreteManifest) {
-	m.RegisterNewAdapterFunc("ssh", Upload, func(name string, dir Direction) Adapter {
+	m.RegisterNewAdapterFunc(SSHAdapterName, Upload, func(name string, dir Direction) Adapter {
 		a := &SSHAdapter{newAdapterBase(m.fs, name, dir, nil), nil, m.sshTransfer}
 		a.transferImpl = a
 		return a
 	})
-	m.RegisterNewAdapterFunc("ssh", Download, func(name string, dir Direction) Adapter {
+	m.RegisterNewAdapterFunc(SSHAdapterName, Download, func(name string, dir Direction) Adapter {
 		a := &SSHAdapter{newAdapterBase(m.fs, name, dir, nil), nil, m.sshTransfer}
 		a.transferImpl = a
 		return a

--- a/tq/ssh.go
+++ b/tq/ssh.go
@@ -420,12 +420,12 @@ func (a *SSHAdapter) Trace(format string, args ...interface{}) {
 }
 
 func configureSSHAdapter(m *concreteManifest) {
-	m.RegisterNewAdapterFunc(SSHAdapterName, Upload, func(name string, dir Direction) Adapter {
+	m.RegisterNewAdapterFunc(SSHAdapterName, Upload, false, func(name string, dir Direction) Adapter {
 		a := &SSHAdapter{newAdapterBase(m.fs, name, dir, nil), nil, m.sshTransfer}
 		a.transferImpl = a
 		return a
 	})
-	m.RegisterNewAdapterFunc(SSHAdapterName, Download, func(name string, dir Direction) Adapter {
+	m.RegisterNewAdapterFunc(SSHAdapterName, Download, false, func(name string, dir Direction) Adapter {
 		a := &SSHAdapter{newAdapterBase(m.fs, name, dir, nil), nil, m.sshTransfer}
 		a.transferImpl = a
 		return a

--- a/tq/ssh.go
+++ b/tq/ssh.go
@@ -158,6 +158,9 @@ type SSHAdapter struct {
 // WorkerStarting is called when a worker goroutine starts to process jobs
 // Implementations can run some startup logic here & return some context if needed
 func (a *SSHAdapter) WorkerStarting(workerNum int) (interface{}, error) {
+	if a.transfer == nil {
+		return nil, errors.New(tr.Tr.Get("missing SSH transfer connection for SSH transfer adapter"))
+	}
 	a.transfer.SetConnectionCountAtLeast(workerNum + 1)
 	return workerNum, nil
 }

--- a/tq/ssh_test.go
+++ b/tq/ssh_test.go
@@ -1,0 +1,19 @@
+package tq
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSSHAdapterWorkerStartingNilTransfer(t *testing.T) {
+	a := &SSHAdapter{
+		adapterBase: newAdapterBase(nil, SSHAdapterName, Download, nil),
+		transfer:    nil,
+	}
+	a.transferImpl = a
+
+	_, err := a.WorkerStarting(0)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "SSH transfer adapter")
+}

--- a/tq/transfer_test.go
+++ b/tq/transfer_test.go
@@ -87,7 +87,10 @@ func TestAdapterRegAndOverride(t *testing.T) {
 		assert.Equal(Upload, ua.Direction())
 	}
 
-	m.RegisterNewAdapterFunc("test", Upload, newTestAdapter)
+	assert.False(m.isCustomAdapter("test", Download))
+	assert.False(m.isCustomAdapter("test", Upload))
+
+	m.RegisterNewAdapterFunc("test", Upload, true, newTestAdapter)
 	assert.Nil(m.NewAdapter("test", Download))
 	assert.NotNil(m.NewAdapter("test", Upload))
 
@@ -103,7 +106,10 @@ func TestAdapterRegAndOverride(t *testing.T) {
 		assert.Equal(Upload, ua.Direction())
 	}
 
-	m.RegisterNewAdapterFunc("test", Download, newTestAdapter)
+	assert.False(m.isCustomAdapter("test", Download))
+	assert.True(m.isCustomAdapter("test", Upload))
+
+	m.RegisterNewAdapterFunc("test", Download, true, newTestAdapter)
 	assert.NotNil(m.NewAdapter("test", Download))
 	assert.NotNil(m.NewAdapter("test", Upload))
 
@@ -119,8 +125,11 @@ func TestAdapterRegAndOverride(t *testing.T) {
 		assert.Equal(Upload, ua.Direction())
 	}
 
+	assert.True(m.isCustomAdapter("test", Download))
+	assert.True(m.isCustomAdapter("test", Upload))
+
 	// Test override
-	m.RegisterNewAdapterFunc("test", Upload, newRenamedTestAdapter)
+	m.RegisterNewAdapterFunc("test", Upload, false, newRenamedTestAdapter)
 	ua = m.NewUploadAdapter("test")
 	if assert.NotNil(ua) {
 		assert.Equal("RENAMED", ua.Name())
@@ -133,12 +142,17 @@ func TestAdapterRegAndOverride(t *testing.T) {
 		assert.Equal(Download, da.Direction())
 	}
 
-	m.RegisterNewAdapterFunc("test", Download, newRenamedTestAdapter)
+	assert.True(m.isCustomAdapter("test", Download))
+	assert.False(m.isCustomAdapter("test", Upload))
+
+	m.RegisterNewAdapterFunc("test", Download, false, newRenamedTestAdapter)
 	da = m.NewDownloadAdapter("test")
 	if assert.NotNil(da) {
 		assert.Equal("RENAMED", da.Name())
 		assert.Equal(Download, da.Direction())
 	}
+
+	assert.False(m.isCustomAdapter("test", Download))
 }
 
 func TestAdapterRegButBasicOnly(t *testing.T) {
@@ -151,8 +165,8 @@ func TestAdapterRegButBasicOnly(t *testing.T) {
 
 	assert := assert.New(t)
 
-	m.RegisterNewAdapterFunc("test", Upload, newTestAdapter)
-	m.RegisterNewAdapterFunc("test", Download, newTestAdapter)
+	m.RegisterNewAdapterFunc("test", Upload, false, newTestAdapter)
+	m.RegisterNewAdapterFunc("test", Download, false, newTestAdapter)
 	// Will still be created if we ask for them
 	da := m.NewDownloadAdapter("test")
 	if assert.NotNil(da) {

--- a/tq/transfer_test.go
+++ b/tq/transfer_test.go
@@ -87,8 +87,9 @@ func TestAdapterRegAndOverride(t *testing.T) {
 		assert.Equal(Upload, ua.Direction())
 	}
 
-	assert.False(m.isCustomAdapter("test", Download))
-	assert.False(m.isCustomAdapter("test", Upload))
+	assert.False(m.isCustomAdapter("test", "download"))
+	assert.False(m.isCustomAdapter("test", "upload"))
+	assert.False(m.isCustomAdapter("test", ""))
 
 	m.RegisterNewAdapterFunc("test", Upload, true, newTestAdapter)
 	assert.Nil(m.NewAdapter("test", Download))
@@ -106,8 +107,8 @@ func TestAdapterRegAndOverride(t *testing.T) {
 		assert.Equal(Upload, ua.Direction())
 	}
 
-	assert.False(m.isCustomAdapter("test", Download))
-	assert.True(m.isCustomAdapter("test", Upload))
+	assert.False(m.isCustomAdapter("test", "download"))
+	assert.True(m.isCustomAdapter("test", "upload"))
 
 	m.RegisterNewAdapterFunc("test", Download, true, newTestAdapter)
 	assert.NotNil(m.NewAdapter("test", Download))
@@ -125,8 +126,9 @@ func TestAdapterRegAndOverride(t *testing.T) {
 		assert.Equal(Upload, ua.Direction())
 	}
 
-	assert.True(m.isCustomAdapter("test", Download))
-	assert.True(m.isCustomAdapter("test", Upload))
+	assert.True(m.isCustomAdapter("test", "download"))
+	assert.True(m.isCustomAdapter("test", "upload"))
+	assert.False(m.isCustomAdapter("test", ""))
 
 	// Test override
 	m.RegisterNewAdapterFunc("test", Upload, false, newRenamedTestAdapter)
@@ -142,8 +144,8 @@ func TestAdapterRegAndOverride(t *testing.T) {
 		assert.Equal(Download, da.Direction())
 	}
 
-	assert.True(m.isCustomAdapter("test", Download))
-	assert.False(m.isCustomAdapter("test", Upload))
+	assert.True(m.isCustomAdapter("test", "download"))
+	assert.False(m.isCustomAdapter("test", "upload"))
 
 	m.RegisterNewAdapterFunc("test", Download, false, newRenamedTestAdapter)
 	da = m.NewDownloadAdapter("test")
@@ -152,7 +154,7 @@ func TestAdapterRegAndOverride(t *testing.T) {
 		assert.Equal(Download, da.Direction())
 	}
 
-	assert.False(m.isCustomAdapter("test", Download))
+	assert.False(m.isCustomAdapter("test", "download"))
 }
 
 func TestAdapterRegButBasicOnly(t *testing.T) {

--- a/tq/tus_upload.go
+++ b/tq/tus_upload.go
@@ -156,7 +156,7 @@ func (a *tusUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb ProgressC
 }
 
 func configureTusAdapter(m *concreteManifest) {
-	m.RegisterNewAdapterFunc(TusAdapterName, Upload, func(name string, dir Direction) Adapter {
+	m.RegisterNewAdapterFunc(TusAdapterName, Upload, false, func(name string, dir Direction) Adapter {
 		switch dir {
 		case Upload:
 			bu := &tusUploadAdapter{newAdapterBase(m.fs, name, dir, nil)}


### PR DESCRIPTION
As reported in #6144, the Git LFS client may crash when the `lfs.standaloneTransferAgent` configuration option is set to `ssh`, but the remote Git LFS service does not have an SSH URL or does not support the "pure" SSH-only Git LFS transfer protocol.

First, this PR resolves the crash by guarding against a `nil` value when the `SSHAdapter` structure's `WorkerStarting()` method tries to [dereference](https://github.com/git-lfs/git-lfs/blob/4f71871c143dc9898addeb6fc1c0969bbf073fac/tq/ssh.go#L157) the structure's `transfer` element.

Second, this PR introduces a check on the value of the `lfs.standaloneTransferAgent` configuration option to ensure that it references a valid custom transfer adapter, since it is not intended to be set with the name of an internal non-standalone adapter such as our `basic` (i.e., HTTP) or `ssh` adapters.  If the option is set to the name of one of these adapters, or to an adapter name not registered with an `lfs.customTransfer.<name>.path` option, it will now be ignored.  Note, though, that we do allow the `lfs.standaloneTransferAgent` to be set with the name of the internal `lfs-standalone-file` adapter, since it is an adapter which functions in standalone mode.

To make it possible to perform this check on the validity of the `lfs.standaloneTransferAgent` option's value, we add several internal maps to our `concreteManifest` [structure](https://github.com/git-lfs/git-lfs/blob/4f71871c143dc9898addeb6fc1c0969bbf073fac/tq/manifest.go#L134-L151), and update the `RegisterNewAdapterFunc()` [method](https://github.com/git-lfs/git-lfs/blob/4f71871c143dc9898addeb6fc1c0969bbf073fac/tq/manifest.go#L328-L341) so it now requires a flag indicating whether a given adapter is considered a custom adapter or not.

We then add a number of new tests to our `t/t-custom-transfers.sh` shell test script to verify that our changes are effective, and expand the checks of the `RegisterNewAdapterFunc()` method in our Go test suite.

As well, we take the opportunity to introduce an `SSHAdapterName` constant for our `ssh` adapter, and to update our documentation of the `lfs.standaloneTransferAgent` and `lfs.customTransfer.<name>.path` configuration options.

This PR will be most easily reviewed on a commit-by-commit basis, with whitespace differences ignored.


Fixes #6144.
/cc @matan7890 as reporter.