### PR TITLE
Add corrupt object download tests

### DIFF
--- a/t/cmd/lfstest-gitserver.go
+++ b/t/cmd/lfstest-gitserver.go
@@ -63,6 +63,7 @@ var (
 		"status-storage-403", "status-storage-404", "status-storage-410", "status-storage-422", "status-storage-500", "status-storage-503",
 		"return-expired-action", "return-expired-action-forever", "return-invalid-size",
 		"object-authenticated", "storage-upload-retry", "storage-upload-retry-later", "storage-upload-retry-later-no-header", "unknown-oid",
+		"storage-download-corrupt",
 		"storage-download-retry-later", "storage-download-retry-later-no-header", "storage-download-retry",
 		"storage-download-retry-range", "storage-download-retry-range-rejected", "storage-download-retry-no-invalid-range",
 		"storage-download-encoding-gzip", "storage-download-encoding-zstd", "storage-download-encoding-zstd-retry-range",
@@ -795,6 +796,11 @@ func storageHandler(w http.ResponseWriter, r *http.Request) {
 
 		if by, ok := largeObjects.Get(repo, oid); ok {
 			switch oidHandlers[oid] {
+			case "storage-download-corrupt":
+				// Since the object contents are entirely
+				// lowercase we can "invert" the case of each
+				// character just by converting to uppercase.
+				by = bytes.ToUpper(by)
 			case "storage-download-retry-later":
 				if secsToWait, wait := checkRateLimit("storage", "download", repo, oid); wait {
 					statusCode = http.StatusTooManyRequests

--- a/t/t-batch-storage-corrupt.sh
+++ b/t/t-batch-storage-corrupt.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+
+. "$(dirname "$0")/testlib.sh"
+
+begin_test "batch storage HTTP download of corrupt object"
+(
+  set -e
+
+  reponame="batch-storage-download-corrupt-http"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.dat"
+
+  # This content announces to the server that it should corrupt the
+  # contents of the object before returning it.
+  contents="storage-download-corrupt"
+  contents_oid="$(calc_oid "$contents")"
+  printf "%s" "$contents" > a.dat
+
+  git add .gitattributes a.dat
+  git commit -m "initial commit"
+
+  git push origin main
+
+  assert_server_object "$reponame" "$contents_oid"
+
+  rm -f a.dat
+  rm -rf .git/lfs/objects
+
+  # We expect the server to corrupt the object's contents by inverting
+  # the case of each character.
+  inverted_contents_oid="$(calc_oid "$(invert_case "$contents")")"
+
+  GIT_TRACE=1 git lfs pull 2>&1 | tee pull.log
+  [ 0 -ne "${PIPESTATUS[0]}" ]
+
+  grep "expected OID $contents_oid, got $inverted_contents_oid after ${#contents} bytes written" pull.log
+  grep "Failed to fetch some objects" pull.log
+
+  refute_local_object "$contents_oid"
+)
+end_test
+
+begin_test "batch storage SSH download of corrupt object"
+(
+  set -e
+
+  setup_pure_ssh
+
+  reponame="batch-storage-download-corrupt-ssh"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  sshurl=$(ssh_remote "$reponame")
+  git config lfs.url "$sshurl"
+
+  git lfs track "*.dat"
+
+  contents="storage-download-corrupt"
+  contents_oid="$(calc_oid "$contents")"
+  printf "%s" "$contents" > a.dat
+
+  git add .gitattributes a.dat
+  git commit -m "initial commit"
+
+  git push origin main
+
+  assert_remote_object "$reponame" "$contents_oid" "${#contents}"
+
+  rm -f a.dat
+  rm -rf .git/lfs/objects
+
+  # We corrupt the object's contents in the remote repository by inverting
+  # the case of each character.
+  inverted_contents="$(invert_case "$contents")"
+  inverted_contents_oid="$(calc_oid "$inverted_contents")"
+
+  remote_path="$(canonical_path "$REMOTEDIR/$reponame.git")"
+  pushd "$remote_path"
+    printf "%s" "$inverted_contents" >"$(local_object_path "$contents_oid")"
+  popd
+
+  GIT_TRACE=1 git lfs pull 2>&1 | tee pull.log
+  [ 0 -ne "${PIPESTATUS[0]}" ]
+
+  grep "expected OID $contents_oid, got $inverted_contents_oid after ${#contents} bytes written" pull.log
+  grep "Failed to fetch some objects" pull.log
+
+  refute_local_object "$contents_oid"
+)
+end_test
+
+begin_test "batch storage custom adapter download of corrupt object"
+(
+  set -e
+
+  # The "custom-transfer-" prefix indicates to the server to advertise
+  # support for custom transfers.
+  reponame="custom-transfer-batch-storage-download-corrupt"
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" "$reponame"
+
+  git lfs track "*.dat"
+
+  # This content announces to the server that it should corrupt the
+  # contents of the object before returning it.
+  contents="storage-download-corrupt"
+  contents_oid="$(calc_oid "$contents")"
+  printf "%s" "$contents" > a.dat
+
+  git add .gitattributes a.dat
+  git commit -m "initial commit"
+
+  git config lfs.customTransfer.testcustom.path lfstest-customadapter
+
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git push origin main 2>&1 | tee push.log
+  [ 0 -eq "${PIPESTATUS[0]}" ]
+
+  grep "tq: starting transfer adapter" push.log
+  grep "xfer: started custom adapter process" push.log
+
+  assert_server_object "$reponame" "$contents_oid"
+
+  rm -f a.dat
+  rm -rf .git/lfs/objects
+
+  # We expect the server to corrupt the object's contents by inverting
+  # the case of each character.
+  inverted_contents_oid="$(calc_oid "$(invert_case "$contents")")"
+
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git lfs pull 2>&1 | tee pull.log
+  [ 0 -ne "${PIPESTATUS[0]}" ]
+
+  grep "tq: starting transfer adapter" pull.log
+  grep "xfer: started custom adapter process" pull.log
+
+  grep "downloaded file failed checks" pull.log
+  grep "has an invalid hash $inverted_contents_oid, expected $contents_oid" pull.log
+  grep "Failed to fetch some objects" pull.log
+
+  refute_local_object "$contents_oid"
+)
+end_test

--- a/t/t-batch-storage-corrupt.sh
+++ b/t/t-batch-storage-corrupt.sh
@@ -11,6 +11,10 @@ begin_test "batch storage HTTP download of corrupt object"
   clone_repo "$reponame" "$reponame"
 
   git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  initial_sha="$(git rev-parse HEAD)"
 
   # This content announces to the server that it should corrupt the
   # contents of the object before returning it.
@@ -18,8 +22,8 @@ begin_test "batch storage HTTP download of corrupt object"
   contents_oid="$(calc_oid "$contents")"
   printf "%s" "$contents" > a.dat
 
-  git add .gitattributes a.dat
-  git commit -m "initial commit"
+  git add a.dat
+  git commit -m "add a.dat"
 
   git push origin main
 
@@ -39,6 +43,37 @@ begin_test "batch storage HTTP download of corrupt object"
   grep "Failed to fetch some objects" pull.log
 
   refute_local_object "$contents_oid"
+  refute_local_object "$inverted_contents_oid"
+
+  expected="${contents_oid:0:10} - a.dat"
+  [ "$expected" = "$(git lfs ls-files)" ]
+
+  git lfs fsck --objects 2>&1 | tee fsck.log
+  [ 1 -eq "${PIPESTATUS[0]}" ]
+
+  grep "objects: openError: a.dat ($contents_oid) could not be checked: .*" fsck.log
+
+  # Test again using "git pull", which should not advance HEAD after the
+  # smudge filter reports an error.
+  git reset --hard HEAD^
+
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git pull origin main 2>&1 | tee pull.log
+  [ 0 -ne "${PIPESTATUS[0]}" ]
+
+  grep "expected OID $contents_oid, got $inverted_contents_oid after ${#contents} bytes written" pull.log
+  grep "Smudge error: Error downloading a.dat ($contents_oid)" pull.log
+
+  refute_local_object "$contents_oid"
+  refute_local_object "$inverted_contents_oid"
+
+  [ "$initial_sha" = "$(git rev-parse HEAD)" ]
+
+  [ -z "$(git lfs ls-files)" ]
+
+  git lfs fsck --objects 2>&1 | tee fsck.log
+  [ 0 -eq "${PIPESTATUS[0]}" ]
+
+  grep "Git LFS fsck OK" fsck.log
 )
 end_test
 
@@ -56,13 +91,17 @@ begin_test "batch storage SSH download of corrupt object"
   git config lfs.url "$sshurl"
 
   git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  initial_sha="$(git rev-parse HEAD)"
 
   contents="storage-download-corrupt"
   contents_oid="$(calc_oid "$contents")"
   printf "%s" "$contents" > a.dat
 
-  git add .gitattributes a.dat
-  git commit -m "initial commit"
+  git add a.dat
+  git commit -m "add a.dat"
 
   git push origin main
 
@@ -88,6 +127,37 @@ begin_test "batch storage SSH download of corrupt object"
   grep "Failed to fetch some objects" pull.log
 
   refute_local_object "$contents_oid"
+  refute_local_object "$inverted_contents_oid"
+
+  expected="${contents_oid:0:10} - a.dat"
+  [ "$expected" = "$(git lfs ls-files)" ]
+
+  git lfs fsck --objects 2>&1 | tee fsck.log
+  [ 1 -eq "${PIPESTATUS[0]}" ]
+
+  grep "objects: openError: a.dat ($contents_oid) could not be checked: .*" fsck.log
+
+  # Test again using "git pull", which should not advance HEAD after the
+  # smudge filter reports an error.
+  git reset --hard HEAD^
+
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git pull origin main 2>&1 | tee pull.log
+  [ 0 -ne "${PIPESTATUS[0]}" ]
+
+  grep "expected OID $contents_oid, got $inverted_contents_oid after ${#contents} bytes written" pull.log
+  grep "Smudge error: Error downloading a.dat ($contents_oid)" pull.log
+
+  refute_local_object "$contents_oid"
+  refute_local_object "$inverted_contents_oid"
+
+  [ "$initial_sha" = "$(git rev-parse HEAD)" ]
+
+  [ -z "$(git lfs ls-files)" ]
+
+  git lfs fsck --objects 2>&1 | tee fsck.log
+  [ 0 -eq "${PIPESTATUS[0]}" ]
+
+  grep "Git LFS fsck OK" fsck.log
 )
 end_test
 
@@ -102,6 +172,10 @@ begin_test "batch storage custom adapter download of corrupt object"
   clone_repo "$reponame" "$reponame"
 
   git lfs track "*.dat"
+  git add .gitattributes
+  git commit -m "initial commit"
+
+  initial_sha="$(git rev-parse HEAD)"
 
   # This content announces to the server that it should corrupt the
   # contents of the object before returning it.
@@ -109,8 +183,8 @@ begin_test "batch storage custom adapter download of corrupt object"
   contents_oid="$(calc_oid "$contents")"
   printf "%s" "$contents" > a.dat
 
-  git add .gitattributes a.dat
-  git commit -m "initial commit"
+  git add a.dat
+  git commit -m "add a.dat"
 
   git config lfs.customTransfer.testcustom.path lfstest-customadapter
 
@@ -140,5 +214,40 @@ begin_test "batch storage custom adapter download of corrupt object"
   grep "Failed to fetch some objects" pull.log
 
   refute_local_object "$contents_oid"
+  refute_local_object "$inverted_contents_oid"
+
+  expected="${contents_oid:0:10} - a.dat"
+  [ "$expected" = "$(git lfs ls-files)" ]
+
+  git lfs fsck --objects 2>&1 | tee fsck.log
+  [ 1 -eq "${PIPESTATUS[0]}" ]
+
+  grep "objects: openError: a.dat ($contents_oid) could not be checked: .*" fsck.log
+
+  # Test again using "git pull", which should not advance HEAD after the
+  # smudge filter reports an error.
+  git reset --hard HEAD^
+
+  GIT_TRACE=1 GIT_TRANSFER_TRACE=1 git pull origin main 2>&1 | tee pull.log
+  [ 0 -ne "${PIPESTATUS[0]}" ]
+
+  grep "tq: starting transfer adapter" pull.log
+  grep "xfer: started custom adapter process" pull.log
+
+  grep "downloaded file failed checks" pull.log
+  grep "has an invalid hash $inverted_contents_oid, expected $contents_oid" pull.log
+  grep "Smudge error: Error downloading a.dat ($contents_oid)" pull.log
+
+  refute_local_object "$contents_oid"
+  refute_local_object "$inverted_contents_oid"
+
+  [ "$initial_sha" = "$(git rev-parse HEAD)" ]
+
+  [ -z "$(git lfs ls-files)" ]
+
+  git lfs fsck --objects 2>&1 | tee fsck.log
+  [ 0 -eq "${PIPESTATUS[0]}" ]
+
+  grep "Git LFS fsck OK" fsck.log
 )
 end_test


### PR DESCRIPTION
This PR adds tests which confirm that the Git LFS client verifies the contents of the objects it downloads from remote services, and that the client does not save an object to the local filesystem if the object's contents do not match its expected SHA-256 hash value.

Each of the download transfer adapters we support already verify the contents of the objects they download.

At present, however, we do not have tests which confirm these checks are effective, so we add those tests now to a new `t/t-batch-storage-corrupt.sh` shell script.

#### HTTP Downloads

To test our default `basic` download adapter, which makes object transfer requests using HTTP, we add a `batch storage HTTP download of corrupt object` test which first creates an object with the special content key `storage-download-corrupt` and uploads it to our `lfstest-gitserver` test server.  The test then removes the object from the local storage directories and the working tree, and attempts to download it using a `git lfs pull` command.

We also adjust the `lfstest-gitserver` program so that when handling a `GET` request for an object, if the object's content matches the special key `storage-download-corrupt`, the content is replaced with an uppercase version of the same key before being provided to the client.  Our new test then checks that the `basic` download adapter detects the invalid object content, reports an error, and does not write the object content into the local storage directories.

#### SSH Downloads

For our `ssh` download adapter, which makes object transfer requests using SSH, we add a `batch storage SSH download of corrupt object` test that works in a similar fashion to the test of the `basic` adapter, except that in this case the test itself has to corrupt the object's contents in the remote repository before attempting to download the object.

Because our tests of the SSH-based Git LFS transfer protocol do not use a custom test utility like the `lfstest-gitserver` program to provide the remote side of the protocol, our test has to corrupt the objects itself.  (Note that for our tests of the SSH-based transfer protocol we use the `git-lfs-transfer` [program](https://github.com/bk2204/scutiger/tree/614a4f01cfbe6aafa355ca92ed6d1581b5cfc088/scutiger-lfs#git-lfs-transfer) from the `scutiger-lfs` Rust [crate](https://crates.io/crates/scutiger-lfs), and we configure this program to read and write from a local repository.)

#### Custom Transfer Agent Downloads

Finally, for our `custom` download adapter, which makes object transfer requests via an external custom transfer agent, we add a `batch storage custom adapter download of corrupt object` test, which is very similar to our test of the `basic` adapter, except that we set the `lfs.customTransfer.testcustom.path` configuration option so that our `lfstest-customadapter` transfer agent is used to upload and download objects.  This test utility simply acts as a proxy, responding to custom transfer protocol JSON messages from the Git LFS client, and then making HTTP-based object transfers to our `lfstest-gitserver` program and relaying the data back over the custom transfer protocol.

As a consequence, this test can also create an object with the special content key `storage-download-corrupt`, and expect that the `lfstest-gitserver` utility will recognize this key during a download request and replace the object's content with an uppercase version, so the test does not need to do so itself the way our test of the SSH-based object transfer protocol does.