### PR TITLE
Simplify client structure initializations

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -92,11 +92,10 @@ func closeAPIClient() error {
 }
 
 func newLockClient() *locking.Client {
-	lockClient, err := locking.NewClient(cfg.PushRemote(), getAPIClient(), cfg)
-	if err == nil {
-		tools.MkdirAll(cfg.LFSStorageDir(), cfg)
-		err = lockClient.SetupFileCache(cfg.LFSStorageDir())
-	}
+	lockClient := locking.NewClient(cfg.PushRemote(), getAPIClient(), cfg)
+
+	tools.MkdirAll(cfg.LFSStorageDir(), cfg)
+	err := lockClient.SetupFileCache(cfg.LFSStorageDir())
 
 	if err != nil {
 		Exit(tr.Tr.Get("Unable to create lock system: %v", err.Error()))

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -77,11 +77,7 @@ func getAPIClient() *lfsapi.Client {
 	defer global.Unlock()
 
 	if apiClient == nil {
-		c, err := lfsapi.NewClient(cfg)
-		if err != nil {
-			ExitWithError(err)
-		}
-		apiClient = c
+		apiClient = lfsapi.NewClient(cfg)
 	}
 	return apiClient
 }

--- a/lfs/lfs.go
+++ b/lfs/lfs.go
@@ -19,11 +19,7 @@ func Environ(cfg *config.Configuration, manifest tq.Manifest, envOverrides map[s
 	osEnviron := os.Environ()
 	env := make([]string, 0, len(osEnviron)+7)
 
-	api, err := lfsapi.NewClient(cfg)
-	if err != nil {
-		// TODO(@ttaylorr): don't panic
-		panic(err.Error())
-	}
+	api := lfsapi.NewClient(cfg)
 
 	if envOverrides == nil {
 		envOverrides = make(map[string]string, 0)

--- a/lfsapi/auth_test.go
+++ b/lfsapi/auth_test.go
@@ -83,12 +83,11 @@ func TestDoWithAuthApprove(t *testing.T) {
 	defer srv.Close()
 
 	cred := newMockCredentialHelper()
-	c, err := NewClient(lfshttp.NewContext(git.NewReadOnlyConfig("", ""),
+	c := NewClient(lfshttp.NewContext(git.NewReadOnlyConfig("", ""),
 		nil, map[string]string{
 			"lfs.url": srv.URL + "/repo/lfs",
 		},
 	))
-	require.Nil(t, err)
 	c.Credentials = cred
 
 	access := c.Endpoints.AccessFor(srv.URL + "/repo/lfs")
@@ -155,7 +154,7 @@ func TestDoWithAuthReject(t *testing.T) {
 	cred.Approve(invalidCreds)
 	assert.True(t, cred.IsApproved(invalidCreds))
 
-	c, _ := NewClient(nil)
+	c := NewClient(nil)
 	c.Credentials = cred
 	c.Endpoints = NewEndpointFinder(lfshttp.NewContext(git.NewReadOnlyConfig("", ""),
 		nil, map[string]string{
@@ -211,12 +210,11 @@ func TestDoWithAuthNoRetry(t *testing.T) {
 	defer srv.Close()
 
 	cred := newMockCredentialHelper()
-	c, err := NewClient(lfshttp.NewContext(git.NewReadOnlyConfig("", ""),
+	c := NewClient(lfshttp.NewContext(git.NewReadOnlyConfig("", ""),
 		nil, map[string]string{
 			"lfs.url": srv.URL + "/repo/lfs",
 		},
 	))
-	require.Nil(t, err)
 	c.Credentials = cred
 
 	access := c.Endpoints.AccessFor(srv.URL + "/repo/lfs")
@@ -254,12 +252,11 @@ func TestDoWithAuthRetryLimitExceeded(t *testing.T) {
 	defer srv.Close()
 
 	cred := newMockCredentialHelper()
-	c, err := NewClient(lfshttp.NewContext(git.NewReadOnlyConfig("", ""),
+	c := NewClient(lfshttp.NewContext(git.NewReadOnlyConfig("", ""),
 		nil, map[string]string{
 			"lfs.url": srv.URL + "/repo/lfs",
 		},
 	))
-	require.Nil(t, err)
 	c.Credentials = cred
 
 	access := c.Endpoints.AccessFor(srv.URL + "/repo/lfs")
@@ -291,12 +288,11 @@ func TestDoWithAuthNoRetryOn401WhenAuthHeaderPresent(t *testing.T) {
 	defer srv.Close()
 
 	cred := newMockCredentialHelper()
-	c, err := NewClient(lfshttp.NewContext(git.NewReadOnlyConfig("", ""),
+	c := NewClient(lfshttp.NewContext(git.NewReadOnlyConfig("", ""),
 		nil, map[string]string{
 			"lfs.url": srv.URL + "/repo/lfs",
 		},
 	))
-	require.Nil(t, err)
 	c.Credentials = cred
 
 	req, err := http.NewRequest("POST", srv.URL+"/repo/lfs/foo", nil)
@@ -333,12 +329,11 @@ func TestDoWithAuthMultistageRetryLimitExceeded(t *testing.T) {
 	defer srv.Close()
 
 	cred := newNonAdvancingMultistageHelper()
-	c, err := NewClient(lfshttp.NewContext(git.NewReadOnlyConfig("", ""),
+	c := NewClient(lfshttp.NewContext(git.NewReadOnlyConfig("", ""),
 		nil, map[string]string{
 			"lfs.url": srv.URL + "/repo/lfs",
 		},
 	))
-	require.Nil(t, err)
 	c.Credentials = cred
 
 	req, err := http.NewRequest("POST", srv.URL+"/repo/lfs/foo", nil)
@@ -403,12 +398,11 @@ func TestDoAPIRequestWithAuth(t *testing.T) {
 	defer srv.Close()
 
 	cred := newMockCredentialHelper()
-	c, err := NewClient(lfshttp.NewContext(git.NewReadOnlyConfig("", ""),
+	c := NewClient(lfshttp.NewContext(git.NewReadOnlyConfig("", ""),
 		nil, map[string]string{
 			"lfs.url": srv.URL + "/repo/lfs",
 		},
 	))
-	require.Nil(t, err)
 	c.Credentials = cred
 
 	access := c.Endpoints.AccessFor(srv.URL + "/repo/lfs")
@@ -788,7 +782,7 @@ func TestGetCreds(t *testing.T) {
 		}
 
 		ctx := lfshttp.NewContext(git.NewReadOnlyConfig("", ""), nil, test.Config)
-		client, _ := NewClient(ctx)
+		client := NewClient(ctx)
 		client.Credentials = &fakeCredentialFiller{}
 		client.Endpoints = NewEndpointFinder(ctx)
 		credWrapper, err := client.getCreds(test.Remote, client.Endpoints.AccessFor(test.Endpoint), req)
@@ -893,7 +887,7 @@ func TestClientRedirectReauthenticate(t *testing.T) {
 	defer srv1.Close()
 	defer srv2.Close()
 
-	c, err := NewClient(lfshttp.NewContext(nil, nil, nil))
+	c := NewClient(lfshttp.NewContext(nil, nil, nil))
 	cred := creds.NewCredentialCacher()
 	cred.Approve(creds1)
 	cred.Approve(creds2)

--- a/lfsapi/lfsapi.go
+++ b/lfsapi/lfsapi.go
@@ -3,10 +3,8 @@ package lfsapi
 import (
 	"github.com/git-lfs/git-lfs/v3/config"
 	"github.com/git-lfs/git-lfs/v3/creds"
-	"github.com/git-lfs/git-lfs/v3/errors"
 	"github.com/git-lfs/git-lfs/v3/lfshttp"
 	"github.com/git-lfs/git-lfs/v3/ssh"
-	"github.com/git-lfs/git-lfs/v3/tr"
 	"github.com/rubyist/tracerx"
 )
 
@@ -29,14 +27,10 @@ func NewClient(ctx lfshttp.Context) (*Client, error) {
 	gitEnv := ctx.GitEnv()
 	osEnv := ctx.OSEnv()
 
-	httpClient, err := lfshttp.NewClient(ctx)
-	if err != nil {
-		return nil, errors.Wrap(err, tr.Tr.Get("error creating HTTP client"))
-	}
 
 	c := &Client{
 		Endpoints:   NewEndpointFinder(ctx),
-		client:      httpClient,
+		client:      lfshttp.NewClient(ctx),
 		context:     ctx,
 		credContext: creds.NewCredentialHelperContext(gitEnv, osEnv),
 		access:      creds.AllAccessModes(),

--- a/lfsapi/lfsapi.go
+++ b/lfsapi/lfsapi.go
@@ -19,7 +19,7 @@ type Client struct {
 	access  []creds.AccessMode
 }
 
-func NewClient(ctx lfshttp.Context) (*Client, error) {
+func NewClient(ctx lfshttp.Context) *Client {
 	if ctx == nil {
 		ctx = lfshttp.NewContext(nil, nil, nil)
 	}
@@ -27,16 +27,13 @@ func NewClient(ctx lfshttp.Context) (*Client, error) {
 	gitEnv := ctx.GitEnv()
 	osEnv := ctx.OSEnv()
 
-
-	c := &Client{
+	return &Client{
 		Endpoints:   NewEndpointFinder(ctx),
 		client:      lfshttp.NewClient(ctx),
 		context:     ctx,
 		credContext: creds.NewCredentialHelperContext(gitEnv, osEnv),
 		access:      creds.AllAccessModes(),
 	}
-
-	return c, nil
 }
 
 func (c *Client) Context() lfshttp.Context {

--- a/lfsapi/response_test.go
+++ b/lfsapi/response_test.go
@@ -29,7 +29,7 @@ func TestAuthErrWithBody(t *testing.T) {
 	req, err := http.NewRequest("GET", srv.URL+"/test", nil)
 	assert.Nil(t, err)
 
-	c, _ := NewClient(nil)
+	c := NewClient(nil)
 	_, err = c.Do(req)
 	assert.NotNil(t, err)
 	assert.True(t, errors.IsAuthError(err))
@@ -55,7 +55,7 @@ func TestFatalWithBody(t *testing.T) {
 	req, err := http.NewRequest("GET", srv.URL+"/test", nil)
 	assert.Nil(t, err)
 
-	c, _ := NewClient(nil)
+	c := NewClient(nil)
 	_, err = c.Do(req)
 	assert.NotNil(t, err)
 	assert.True(t, errors.IsFatalError(err))
@@ -64,7 +64,7 @@ func TestFatalWithBody(t *testing.T) {
 }
 
 func TestWithNonFatal500WithBody(t *testing.T) {
-	c, _ := NewClient(nil)
+	c := NewClient(nil)
 
 	var called uint32
 
@@ -116,7 +116,7 @@ func TestAuthErrWithoutBody(t *testing.T) {
 	req, err := http.NewRequest("GET", srv.URL+"/test", nil)
 	assert.Nil(t, err)
 
-	c, _ := NewClient(nil)
+	c := NewClient(nil)
 	_, err = c.Do(req)
 	assert.NotNil(t, err)
 	assert.True(t, errors.IsAuthError(err))
@@ -140,7 +140,7 @@ func TestFatalWithoutBody(t *testing.T) {
 	req, err := http.NewRequest("GET", srv.URL+"/test", nil)
 	assert.Nil(t, err)
 
-	c, _ := NewClient(nil)
+	c := NewClient(nil)
 	_, err = c.Do(req)
 	assert.NotNil(t, err)
 	assert.True(t, errors.IsFatalError(err))
@@ -149,7 +149,7 @@ func TestFatalWithoutBody(t *testing.T) {
 }
 
 func TestWithNonFatal500WithoutBody(t *testing.T) {
-	c, _ := NewClient(nil)
+	c := NewClient(nil)
 
 	var called uint32
 

--- a/lfshttp/certs_test.go
+++ b/lfshttp/certs_test.go
@@ -67,10 +67,9 @@ func TestCertFromSSLCAInfoConfig(t *testing.T) {
 	// Test http.<url>.sslcainfo
 	for _, hostName := range sslCAInfoConfigHostNames {
 		hostKey := fmt.Sprintf("http.https://%v.sslcainfo", hostName)
-		c, err := NewClient(NewContext(nil, nil, map[string]string{
+		c := NewClient(NewContext(nil, nil, map[string]string{
 			hostKey: tempfile.Name(),
 		}))
-		assert.Nil(t, err)
 
 		for _, matchedHostTest := range sslCAInfoMatchedHostTests {
 			pool := getRootCAsForHostFromGitconfig(c, matchedHostTest.hostName)
@@ -89,10 +88,9 @@ func TestCertFromSSLCAInfoConfig(t *testing.T) {
 	}
 
 	// Test http.sslcainfo
-	c, err := NewClient(NewContext(nil, nil, map[string]string{
+	c := NewClient(NewContext(nil, nil, map[string]string{
 		"http.sslcainfo": tempfile.Name(),
 	}))
-	assert.Nil(t, err)
 
 	// Should match any host at all
 	for _, matchedHostTest := range sslCAInfoMatchedHostTests {
@@ -110,10 +108,9 @@ func TestCertFromSSLCAInfoEnv(t *testing.T) {
 	assert.Nil(t, err, "Error writing temp cert file")
 	tempfile.Close()
 
-	c, err := NewClient(NewContext(nil, map[string]string{
+	c := NewClient(NewContext(nil, map[string]string{
 		"GIT_SSL_CAINFO": tempfile.Name(),
 	}, nil))
-	assert.Nil(t, err)
 
 	// Should match any host at all
 	for _, matchedHostTest := range sslCAInfoMatchedHostTests {
@@ -131,12 +128,11 @@ func TestCertFromSSLCAInfoEnvIsIgnoredForSchannelBackend(t *testing.T) {
 	assert.Nil(t, err, "Error writing temp cert file")
 	tempfile.Close()
 
-	c, err := NewClient(NewContext(nil, map[string]string{
+	c := NewClient(NewContext(nil, map[string]string{
 		"GIT_SSL_CAINFO": tempfile.Name(),
 	}, map[string]string{
 		"http.sslbackend": "schannel",
 	}))
-	assert.Nil(t, err)
 
 	// Should match any host at all
 	for _, matchedHostTest := range sslCAInfoMatchedHostTests {
@@ -154,13 +150,12 @@ func TestCertFromSSLCAInfoEnvWithSchannelBackend(t *testing.T) {
 	assert.Nil(t, err, "Error writing temp cert file")
 	tempfile.Close()
 
-	c, err := NewClient(NewContext(nil, map[string]string{
+	c := NewClient(NewContext(nil, map[string]string{
 		"GIT_SSL_CAINFO": tempfile.Name(),
 	}, map[string]string{
 		"http.sslbackend":           "schannel",
 		"http.schannelusesslcainfo": "1",
 	}))
-	assert.Nil(t, err)
 
 	// Should match any host at all
 	for _, matchedHostTest := range sslCAInfoMatchedHostTests {
@@ -175,11 +170,9 @@ func TestCertFromSSLCAPathConfig(t *testing.T) {
 	err := os.WriteFile(filepath.Join(tempdir, "cert1.pem"), []byte(testCert), 0644)
 	assert.Nil(t, err, "Error creating cert file")
 
-	c, err := NewClient(NewContext(nil, nil, map[string]string{
+	c := NewClient(NewContext(nil, nil, map[string]string{
 		"http.sslcapath": tempdir,
 	}))
-
-	assert.Nil(t, err)
 
 	// Should match any host at all
 	for _, matchedHostTest := range sslCAInfoMatchedHostTests {
@@ -194,10 +187,9 @@ func TestCertFromSSLCAPathEnv(t *testing.T) {
 	err := os.WriteFile(filepath.Join(tempdir, "cert1.pem"), []byte(testCert), 0644)
 	assert.Nil(t, err, "Error creating cert file")
 
-	c, err := NewClient(NewContext(nil, map[string]string{
+	c := NewClient(NewContext(nil, map[string]string{
 		"GIT_SSL_CAPATH": tempdir,
 	}, nil))
-	assert.Nil(t, err)
 
 	// Should match any host at all
 	for _, matchedHostTest := range sslCAInfoMatchedHostTests {
@@ -207,18 +199,16 @@ func TestCertFromSSLCAPathEnv(t *testing.T) {
 }
 
 func TestCertVerifyDisabledGlobalEnv(t *testing.T) {
-	empty, _ := NewClient(nil)
+	empty := NewClient(nil)
 	httpClient := clientForHost(empty, "anyhost.com")
 	tr, ok := httpClient.Transport.(*http.Transport)
 	if assert.True(t, ok) {
 		assert.False(t, tr.TLSClientConfig.InsecureSkipVerify)
 	}
 
-	c, err := NewClient(NewContext(nil, map[string]string{
+	c := NewClient(NewContext(nil, map[string]string{
 		"GIT_SSL_NO_VERIFY": "1",
 	}, nil))
-
-	assert.Nil(t, err)
 
 	httpClient = clientForHost(c, "anyhost.com")
 	tr, ok = httpClient.Transport.(*http.Transport)
@@ -228,17 +218,16 @@ func TestCertVerifyDisabledGlobalEnv(t *testing.T) {
 }
 
 func TestCertVerifyDisabledGlobalConfig(t *testing.T) {
-	def, _ := NewClient(nil)
+	def := NewClient(nil)
 	httpClient := clientForHost(def, "anyhost.com")
 	tr, ok := httpClient.Transport.(*http.Transport)
 	if assert.True(t, ok) {
 		assert.False(t, tr.TLSClientConfig.InsecureSkipVerify)
 	}
 
-	c, err := NewClient(NewContext(nil, nil, map[string]string{
+	c := NewClient(NewContext(nil, nil, map[string]string{
 		"http.sslverify": "false",
 	}))
-	assert.Nil(t, err)
 
 	httpClient = clientForHost(c, "anyhost.com")
 	tr, ok = httpClient.Transport.(*http.Transport)
@@ -248,7 +237,7 @@ func TestCertVerifyDisabledGlobalConfig(t *testing.T) {
 }
 
 func TestCertVerifyDisabledHostConfig(t *testing.T) {
-	def, _ := NewClient(nil)
+	def := NewClient(nil)
 	httpClient := clientForHost(def, "specifichost.com")
 	tr, ok := httpClient.Transport.(*http.Transport)
 	if assert.True(t, ok) {
@@ -261,10 +250,9 @@ func TestCertVerifyDisabledHostConfig(t *testing.T) {
 		assert.False(t, tr.TLSClientConfig.InsecureSkipVerify)
 	}
 
-	c, err := NewClient(NewContext(nil, nil, map[string]string{
+	c := NewClient(NewContext(nil, nil, map[string]string{
 		"http.https://specifichost.com/.sslverify": "false",
 	}))
-	assert.Nil(t, err)
 
 	httpClient = clientForHost(c, "specifichost.com")
 	tr, ok = httpClient.Transport.(*http.Transport)

--- a/lfshttp/client.go
+++ b/lfshttp/client.go
@@ -83,7 +83,7 @@ type Client struct {
 	sshTries int
 }
 
-func NewClient(ctx Context) (*Client, error) {
+func NewClient(ctx Context) *Client {
 	if ctx == nil {
 		ctx = NewContext(nil, nil, nil)
 	}
@@ -97,7 +97,7 @@ func NewClient(ctx Context) (*Client, error) {
 		sshResolver = withSSHCache(sshResolver)
 	}
 
-	c := &Client{
+	return &Client{
 		SSH:                 sshResolver,
 		DialTimeout:         gitEnv.Int("lfs.dialtimeout", 0),
 		KeepaliveTimeout:    gitEnv.Int("lfs.keepalive", 0),
@@ -112,8 +112,6 @@ func NewClient(ctx Context) (*Client, error) {
 		sshTries:            gitEnv.Int("lfs.ssh.retries", 5),
 		credHelperContext:   creds.NewCredentialHelperContext(gitEnv, osEnv),
 	}
-
-	return c, nil
 }
 
 func (c *Client) GitEnv() config.Environment {

--- a/lfshttp/client.go
+++ b/lfshttp/client.go
@@ -92,6 +92,10 @@ func NewClient(ctx Context) *Client {
 	osEnv := ctx.OSEnv()
 
 	cacheCreds := gitEnv.Bool("lfs.cachecredentials", true)
+
+	// SSHResolver resolves LFS endpoint authentication by running
+	// git-lfs-authenticate over SSH. The returned credentials (URL
+	// and headers) are then used for subsequent HTTPS API requests.
 	var sshResolver SSHResolver = &sshAuthClient{os: osEnv, git: gitEnv}
 	if cacheCreds {
 		sshResolver = withSSHCache(sshResolver)

--- a/lfshttp/client_test.go
+++ b/lfshttp/client_test.go
@@ -114,14 +114,13 @@ func TestClientRedirect(t *testing.T) {
 	srv3Https = srv3.URL
 	srv3Http = fmt.Sprintf("http://%s", srv3InsecureListener.Addr().String())
 
-	c, err := NewClient(NewContext(nil, nil, map[string]string{
+	c := NewClient(NewContext(nil, nil, map[string]string{
 		fmt.Sprintf("http.%s.sslverify", srv3Https):  "false",
 		fmt.Sprintf("http.%s/.sslverify", srv3Https): "false",
 		fmt.Sprintf("http.%s.sslverify", srv3Http):   "false",
 		fmt.Sprintf("http.%s/.sslverify", srv3Http):  "false",
 		fmt.Sprintf("http.sslverify"):                "false",
 	}))
-	require.Nil(t, err)
 
 	// local redirect
 	req, err := http.NewRequest("POST", srv1.URL+"/local", nil)
@@ -179,14 +178,13 @@ func TestClientRedirect(t *testing.T) {
 }
 
 func TestNewClient(t *testing.T) {
-	c, err := NewClient(NewContext(nil, nil, map[string]string{
+	c := NewClient(NewContext(nil, nil, map[string]string{
 		"lfs.dialtimeout":         "151",
 		"lfs.keepalive":           "152",
 		"lfs.tlstimeout":          "153",
 		"lfs.concurrenttransfers": "154",
 	}))
 
-	require.Nil(t, err)
 	assert.Equal(t, 151, c.DialTimeout)
 	assert.Equal(t, 152, c.KeepaliveTimeout)
 	assert.Equal(t, 153, c.TLSTimeout)
@@ -194,49 +192,43 @@ func TestNewClient(t *testing.T) {
 }
 
 func TestNewClientWithGitSSLVerify(t *testing.T) {
-	c, err := NewClient(nil)
-	assert.Nil(t, err)
+	c := NewClient(nil)
 	assert.False(t, c.SkipSSLVerify)
 
 	for _, value := range []string{"true", "1", "t"} {
-		c, err = NewClient(NewContext(nil, nil, map[string]string{
+		c = NewClient(NewContext(nil, nil, map[string]string{
 			"http.sslverify": value,
 		}))
 		t.Logf("http.sslverify: %q", value)
-		assert.Nil(t, err)
 		assert.False(t, c.SkipSSLVerify)
 	}
 
 	for _, value := range []string{"false", "0", "f"} {
-		c, err = NewClient(NewContext(nil, nil, map[string]string{
+		c = NewClient(NewContext(nil, nil, map[string]string{
 			"http.sslverify": value,
 		}))
 		t.Logf("http.sslverify: %q", value)
-		assert.Nil(t, err)
 		assert.True(t, c.SkipSSLVerify)
 	}
 }
 
 func TestNewClientWithOSSSLVerify(t *testing.T) {
-	c, err := NewClient(nil)
-	assert.Nil(t, err)
+	c := NewClient(nil)
 	assert.False(t, c.SkipSSLVerify)
 
 	for _, value := range []string{"false", "0", "f"} {
-		c, err = NewClient(NewContext(nil, map[string]string{
+		c = NewClient(NewContext(nil, map[string]string{
 			"GIT_SSL_NO_VERIFY": value,
 		}, nil))
 		t.Logf("GIT_SSL_NO_VERIFY: %q", value)
-		assert.Nil(t, err)
 		assert.False(t, c.SkipSSLVerify)
 	}
 
 	for _, value := range []string{"true", "1", "t"} {
-		c, err = NewClient(NewContext(nil, map[string]string{
+		c = NewClient(NewContext(nil, map[string]string{
 			"GIT_SSL_NO_VERIFY": value,
 		}, nil))
 		t.Logf("GIT_SSL_NO_VERIFY: %q", value)
-		assert.Nil(t, err)
 		assert.True(t, c.SkipSSLVerify)
 	}
 }
@@ -250,8 +242,7 @@ func TestNewRequest(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		c, err := NewClient(NewContext(nil, nil, nil))
-		require.Nil(t, err)
+		c := NewClient(NewContext(nil, nil, nil))
 
 		req, err := c.NewRequest("POST", Endpoint{Url: test[0]}, test[1], nil)
 		require.Nil(t, err)
@@ -261,8 +252,7 @@ func TestNewRequest(t *testing.T) {
 }
 
 func TestNewRequestWithBody(t *testing.T) {
-	c, err := NewClient(NewContext(nil, nil, nil))
-	require.Nil(t, err)
+	c := NewClient(NewContext(nil, nil, nil))
 
 	body := struct {
 		Test string
@@ -316,10 +306,9 @@ func TestHttp2(t *testing.T) {
 	defer srvTLS.Close()
 	defer srv.Close()
 
-	c, err := NewClient(NewContext(nil, nil, map[string]string{
+	c := NewClient(NewContext(nil, nil, map[string]string{
 		fmt.Sprintf("http.sslverify"): "false",
 	}))
-	require.Nil(t, err)
 
 	req, err := http.NewRequest("GET", srvTLS.URL, nil)
 	require.Nil(t, err)
@@ -374,11 +363,10 @@ func TestHttpVersion(t *testing.T) {
 		defer srvTLS.Close()
 		defer srv.Close()
 
-		c, err := NewClient(NewContext(nil, nil, map[string]string{
+		c := NewClient(NewContext(nil, nil, map[string]string{
 			"http.sslverify": "false",
 			"http.version":   test.Setting,
 		}))
-		require.Nil(t, err)
 
 		req, err := http.NewRequest("GET", srvTLS.URL, nil)
 		require.Nil(t, err)
@@ -432,8 +420,7 @@ func TestExtraHeadersForDuplication(t *testing.T) {
 		})),
 	}
 
-	c, err := NewClient(context)
-	require.Nil(t, err)
+	c := NewClient(context)
 
 	t.Logf("Configured extraHeader: %v", c.GitEnv().GetAll("http.extraHeader"))
 

--- a/lfshttp/proxy_test.go
+++ b/lfshttp/proxy_test.go
@@ -9,12 +9,11 @@ import (
 )
 
 func TestHttpsProxyFromGitConfig(t *testing.T) {
-	c, err := NewClient(NewContext(nil, map[string]string{
+	c := NewClient(NewContext(nil, map[string]string{
 		"HTTPS_PROXY": "https://proxy-from-env:8080",
 	}, map[string]string{
 		"http.proxy": "https://proxy-from-git-config:8080",
 	}))
-	require.Nil(t, err)
 
 	req, err := http.NewRequest("GET", "https://some-host.com:123/foo/bar", nil)
 	require.Nil(t, err)
@@ -25,11 +24,10 @@ func TestHttpsProxyFromGitConfig(t *testing.T) {
 }
 
 func TestProxyForURL(t *testing.T) {
-	c, err := NewClient(NewContext(nil, nil, map[string]string{
+	c := NewClient(NewContext(nil, nil, map[string]string{
 		"http.proxy":                           "https://proxy-for-everyone:8080",
 		"http.https://some-host.com:123.proxy": "https://proxy-for-some-host:8080",
 	}))
-	require.Nil(t, err)
 
 	req, err := http.NewRequest("GET", "https://some-host.com:123/foo/bar", nil)
 	require.Nil(t, err)
@@ -40,12 +38,11 @@ func TestProxyForURL(t *testing.T) {
 }
 
 func TestHttpProxyFromGitConfig(t *testing.T) {
-	c, err := NewClient(NewContext(nil, map[string]string{
+	c := NewClient(NewContext(nil, map[string]string{
 		"HTTPS_PROXY": "https://proxy-from-env:8080",
 	}, map[string]string{
 		"http.proxy": "http://proxy-from-git-config:8080",
 	}))
-	require.Nil(t, err)
 
 	req, err := http.NewRequest("GET", "http://some-host.com:123/foo/bar", nil)
 	require.Nil(t, err)
@@ -56,10 +53,9 @@ func TestHttpProxyFromGitConfig(t *testing.T) {
 }
 
 func TestProxyFromEnvironment(t *testing.T) {
-	c, err := NewClient(NewContext(nil, map[string]string{
+	c := NewClient(NewContext(nil, map[string]string{
 		"HTTPS_PROXY": "https://proxy-from-env:8080",
 	}, nil))
-	require.Nil(t, err)
 
 	req, err := http.NewRequest("GET", "https://some-host.com:123/foo/bar", nil)
 	require.Nil(t, err)
@@ -70,10 +66,9 @@ func TestProxyFromEnvironment(t *testing.T) {
 }
 
 func TestHTTPSProxyFromEnvironment(t *testing.T) {
-	c, err := NewClient(NewContext(nil, map[string]string{
+	c := NewClient(NewContext(nil, map[string]string{
 		"HTTPS_PROXY": "http://proxy-from-env:8080",
 	}, nil))
-	require.Nil(t, err)
 
 	req, err := http.NewRequest("GET", "https://some-host.com:123/foo/bar", nil)
 	require.Nil(t, err)
@@ -84,10 +79,9 @@ func TestHTTPSProxyFromEnvironment(t *testing.T) {
 }
 
 func TestHTTPProxyFromEnvironment(t *testing.T) {
-	c, err := NewClient(NewContext(nil, map[string]string{
+	c := NewClient(NewContext(nil, map[string]string{
 		"HTTPS_PROXY": "http://proxy-from-env:8080",
 	}, nil))
-	require.Nil(t, err)
 
 	req, err := http.NewRequest("GET", "http://some-host.com:123/foo/bar", nil)
 	require.Nil(t, err)
@@ -98,7 +92,7 @@ func TestHTTPProxyFromEnvironment(t *testing.T) {
 }
 
 func TestProxyIsNil(t *testing.T) {
-	c, _ := NewClient(nil)
+	c := NewClient(nil)
 
 	req, err := http.NewRequest("GET", "http://some-host.com:123/foo/bar", nil)
 	require.Nil(t, err)
@@ -109,12 +103,11 @@ func TestProxyIsNil(t *testing.T) {
 }
 
 func TestProxyNoProxy(t *testing.T) {
-	c, err := NewClient(NewContext(nil, map[string]string{
+	c := NewClient(NewContext(nil, map[string]string{
 		"NO_PROXY": "some-host",
 	}, map[string]string{
 		"http.proxy": "https://proxy-from-git-config:8080",
 	}))
-	require.Nil(t, err)
 
 	req, err := http.NewRequest("GET", "https://some-host:8080", nil)
 	require.Nil(t, err)
@@ -125,12 +118,11 @@ func TestProxyNoProxy(t *testing.T) {
 }
 
 func TestProxyNoProxyWithWildcard(t *testing.T) {
-	c, err := NewClient(NewContext(nil, map[string]string{
+	c := NewClient(NewContext(nil, map[string]string{
 		"NO_PROXY": "*.example.com",
 	}, map[string]string{
 		"http.proxy": "https://proxy-from-git-config:8080",
 	}))
-	require.Nil(t, err)
 
 	req, err := http.NewRequest("GET", "https://foo.example.com:8080", nil)
 	require.Nil(t, err)
@@ -141,10 +133,9 @@ func TestProxyNoProxyWithWildcard(t *testing.T) {
 }
 
 func TestSocksProxyFromEnvironment(t *testing.T) {
-	c, err := NewClient(NewContext(nil, map[string]string{
+	c := NewClient(NewContext(nil, map[string]string{
 		"HTTPS_PROXY": "socks5://proxy-from-env:3128",
 	}, nil))
-	require.Nil(t, err)
 
 	req, err := http.NewRequest("GET", "https://some-host.com:123/foo/bar", nil)
 	require.Nil(t, err)
@@ -156,10 +147,9 @@ func TestSocksProxyFromEnvironment(t *testing.T) {
 }
 
 func TestSocks5hProxyFromEnvironment(t *testing.T) {
-	c, err := NewClient(NewContext(nil, map[string]string{
+	c := NewClient(NewContext(nil, map[string]string{
 		"HTTPS_PROXY": "socks5h://proxy-from-env:3128",
 	}, nil))
-	require.Nil(t, err)
 
 	req, err := http.NewRequest("GET", "https://some-host.com:123/foo/bar", nil)
 	require.Nil(t, err)

--- a/lfshttp/retries_test.go
+++ b/lfshttp/retries_test.go
@@ -60,8 +60,7 @@ func TestRequestWithRetries(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c, err := NewClient(nil)
-	require.NoError(t, err)
+	c := NewClient(nil)
 
 	req, err := http.NewRequest("POST", srv.URL, nil)
 	require.NoError(t, err)

--- a/lfshttp/standalone/standalone.go
+++ b/lfshttp/standalone/standalone.go
@@ -71,10 +71,7 @@ func fileUrlFromRemote(cfg *config.Configuration, name string, direction string)
 		}
 	}
 
-	apiClient, err := lfsapi.NewClient(cfg)
-	if err != nil {
-		return nil, err
-	}
+	apiClient := lfsapi.NewClient(cfg)
 
 	for _, remote := range cfg.Remotes() {
 		if remote != name {

--- a/lfshttp/stats_test.go
+++ b/lfshttp/stats_test.go
@@ -32,7 +32,7 @@ func TestStatsWithKey(t *testing.T) {
 	defer srv.Close()
 
 	out := &bytes.Buffer{}
-	c, _ := NewClient(nil)
+	c := NewClient(nil)
 	c.ConcurrentTransfers = 5
 	c.LogHTTPStats(nopCloser(out))
 
@@ -98,7 +98,7 @@ func TestStatsWithoutKey(t *testing.T) {
 	defer srv.Close()
 
 	out := &bytes.Buffer{}
-	c, _ := NewClient(nil)
+	c := NewClient(nil)
 	c.ConcurrentTransfers = 5
 	c.LogHTTPStats(nopCloser(out))
 
@@ -140,7 +140,7 @@ func TestStatsDisabled(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c, _ := NewClient(nil)
+	c := NewClient(nil)
 	c.ConcurrentTransfers = 5
 
 	req, err := http.NewRequest("POST", srv.URL, nil)

--- a/lfshttp/verbose_test.go
+++ b/lfshttp/verbose_test.go
@@ -36,7 +36,7 @@ func TestVerboseEnabled(t *testing.T) {
 	defer srv.Close()
 
 	out := &bytes.Buffer{}
-	c, _ := NewClient(nil)
+	c := NewClient(nil)
 	c.Verbose = true
 	c.VerboseOut = out
 
@@ -93,7 +93,7 @@ func TestVerboseWithBinaryBody(t *testing.T) {
 	defer srv.Close()
 
 	out := &bytes.Buffer{}
-	c, _ := NewClient(nil)
+	c := NewClient(nil)
 	c.Verbose = true
 	c.VerboseOut = out
 
@@ -151,7 +151,7 @@ func TestVerboseEnabledWithDebugging(t *testing.T) {
 	defer srv.Close()
 
 	out := &bytes.Buffer{}
-	c, _ := NewClient(nil)
+	c := NewClient(nil)
 	c.Verbose = true
 	c.VerboseOut = out
 	c.DebuggingVerbose = true
@@ -210,7 +210,7 @@ func TestVerboseDisabled(t *testing.T) {
 	defer srv.Close()
 
 	out := &bytes.Buffer{}
-	c, _ := NewClient(nil)
+	c := NewClient(nil)
 	c.Verbose = false
 	c.VerboseOut = out
 	c.DebuggingVerbose = true

--- a/locking/api_test.go
+++ b/locking/api_test.go
@@ -55,10 +55,9 @@ func TestAPILock(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c, err := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
+	c := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
 		"lfs.url": srv.URL + "/api",
 	}))
-	require.Nil(t, err)
 
 	lc := &httpLockClient{Client: c}
 	lockRes, status, err := lc.Lock("", &lockRequest{Path: "request", Ref: &lockRef{Name: "refs/heads/master"}})
@@ -103,10 +102,9 @@ func TestAPIUnlock(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c, err := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
+	c := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
 		"lfs.url": srv.URL + "/api",
 	}))
-	require.Nil(t, err)
 
 	lc := &httpLockClient{Client: c}
 	unlockRes, status, err := lc.Unlock(&git.Ref{
@@ -151,10 +149,9 @@ func TestAPISearch(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c, err := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
+	c := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
 		"lfs.url": srv.URL + "/api",
 	}))
-	require.Nil(t, err)
 
 	lc := &httpLockClient{Client: c}
 	locks, status, err := lc.Search("", &lockSearchRequest{
@@ -206,10 +203,9 @@ func TestAPISearchVerifiable(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c, err := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
+	c := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
 		"lfs.url": srv.URL + "/api",
 	}))
-	require.Nil(t, err)
 
 	lc := &httpLockClient{Client: c}
 	locks, status, err := lc.SearchVerifiable("", &lockVerifiableRequest{

--- a/locking/locks.go
+++ b/locking/locks.go
@@ -60,7 +60,7 @@ type Client struct {
 // NewClient creates a new locking client with the given configuration
 // You must call the returned object's `Close` method when you are finished with
 // it
-func NewClient(remote string, lfsClient *lfsapi.Client, cfg *config.Configuration) (*Client, error) {
+func NewClient(remote string, lfsClient *lfsapi.Client, cfg *config.Configuration) *Client {
 	return &Client{
 		Remote:             remote,
 		client:             newGenericLockClient(lfsClient),
@@ -69,7 +69,7 @@ func NewClient(remote string, lfsClient *lfsapi.Client, cfg *config.Configuratio
 		ModifyIgnoredFiles: lfsClient.GitEnv().Bool("lfs.lockignoredfiles", false),
 		LocalWorkingDir:    cfg.LocalWorkingDir(),
 		LocalGitDir:        cfg.LocalGitDir(),
-	}, nil
+	}
 }
 
 func (c *Client) SetupFileCache(path string) error {

--- a/locking/locks_test.go
+++ b/locking/locks_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/git-lfs/git-lfs/v3/lfsapi"
 	"github.com/git-lfs/git-lfs/v3/lfshttp"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type LocksById []Lock
@@ -49,12 +48,11 @@ func TestRemoteLocksWithCache(t *testing.T) {
 		srv.Close()
 	}()
 
-	lfsclient, err := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
+	lfsclient := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
 		"lfs.url":    srv.URL + "/api",
 		"user.name":  "Fred",
 		"user.email": "fred@bloggs.com",
 	}))
-	require.Nil(t, err)
 
 	client, err := NewClient("", lfsclient, config.New())
 	assert.Nil(t, err)
@@ -154,12 +152,11 @@ func TestRefreshCache(t *testing.T) {
 		srv.Close()
 	}()
 
-	lfsclient, err := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
+	lfsclient := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
 		"lfs.url":    srv.URL + "/api",
 		"user.name":  "Fred",
 		"user.email": "fred@bloggs.com",
 	}))
-	require.Nil(t, err)
 
 	client, err := NewClient("", lfsclient, config.New())
 	assert.Nil(t, err)
@@ -233,12 +230,11 @@ func TestSearchLocksVerifiableWithCache(t *testing.T) {
 
 	defer srv.Close()
 
-	lfsclient, err := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
+	lfsclient := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
 		"lfs.url":    srv.URL + "/api",
 		"user.name":  "Fred",
 		"user.email": "fred@bloggs.com",
 	}))
-	require.Nil(t, err)
 
 	client, err := NewClient("", lfsclient, config.New())
 	assert.Nil(t, client.SetupFileCache(tempDir))

--- a/locking/locks_test.go
+++ b/locking/locks_test.go
@@ -54,8 +54,9 @@ func TestRemoteLocksWithCache(t *testing.T) {
 		"user.email": "fred@bloggs.com",
 	}))
 
-	client, err := NewClient("", lfsclient, config.New())
-	assert.Nil(t, err)
+	client := NewClient("", lfsclient, config.New())
+	defer client.Close()
+
 	assert.Nil(t, client.SetupFileCache(tempDir))
 
 	client.RemoteRef = &git.Ref{Name: "refs/heads/master"}
@@ -158,8 +159,9 @@ func TestRefreshCache(t *testing.T) {
 		"user.email": "fred@bloggs.com",
 	}))
 
-	client, err := NewClient("", lfsclient, config.New())
-	assert.Nil(t, err)
+	client := NewClient("", lfsclient, config.New())
+	defer client.Close()
+
 	assert.Nil(t, client.SetupFileCache(tempDir))
 
 	// Should start with no cached items
@@ -236,7 +238,9 @@ func TestSearchLocksVerifiableWithCache(t *testing.T) {
 		"user.email": "fred@bloggs.com",
 	}))
 
-	client, err := NewClient("", lfsclient, config.New())
+	client := NewClient("", lfsclient, config.New())
+	defer client.Close()
+
 	assert.Nil(t, client.SetupFileCache(tempDir))
 
 	client.RemoteRef = &git.Ref{Name: "refs/heads/master"}

--- a/ssh/ssh_test.go
+++ b/ssh/ssh_test.go
@@ -13,8 +13,7 @@ import (
 )
 
 func TestSSHGetLFSExeAndArgs(t *testing.T) {
-	cli, err := lfshttp.NewClient(nil)
-	require.Nil(t, err)
+	cli := lfshttp.NewClient(nil)
 
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
@@ -36,11 +35,10 @@ func TestSSHGetLFSExeAndArgs(t *testing.T) {
 }
 
 func TestSSHGetExeAndArgsSsh(t *testing.T) {
-	cli, err := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
+	cli := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
 		"GIT_SSH_COMMAND": "",
 		"GIT_SSH":         "",
 	}, nil))
-	require.Nil(t, err)
 
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
@@ -52,11 +50,10 @@ func TestSSHGetExeAndArgsSsh(t *testing.T) {
 }
 
 func TestSSHGetExeAndArgsSshCustomPort(t *testing.T) {
-	cli, err := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
+	cli := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
 		"GIT_SSH_COMMAND": "",
 		"GIT_SSH":         "",
 	}, nil))
-	require.Nil(t, err)
 
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
@@ -69,13 +66,12 @@ func TestSSHGetExeAndArgsSshCustomPort(t *testing.T) {
 }
 
 func TestSSHGetExeAndArgsSshNoMultiplexing(t *testing.T) {
-	cli, err := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
+	cli := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
 		"GIT_SSH_COMMAND": "",
 		"GIT_SSH":         "",
 	}, map[string]string{
 		"lfs.ssh.automultiplex": "false",
 	}))
-	require.Nil(t, err)
 
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
@@ -89,13 +85,12 @@ func TestSSHGetExeAndArgsSshNoMultiplexing(t *testing.T) {
 }
 
 func TestSSHGetExeAndArgsSshMultiplexingMaster(t *testing.T) {
-	cli, err := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
+	cli := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
 		"GIT_SSH_COMMAND": "",
 		"GIT_SSH":         "",
 	}, map[string]string{
 		"lfs.ssh.automultiplex": "true",
 	}))
-	require.Nil(t, err)
 
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
@@ -112,13 +107,12 @@ func TestSSHGetExeAndArgsSshMultiplexingMaster(t *testing.T) {
 }
 
 func TestSSHGetExeAndArgsSshMultiplexingExtra(t *testing.T) {
-	cli, err := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
+	cli := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
 		"GIT_SSH_COMMAND": "",
 		"GIT_SSH":         "",
 	}, map[string]string{
 		"lfs.ssh.automultiplex": "true",
 	}))
-	require.Nil(t, err)
 
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
@@ -134,11 +128,10 @@ func TestSSHGetExeAndArgsSshMultiplexingExtra(t *testing.T) {
 func TestSSHGetExeAndArgsPlink(t *testing.T) {
 	plink := filepath.Join("Users", "joebloggs", "bin", "plink.exe")
 
-	cli, err := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
+	cli := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
 		"GIT_SSH_COMMAND": "",
 		"GIT_SSH":         plink,
 	}, nil))
-	require.Nil(t, err)
 
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
@@ -152,11 +145,10 @@ func TestSSHGetExeAndArgsPlink(t *testing.T) {
 func TestSSHGetExeAndArgsPlinkCustomPort(t *testing.T) {
 	plink := filepath.Join("Users", "joebloggs", "bin", "plink")
 
-	cli, err := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
+	cli := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
 		"GIT_SSH_COMMAND": "",
 		"GIT_SSH":         plink,
 	}, nil))
-	require.Nil(t, err)
 
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
@@ -171,12 +163,11 @@ func TestSSHGetExeAndArgsPlinkCustomPort(t *testing.T) {
 func TestSSHGetExeAndArgsPlinkCustomPortExplicitEnvironment(t *testing.T) {
 	plink := filepath.Join("Users", "joebloggs", "bin", "ssh")
 
-	cli, err := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
+	cli := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
 		"GIT_SSH_COMMAND": "",
 		"GIT_SSH":         plink,
 		"GIT_SSH_VARIANT": "plink",
 	}, nil))
-	require.Nil(t, err)
 
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
@@ -191,12 +182,11 @@ func TestSSHGetExeAndArgsPlinkCustomPortExplicitEnvironment(t *testing.T) {
 func TestSSHGetExeAndArgsPlinkCustomPortExplicitEnvironmentPutty(t *testing.T) {
 	plink := filepath.Join("Users", "joebloggs", "bin", "ssh")
 
-	cli, err := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
+	cli := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
 		"GIT_SSH_COMMAND": "",
 		"GIT_SSH":         plink,
 		"GIT_SSH_VARIANT": "putty",
 	}, nil))
-	require.Nil(t, err)
 
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
@@ -211,12 +201,11 @@ func TestSSHGetExeAndArgsPlinkCustomPortExplicitEnvironmentPutty(t *testing.T) {
 func TestSSHGetExeAndArgsPlinkCustomPortExplicitEnvironmentSsh(t *testing.T) {
 	plink := filepath.Join("Users", "joebloggs", "bin", "ssh")
 
-	cli, err := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
+	cli := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
 		"GIT_SSH_COMMAND": "",
 		"GIT_SSH":         plink,
 		"GIT_SSH_VARIANT": "ssh",
 	}, nil))
-	require.Nil(t, err)
 
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
@@ -231,11 +220,10 @@ func TestSSHGetExeAndArgsPlinkCustomPortExplicitEnvironmentSsh(t *testing.T) {
 func TestSSHGetExeAndArgsTortoisePlink(t *testing.T) {
 	plink := filepath.Join("Users", "joebloggs", "bin", "tortoiseplink.exe")
 
-	cli, err := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
+	cli := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
 		"GIT_SSH_COMMAND": "",
 		"GIT_SSH":         plink,
 	}, nil))
-	require.Nil(t, err)
 
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
@@ -249,11 +237,10 @@ func TestSSHGetExeAndArgsTortoisePlink(t *testing.T) {
 func TestSSHGetExeAndArgsTortoisePlinkCustomPort(t *testing.T) {
 	plink := filepath.Join("Users", "joebloggs", "bin", "tortoiseplink")
 
-	cli, err := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
+	cli := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
 		"GIT_SSH_COMMAND": "",
 		"GIT_SSH":         plink,
 	}, nil))
-	require.Nil(t, err)
 
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
@@ -268,12 +255,11 @@ func TestSSHGetExeAndArgsTortoisePlinkCustomPort(t *testing.T) {
 func TestSSHGetExeAndArgsTortoisePlinkCustomPortExplicitEnvironment(t *testing.T) {
 	plink := filepath.Join("Users", "joebloggs", "bin", "ssh")
 
-	cli, err := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
+	cli := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
 		"GIT_SSH_COMMAND": "",
 		"GIT_SSH":         plink,
 		"GIT_SSH_VARIANT": "tortoiseplink",
 	}, nil))
-	require.Nil(t, err)
 
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
@@ -288,14 +274,13 @@ func TestSSHGetExeAndArgsTortoisePlinkCustomPortExplicitEnvironment(t *testing.T
 func TestSSHGetExeAndArgsTortoisePlinkCustomPortExplicitConfig(t *testing.T) {
 	plink := filepath.Join("Users", "joebloggs", "bin", "ssh")
 
-	cli, err := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
+	cli := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
 		"GIT_SSH_COMMAND": "",
 		"GIT_SSH":         plink,
 		"GIT_SSH_VARIANT": "tortoiseplink",
 	}, map[string]string{
 		"ssh.variant": "tortoiseplink",
 	}))
-	require.Nil(t, err)
 
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
@@ -310,13 +295,12 @@ func TestSSHGetExeAndArgsTortoisePlinkCustomPortExplicitConfig(t *testing.T) {
 func TestSSHGetExeAndArgsTortoisePlinkCustomPortExplicitConfigOverride(t *testing.T) {
 	plink := filepath.Join("Users", "joebloggs", "bin", "ssh")
 
-	cli, err := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
+	cli := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
 		"GIT_SSH_COMMAND": "",
 		"GIT_SSH":         plink,
 	}, map[string]string{
 		"ssh.variant": "putty",
 	}))
-	require.Nil(t, err)
 
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
@@ -329,12 +313,11 @@ func TestSSHGetExeAndArgsTortoisePlinkCustomPortExplicitConfigOverride(t *testin
 }
 
 func TestSSHGetExeAndArgsSshCommandPrecedence(t *testing.T) {
-	cli, err := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
+	cli := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
 		"GIT_SSH_COMMAND": "sshcmd",
 		"GIT_SSH":         "bad",
 		"GIT_SSH_VARIANT": "simple",
 	}, nil))
-	require.Nil(t, err)
 
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
@@ -346,11 +329,10 @@ func TestSSHGetExeAndArgsSshCommandPrecedence(t *testing.T) {
 }
 
 func TestSSHGetExeAndArgsSshCommandArgs(t *testing.T) {
-	cli, err := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
+	cli := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
 		"GIT_SSH_COMMAND": "sshcmd --args 1",
 		"GIT_SSH_VARIANT": "simple",
 	}, nil))
-	require.Nil(t, err)
 
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
@@ -362,11 +344,10 @@ func TestSSHGetExeAndArgsSshCommandArgs(t *testing.T) {
 }
 
 func TestSSHGetExeAndArgsSshCommandArgsWithMixedQuotes(t *testing.T) {
-	cli, err := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
+	cli := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
 		"GIT_SSH_COMMAND": "sshcmd foo 'bar \"baz\"'",
 		"GIT_SSH_VARIANT": "simple",
 	}, nil))
-	require.Nil(t, err)
 
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
@@ -378,10 +359,9 @@ func TestSSHGetExeAndArgsSshCommandArgsWithMixedQuotes(t *testing.T) {
 }
 
 func TestSSHGetExeAndArgsSshCommandCustomPort(t *testing.T) {
-	cli, err := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
+	cli := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
 		"GIT_SSH_COMMAND": "sshcmd",
 	}, nil))
-	require.Nil(t, err)
 
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
@@ -394,12 +374,11 @@ func TestSSHGetExeAndArgsSshCommandCustomPort(t *testing.T) {
 }
 
 func TestSSHGetExeAndArgsCoreSshCommand(t *testing.T) {
-	cli, err := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
+	cli := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
 		"GIT_SSH_COMMAND": "sshcmd --args 2",
 	}, map[string]string{
 		"core.sshcommand": "sshcmd --args 1",
 	}))
-	require.Nil(t, err)
 
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
@@ -411,10 +390,9 @@ func TestSSHGetExeAndArgsCoreSshCommand(t *testing.T) {
 }
 
 func TestSSHGetExeAndArgsCoreSshCommandArgsWithMixedQuotes(t *testing.T) {
-	cli, err := lfshttp.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
+	cli := lfshttp.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
 		"core.sshcommand": "sshcmd foo 'bar \"baz\"'",
 	}))
-	require.Nil(t, err)
 
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
@@ -426,10 +404,9 @@ func TestSSHGetExeAndArgsCoreSshCommandArgsWithMixedQuotes(t *testing.T) {
 }
 
 func TestSSHGetExeAndArgsConfigVersusEnv(t *testing.T) {
-	cli, err := lfshttp.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
+	cli := lfshttp.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
 		"core.sshcommand": "sshcmd --args 1",
 	}))
-	require.Nil(t, err)
 
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
@@ -443,10 +420,9 @@ func TestSSHGetExeAndArgsConfigVersusEnv(t *testing.T) {
 func TestSSHGetExeAndArgsPlinkCommand(t *testing.T) {
 	plink := filepath.Join("Users", "joebloggs", "bin", "plink.exe")
 
-	cli, err := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
+	cli := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
 		"GIT_SSH_COMMAND": plink,
 	}, nil))
-	require.Nil(t, err)
 
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
@@ -460,10 +436,9 @@ func TestSSHGetExeAndArgsPlinkCommand(t *testing.T) {
 func TestSSHGetExeAndArgsPlinkCommandCustomPort(t *testing.T) {
 	plink := filepath.Join("Users", "joebloggs", "bin", "plink")
 
-	cli, err := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
+	cli := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
 		"GIT_SSH_COMMAND": plink,
 	}, nil))
-	require.Nil(t, err)
 
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
@@ -478,10 +453,9 @@ func TestSSHGetExeAndArgsPlinkCommandCustomPort(t *testing.T) {
 func TestSSHGetExeAndArgsTortoisePlinkCommand(t *testing.T) {
 	plink := filepath.Join("Users", "joebloggs", "bin", "tortoiseplink.exe")
 
-	cli, err := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
+	cli := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
 		"GIT_SSH_COMMAND": plink,
 	}, nil))
-	require.Nil(t, err)
 
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
@@ -495,10 +469,9 @@ func TestSSHGetExeAndArgsTortoisePlinkCommand(t *testing.T) {
 func TestSSHGetExeAndArgsTortoisePlinkCommandCustomPort(t *testing.T) {
 	plink := filepath.Join("Users", "joebloggs", "bin", "tortoiseplink")
 
-	cli, err := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
+	cli := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
 		"GIT_SSH_COMMAND": plink,
 	}, nil))
-	require.Nil(t, err)
 
 	meta := ssh.SSHMetadata{}
 	meta.UserAndHost = "user@foo.com"
@@ -511,11 +484,10 @@ func TestSSHGetExeAndArgsTortoisePlinkCommandCustomPort(t *testing.T) {
 }
 
 func TestSSHGetLFSExeAndArgsWithCustomSSH(t *testing.T) {
-	cli, err := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
+	cli := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
 		"GIT_SSH":         "not-ssh",
 		"GIT_SSH_VARIANT": "simple",
 	}, nil))
-	require.Nil(t, err)
 
 	u, err := url.Parse("ssh://git@host.com:12345/repo")
 	require.Nil(t, err)
@@ -532,8 +504,7 @@ func TestSSHGetLFSExeAndArgsWithCustomSSH(t *testing.T) {
 }
 
 func TestSSHGetLFSExeAndArgsInvalidOptionsAsHost(t *testing.T) {
-	cli, err := lfshttp.NewClient(nil)
-	require.Nil(t, err)
+	cli := lfshttp.NewClient(nil)
 
 	u, err := url.Parse("ssh://-oProxyCommand=gnome-calculator/repo")
 	require.Nil(t, err)
@@ -550,11 +521,10 @@ func TestSSHGetLFSExeAndArgsInvalidOptionsAsHost(t *testing.T) {
 }
 
 func TestSSHGetLFSExeAndArgsInvalidOptionsAsHostWithCustomSSH(t *testing.T) {
-	cli, err := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
+	cli := lfshttp.NewClient(lfshttp.NewContext(nil, map[string]string{
 		"GIT_SSH":         "not-ssh",
 		"GIT_SSH_VARIANT": "simple",
 	}, nil))
-	require.Nil(t, err)
 
 	u, err := url.Parse("ssh://--oProxyCommand=gnome-calculator/repo")
 	require.Nil(t, err)
@@ -571,8 +541,7 @@ func TestSSHGetLFSExeAndArgsInvalidOptionsAsHostWithCustomSSH(t *testing.T) {
 }
 
 func TestSSHGetExeAndArgsInvalidOptionsAsHost(t *testing.T) {
-	cli, err := lfshttp.NewClient(nil)
-	require.Nil(t, err)
+	cli := lfshttp.NewClient(nil)
 
 	u, err := url.Parse("ssh://-oProxyCommand=gnome-calculator")
 	require.Nil(t, err)
@@ -590,8 +559,7 @@ func TestSSHGetExeAndArgsInvalidOptionsAsHost(t *testing.T) {
 }
 
 func TestSSHGetExeAndArgsInvalidOptionsAsPath(t *testing.T) {
-	cli, err := lfshttp.NewClient(nil)
-	require.Nil(t, err)
+	cli := lfshttp.NewClient(nil)
 
 	u, err := url.Parse("ssh://git@git-host.com/-oProxyCommand=gnome-calculator")
 	require.Nil(t, err)

--- a/t/cmd/lfstest-customadapter.go
+++ b/t/cmd/lfstest-customadapter.go
@@ -29,11 +29,7 @@ func main() {
 	scanner := bufio.NewScanner(os.Stdin)
 	writer := bufio.NewWriter(os.Stdout)
 	errWriter := bufio.NewWriter(os.Stderr)
-	apiClient, err := lfsapi.NewClient(cfg)
-	if err != nil {
-		writeToStderr("Error creating api client: "+err.Error(), errWriter)
-		os.Exit(1)
-	}
+	apiClient := lfsapi.NewClient(cfg)
 
 	for scanner.Scan() {
 		line := scanner.Text()

--- a/t/git-lfs-test-server-api/main.go
+++ b/t/git-lfs-test-server-api/main.go
@@ -149,10 +149,7 @@ func buildManifest(r *t.Repo) (tq.Manifest, error) {
 		endp = finder.NewEndpoint("upload", apiUrl)
 	}
 
-	apiClient, err := lfsapi.NewClient(r)
-	if err != nil {
-		return nil, err
-	}
+	apiClient := lfsapi.NewClient(r)
 	apiClient.Endpoints = &constantEndpoint{
 		e:              endp,
 		EndpointFinder: apiClient.Endpoints,

--- a/tq/api_test.go
+++ b/tq/api_test.go
@@ -55,10 +55,9 @@ func TestAPIBatch(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c, err := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
+	c := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
 		"lfs.url": srv.URL + "/api",
 	}))
-	require.Nil(t, err)
 
 	tqc := &tqClient{Client: c}
 	bReq := &batchRequest{
@@ -111,10 +110,9 @@ func TestAPIBatchOnlyBasic(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c, err := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
+	c := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
 		"lfs.url": srv.URL + "/api",
 	}))
-	require.Nil(t, err)
 
 	tqc := &tqClient{Client: c}
 	bReq := &batchRequest{
@@ -129,8 +127,7 @@ func TestAPIBatchOnlyBasic(t *testing.T) {
 }
 
 func TestAPIBatchEmptyObjects(t *testing.T) {
-	c, err := lfsapi.NewClient(nil)
-	require.Nil(t, err)
+	c := lfsapi.NewClient(nil)
 
 	tqc := &tqClient{Client: c}
 	bReq := &batchRequest{

--- a/tq/custom_test.go
+++ b/tq/custom_test.go
@@ -6,15 +6,13 @@ import (
 	"github.com/git-lfs/git-lfs/v3/lfsapi"
 	"github.com/git-lfs/git-lfs/v3/lfshttp"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestCustomTransferBasicConfig(t *testing.T) {
 	path := "/path/to/binary"
-	cli, err := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
+	cli := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
 		"lfs.customtransfer.testsimple.path": path,
 	}))
-	require.Nil(t, err)
 
 	m := NewManifest(nil, cli, "", "")
 	u := m.NewUploadAdapter("testsimple")
@@ -37,13 +35,12 @@ func TestCustomTransferBasicConfig(t *testing.T) {
 func TestCustomTransferDownloadConfig(t *testing.T) {
 	path := "/path/to/binary"
 	args := "-c 1 --whatever"
-	cli, err := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
+	cli := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
 		"lfs.customtransfer.testdownload.path":       path,
 		"lfs.customtransfer.testdownload.args":       args,
 		"lfs.customtransfer.testdownload.concurrent": "false",
 		"lfs.customtransfer.testdownload.direction":  "download",
 	}))
-	require.Nil(t, err)
 
 	m := NewManifest(nil, cli, "", "")
 	u := m.NewUploadAdapter("testdownload")
@@ -63,13 +60,12 @@ func TestCustomTransferDownloadConfig(t *testing.T) {
 func TestCustomTransferUploadConfig(t *testing.T) {
 	path := "/path/to/binary"
 	args := "-c 1 --whatever"
-	cli, err := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
+	cli := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
 		"lfs.customtransfer.testupload.path":       path,
 		"lfs.customtransfer.testupload.args":       args,
 		"lfs.customtransfer.testupload.concurrent": "false",
 		"lfs.customtransfer.testupload.direction":  "upload",
 	}))
-	require.Nil(t, err)
 
 	m := NewManifest(nil, cli, "", "")
 	d := m.NewDownloadAdapter("testupload")
@@ -89,13 +85,12 @@ func TestCustomTransferUploadConfig(t *testing.T) {
 func TestCustomTransferBothConfig(t *testing.T) {
 	path := "/path/to/binary"
 	args := "-c 1 --whatever --yeah"
-	cli, err := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
+	cli := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
 		"lfs.customtransfer.testboth.path":       path,
 		"lfs.customtransfer.testboth.args":       args,
 		"lfs.customtransfer.testboth.concurrent": "yes",
 		"lfs.customtransfer.testboth.direction":  "both",
 	}))
-	require.Nil(t, err)
 
 	m := NewManifest(nil, cli, "", "")
 	d := m.NewDownloadAdapter("testboth")

--- a/tq/manifest.go
+++ b/tq/manifest.go
@@ -185,18 +185,20 @@ func (m *concreteManifest) Upgraded() bool {
 	return true
 }
 
+func (m *concreteManifest) Shutdown() error {
+	if m.sshTransfer != nil {
+		return m.sshTransfer.Shutdown()
+	}
+	return nil
+}
+
 func NewManifest(f *fs.Filesystem, apiClient *lfsapi.Client, operation, remote string) Manifest {
 	return newLazyManifest(f, apiClient, operation, remote)
 }
 
 func newConcreteManifest(f *fs.Filesystem, apiClient *lfsapi.Client, operation, remote string) *concreteManifest {
 	if apiClient == nil {
-		cli, err := lfsapi.NewClient(nil)
-		if err != nil {
-			tracerx.Printf("unable to init tq.Manifest: %s", err)
-			return nil
-		}
-		apiClient = cli
+		apiClient = lfsapi.NewClient(nil)
 	}
 
 	sshTransfer := apiClient.SSHTransfer(operation, remote)

--- a/tq/manifest.go
+++ b/tq/manifest.go
@@ -185,13 +185,6 @@ func (m *concreteManifest) Upgraded() bool {
 	return true
 }
 
-func (m *concreteManifest) Shutdown() error {
-	if m.sshTransfer != nil {
-		return m.sshTransfer.Shutdown()
-	}
-	return nil
-}
-
 func NewManifest(f *fs.Filesystem, apiClient *lfsapi.Client, operation, remote string) Manifest {
 	return newLazyManifest(f, apiClient, operation, remote)
 }

--- a/tq/manifest_test.go
+++ b/tq/manifest_test.go
@@ -7,32 +7,28 @@ import (
 	"github.com/git-lfs/git-lfs/v3/lfsapi"
 	"github.com/git-lfs/git-lfs/v3/lfshttp"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestManifestIsConfigurable(t *testing.T) {
-	cli, err := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
+	cli := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
 		"lfs.transfer.maxretries": "3",
 	}))
-	require.Nil(t, err)
 
 	m := NewManifest(nil, cli, "", "")
 	assert.Equal(t, 3, m.MaxRetries())
 }
 
 func TestManifestClampsValidValues(t *testing.T) {
-	cli, err := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
+	cli := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
 		"lfs.transfer.maxretries": "-1",
 	}))
-	require.Nil(t, err)
 
 	m := NewManifest(nil, cli, "", "")
 	assert.Equal(t, 8, m.MaxRetries())
 }
 
 func TestLazyManifestConcurrentUpgrade(t *testing.T) {
-	cli, err := lfsapi.NewClient(lfshttp.NewContext(nil, nil, nil))
-	require.Nil(t, err)
+	cli := lfsapi.NewClient(lfshttp.NewContext(nil, nil, nil))
 
 	m := NewManifest(nil, cli, "", "")
 
@@ -56,10 +52,9 @@ func TestLazyManifestConcurrentUpgrade(t *testing.T) {
 }
 
 func TestManifestIgnoresNonInts(t *testing.T) {
-	cli, err := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
+	cli := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
 		"lfs.transfer.maxretries": "not_an_int",
 	}))
-	require.Nil(t, err)
 
 	m := NewManifest(nil, cli, "", "")
 	assert.Equal(t, 8, m.MaxRetries())

--- a/tq/transfer_test.go
+++ b/tq/transfer_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/git-lfs/git-lfs/v3/lfsapi"
 	"github.com/git-lfs/git-lfs/v3/lfshttp"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type testAdapter struct {
@@ -142,10 +141,9 @@ func TestAdapterRegAndOverride(t *testing.T) {
 }
 
 func TestAdapterRegButBasicOnly(t *testing.T) {
-	cli, err := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
+	cli := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
 		"lfs.basictransfersonly": "yes",
 	}))
-	require.Nil(t, err)
 
 	m := NewManifest(nil, cli, "", "")
 

--- a/tq/verify_test.go
+++ b/tq/verify_test.go
@@ -10,11 +10,10 @@ import (
 	"github.com/git-lfs/git-lfs/v3/lfsapi"
 	"github.com/git-lfs/git-lfs/v3/lfshttp"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestVerifyWithoutAction(t *testing.T) {
-	c, _ := lfsapi.NewClient(nil)
+	c := lfsapi.NewClient(nil)
 	tr := &Transfer{
 		Oid:  "abc",
 		Size: 123,
@@ -48,12 +47,12 @@ func TestVerifySuccess(t *testing.T) {
 	// Set auth on the server URL but not on the /verify endpoint. Since auth
 	// will cause the request to fail, this will test that the correct access
 	// mode is being passed to `DoWithAuth()`
-	c, err := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
+	c := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
 		"lfs.transfer.maxverifies":          "1",
 		"lfs." + srv.URL + ".access":        "Basic",
 		"lfs." + srv.URL + "/verify.access": "None",
 	}))
-	require.Nil(t, err)
+
 	tr := &Transfer{
 		Oid:  "abcd1234",
 		Size: 123,


### PR DESCRIPTION
This PR simplifies all of the factory functions we use to construct new API, HTTP, and locking clients by removing their unused `error` return values.

For historical reasons, the `NewClient()` functions in our `lfsapi`, `lfshttp`, and `locking` packages all return a value with the `error` type, but at present none of the functions could ever actually encounter an error condition and return a non-`nil` `error` value.  We can therefore just eliminate these unused return values.

This PR will be most easily reviewed on a commit-by-commit basis.

#### Avoiding Future Deadlocks

One specific advantage of this change is that the `getAPIClient()` function in our `commands` package will no longer need to include a conditional [block](https://github.com/git-lfs/git-lfs/blob/e09c0f6216dadd0624eb425e8965f28868f9cd47/commands/commands.go#L81-L83) which checks the `error` return value from the `lfsapi.NewClient()` constructor function.  This block handles the (hypothetical) case of a non-`nil` `error` return value by calling the `ExitWithError()` function, which causes the Git LFS client to exit immediately.

In a future PR, we may revise the `ExitWithError()` function so that it performs various cleanup operations prior to calling `os.Exit()` function, but only after first acquiring the same `global` [mutex](https://github.com/git-lfs/git-lfs/blob/e09c0f6216dadd0624eb425e8965f28868f9cd47/commands/commands.go#L44) that the `getAPIClient()` function also [acquires](https://github.com/git-lfs/git-lfs/blob/e09c0f6216dadd0624eb425e8965f28868f9cd47/commands/commands.go#L76-L77).  With this goal in mind, we need to ensure that the `getAPIClient()` function does not invoke the `ExitWithError()` function, since that would result in a deadlock condition.