### PR TITLE
Use consistent exit functions for all commands

### DIFF
--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -32,7 +32,7 @@ func checkoutCommand(cmd *cobra.Command, args []string) {
 	// repository but will exit non-zero, as other commands already do.
 	if cfg.LocalWorkingDir() == "" {
 		Print(tr.Tr.Get("This operation must be run in a work tree."))
-		os.Exit(0)
+		return
 	}
 
 	stage, err := whichCheckout()

--- a/commands/command_fsck.go
+++ b/commands/command_fsck.go
@@ -97,7 +97,7 @@ func fsckCommand(cmd *cobra.Command, args []string) {
 	}
 
 	if fsckDryRun || len(corruptOids) == 0 {
-		os.Exit(1)
+		ExitWithCode(1)
 	}
 
 	badDir := filepath.Join(cfg.LFSStorageDir(), "bad")
@@ -120,7 +120,7 @@ func fsckCommand(cmd *cobra.Command, args []string) {
 			ExitWithError(err)
 		}
 	}
-	os.Exit(1)
+	ExitWithCode(1)
 }
 
 // doFsckObjects checks that the objects in the given ref are correct and exist.

--- a/commands/command_install.go
+++ b/commands/command_install.go
@@ -24,7 +24,7 @@ func installCommand(cmd *cobra.Command, args []string) {
 	if err := cmdInstallOptions().Install(); err != nil {
 		Print(tr.Tr.Get("warning: %s", err.Error()))
 		Print(tr.Tr.Get("Run `git lfs install --force` to reset Git configuration."))
-		os.Exit(2)
+		ExitWithCode(2)
 	}
 
 	if !skipRepoInstall && (localInstall || worktreeInstall || cfg.InRepo()) {

--- a/commands/command_lock.go
+++ b/commands/command_lock.go
@@ -69,7 +69,7 @@ func lockCommand(cmd *cobra.Command, args []string) {
 
 	if !success {
 		lockClient.Close()
-		os.Exit(2)
+		ExitWithCode(2)
 	}
 }
 

--- a/commands/command_merge_driver.go
+++ b/commands/command_merge_driver.go
@@ -43,7 +43,7 @@ func mergeDriverCommand(cmd *cobra.Command, args []string) {
 	if err != nil {
 		ExitWithError(err)
 	}
-	os.Exit(status)
+	ExitWithCode(status)
 }
 
 func processFiles(fileSpecifiers map[string]string, program string, outputFile string) (int, error) {

--- a/commands/command_pointer.go
+++ b/commands/command_pointer.go
@@ -61,10 +61,10 @@ func pointerCommand(cmd *cobra.Command, args []string) {
 
 		p, err := lfs.DecodePointer(r)
 		if err != nil {
-			os.Exit(1)
+			ExitWithCode(1)
 		}
 		if pointerStrict && !p.Canonical {
-			os.Exit(2)
+			ExitWithCode(2)
 		}
 		r.Close()
 		return
@@ -79,7 +79,7 @@ func pointerCommand(cmd *cobra.Command, args []string) {
 		buildFile, err := os.Open(pointerFile)
 		if err != nil {
 			Error(err.Error())
-			os.Exit(1)
+			ExitWithCode(1)
 		}
 
 		var ptr *lfs.Pointer
@@ -89,7 +89,7 @@ func pointerCommand(cmd *cobra.Command, args []string) {
 			if err != nil {
 				Error(err.Error())
 				buildFile.Close()
-				os.Exit(1)
+				ExitWithCode(1)
 			}
 
 			ptr = lfs.NewPointer(hex.EncodeToString(oidHash.Sum(nil)), size, nil)
@@ -100,7 +100,7 @@ func pointerCommand(cmd *cobra.Command, args []string) {
 			if err != nil {
 				Error(err.Error())
 				buildFile.Close()
-				os.Exit(1)
+				ExitWithCode(1)
 			}
 
 			ptr = cleaned.Pointer
@@ -120,7 +120,7 @@ func pointerCommand(cmd *cobra.Command, args []string) {
 			buildOid, err = git.HashObject(bytes.NewReader(buf.Bytes()))
 			if err != nil {
 				Error(err.Error())
-				os.Exit(1)
+				ExitWithCode(1)
 			}
 			fmt.Fprint(os.Stderr, "\n", tr.Tr.Get("Git blob OID: %s", buildOid), "\n\n")
 		}
@@ -133,7 +133,7 @@ func pointerCommand(cmd *cobra.Command, args []string) {
 		compFile, err := pointerReader()
 		if err != nil {
 			Error(err.Error())
-			os.Exit(1)
+			ExitWithCode(1)
 		}
 
 		buf := &bytes.Buffer{}
@@ -149,7 +149,7 @@ func pointerCommand(cmd *cobra.Command, args []string) {
 
 		if err != nil {
 			Error(err.Error())
-			os.Exit(1)
+			ExitWithCode(1)
 		}
 
 		fmt.Fprint(os.Stderr, buf.String())
@@ -157,7 +157,7 @@ func pointerCommand(cmd *cobra.Command, args []string) {
 			compareOid, err = git.HashObject(bytes.NewReader(buf.Bytes()))
 			if err != nil {
 				Error(err.Error())
-				os.Exit(1)
+				ExitWithCode(1)
 			}
 			fmt.Fprint(os.Stderr, "\n", tr.Tr.Get("Git blob OID: %s", compareOid), "\n")
 		}
@@ -168,12 +168,12 @@ func pointerCommand(cmd *cobra.Command, args []string) {
 		if hasExtensionsConfig || len(comparePointer.Extensions) > 0 {
 			fmt.Fprint(os.Stderr, tr.Tr.Get("note: Mismatch may be due to differing LFS extensions."), "\n")
 		}
-		os.Exit(1)
+		ExitWithCode(1)
 	}
 
 	if !something {
 		Error(tr.Tr.Get("Nothing to do!"))
-		os.Exit(1)
+		ExitWithCode(1)
 	}
 }
 

--- a/commands/command_post_checkout.go
+++ b/commands/command_post_checkout.go
@@ -28,7 +28,7 @@ func postCheckoutCommand(cmd *cobra.Command, args []string) {
 
 	// Skip entire hook if lockable read only feature is disabled
 	if !cfg.SetLockableFilesReadOnly() {
-		os.Exit(0)
+		return
 	}
 
 	requireGitVersion()
@@ -37,7 +37,7 @@ func postCheckoutCommand(cmd *cobra.Command, args []string) {
 
 	// Skip this hook if no lockable patterns have been configured
 	if len(lockClient.GetLockablePatterns()) == 0 {
-		os.Exit(0)
+		return
 	}
 
 	if args[2] == "1" && args[0] != "0000000000000000000000000000000000000000" {

--- a/commands/command_post_checkout.go
+++ b/commands/command_post_checkout.go
@@ -1,8 +1,6 @@
 package commands
 
 import (
-	"os"
-
 	"github.com/git-lfs/git-lfs/v3/git"
 	"github.com/git-lfs/git-lfs/v3/locking"
 	"github.com/git-lfs/git-lfs/v3/tr"
@@ -23,7 +21,7 @@ import (
 func postCheckoutCommand(cmd *cobra.Command, args []string) {
 	if len(args) != 3 {
 		Print(tr.Tr.Get("This should be run through Git's post-checkout hook.  Run `git lfs update` to install it."))
-		os.Exit(1)
+		ExitWithCode(1)
 	}
 
 	// Skip entire hook if lockable read only feature is disabled
@@ -45,7 +43,6 @@ func postCheckoutCommand(cmd *cobra.Command, args []string) {
 	} else {
 		postCheckoutFileChange(lockClient)
 	}
-
 }
 
 func postCheckoutRevChange(client *locking.Client, pre, post string) {

--- a/commands/command_post_commit.go
+++ b/commands/command_post_commit.go
@@ -1,8 +1,6 @@
 package commands
 
 import (
-	"os"
-
 	"github.com/git-lfs/git-lfs/v3/git"
 	"github.com/git-lfs/git-lfs/v3/tr"
 	"github.com/rubyist/tracerx"
@@ -39,14 +37,13 @@ func postCommitCommand(cmd *cobra.Command, args []string) {
 
 	if err != nil {
 		LoggedError(err, tr.Tr.Get("Warning: post-commit failed: %v", err))
-		os.Exit(1)
+		ExitWithCode(1)
 	}
 	tracerx.Printf("post-commit: checking write flags on %v", files)
 	err = lockClient.FixLockableFileWriteFlags(files)
 	if err != nil {
 		LoggedError(err, tr.Tr.Get("Warning: post-commit locked file check failed: %v", err))
 	}
-
 }
 
 func init() {

--- a/commands/command_post_commit.go
+++ b/commands/command_post_commit.go
@@ -20,7 +20,7 @@ func postCommitCommand(cmd *cobra.Command, args []string) {
 
 	// Skip entire hook if lockable read only feature is disabled
 	if !cfg.SetLockableFilesReadOnly() {
-		os.Exit(0)
+		return
 	}
 
 	requireGitVersion()
@@ -29,7 +29,7 @@ func postCommitCommand(cmd *cobra.Command, args []string) {
 
 	// Skip this hook if no lockable patterns have been configured
 	if len(lockClient.GetLockablePatterns()) == 0 {
-		os.Exit(0)
+		return
 	}
 
 	tracerx.Printf("post-commit: checking file write flags at HEAD")

--- a/commands/command_post_merge.go
+++ b/commands/command_post_merge.go
@@ -20,7 +20,7 @@ func postMergeCommand(cmd *cobra.Command, args []string) {
 
 	// Skip entire hook if lockable read only feature is disabled
 	if !cfg.SetLockableFilesReadOnly() {
-		os.Exit(0)
+		return
 	}
 
 	requireGitVersion()
@@ -29,7 +29,7 @@ func postMergeCommand(cmd *cobra.Command, args []string) {
 
 	// Skip this hook if no lockable patterns have been configured
 	if len(lockClient.GetLockablePatterns()) == 0 {
-		os.Exit(0)
+		return
 	}
 
 	// The only argument this hook receives is a flag indicating whether the

--- a/commands/command_post_merge.go
+++ b/commands/command_post_merge.go
@@ -1,8 +1,6 @@
 package commands
 
 import (
-	"os"
-
 	"github.com/git-lfs/git-lfs/v3/tr"
 	"github.com/rubyist/tracerx"
 	"github.com/spf13/cobra"
@@ -15,7 +13,7 @@ import (
 func postMergeCommand(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
 		Print(tr.Tr.Get("This should be run through Git's post-merge hook.  Run `git lfs update` to install it."))
-		os.Exit(1)
+		ExitWithCode(1)
 	}
 
 	// Skip entire hook if lockable read only feature is disabled

--- a/commands/command_pre_push.go
+++ b/commands/command_pre_push.go
@@ -42,7 +42,7 @@ var (
 func prePushCommand(cmd *cobra.Command, args []string) {
 	if len(args) == 0 {
 		Print(tr.Tr.Get("This should be run through Git's pre-push hook.  Run `git lfs update` to install it."))
-		os.Exit(1)
+		ExitWithCode(1)
 	}
 
 	if cfg.Os.Bool("GIT_LFS_SKIP_PUSH", false) {

--- a/commands/command_push.go
+++ b/commands/command_push.go
@@ -73,13 +73,13 @@ func pushCommand(cmd *cobra.Command, args []string) {
 		// easier and avoid having to special-case this in scripts.
 		if !useStdin && len(argList) < 1 {
 			Print(tr.Tr.Get("At least one object ID must be supplied with --object-id"))
-			os.Exit(1)
+			ExitWithCode(1)
 		}
 		uploadsWithObjectIDs(ctx, argList)
 	} else {
 		if !useStdin && !pushAll && len(argList) < 1 {
 			Print(tr.Tr.Get("At least one ref must be supplied without --all"))
-			os.Exit(1)
+			ExitWithCode(1)
 		}
 		uploadsBetweenRefAndRemote(ctx, argList)
 	}

--- a/commands/command_smudge.go
+++ b/commands/command_smudge.go
@@ -139,7 +139,7 @@ func smudge(gf *lfs.GitFilter, to io.Writer, from io.Reader, filename string, sk
 
 		LoggedError(err, tr.Tr.Get("Error downloading object: %s (%s): %s", filename, oid, err))
 		if !cfg.SkipDownloadErrors() {
-			os.Exit(2)
+			ExitWithCode(2)
 		}
 	}
 

--- a/commands/command_standalone_file.go
+++ b/commands/command_standalone_file.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/git-lfs/git-lfs/v3/lfshttp/standalone"
@@ -11,8 +10,7 @@ import (
 func standaloneFileCommand(cmd *cobra.Command, args []string) {
 	err := standalone.ProcessStandaloneData(cfg, os.Stdin, os.Stdout)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(2)
+		ExitWithError(err)
 	}
 }
 

--- a/commands/command_track.go
+++ b/commands/command_track.go
@@ -237,7 +237,7 @@ ArgsLoop:
 	}
 
 	if sawError {
-		os.Exit(2)
+		ExitWithCode(2)
 	}
 	// If we didn't modify things, but that's because the patterns
 	// were already supported, don't return an error, since what the
@@ -245,7 +245,7 @@ ArgsLoop:
 	// Otherwise, if we didn't modify things but only because the
 	// patterns were disallowed, return an error.
 	if !modified && len(changedAttribLines) > 0 {
-		os.Exit(1)
+		ExitWithCode(1)
 	}
 }
 

--- a/commands/command_unlock.go
+++ b/commands/command_unlock.go
@@ -132,7 +132,7 @@ func unlockCommand(cmd *cobra.Command, args []string) {
 	}
 	if !success {
 		lockClient.Close()
-		os.Exit(2)
+		ExitWithCode(2)
 	}
 }
 

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -208,6 +208,11 @@ func uninstallHooks() error {
 	return nil
 }
 
+// ExitWithCode exits immediately with the given code.
+func ExitWithCode(code int) {
+	os.Exit(code)
+}
+
 // Error prints a formatted message to Stderr.  It also gets printed to the
 // panic log if one is created for this command.
 func Error(format string, args ...interface{}) {
@@ -297,14 +302,14 @@ func requireStdin(msg string) {
 
 	if len(out) > 0 {
 		Error(out)
-		os.Exit(1)
+		ExitWithCode(1)
 	}
 }
 
 func requireInRepo() {
 	if !cfg.InRepo() {
 		Print(tr.Tr.Get("Not in a Git repository."))
-		os.Exit(128)
+		ExitWithCode(128)
 	}
 }
 
@@ -314,7 +319,7 @@ func requireInRepo() {
 func requireWorkingCopy() {
 	if cfg.LocalWorkingDir() == "" {
 		Print(tr.Tr.Get("This operation must be run in a work tree."))
-		os.Exit(128)
+		ExitWithCode(128)
 	}
 }
 
@@ -339,7 +344,7 @@ func verifyRepositoryVersion() {
 		cfg.SetGitLocalKey(key, "0")
 	} else if val != "0" {
 		Print(tr.Tr.Get("Unknown repository format version: %s", val))
-		os.Exit(128)
+		ExitWithCode(128)
 	}
 }
 

--- a/commands/uploader.go
+++ b/commands/uploader.go
@@ -290,12 +290,12 @@ func (c *uploadContext) ReportErrors() {
 				tr.Tr.Get("hint: You can disable this check with: `git config lfs.allowincompletepush true`"),
 			}
 			Print(strings.Join(pushMissingHint, "\n"))
-			os.Exit(2)
+			ExitWithCode(2)
 		}
 	}
 
 	if len(c.otherErrs) > 0 {
-		os.Exit(2)
+		ExitWithCode(2)
 	}
 
 	if c.lockVerifier.HasUnownedLocks() {

--- a/lfshttp/standalone/standalone.go
+++ b/lfshttp/standalone/standalone.go
@@ -207,7 +207,7 @@ func newHandler(cfg *config.Configuration, output *os.File, msg *inputMessage) (
 }
 
 // dispatch dispatches the event depending on the message type.
-func (h *fileHandler) dispatch(msg *inputMessage) bool {
+func (h *fileHandler) dispatch(msg *inputMessage) (bool, error) {
 	switch msg.Event {
 	case "init":
 		fmt.Fprintln(h.output, "{}")
@@ -216,11 +216,11 @@ func (h *fileHandler) dispatch(msg *inputMessage) bool {
 	case "download":
 		h.respond(h.download(msg.Oid, msg.Size))
 	case "terminate":
-		return false
+		return false, nil
 	default:
-		standaloneFailure(tr.Tr.Get("unknown event %q", msg.Event), nil)
+		return false, errors.New(tr.Tr.Get("unknown event %q", msg.Event))
 	}
-	return true
+	return true, nil
 }
 
 // respond sends a response to an upload or download command, using the return
@@ -274,18 +274,13 @@ func (h *fileHandler) download(oid string, size int64) (string, string, error) {
 	return oid, path, lfs.LinkOrCopy(h.config, src, path)
 }
 
-// standaloneFailure reports a fatal error.
-func standaloneFailure(msg string, err error) {
-	fmt.Fprintf(os.Stderr, "%s: %s\n", msg, err)
-	os.Exit(2)
-}
-
 // ProcessStandaloneData is the primary endpoint for processing data with a
 // standalone transfer agent. It reads input from the specified input file and
 // produces output to the specified output file.
 func ProcessStandaloneData(cfg *config.Configuration, input *os.File, output *os.File) error {
 	var handler *fileHandler
 
+	var eventErr error
 	scanner := bufio.NewScanner(input)
 	for scanner.Scan() {
 		var msg inputMessage
@@ -306,15 +301,17 @@ func ProcessStandaloneData(cfg *config.Configuration, input *os.File, output *os
 				return err
 			}
 		}
-		if !handler.dispatch(&msg) {
+		if cont, err := handler.dispatch(&msg); !cont || err != nil {
+			eventErr = err
 			break
 		}
 	}
 	if handler != nil {
 		os.RemoveAll(handler.tempdir)
 	}
-	if err := scanner.Err(); err != nil {
-		return errors.Wrap(err, tr.Tr.Get("error reading input"))
+	err := scanner.Err()
+	if err != nil {
+		err = errors.Wrap(err, tr.Tr.Get("error reading input"))
 	}
-	return nil
+	return errors.Join(eventErr, err)
 }


### PR DESCRIPTION
This PR updates a number of Git LFS commands to ensure that all our commands use a consistent set of utility functions when they need to stop and exit immediately.

These changes will help minimize the revisions that will be necessary in a future PR to guarantee that our commands always perform a common set of cleanup steps before exiting.

#### Specific Changes

In this PR, we first update several commands' implementation functions to either use the existing `ExitWithError()` utility [function](https://github.com/git-lfs/git-lfs/blob/e09c0f6216dadd0624eb425e8965f28868f9cd47/commands/commands.go#L237-L241) or, if they intend to exit with a status code of zero, to simply return and allow our normal call stack to completely unwind.

In the particular case of our `git lfs standalone-file` command, we also revise our `lfshttp/standalone` package to eliminate the `standaloneFailure()` [function](https://github.com/git-lfs/git-lfs/blob/e09c0f6216dadd0624eb425e8965f28868f9cd47/lfshttp/standalone/standalone.go#L277-L281) which at present calls the `os.Exit()` function directly.  To make this possible, we adjust our handling of unknown Git LFS custom transfer protocol event messages so that we now report an error back up to the `standaloneFileCommand()` function in the `commands` package.

We then introduce a new `ExitWithCode()` utility function which, in its initial form, just calls the `os.Exit()` function with a given status code.  In a subsequent PR, however, we may expand this function and the small set of remaining functions which call the `os.Exit()` function to ensure they all execute a standard cleanup and shutdown sequence before exiting.

