### PR TITLE
Reuse SSH sessions when possible and only close at client exit

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -39,9 +39,10 @@ var (
 	ManPages     = make(map[string]string, 20)
 	tqManifest   = make(map[string]tq.Manifest)
 
-	cfg       *config.Configuration
-	apiClient *lfsapi.Client
-	global    sync.Mutex
+	cfg         *config.Configuration
+	apiClient   *lfsapi.Client
+	global      sync.Mutex
+	cleanupOnce sync.Once
 
 	oldEnv = make(map[string]string)
 
@@ -280,6 +281,10 @@ func Panic(err error, format string, args ...interface{}) {
 }
 
 func Cleanup() {
+	cleanupOnce.Do(doCleanup)
+}
+
+func doCleanup() {
 	if err := cfg.Cleanup(); err != nil {
 		fmt.Fprintln(os.Stderr, tr.Tr.Get("Error clearing old temporary files: %s", err))
 	}

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -288,6 +288,10 @@ func Cleanup() {
 }
 
 func doCleanup() {
+	if err := closeAPIClient(); err != nil {
+		fmt.Fprintln(os.Stderr, tr.Tr.Get("Error closing API client: %s", err))
+	}
+
 	if err := cfg.Cleanup(); err != nil {
 		fmt.Fprintln(os.Stderr, tr.Tr.Get("Error clearing old temporary files: %s", err))
 	}

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -206,6 +206,7 @@ func uninstallHooks() error {
 
 // ExitWithCode exits immediately with the given code.
 func ExitWithCode(code int) {
+	Cleanup()
 	os.Exit(code)
 }
 
@@ -232,6 +233,7 @@ func Print(format string, args ...interface{}) {
 // Exit prints a formatted message and exits.
 func Exit(format string, args ...interface{}) {
 	Error(format, args...)
+	Cleanup()
 	os.Exit(2)
 }
 
@@ -277,6 +279,7 @@ func LoggedError(err error, format string, args ...interface{}) {
 // a log file before exiting.
 func Panic(err error, format string, args ...interface{}) {
 	LoggedError(err, format, args...)
+	Cleanup()
 	os.Exit(2)
 }
 

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -89,7 +89,11 @@ func closeAPIClient() error {
 	if apiClient == nil {
 		return nil
 	}
-	return apiClient.Close()
+
+	err := apiClient.Close()
+	apiClient = nil
+
+	return err
 }
 
 func newLockClient() *locking.Client {

--- a/commands/lockverifier.go
+++ b/commands/lockverifier.go
@@ -13,6 +13,7 @@ import (
 	"github.com/git-lfs/git-lfs/v3/locking"
 	"github.com/git-lfs/git-lfs/v3/tq"
 	"github.com/git-lfs/git-lfs/v3/tr"
+	"github.com/rubyist/tracerx"
 )
 
 type verifyState byte
@@ -55,6 +56,8 @@ func (lv *lockVerifier) Verify(ref *git.Ref) {
 		return
 	}
 
+	tracerx.Printf("verifying locks for %s", ref.Name)
+
 	lockClient := newLockClient()
 	lockClient.RemoteRef = ref
 	ours, theirs, err := lockClient.SearchLocksVerifiable(0, false)
@@ -84,6 +87,8 @@ func (lv *lockVerifier) Verify(ref *git.Ref) {
 	lv.addLocks(ref, ours, lv.ourLocks)
 	lv.addLocks(ref, theirs, lv.theirLocks)
 	lv.verifiedRefs[ref.Refspec()] = true
+
+	tracerx.Printf("verified locks for %s", ref.Name)
 }
 
 func (lv *lockVerifier) addLocks(ref *git.Ref, locks []locking.Lock, set map[string]*refLock) {

--- a/commands/run.go
+++ b/commands/run.go
@@ -152,7 +152,6 @@ Simply type ` + root.Name() + ` help [path to command] for full details.`,
 	}
 
 	err := root.Execute()
-	closeAPIClient()
 
 	if err != nil {
 		return 127

--- a/git-lfs.go
+++ b/git-lfs.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"sync"
 	"syscall"
 
 	"github.com/git-lfs/git-lfs/v3/commands"
@@ -15,12 +14,10 @@ func main() {
 	c := make(chan os.Signal)
 	signal.Notify(c, os.Interrupt, os.Kill)
 
-	var once sync.Once
-
 	go func() {
 		for {
 			sig := <-c
-			once.Do(commands.Cleanup)
+			commands.Cleanup()
 			fmt.Fprintf(os.Stderr, "\n%s\n", tr.Tr.Get("Exiting because of %q signal.", sig))
 
 			exitCode := 1
@@ -32,6 +29,6 @@ func main() {
 	}()
 
 	code := commands.Run()
-	once.Do(commands.Cleanup)
+	commands.Cleanup()
 	os.Exit(code)
 }

--- a/lfs/lfs.go
+++ b/lfs/lfs.go
@@ -20,6 +20,7 @@ func Environ(cfg *config.Configuration, manifest tq.Manifest, envOverrides map[s
 	env := make([]string, 0, len(osEnviron)+7)
 
 	api := lfsapi.NewClient(cfg)
+	defer api.Close()
 
 	if envOverrides == nil {
 		envOverrides = make(map[string]string, 0)

--- a/lfsapi/client.go
+++ b/lfsapi/client.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/git-lfs/git-lfs/v3/config"
 	"github.com/git-lfs/git-lfs/v3/creds"
+	"github.com/git-lfs/git-lfs/v3/errors"
 	"github.com/git-lfs/git-lfs/v3/lfshttp"
 )
 
@@ -51,5 +52,5 @@ func (c *Client) LogHTTPStats(w io.WriteCloser) {
 }
 
 func (c *Client) Close() error {
-	return c.client.Close()
+	return errors.Join(c.closeSSHTransfers(), c.client.Close())
 }

--- a/lfsapi/lfsapi.go
+++ b/lfsapi/lfsapi.go
@@ -65,8 +65,11 @@ func (c *Client) SSHTransfer(operation, remote string) *ssh.SSHTransfer {
 
 	sshTransfer, ok := c.sshTransfers[k]
 	if !ok {
-		sshTransfer = c.initSSHTransfer(operation, remote)
-		c.sshTransfers[k] = sshTransfer
+		var err error
+		sshTransfer, err = c.initSSHTransfer(operation, remote)
+		if err == nil {
+			c.sshTransfers[k] = sshTransfer
+		}
 	}
 
 	return sshTransfer
@@ -75,16 +78,16 @@ func (c *Client) SSHTransfer(operation, remote string) *ssh.SSHTransfer {
 // initSSHTransfer returns either an suitable transfer object or nil if the
 // server is not using an SSH remote or the git-lfs-transfer style of SSH
 // remote.
-func (c *Client) initSSHTransfer(operation, remote string) *ssh.SSHTransfer {
+func (c *Client) initSSHTransfer(operation, remote string) (*ssh.SSHTransfer, error) {
 	endpoint := c.Endpoints.Endpoint(operation, remote)
 	if len(endpoint.SSHMetadata.UserAndHost) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	uc := config.NewURLConfig(c.context.GitEnv())
 	if val, ok := uc.Get("lfs", endpoint.OriginalUrl, "sshtransfer"); ok && val != "negotiate" && val != "always" {
 		tracerx.Printf("skipping pure SSH protocol connection by request (%s, %s)", operation, remote)
-		return nil
+		return nil, nil
 	}
 
 	ctx := c.Context()
@@ -92,10 +95,10 @@ func (c *Client) initSSHTransfer(operation, remote string) *ssh.SSHTransfer {
 	sshTransfer, err := ssh.NewSSHTransfer(ctx.OSEnv(), ctx.GitEnv(), &endpoint.SSHMetadata, operation)
 	if err != nil {
 		tracerx.Printf("pure SSH protocol connection failed (%s, %s): %s", operation, remote, err)
-		return nil
+		return nil, err
 	}
 
-	return sshTransfer
+	return sshTransfer, nil
 }
 
 func (c *Client) closeSSHTransfers() error {

--- a/lfsapi/lfsapi.go
+++ b/lfsapi/lfsapi.go
@@ -1,6 +1,9 @@
 package lfsapi
 
 import (
+	"fmt"
+	"sync"
+
 	"github.com/git-lfs/git-lfs/v3/config"
 	"github.com/git-lfs/git-lfs/v3/creds"
 	"github.com/git-lfs/git-lfs/v3/lfshttp"
@@ -17,6 +20,9 @@ type Client struct {
 	client  *lfshttp.Client
 	context lfshttp.Context
 	access  []creds.AccessMode
+
+	sshTransfers      map[string]*ssh.SSHTransfer
+	sshTransfersMutex *sync.Mutex
 }
 
 func NewClient(ctx lfshttp.Context) *Client {
@@ -33,6 +39,9 @@ func NewClient(ctx lfshttp.Context) *Client {
 		context:     ctx,
 		credContext: creds.NewCredentialHelperContext(gitEnv, osEnv),
 		access:      creds.AllAccessModes(),
+
+		sshTransfers:      make(map[string]*ssh.SSHTransfer),
+		sshTransfersMutex: &sync.Mutex{},
 	}
 }
 
@@ -40,22 +49,43 @@ func (c *Client) Context() lfshttp.Context {
 	return c.context
 }
 
-// SSHTransfer returns either an suitable transfer object or nil if the
-// server is not using an SSH remote or the git-lfs-transfer style of SSH
-// remote.
+// SSHTransfer returns either an suitable transfer object or nil.  For a
+// given operation and remote, the same transfer object (or nil) will
+// always be returned.
 func (c *Client) SSHTransfer(operation, remote string) *ssh.SSHTransfer {
 	if len(operation) == 0 {
 		return nil
 	}
+
+	k := fmt.Sprintf("%s.%s", operation, remote)
+
+	c.sshTransfersMutex.Lock()
+	defer c.sshTransfersMutex.Unlock()
+
+	sshTransfer, ok := c.sshTransfers[k]
+	if !ok {
+		sshTransfer = c.initSSHTransfer(operation, remote)
+		c.sshTransfers[k] = sshTransfer
+	}
+
+	return sshTransfer
+}
+
+// initSSHTransfer returns either an suitable transfer object or nil if the
+// server is not using an SSH remote or the git-lfs-transfer style of SSH
+// remote.
+func (c *Client) initSSHTransfer(operation, remote string) *ssh.SSHTransfer {
 	endpoint := c.Endpoints.Endpoint(operation, remote)
 	if len(endpoint.SSHMetadata.UserAndHost) == 0 {
 		return nil
 	}
+
 	uc := config.NewURLConfig(c.context.GitEnv())
 	if val, ok := uc.Get("lfs", endpoint.OriginalUrl, "sshtransfer"); ok && val != "negotiate" && val != "always" {
 		tracerx.Printf("skipping pure SSH protocol connection by request (%s, %s)", operation, remote)
 		return nil
 	}
+
 	ctx := c.Context()
 	tracerx.Printf("attempting pure SSH protocol connection (%s, %s)", operation, remote)
 	sshTransfer, err := ssh.NewSSHTransfer(ctx.OSEnv(), ctx.GitEnv(), &endpoint.SSHMetadata, operation)
@@ -63,5 +93,6 @@ func (c *Client) SSHTransfer(operation, remote string) *ssh.SSHTransfer {
 		tracerx.Printf("pure SSH protocol connection failed (%s, %s): %s", operation, remote, err)
 		return nil
 	}
+
 	return sshTransfer
 }

--- a/lfsapi/lfsapi.go
+++ b/lfsapi/lfsapi.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/git-lfs/git-lfs/v3/config"
 	"github.com/git-lfs/git-lfs/v3/creds"
+	"github.com/git-lfs/git-lfs/v3/errors"
 	"github.com/git-lfs/git-lfs/v3/lfshttp"
 	"github.com/git-lfs/git-lfs/v3/ssh"
 	"github.com/rubyist/tracerx"
@@ -95,4 +96,20 @@ func (c *Client) initSSHTransfer(operation, remote string) *ssh.SSHTransfer {
 	}
 
 	return sshTransfer
+}
+
+func (c *Client) closeSSHTransfers() error {
+	c.sshTransfersMutex.Lock()
+	defer c.sshTransfersMutex.Unlock()
+
+	var multiErr error
+	for _, sshTransfer := range c.sshTransfers {
+		if sshTransfer != nil {
+			multiErr = errors.Join(multiErr, sshTransfer.Shutdown())
+		}
+	}
+
+	clear(c.sshTransfers)
+
+	return multiErr
 }

--- a/lfshttp/standalone/standalone.go
+++ b/lfshttp/standalone/standalone.go
@@ -72,6 +72,7 @@ func fileUrlFromRemote(cfg *config.Configuration, name string, direction string)
 	}
 
 	apiClient := lfsapi.NewClient(cfg)
+	defer apiClient.Close()
 
 	for _, remote := range cfg.Remotes() {
 		if remote != name {

--- a/ssh/connection.go
+++ b/ssh/connection.go
@@ -167,7 +167,7 @@ func (st *SSHTransfer) setConnectionCount(n int) error {
 		}
 		for i, item := range st.conn[tn:count] {
 			if item == nil {
-				tracerx.Printf("skipping uninitialized lazy pure SSH connection (#%d) (resetting total from %d to %d)", i, count, n)
+				tracerx.Printf("skipping uninitialized lazy pure SSH connection (#%d) (resetting total from %d to %d)", tn+i, count, n)
 				continue
 			}
 			tracerx.Printf("terminating pure SSH connection (#%d) (resetting total from %d to %d)", tn+i, count, n)

--- a/t/cmd/lfstest-customadapter.go
+++ b/t/cmd/lfstest-customadapter.go
@@ -30,6 +30,7 @@ func main() {
 	writer := bufio.NewWriter(os.Stdout)
 	errWriter := bufio.NewWriter(os.Stderr)
 	apiClient := lfsapi.NewClient(cfg)
+	defer apiClient.Close()
 
 	for scanner.Scan() {
 		line := scanner.Text()

--- a/t/git-lfs-test-server-api/main.go
+++ b/t/git-lfs-test-server-api/main.go
@@ -72,10 +72,8 @@ func testServerApi(cmd *cobra.Command, args []string) {
 	repo.Pushd()
 	defer repo.Popd()
 
-	manifest, err := buildManifest(repo)
-	if err != nil {
-		exit("error building tq.Manifest: %s", err.Error())
-	}
+	apiClient, manifest := buildManifest(repo)
+	defer apiClient.Close()
 
 	var oidsExist, oidsMissing []TestObject
 	if len(args) >= 2 {
@@ -138,7 +136,7 @@ func (*testDataCallback) Errorf(format string, args ...interface{}) {
 	fmt.Printf(format, args...)
 }
 
-func buildManifest(r *t.Repo) (tq.Manifest, error) {
+func buildManifest(r *t.Repo) (*lfsapi.Client, tq.Manifest) {
 	// Configure the endpoint manually
 	finder := lfsapi.NewEndpointFinder(r)
 
@@ -154,7 +152,7 @@ func buildManifest(r *t.Repo) (tq.Manifest, error) {
 		e:              endp,
 		EndpointFinder: apiClient.Endpoints,
 	}
-	return tq.NewManifest(r.Filesystem(), apiClient, "", ""), nil
+	return apiClient, tq.NewManifest(r.Filesystem(), apiClient, "", "")
 }
 
 type constantEndpoint struct {

--- a/t/t-batch-transfer.sh
+++ b/t/t-batch-transfer.sh
@@ -255,12 +255,16 @@ begin_test "batch transfers with ssh endpoint (git-lfs-transfer)"
   # enforce their use in order to match other platforms' connection counts.
   git config --global lfs.ssh.autoMultiplex true
 
-  GIT_TRACE=1 git push origin main >push.log 2>&1
+  GIT_TRACE=1 git push origin main 2>&1 | tee push.log
+  [ 0 -eq "${PIPESTATUS[0]}" ]
+
   assert_ssh_transfer_sessions 'push.log' 'upload' 1 8
   assert_remote_object "$reponame" "$(calc_oid "$contents")" "${#contents}"
 
   cd ..
   GIT_TRACE=1 git clone "$sshurl" "$reponame-2" 2>&1 | tee clone.log
+  [ 0 -eq "${PIPESTATUS[0]}" ]
+
   assert_ssh_transfer_sessions 'clone.log' 'download' 1 8
 
   cd "$reponame-2"
@@ -295,7 +299,9 @@ begin_test "batch transfers with ssh endpoint and multiple objects (git-lfs-tran
   # enforce their use in order to match other platforms' connection counts.
   git config --global lfs.ssh.autoMultiplex true
 
-  GIT_TRACE=1 git push origin main >push.log 2>&1
+  GIT_TRACE=1 git push origin main 2>&1 | tee push.log
+  [ 0 -eq "${PIPESTATUS[0]}" ]
+
   assert_ssh_transfer_sessions 'push.log' 'upload' 3 8
   assert_remote_object "$reponame" "$(calc_oid "$contents1")" "${#contents1}"
   assert_remote_object "$reponame" "$(calc_oid "$contents2")" "${#contents2}"
@@ -303,6 +309,8 @@ begin_test "batch transfers with ssh endpoint and multiple objects (git-lfs-tran
 
   cd ..
   GIT_TRACE=1 git clone "$sshurl" "$reponame-2" 2>&1 | tee clone.log
+  [ 0 -eq "${PIPESTATUS[0]}" ]
+
   assert_ssh_transfer_sessions 'clone.log' 'download' 3 8
 
   cd "$reponame-2"
@@ -340,7 +348,9 @@ begin_test "batch transfers with ssh endpoint and multiple objects and batches (
   # Allow no more than two objects to be transferred in each batch.
   git config --global lfs.concurrentTransfers 2
 
-  GIT_TRACE=1 git push origin main >push.log 2>&1
+  GIT_TRACE=1 git push origin main 2>&1 | tee push.log
+  [ 0 -eq "${PIPESTATUS[0]}" ]
+
   assert_ssh_transfer_sessions 'push.log' 'upload' 3 2
   assert_remote_object "$reponame" "$(calc_oid "$contents1")" "${#contents1}"
   assert_remote_object "$reponame" "$(calc_oid "$contents2")" "${#contents2}"
@@ -348,6 +358,8 @@ begin_test "batch transfers with ssh endpoint and multiple objects and batches (
 
   cd ..
   GIT_TRACE=1 git clone "$sshurl" "$reponame-2" 2>&1 | tee clone.log
+  [ 0 -eq "${PIPESTATUS[0]}" ]
+
   assert_ssh_transfer_sessions 'clone.log' 'download' 3 2
 
   cd "$reponame-2"

--- a/t/t-batch-transfer.sh
+++ b/t/t-batch-transfer.sh
@@ -2,6 +2,8 @@
 
 . "$(dirname "$0")/testlib.sh"
 
+setup_expected_concurrent_transfers
+
 begin_test "batch transfer"
 (
   set -e
@@ -179,10 +181,10 @@ assert_ssh_transfer_sessions() {
   local log="$1"
   local direction="$2"
   local num_objs="$3"
-  local objs_per_batch="$4"
+  local max_concurrency="$4"
 
   local min_expected_start=1
-  local max_expected_start=$(( num_objs > objs_per_batch ? objs_per_batch : num_objs ))
+  local max_expected_start=$(( num_objs > max_concurrency ? max_concurrency : num_objs ))
   local min_expected_end=1
   local max_expected_end="$max_expected_start"
 
@@ -258,14 +260,14 @@ begin_test "batch transfers with ssh endpoint (git-lfs-transfer)"
   GIT_TRACE=1 git push origin main 2>&1 | tee push.log
   [ 0 -eq "${PIPESTATUS[0]}" ]
 
-  assert_ssh_transfer_sessions 'push.log' 'upload' 1 8
+  assert_ssh_transfer_sessions 'push.log' 'upload' 1 "$expectedConcurrentTransfers"
   assert_remote_object "$reponame" "$(calc_oid "$contents")" "${#contents}"
 
   cd ..
   GIT_TRACE=1 git clone "$sshurl" "$reponame-2" 2>&1 | tee clone.log
   [ 0 -eq "${PIPESTATUS[0]}" ]
 
-  assert_ssh_transfer_sessions 'clone.log' 'download' 1 8
+  assert_ssh_transfer_sessions 'clone.log' 'download' 1 "$expectedConcurrentTransfers"
 
   cd "$reponame-2"
   git lfs fsck
@@ -302,7 +304,7 @@ begin_test "batch transfers with ssh endpoint and multiple objects (git-lfs-tran
   GIT_TRACE=1 git push origin main 2>&1 | tee push.log
   [ 0 -eq "${PIPESTATUS[0]}" ]
 
-  assert_ssh_transfer_sessions 'push.log' 'upload' 3 8
+  assert_ssh_transfer_sessions 'push.log' 'upload' 3 "$expectedConcurrentTransfers"
   assert_remote_object "$reponame" "$(calc_oid "$contents1")" "${#contents1}"
   assert_remote_object "$reponame" "$(calc_oid "$contents2")" "${#contents2}"
   assert_remote_object "$reponame" "$(calc_oid "$contents3")" "${#contents3}"
@@ -311,7 +313,7 @@ begin_test "batch transfers with ssh endpoint and multiple objects (git-lfs-tran
   GIT_TRACE=1 git clone "$sshurl" "$reponame-2" 2>&1 | tee clone.log
   [ 0 -eq "${PIPESTATUS[0]}" ]
 
-  assert_ssh_transfer_sessions 'clone.log' 'download' 3 8
+  assert_ssh_transfer_sessions 'clone.log' 'download' 3 "$expectedConcurrentTransfers"
 
   cd "$reponame-2"
   git lfs fsck

--- a/t/t-batch-transfer.sh
+++ b/t/t-batch-transfer.sh
@@ -318,13 +318,13 @@ begin_test "batch transfers with ssh endpoint and multiple objects (git-lfs-tran
 )
 end_test
 
-begin_test "batch transfers with ssh endpoint and multiple objects and batches (git-lfs-transfer)"
+begin_test "batch transfers with ssh endpoint and multiple objects exceeding workers (git-lfs-transfer)"
 (
   set -e
 
   setup_pure_ssh
 
-  reponame="batch-ssh-transfer-multiple-batch"
+  reponame="batch-ssh-transfer-multiple-exceeding-workers"
   setup_remote_repo "$reponame"
   clone_repo "$reponame" "$reponame"
 
@@ -345,7 +345,7 @@ begin_test "batch transfers with ssh endpoint and multiple objects and batches (
   # enforce their use in order to match other platforms' connection counts.
   git config --global lfs.ssh.autoMultiplex true
 
-  # Allow no more than two objects to be transferred in each batch.
+  # Allow no more than two concurrent workers to transfer objects at once.
   git config --global lfs.concurrentTransfers 2
 
   GIT_TRACE=1 git push origin main 2>&1 | tee push.log

--- a/t/t-batch-transfer.sh
+++ b/t/t-batch-transfer.sh
@@ -193,7 +193,8 @@ assert_ssh_transfer_sessions() {
   # Versions of Git prior to 2.11.0 invoke Git LFS via the "smudge" filter
   # rather than the "process" filter, so a separate Git LFS process runs for
   # each downloaded object and spawns its own control socket SSH connection.
-  if [ "download" = "$direction" ]; then
+  smudge_count="$(grep -c "exec: .*git-lfs smudge --" "$log")" || true
+  if [ 0 -lt "$smudge_count" ]; then
     gitversion="$(git version | cut -d" " -f3)"
     set +e
     compare_version "$gitversion" '2.11.0'
@@ -356,6 +357,55 @@ begin_test "batch transfers with ssh endpoint and multiple objects exceeding wor
   assert_ssh_transfer_sessions 'clone.log' 'download' 3 2
 
   cd "$reponame-2"
+  git lfs fsck
+)
+end_test
+
+begin_test "batch transfers with ssh endpoint and multiple branches (git-lfs-transfer)"
+(
+  set -e
+
+  setup_pure_ssh
+
+  reponame="batch-ssh-transfer-multiple-branches"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.dat"
+
+  contents1="test1"
+  printf "%s" "$contents1" >test1.dat
+  git add .gitattributes test1.dat
+  git commit -m "initial commit"
+
+  git checkout -b second main
+
+  contents2="test2"
+  printf "%s" "$contents2" >test2.dat
+  git add test2.dat
+  git commit -m "second"
+
+  sshurl=$(ssh_remote "$reponame")
+  git config lfs.url "$sshurl"
+
+  # On Windows we do not multiplex SSH connections by default, so we
+  # enforce their use in order to match other platforms' connection counts.
+  git config --global lfs.ssh.autoMultiplex true
+
+  GIT_TRACE=1 git push --all origin 2>&1 | tee push.log
+  [ 0 -eq "${PIPESTATUS[0]}" ]
+
+  assert_ssh_transfer_sessions 'push.log' 'upload' 2 "$expectedConcurrentTransfers"
+  assert_remote_object "$reponame" "$(calc_oid "$contents1")" "${#contents1}"
+  assert_remote_object "$reponame" "$(calc_oid "$contents2")" "${#contents2}"
+
+  rm -rf .git/lfs/objects
+
+  GIT_TRACE=1 git lfs fetch --all 2>&1 | tee fetch.log
+  [ 0 -eq "${PIPESTATUS[0]}" ]
+
+  assert_ssh_transfer_sessions 'fetch.log' 'download' 2 "$expectedConcurrentTransfers"
+
   git lfs fsck
 )
 end_test

--- a/t/t-batch-transfer.sh
+++ b/t/t-batch-transfer.sh
@@ -190,15 +190,6 @@ assert_ssh_transfer_sessions() {
 
   local expected_ctrl=1
 
-  # On upload we currently spawn one extra control socket SSH connection
-  # to run locking commands and never shut it down cleanly, so our expected
-  # start counts are higher than our expected termination counts.
-  if [ "upload" = "$direction" ]; then
-    (( ++expected_ctrl ))
-    (( ++min_expected_start ))
-    (( ++max_expected_start ))
-  fi
-
   # Versions of Git prior to 2.11.0 invoke Git LFS via the "smudge" filter
   # rather than the "process" filter, so a separate Git LFS process runs for
   # each downloaded object and spawns its own control socket SSH connection.

--- a/tq/custom_test.go
+++ b/tq/custom_test.go
@@ -13,6 +13,7 @@ func TestCustomTransferBasicConfig(t *testing.T) {
 	cli := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
 		"lfs.customtransfer.testsimple.path": path,
 	}))
+	defer cli.Close()
 
 	m := NewManifest(nil, cli, "", "")
 	u := m.NewUploadAdapter("testsimple")
@@ -41,6 +42,7 @@ func TestCustomTransferDownloadConfig(t *testing.T) {
 		"lfs.customtransfer.testdownload.concurrent": "false",
 		"lfs.customtransfer.testdownload.direction":  "download",
 	}))
+	defer cli.Close()
 
 	m := NewManifest(nil, cli, "", "")
 	u := m.NewUploadAdapter("testdownload")
@@ -66,6 +68,7 @@ func TestCustomTransferUploadConfig(t *testing.T) {
 		"lfs.customtransfer.testupload.concurrent": "false",
 		"lfs.customtransfer.testupload.direction":  "upload",
 	}))
+	defer cli.Close()
 
 	m := NewManifest(nil, cli, "", "")
 	d := m.NewDownloadAdapter("testupload")
@@ -91,6 +94,7 @@ func TestCustomTransferBothConfig(t *testing.T) {
 		"lfs.customtransfer.testboth.concurrent": "yes",
 		"lfs.customtransfer.testboth.direction":  "both",
 	}))
+	defer cli.Close()
 
 	m := NewManifest(nil, cli, "", "")
 	d := m.NewDownloadAdapter("testboth")

--- a/tq/manifest.go
+++ b/tq/manifest.go
@@ -190,10 +190,6 @@ func NewManifest(f *fs.Filesystem, apiClient *lfsapi.Client, operation, remote s
 }
 
 func newConcreteManifest(f *fs.Filesystem, apiClient *lfsapi.Client, operation, remote string) *concreteManifest {
-	if apiClient == nil {
-		apiClient = lfsapi.NewClient(nil)
-	}
-
 	sshTransfer := apiClient.SSHTransfer(operation, remote)
 	useSSHMultiplexing := false
 	if sshTransfer != nil {

--- a/tq/manifest_test.go
+++ b/tq/manifest_test.go
@@ -13,6 +13,7 @@ func TestManifestIsConfigurable(t *testing.T) {
 	cli := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
 		"lfs.transfer.maxretries": "3",
 	}))
+	defer cli.Close()
 
 	m := NewManifest(nil, cli, "", "")
 	assert.Equal(t, 3, m.MaxRetries())
@@ -22,6 +23,7 @@ func TestManifestClampsValidValues(t *testing.T) {
 	cli := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
 		"lfs.transfer.maxretries": "-1",
 	}))
+	defer cli.Close()
 
 	m := NewManifest(nil, cli, "", "")
 	assert.Equal(t, 8, m.MaxRetries())
@@ -29,6 +31,7 @@ func TestManifestClampsValidValues(t *testing.T) {
 
 func TestLazyManifestConcurrentUpgrade(t *testing.T) {
 	cli := lfsapi.NewClient(lfshttp.NewContext(nil, nil, nil))
+	defer cli.Close()
 
 	m := NewManifest(nil, cli, "", "")
 
@@ -55,6 +58,7 @@ func TestManifestIgnoresNonInts(t *testing.T) {
 	cli := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
 		"lfs.transfer.maxretries": "not_an_int",
 	}))
+	defer cli.Close()
 
 	m := NewManifest(nil, cli, "", "")
 	assert.Equal(t, 8, m.MaxRetries())

--- a/tq/transfer_queue.go
+++ b/tq/transfer_queue.go
@@ -991,14 +991,6 @@ func (q *TransferQueue) Wait() {
 	q.meter.Flush()
 	q.errorwait.Wait()
 
-	if q.manifest.Upgraded() {
-		manifest := q.manifest.Upgrade()
-		if manifest.sshTransfer != nil {
-			manifest.sshTransfer.Shutdown()
-			manifest.sshTransfer = nil
-		}
-	}
-
 	if q.unsupportedContentType {
 		fmt.Fprintln(os.Stderr, tr.Tr.Get(`info: Uploading failed due to unsupported Content-Type header(s).
 info: Consider disabling Content-Type detection with:

--- a/tq/transfer_queue_test.go
+++ b/tq/transfer_queue_test.go
@@ -4,15 +4,22 @@ import (
 	"testing"
 	"time"
 
+	"github.com/git-lfs/git-lfs/v3/lfsapi"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestManifestDefaultsToFixedRetries(t *testing.T) {
-	assert.Equal(t, 8, NewManifest(nil, nil, "", "").MaxRetries())
+	cli := lfsapi.NewClient(nil)
+	defer cli.Close()
+
+	assert.Equal(t, 8, NewManifest(nil, cli, "", "").MaxRetries())
 }
 
 func TestManifestDefaultsToFixedRetryDelay(t *testing.T) {
-	assert.Equal(t, 10, NewManifest(nil, nil, "", "").MaxRetryDelay())
+	cli := lfsapi.NewClient(nil)
+	defer cli.Close()
+
+	assert.Equal(t, 10, NewManifest(nil, cli, "", "").MaxRetryDelay())
 }
 
 func TestRetryCounterDefaultsToFixedRetries(t *testing.T) {
@@ -75,15 +82,21 @@ func TestRetryCounterLimitsDelay(t *testing.T) {
 }
 
 func TestBatchSizeReturnsBatchSize(t *testing.T) {
+	cli := lfsapi.NewClient(nil)
+	defer cli.Close()
+
 	q := NewTransferQueue(
-		Upload, NewManifest(nil, nil, "", ""), "origin", WithBatchSize(3))
+		Upload, NewManifest(nil, cli, "", ""), "origin", WithBatchSize(3))
 
 	assert.Equal(t, 3, q.BatchSize())
 }
 
 func TestUseAdapterReusesWhenNameMatches(t *testing.T) {
+	cli := lfsapi.NewClient(nil)
+	defer cli.Close()
+
 	q := NewTransferQueue(
-		Download, NewManifest(nil, nil, "", ""), "origin")
+		Download, NewManifest(nil, cli, "", ""), "origin")
 
 	// Set an initial adapter.
 	q.useAdapter("basic")
@@ -97,8 +110,11 @@ func TestUseAdapterReusesWhenNameMatches(t *testing.T) {
 }
 
 func TestUseAdapterReusesWhenNameIsEmpty(t *testing.T) {
+	cli := lfsapi.NewClient(nil)
+	defer cli.Close()
+
 	q := NewTransferQueue(
-		Download, NewManifest(nil, nil, "", ""), "origin")
+		Download, NewManifest(nil, cli, "", ""), "origin")
 
 	q.useAdapter("basic")
 	first := q.adapter
@@ -111,8 +127,11 @@ func TestUseAdapterReusesWhenNameIsEmpty(t *testing.T) {
 }
 
 func TestUseAdapterSwitchesFromNonDefaultWhenNameIsEmpty(t *testing.T) {
+	cli := lfsapi.NewClient(nil)
+	defer cli.Close()
+
 	q := NewTransferQueue(
-		Download, NewManifest(nil, nil, "", ""), "origin")
+		Download, NewManifest(nil, cli, "", ""), "origin")
 
 	q.useAdapter("ssh")
 	first := q.adapter
@@ -127,8 +146,11 @@ func TestUseAdapterSwitchesFromNonDefaultWhenNameIsEmpty(t *testing.T) {
 }
 
 func TestUseAdapterSwitchesWhenNameDiffers(t *testing.T) {
+	cli := lfsapi.NewClient(nil)
+	defer cli.Close()
+
 	q := NewTransferQueue(
-		Download, NewManifest(nil, nil, "", ""), "origin")
+		Download, NewManifest(nil, cli, "", ""), "origin")
 
 	q.useAdapter("basic")
 	first := q.adapter

--- a/tq/transfer_test.go
+++ b/tq/transfer_test.go
@@ -41,7 +41,10 @@ func newRenamedTestAdapter(name string, dir Direction) Adapter {
 }
 
 func TestBasicAdapterExists(t *testing.T) {
-	m := NewManifest(nil, nil, "", "")
+	cli := lfsapi.NewClient(nil)
+	defer cli.Close()
+
+	m := NewManifest(nil, cli, "", "")
 
 	assert := assert.New(t)
 
@@ -68,7 +71,10 @@ func TestBasicAdapterExists(t *testing.T) {
 }
 
 func TestAdapterRegAndOverride(t *testing.T) {
-	m := NewManifest(nil, nil, "", "")
+	cli := lfsapi.NewClient(nil)
+	defer cli.Close()
+
+	m := NewManifest(nil, cli, "", "")
 	assert := assert.New(t)
 
 	assert.Nil(m.NewAdapter("test", Download))
@@ -144,6 +150,7 @@ func TestAdapterRegButBasicOnly(t *testing.T) {
 	cli := lfsapi.NewClient(lfshttp.NewContext(nil, nil, map[string]string{
 		"lfs.basictransfersonly": "yes",
 	}))
+	defer cli.Close()
 
 	m := NewManifest(nil, cli, "", "")
 


### PR DESCRIPTION
This PR updates the Git LFS client so that where possible, SSH sessions are reused for multiple related operations.

This change will permit the "pure" SSH-based Git LFS transfer protocol to be used when pushing or fetching multiple branches, resolving the issue reported in #6118.

As well, this PR revises the Git LFS client so that when exiting, it always tries to cleanly terminate any SSH sessions that were started for the "pure" SSH-based transfer protocol.

This PR will be most easily reviewed on a commit-by-commit basis, with whitespace differences ignored.

#### SSH Session Reuse

When we introduced support for the "pure" SSH-based Git LFS object transfer protocol in PR #4446, we designed the `SSHTransfer` [structure](https://github.com/git-lfs/git-lfs/blob/14ae1707938bf0a7b77e5bfe333b196574bbc843/ssh/connection.go#L15-L24) in our `ssh` package to be the basic abstraction with which we represent and manage SSH processes and connections for the protocol.

In commit 31d3fb7ceeef219bc7ee466d5938306000de052d of the same PR we added an `SSHTransfer()` [method](https://github.com/git-lfs/git-lfs/blob/14ae1707938bf0a7b77e5bfe333b196574bbc843/lfsapi/lfsapi.go#L43-L67) to the `Client` structure of our `lfsapi` package in order to provide a common interface through which we could initiate and share SSH sessions.  This method always returns either a new `SSHTransfer` structure, representing a new SSH session and underlying set of connections, or else returns a `nil` value to indicate that the "pure" SSH-based Git LFS protocols are not supported by the remote service, or that an error condition has occurred.
    
Because the `SSHTransfer()` method always returns a new SSH session (when it does not return `nil`), at present we [create](https://github.com/git-lfs/git-lfs/blob/14ae1707938bf0a7b77e5bfe333b196574bbc843/tq/manifest.go#L197) [separate](https://github.com/git-lfs/git-lfs/blob/14ae1707938bf0a7b77e5bfe333b196574bbc843/locking/api.go#L344) sessions for both object transfer requests and locking requests.

Further, as reported in #6118, when a transfer queue completes we shut down any SSH session it was using, but then we attempt to reuse that session in subsequent transfer queues, which causes an error.

Specifically, when uploading or downloading objects for multiple Git references, we [establish](https://github.com/git-lfs/git-lfs/blob/14ae1707938bf0a7b77e5bfe333b196574bbc843/commands/commands.go#L69) a single transfer manifest for the entire operation.  The first time one of the methods of the `lazyManifest` structure in our `tq` package is invoked, it creates a `concreteManifest` structure by [calling](https://github.com/git-lfs/git-lfs/blob/14ae1707938bf0a7b77e5bfe333b196574bbc843/tq/manifest.go#L123) the `newConcreteManifest()` function, which [calls](https://github.com/git-lfs/git-lfs/blob/14ae1707938bf0a7b77e5bfe333b196574bbc843/tq/manifest.go#L197) the `SSHTransfer()` function of our `lfsapi` package.  Thus if that function returns a non-`nil` value (i.e., an `SSHTransfer` structure), then the manifest retains a pointer to that structure for the lifetime of the Git LFS client process.
    
We then pass that manifest to the `NewTransferQueue()` function [each](https://github.com/git-lfs/git-lfs/blob/14ae1707938bf0a7b77e5bfe333b196574bbc843/commands/uploader.go#L122-L126) [time](https://github.com/git-lfs/git-lfs/blob/14ae1707938bf0a7b77e5bfe333b196574bbc843/commands/command_filter_process.go#L106-L112) we start a new transfer queue.  After all the objects to be transferred have been added to the queue, we [then](https://github.com/git-lfs/git-lfs/blob/14ae1707938bf0a7b77e5bfe333b196574bbc843/commands/uploader.go#L247) [call](https://github.com/git-lfs/git-lfs/blob/14ae1707938bf0a7b77e5bfe333b196574bbc843/commands/command_filter_process.go#L154) the `Wait()` method of the `TransferQueue` structure.
    
When all the object transfers are complete, if the queue's manifest contains non-`nil` `sshTransfer` field, then the `Wait()` method [calls](https://github.com/git-lfs/git-lfs/blob/14ae1707938bf0a7b77e5bfe333b196574bbc843/tq/transfer_queue.go#L996-L999) the `Shutdown()` method of the `SSHTransfer` structure, which closes the underlying SSH connections.
    
The consequence is that if we then attempt to start another queue for the same operation and remote endpoint, we do attempt to reuse the same `SSHTransfer` structure and associated SSH session, but all of its SSH processes and connections have been terminated.  This leads to the error reported in #6118.

To avoid this problem, we first refactor the `SSHTransfer()` method in the `lfsapi` package into two methods.  The new `initSSHTransfer()` method performs the same actions as the `SSHTransfer()` method did before, and as such may return
a `nil` value if the remote service does not support the `git-lfs-transfer` command.

The `SSHTransfer()` method now maintains a map of the SSH sessions for which it has called the `initSSHTransfer()` method, and only calls that method if it is required.  Otherwise, the value returned by the `initSSHTransfer()` method for the given `operation` and `remote` parameters is returned again, even if it is a `nil` value.

To maintain this map safely, the` SSHTransfer()` method first acquires a mutex, which we add to the `Client` structure along with the map.  For keys, we use a concatenation of the unique pairs of `operation` and `remote` strings passed to the method as its parameters.  This technique follows the existing approach used in our `commands` package, where we [construct](https://github.com/git-lfs/git-lfs/blob/14ae1707938bf0a7b77e5bfe333b196574bbc843/commands/commands.go#L67) keys for the global `tqManifest` map by concatenating the `operation` and `remote` string parameters of the `getTransferManifestOperationRemote()` function.

One advantage of this change is that it also resolves the problem whereby we would previously create an extra SSH process and connection for each locking request, even if they were to be made to the same remote service as subsequent object transfer requests, and for the same type of operation (i.e., an upload or download operation).

Another advantage is that when the Git LFS client is exiting, we can identify the set of SSH sessions that were opened for the SSH-based transfer protocol and attempt to terminate them all properly, instead of closing the individual session used for a transfer queue after that queue has completed.

To do this, we add a `closeSSHTransfers()` method to the `Client` structure in the `lfsapi` package, and then invoke this new method from the `Client` structure's `Close()` [method](https://github.com/git-lfs/git-lfs/blob/14ae1707938bf0a7b77e5bfe333b196574bbc843/lfsapi/client.go#L53-L55).  The `Close()` method is [called](https://github.com/git-lfs/git-lfs/blob/14ae1707938bf0a7b77e5bfe333b196574bbc843/commands/commands.go#L91) by the `commands` package's `closeAPIClient()` function when a Git LFS command has [completed](https://github.com/git-lfs/git-lfs/blob/14ae1707938bf0a7b77e5bfe333b196574bbc843/commands/run.go#L155) normally.

Our new `closeSSHTransfers()` method iterates over all the non-`nil` values in the map maintained by the `SSHTransfer()` method and calls the `Shutdown()` method of each `SSHTransfer` structure, thus attempting to terminate them properly.  We can then revise the `Wait()` method of the `TransferQueue structure` so that it no longer attempts to shut down the SSH session associated with the queue's manifest.
    
Collectively, these revisions and enhancements should resolve the problem reported in #6118.  To verify this, we add a new test to our `t/t-batch-transfer.sh` shell script which runs each of the `git push` and `git lfs fetch` commands for multiple branches, causing both commands to start and stop more than a single transfer queue.

#### Consistent Exit Handling

The changes described above ensure we reuse SSH sessions for the "pure" SSH-based Git LFS transfer protocols, and that we only attempt to terminate them when the client is exiting, at least under normal circumstances.

However, if [certain](https://github.com/git-lfs/git-lfs/blob/14ae1707938bf0a7b77e5bfe333b196574bbc843/commands/command_filter_process.go#L184) [errors](https://github.com/git-lfs/git-lfs/blob/14ae1707938bf0a7b77e5bfe333b196574bbc843/commands/lockverifier.go#L75) occur or if one of the signals we [trap](https://github.com/git-lfs/git-lfs/blob/14ae1707938bf0a7b77e5bfe333b196574bbc843/git-lfs.go#L16) is received, then the Git LFS client may halt immediately, and in these cases we would like it to at least attempt to terminate any SSH sessions started for the SSH-based transfer protocol.

In PR #6255 we revised all of the individual command implementation functions in our `commands` package so that they always invoke one of a small set of exit wrapper functions when they need to force the client to halt.  We can now take advantage of this fact to ensure that regardless of circumstances, the Git LFS client will always attempt to terminate any active SSH sessions that were opened for the "pure" SSH-based Git LFS transfer protocols.

Most obviously, we add a call to the `Cleanup()` [function](https://github.com/git-lfs/git-lfs/blob/14ae1707938bf0a7b77e5bfe333b196574bbc843/commands/commands.go#L282-L286) of our `commands` package to each of the exit wrapper functions, just before they call the `Exit()` function of the Go standard library's `os` package.

Next, we refactor the `Cleanup()` function into two functions, with the actual cleanup activities performed by a new `doCleanup()` function, which is then invoked by the `Cleanup()` function exactly one time only, via the `Do()` method of a `Once` structure from the `sync` package of the Go standard library.  We assign this `Once` structure to a new `cleanupOnce` global variable in our `commands` package, which replaces the `once` [variable](https://github.com/git-lfs/git-lfs/blob/14ae1707938bf0a7b77e5bfe333b196574bbc843/git-lfs.go#L18) of the same type in our `main` package.  In our `main()` function, we then just call the `commands` package's `Cleanup()` directly in the [two](https://github.com/git-lfs/git-lfs/blob/14ae1707938bf0a7b77e5bfe333b196574bbc843/git-lfs.go#L23) [instances](https://github.com/git-lfs/git-lfs/blob/14ae1707938bf0a7b77e5bfe333b196574bbc843/git-lfs.go#L35) where we previously did so via the `once` variable's `Do()` method.

Finally, we add to the `doCleanup()` function a call to the `closeAPIClient()` [function](https://github.com/git-lfs/git-lfs/blob/14ae1707938bf0a7b77e5bfe333b196574bbc843/commands/commands.go#L85-L92), which acquires the necessary `global` mutex before invoking the global `apiClient` variable's `Close()` method.  This supplants the legacy [call](https://github.com/git-lfs/git-lfs/blob/14ae1707938bf0a7b77e5bfe333b196574bbc843/commands/run.go#L155) to the `closeAPIClient()` function from our `Run()` function, so we just remove that call.

#### Other Changes

In addition to the principal changes described above, this PR also makes a number of small refinements, including:

- We fix the SSH connection IDs in the trace log messages we [output](https://github.com/git-lfs/git-lfs/blob/14ae1707938bf0a7b77e5bfe333b196574bbc843/ssh/connection.go#L170) when uninitialized connections are ignored while reducing the number of active connections.
- We output new messages to help clarify when lock [verification](https://github.com/git-lfs/git-lfs/blob/14ae1707938bf0a7b77e5bfe333b196574bbc843/commands/lockverifier.go#L49-L87) begins and ends in our trace logs.
- We update our existing [tests](https://github.com/git-lfs/git-lfs/blob/14ae1707938bf0a7b77e5bfe333b196574bbc843/t/t-batch-transfer.sh#L235-L356) of the "pure" SSH-based Git LFS object transfer protocol to perform additional checks and to make use of the `setup_expected_concurrent_transfers()` test helper [function](https://github.com/git-lfs/git-lfs/blob/14ae1707938bf0a7b77e5bfe333b196574bbc843/t/testhelpers.sh#L1088-L1097) we added in PR [#6241](https://github.com/git-lfs/git-lfs/pull/6241).
- We rename [one](https://github.com/git-lfs/git-lfs/blob/14ae1707938bf0a7b77e5bfe333b196574bbc843/t/t-batch-transfer.sh#L313-L356) of these tests and revise our `assert_ssh_transfer_sessions()` test helper [function](https://github.com/git-lfs/git-lfs/blob/14ae1707938bf0a7b77e5bfe333b196574bbc843/t/t-batch-transfer.sh#L178-L233) to correctly reflect the conditions checked by the test, in which the number of SSH connections is limited to fewer than the number of objects to be transferred in a single batch.  This causes the transfer of some objects to be delayed, but still performed within the same batch as the others (and to be performed by the same transfer queue).
- We revise a number of our Go test functions and secondary programs so that we consistently call the `Close()` [method](https://github.com/git-lfs/git-lfs/blob/14ae1707938bf0a7b77e5bfe333b196574bbc843/lfsapi/client.go#L53-L55) of the `lfsapi` package's `Client` structure type, whenever such a structure has reached the end of its lifetime.  For the same reason, we update one instance in the Git LFS client where we [create](https://github.com/git-lfs/git-lfs/blob/14ae1707938bf0a7b77e5bfe333b196574bbc843/lfs/lfs.go#L22) a temporary `Client` structure, and eliminate another similar [instance](https://github.com/git-lfs/git-lfs/blob/14ae1707938bf0a7b77e5bfe333b196574bbc843/tq/manifest.go#L193-L195) which exists solely to support some of our Go test functions.

Resolves #6118.
/cc @galets as reporter.