### PR TITLE
Temporarily restore concurrency limit to historical fixed default

### DIFF
--- a/docs/man/git-lfs-config.adoc
+++ b/docs/man/git-lfs-config.adoc
@@ -137,8 +137,7 @@ occurs.
 
 * `lfs.concurrenttransfers`
 +
-The number of concurrent uploads/downloads. Default is 3x the number of
-logical CPUs, with a minimum of 8.
+The number of concurrent uploads/downloads. Default is 8.
 * `lfs.basictransfersonly`
 +
 If set to true, only basic HTTP upload/download transfers will be used,

--- a/lfshttp/client.go
+++ b/lfshttp/client.go
@@ -12,7 +12,6 @@ import (
 	"net/url"
 	"os"
 	"regexp"
-	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -32,18 +31,18 @@ const MediaType = "application/vnd.git-lfs+json"
 const RequestContentType = MediaType + "; charset=utf-8"
 
 const (
-	MinConcurrentTransfers = 8
+	defaultConcurrentTransfers = 8
 )
 
-// DefaultConcurrentTransfers scales with CPU count. Downloads are
-// I/O-bound (network + disk) so we use 3× NCPU to keep many connections
-// saturated while a few are stalled on TLS handshakes or server latency.
+// At present, we return a fixed default value of 8 concurrent transfers,
+// which is less than ideal for HTTP-based transfers when many objects
+// are transferred by a single "git lfs filter-process" command.
+//
+// However, the "lfs.concurrentTransfers" setting also controls the number
+// of processes we spawn for SSH-based or custom transfers, and we want
+// to avoid spawning large numbers of separate processes.
 func DefaultConcurrentTransfers() int {
-	n := runtime.NumCPU() * 3
-	if n < MinConcurrentTransfers {
-		return MinConcurrentTransfers
-	}
-	return n
+	return defaultConcurrentTransfers
 }
 
 var (

--- a/t/testhelpers.sh
+++ b/t/testhelpers.sh
@@ -1085,13 +1085,16 @@ pktize_flush() {
   printf '0000'
 }
 
-# Compute the expected default ConcurrentTransfers value (3 × NCPU,
-# min 8) so tests stay correct on any machine.  We use a small Go
-# helper to get runtime.NumCPU() so the value always matches what the
-# git-lfs binary sees, even inside containers with cgroup limits.
+# At present, we expect a fixed default value of 8 concurrent transfers,
+# which is less than ideal for HTTP-based transfers when many objects
+# are transferred by a single "git lfs filter-process" command.
+#
+# However, the "lfs.concurrentTransfers" setting also controls the number
+# of processes we spawn for SSH-based or custom transfers, and we want
+# to avoid spawning large numbers of separate processes.
+#
+# In the future, we may allow this default value to be scaled by the
+# number of CPUs, as returned by our lfstest-getnumcpu utility.
 setup_expected_concurrent_transfers() {
-  _ncpu=$(lfstest-getnumcpu)
-  _ct=$(( _ncpu * 3 ))
-  [ "$_ct" -lt 8 ] && _ct=8
-  expectedConcurrentTransfers=$_ct
+  expectedConcurrentTransfers=8
 }

--- a/tq/manifest.go
+++ b/tq/manifest.go
@@ -240,11 +240,12 @@ func newConcreteManifest(f *fs.Filesystem, apiClient *lfsapi.Client, operation, 
 	}
 
 	if sshTransfer != nil {
+		// Multiple concurrent transfers are not supported
+		// when SSH multiplexing is disabled.
 		if !useSSHMultiplexing {
 			m.concurrentTransfers = 1
 		}
 
-		// Multiple concurrent transfers are not yet supported.
 		m.batchClientAdapter = &SSHBatchClient{
 			maxRetries: m.maxRetries,
 			transfer:   sshTransfer,


### PR DESCRIPTION
This PR reverses the key change from PR #6241 and restores the fixed, historical default of 8 for the `lfs.concurrentTransfers` configuration option, so that we do not spawn large numbers of child processes when transferring objects using our "pure" SSH protocol or when using a custom transfer agent.

After the upcoming v3.8.0 Git LFS release we will revisit the issue of scaling default concurrency settings with CPU counts while limiting the number of child processes we might create.  See #6259 for that discussion.

This PR will be most easily reviewed on a commit-by-commit basis.

#### Additional Context

As discussed in PRs #6241 and #6234, we would like to refine the concurrency controls for the Git LFS client so that they can scale with the number of available CPUs, at least when performing HTTP-based object transfers.

We adopted an initial implementation of in PR #6241, which was effective for HTTP object transfers and improved performance significantly on multi-core CPUs.

However, this change also has the unintended effect of scaling the number of child processes we execute when handling object transfers using a custom agent or when using multiplexed SSH connections.  While some systems may not be affected, creating large numbers of separate processes is at best not ideal and at worst may run afoul of system or container limits.

We therefore temporarily reverse the key change from PR #6241 and restore the fixed, historical default of 8 for the `lfs.concurrentTransfers` configuration option.

After our upcoming release of version 3.8.0 of the Git LFS client, we intend to revisit this issue and find a more comprehensive solution so that we can safely scale thread counts while keeping process counts within reasonable bounds.

#### Other Changes

We also take the opportunity to correct the placement and wording of a [comment](https://github.com/git-lfs/git-lfs/blob/4267a957a4ec729d3390dda642c24575b85fc5a8/tq/manifest.go#L252) regarding concurrency support for SSH-based object transfers.

/cc @joshfriend as the author of PRs #6241 and #6234.