### PR TITLE
fix: chunked content length

### DIFF
--- a/tq/basic_upload.go
+++ b/tq/basic_upload.go
@@ -55,13 +55,13 @@ func (a *basicUploadAdapter) DoTransfer(ctx interface{}, t *Transfer, cb Progres
 		return err
 	}
 
-	if req.Header.Get("Transfer-Encoding") == "chunked" {
+	if isChunkedTransferEncoding(req.Header.Get("Transfer-Encoding")) {
 		req.TransferEncoding = []string{"chunked"}
+		req.ContentLength = -1
 	} else {
 		req.Header.Set("Content-Length", strconv.FormatInt(t.Size, 10))
+		req.ContentLength = t.Size
 	}
-
-	req.ContentLength = t.Size
 
 	f, err := os.OpenFile(t.Path, os.O_RDONLY, 0644)
 	if err != nil {
@@ -208,6 +208,18 @@ func newStartCallbackReader(r lfsapi.ReadSeekCloser, cb func() error) *startCall
 		ReadSeekCloser: r,
 		cb:             cb,
 	}
+}
+
+// isChunkedTransferEncoding reports whether the Transfer-Encoding header value
+// contains "chunked" as a transfer-coding token. Tokens are case-insensitive
+// and the header may be a comma-separated list per RFC 7230 §3.3.1.
+func isChunkedTransferEncoding(v string) bool {
+	for _, tok := range strings.Split(v, ",") {
+		if strings.EqualFold(strings.TrimSpace(tok), "chunked") {
+			return true
+		}
+	}
+	return false
 }
 
 func configureBasicUploadAdapter(m *concreteManifest) {

--- a/tq/basic_upload_test.go
+++ b/tq/basic_upload_test.go
@@ -1,0 +1,89 @@
+package tq
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/git-lfs/git-lfs/v3/lfsapi"
+	"github.com/git-lfs/git-lfs/v3/lfshttp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBasicUploadAdapterContentLengthWithChunked(t *testing.T) {
+	const content = "hello chunked upload"
+
+	f, err := os.CreateTemp("", "git-lfs-upload-test-*")
+	require.Nil(t, err)
+	defer os.Remove(f.Name())
+	_, err = f.WriteString(content)
+	require.Nil(t, err)
+	f.Close()
+
+	tests := []struct {
+		name              string
+		actionHeaders     map[string]string
+		wantContentLength string
+	}{
+		{
+			name:              "chunked: Content-Length header must be absent",
+			actionHeaders:     map[string]string{"Transfer-Encoding": "chunked"},
+			wantContentLength: "",
+		},
+		{
+			name:              "chunked uppercase: Content-Length header must be absent",
+			actionHeaders:     map[string]string{"Transfer-Encoding": "Chunked"},
+			wantContentLength: "",
+		},
+		{
+			name:              "chunked in list: Content-Length header must be absent",
+			actionHeaders:     map[string]string{"Transfer-Encoding": "gzip, chunked"},
+			wantContentLength: "",
+		},
+		{
+			name:              "normal: Content-Length header must equal file size",
+			actionHeaders:     map[string]string{},
+			wantContentLength: strconv.Itoa(len(content)),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var capturedContentLength string
+			var requestReceived bool
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestReceived = true
+				capturedContentLength = r.Header.Get("Content-Length")
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer srv.Close()
+
+			c := lfsapi.NewClient(lfshttp.NewContext(nil, nil, nil))
+			bu := &basicUploadAdapter{newAdapterBase(nil, BasicAdapterName, Upload, nil)}
+			bu.transferImpl = bu
+			bu.apiClient = c
+
+			transfer := &Transfer{
+				Oid:           "abc123def456",
+				Size:          int64(len(content)),
+				Path:          f.Name(),
+				Authenticated: true,
+				Actions: map[string]*Action{
+					"upload": {
+						Href:   srv.URL + "/upload",
+						Header: tc.actionHeaders,
+					},
+				},
+			}
+
+			err := bu.DoTransfer(nil, transfer, nil, nil)
+			require.Nil(t, err)
+			assert.True(t, requestReceived, "expected upload request to reach the server")
+			assert.Equal(t, tc.wantContentLength, capturedContentLength)
+		})
+	}
+}


### PR DESCRIPTION
When a server's LFS batch response includes `Transfer-Encoding: chunked` in an upload action's `header` map (as Gitea 1.26.0 now does via go-gitea/gitea#36380), git-lfs correctly sets `req.TransferEncoding` but unconditionally also sets `req.ContentLength = t.Size`, which causes two problems:

Number one is around HTTP/1.1: (Go's) `net/http` client sends both `Transfer-Encoding: chunked` and `Content-Length` (which [RFC 7230 forbids](https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2)). Proxies that key their buffering decision on the presence of `Content-Length` (most notably Cloudflare, which has a 100 MB buffer cap on their free plan) ignore the chunked signal, buffer the body against the declared length, and return HTTP 413 for files exceeding that cap.

The second one is around HTTP/2: the protocol strips `Transfer-Encoding` entirely; Go's HTTP/2 client ignores `req.TransferEncoding` and falls back to `req.ContentLength`. So, basically, the chunked signal is silently discarded, which means that the Gitea server-side fix has no effect at all on TLS connections (where HTTP/2 is the default).

The solution is thus to set `req.ContentLength = -1`, which makes Go omit the `Content-Length` header entirely. In HTTP/1.1 this produces a clean chunked request with no conflicting header; in HTTP/2 it causes the client to use unknown-length streaming semantics, which achieves the same result. In both cases the proxy has no declared size to buffer against and must stream the body through.