### PR TITLE
chore: improve git-lfs maintenance path

### DIFF
--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -42,3 +42,9 @@ func TestRepositoryPermissions(t *testing.T) {
 		assert.Equal(t, v, fs.RepositoryPermissions(false))
 	}
 }
+
+func TestRepositoryPermissionsZero(t *testing.T) {
+	fs := Filesystem{repoPerms: 0}
+	assert.Equal(t, os.FileMode(0), fs.RepositoryPermissions(false))
+	assert.Equal(t, os.FileMode(0), fs.RepositoryPermissions(true))
+}

--- a/tq/api_test.go
+++ b/tq/api_test.go
@@ -18,8 +18,8 @@ import (
 )
 
 func TestAPIBatch(t *testing.T) {
-	require.NotNil(t, batchReqSchema, batchReqSchema.Source)
-	require.NotNil(t, batchResSchema, batchResSchema.Source)
+	require.NotNil(t, batchReqSchema)
+	require.NotNil(t, batchResSchema)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/objects/batch" {
@@ -75,8 +75,8 @@ func TestAPIBatch(t *testing.T) {
 }
 
 func TestAPIBatchOnlyBasic(t *testing.T) {
-	require.NotNil(t, batchReqSchema, batchReqSchema.Source)
-	require.NotNil(t, batchResSchema, batchResSchema.Source)
+	require.NotNil(t, batchReqSchema)
+	require.NotNil(t, batchResSchema)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/objects/batch" {


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in fs/fs_test.go, tq/api_test.go related to CI, Docker, Kubernetes, build tooling, release automation; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.