### PR TITLE
Update tests to dynamically match internal program limits

### DIFF
--- a/lfs/gitfilter_clean.go
+++ b/lfs/gitfilter_clean.go
@@ -76,11 +76,11 @@ func (f *GitFilter) copyToTemp(reader io.Reader, fileSize int64, cb tools.CopyCa
 
 	ptr, buf, err := DecodeFrom(reader)
 
-	by := make([]byte, blobSizeCutoff)
+	by := make([]byte, BlobSizeCutoff)
 	n, rerr := buf.Read(by)
 	by = by[:n]
 
-	if rerr != nil || (err == nil && len(by) < blobSizeCutoff) {
+	if rerr != nil || (err == nil && len(by) < BlobSizeCutoff) {
 		err = errors.NewCleanPointerError(ptr, by)
 		return
 	}

--- a/lfs/gitscanner_catfilebatch.go
+++ b/lfs/gitscanner_catfilebatch.go
@@ -138,7 +138,7 @@ func (s *PointerScanner) next(blob string) (string, string, *WrappedPointer, err
 
 	var buf *bytes.Buffer
 	var to io.Writer = sha
-	if size < blobSizeCutoff {
+	if size < BlobSizeCutoff {
 		buf = bytes.NewBuffer(make([]byte, 0, size))
 		to = io.MultiWriter(to, buf)
 	}
@@ -155,7 +155,7 @@ func (s *PointerScanner) next(blob string) (string, string, *WrappedPointer, err
 	var pointer *WrappedPointer
 	var contentsSha string
 
-	if size < blobSizeCutoff {
+	if size < BlobSizeCutoff {
 		if p, err := DecodePointer(bytes.NewReader(buf.Bytes())); err != nil {
 			contentsSha = fmt.Sprintf("%x", sha.Sum(nil))
 		} else {

--- a/lfs/gitscanner_catfilebatchcheck.go
+++ b/lfs/gitscanner_catfilebatchcheck.go
@@ -13,7 +13,7 @@ import (
 
 // runCatFileBatchCheck uses 'git cat-file --batch-check' to get the type and
 // size of a git object. Any object that isn't of type blob and under the
-// blobSizeCutoff will be ignored, unless it's a locked file. revs is a channel
+// BlobSizeCutoff will be ignored, unless it's a locked file. revs is a channel
 // over which strings containing git sha1s will be sent. It returns a channel
 // from which sha1 strings can be read.
 func runCatFileBatchCheck(smallRevCh chan string, lockableCh chan string, lockableSet *lockableNameSet, revs *StringChannelWrapper, errCh chan error) error {
@@ -23,7 +23,7 @@ func runCatFileBatchCheck(smallRevCh chan string, lockableCh chan string, lockab
 	}
 
 	go func() {
-		scanner := &catFileBatchCheckScanner{s: bufio.NewScanner(cmd.Stdout), limit: blobSizeCutoff}
+		scanner := &catFileBatchCheckScanner{s: bufio.NewScanner(cmd.Stdout), limit: BlobSizeCutoff}
 		for r := range revs.Results {
 			cmd.Stdin.Write([]byte(r + "\n"))
 			hasNext := scanner.Scan()

--- a/lfs/gitscanner_tree.go
+++ b/lfs/gitscanner_tree.go
@@ -18,7 +18,7 @@ func runScanTree(cb GitScannerFoundPointer, ref string, filter *filepathfilter.F
 	// We don't use the nameMap approach here since that's imprecise when >1 file
 	// can be using the same content
 	treeShas, err := lsTreeBlobs(ref, func(t *git.TreeBlob) bool {
-		return t != nil && t.Size < blobSizeCutoff && filter.Allows(t.Filename)
+		return t != nil && t.Size < BlobSizeCutoff && filter.Allows(t.Filename)
 	})
 	if err != nil {
 		return err
@@ -44,11 +44,11 @@ func runScanLFSFiles(cb GitScannerFoundPointer, ref string, filter *filepathfilt
 	var err error
 	if git.IsGitVersionAtLeast("2.42.0") {
 		treeShas, err = lsFilesBlobs(func(t *git.TreeBlob) bool {
-			return t != nil && t.Size < blobSizeCutoff && filter.Allows(t.Filename)
+			return t != nil && t.Size < BlobSizeCutoff && filter.Allows(t.Filename)
 		})
 	} else {
 		treeShas, err = lsTreeBlobs(ref, func(t *git.TreeBlob) bool {
-			return t != nil && t.Size < blobSizeCutoff && filter.Allows(t.Filename)
+			return t != nil && t.Size < BlobSizeCutoff && filter.Allows(t.Filename)
 		})
 	}
 	// We don't use the nameMap approach here since that's imprecise when >1 file
@@ -210,7 +210,7 @@ func catFileBatchTreeForPointers(treeblobs *TreeBlobChannelWrapper, gitEnv, osEn
 			if err := oscanner.Err(); err != nil {
 				return nil, nil, err
 			}
-		} else if t.Size < blobSizeCutoff {
+		} else if t.Size < BlobSizeCutoff {
 			hasNext = pscanner.Scan(t.Oid)
 
 			// It's intentional that we insert nil for

--- a/lfs/pointer.go
+++ b/lfs/pointer.go
@@ -91,7 +91,7 @@ func EncodePointer(writer io.Writer, pointer *Pointer) (int, error) {
 
 func DecodePointerFromBlob(b *gitobj.Blob) (*Pointer, error) {
 	// Check size before reading
-	if b.Size >= blobSizeCutoff {
+	if b.Size >= BlobSizeCutoff {
 		return nil, errors.NewNotAPointerError(errors.New(tr.Tr.Get("blob size exceeds Git LFS pointer size cutoff")))
 	}
 	return DecodePointer(b.Contents)
@@ -105,7 +105,7 @@ func DecodePointerFromFile(file string) (*Pointer, error) {
 	}
 	if !stat.Mode().IsRegular() {
 		return nil, errors.New(tr.Tr.Get("not a regular file: %q", file))
-	} else if stat.Size() >= blobSizeCutoff {
+	} else if stat.Size() >= BlobSizeCutoff {
 		return nil, errors.NewNotAPointerError(errors.New(tr.Tr.Get("file size exceeds Git LFS pointer size cutoff")))
 	}
 	f, err := os.OpenFile(file, os.O_RDONLY, 0644)
@@ -127,7 +127,7 @@ func DecodePointer(reader io.Reader) (*Pointer, error) {
 // If the pointer could not be decoded, an io.Reader containing the entire
 // blob's data will be returned, along with a parse error.
 func DecodeFrom(reader io.Reader) (*Pointer, io.Reader, error) {
-	buf := make([]byte, blobSizeCutoff)
+	buf := make([]byte, BlobSizeCutoff)
 	n, err := reader.Read(buf)
 	buf = buf[:n]
 

--- a/lfs/scanner.go
+++ b/lfs/scanner.go
@@ -7,9 +7,9 @@ import (
 )
 
 const (
-	// blobSizeCutoff is used to determine which files to scan for Git LFS
+	// BlobSizeCutoff is used to determine which files to scan for Git LFS
 	// pointers.  Any file with a size below this cutoff will be scanned.
-	blobSizeCutoff = 1024
+	BlobSizeCutoff = 1024
 
 	// stdoutBufSize is the size of the buffers given to a sub-process stdout
 	stdoutBufSize = 16384
@@ -32,7 +32,7 @@ type WrappedPointer struct {
 
 // catFileBatchCheck uses git cat-file --batch-check to get the type
 // and size of a git object. Any object that isn't of type blob and
-// under the blobSizeCutoff will be ignored. revs is a channel over
+// under the BlobSizeCutoff will be ignored. revs is a channel over
 // which strings containing git sha1s will be sent. It returns a channel
 // from which sha1 strings can be read.
 func catFileBatchCheck(revs *StringChannelWrapper, lockableSet *lockableNameSet) (*StringChannelWrapper, chan string, error) {

--- a/t/Makefile
+++ b/t/Makefile
@@ -28,6 +28,7 @@ TEST_CMDS += ../bin/lfstest-caseinverterextension$X
 TEST_CMDS += ../bin/lfstest-count-tests$X
 TEST_CMDS += ../bin/lfstest-customadapter$X
 TEST_CMDS += ../bin/lfstest-genrandom$X
+TEST_CMDS += ../bin/lfstest-getlimit$X
 TEST_CMDS += ../bin/lfstest-getnumcpu$X
 TEST_CMDS += ../bin/lfstest-gitserver$X
 TEST_CMDS += ../bin/lfstest-nanomtime$X

--- a/t/cmd/lfstest-getlimit.go
+++ b/t/cmd/lfstest-getlimit.go
@@ -1,0 +1,38 @@
+//go:build testtools
+// +build testtools
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/git-lfs/git-lfs/v3/lfs"
+	"github.com/git-lfs/git-lfs/v3/tools"
+	"github.com/git-lfs/pktline"
+)
+
+func main() {
+	if len(os.Args) == 2 {
+		switch os.Args[1] {
+		case "--max-bufio-scan-token-size":
+			fmt.Print(bufio.MaxScanTokenSize)
+		case "--max-pktline-len":
+			fmt.Print(pktline.MaxPacketLength)
+		case "--max-pointer-size":
+			fmt.Print(lfs.BlobSizeCutoff)
+		case "--max-spool-mem-buffer-size":
+			fmt.Print(tools.MemoryBufferLimit)
+		default:
+			fmt.Fprintf(os.Stderr, "unknown argument: %s\n", os.Args[1])
+			os.Exit(1)
+		}
+	} else {
+		fmt.Fprintf(os.Stderr, "invalid arguments: %s\n", strings.Join(os.Args, " "))
+		os.Exit(1)
+	}
+
+	os.Exit(0)
+}

--- a/t/t-checkout.sh
+++ b/t/t-checkout.sh
@@ -828,6 +828,7 @@ begin_test "checkout: read-only file"
   filename="a.txt"
 
   setup_remote_repo_with_file "$reponame" "$filename"
+  contents_oid="$(calc_oid_file "$filename")"
 
   pushd "$TRASHDIR" > /dev/null
     GIT_LFS_SKIP_SMUDGE=1 clone_repo "$reponame" "${reponame}-assert"
@@ -835,7 +836,7 @@ begin_test "checkout: read-only file"
     chmod a-w "$filename"
 
     refute_file_writeable "$filename"
-    assert_pointer "refs/heads/main" "$filename" "$(calc_oid "$filename\n")" 6
+    assert_pointer "refs/heads/main" "$filename" "$contents_oid" 6
 
     git lfs fetch
     git lfs checkout "$filename"

--- a/t/t-clean.sh
+++ b/t/t-clean.sh
@@ -33,12 +33,15 @@ begin_test "clean pseudo pointer"
   set -e
   clean_setup "pseudo"
 
-  echo "version https://git-lfs.github.com/spec/v1
+  contents="version https://git-lfs.github.com/spec/v1
 oid sha256:7cd8be1d2cd0dd22cd9d229bb6b5785009a05e8b39d405615d882caac56562b5
-size 1024
+size 9999
 
-This is my test pointer.  There are many like it, but this one is mine." | git lfs clean | tee clean.log
-  [ "$(pointer f492acbebb5faa22da4c1501c022af035469f624f426631f31936575873fefe1 202)" = "$(cat clean.log)" ]
+This is my test pointer.  There are many like it, but this one is mine."
+  contents_oid="$(calc_oid "$contents")"
+
+  printf "%s" "$contents" | git lfs clean | tee clean.log
+  [ "$(pointer "$contents_oid" "${#contents}")" = "$(cat clean.log)" ]
 )
 end_test
 
@@ -47,13 +50,19 @@ begin_test "clean pseudo pointer with extra data"
   set -e
   clean_setup "extra-data"
 
-  # pointer includes enough extra data to fill the 'git lfs clean' buffer
-  printf "version https://git-lfs.github.com/spec/v1
+  # Test with an invalid pointer larger than the size of the read buffer used
+  # when decoding pointers.  See https://github.com/git-lfs/git-lfs/pull/271.
+  max_pointer_size="$(lfstest-getlimit --max-pointer-size)"
+  fill="$(head -c "$max_pointer_size" /dev/zero | tr '\0' '\n'; printf "EOF")"
+  contents="$(printf "version https://git-lfs.github.com/spec/v1
 oid sha256:7cd8be1d2cd0dd22cd9d229bb6b5785009a05e8b39d405615d882caac56562b5
-size 1024
-\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n
-This is my test pointer.  There are many like it, but this one is mine.\n" | git lfs clean | tee clean.log
-  [ "$(pointer c2f909f6961bf85a92e2942ef3ed80c938a3d0ebaee6e72940692581052333be 586)" = "$(cat clean.log)" ]
+size 9999
+${fill%EOF}
+This is my test pointer.  There are many like it, but this one is mine.")"
+  contents_oid="$(calc_oid "$contents")"
+
+  printf "%s" "$contents" | git lfs clean | tee clean.log
+  [ "$(pointer "$contents_oid" "${#contents}")" = "$(cat clean.log)" ]
 )
 end_test
 
@@ -88,8 +97,13 @@ begin_test "clean stdin"
   git init "$reponame"
   cd "$reponame"
 
-  lfstest-genrandom --base64 1024 >small.dat
-  lfstest-genrandom --base64 2048 >large.dat
+  # Test with file sizes equal to and larger than the
+  # size of the read buffer used when decoding pointers.
+  # See https://github.com/git-lfs/git-lfs/issues/2487
+  # and https://github.com/git-lfs/git-lfs/pull/2488.
+  max_pointer_size="$(lfstest-getlimit --max-pointer-size)"
+  lfstest-genrandom --base64 "$max_pointer_size" >small.dat
+  lfstest-genrandom --base64 $((max_pointer_size * 2)) >large.dat
 
   expected_small="$(calc_oid_file "small.dat")"
   expected_large="$(calc_oid_file "large.dat")"

--- a/t/t-commit-delete-push.sh
+++ b/t/t-commit-delete-push.sh
@@ -12,8 +12,8 @@ begin_test "commit, delete, then push"
 
   git lfs track "*.dat"
 
-  deleted_oid=$(calc_oid "deleted\n")
   echo "deleted" > deleted.dat
+  deleted_oid="$(calc_oid_file "deleted.dat")"
   git add deleted.dat .gitattributes
   git commit -m "add deleted file"
 
@@ -21,8 +21,8 @@ begin_test "commit, delete, then push"
 
   assert_pointer "main" "deleted.dat" "$deleted_oid" 8
 
-  added_oid=$(calc_oid "added\n")
   echo "added" > added.dat
+  added_oid="$(calc_oid_file "added.dat")"
   git add added.dat
   git commit -m "add file"
 

--- a/t/t-filter-process.sh
+++ b/t/t-filter-process.sh
@@ -194,8 +194,8 @@ begin_test "filter process: non-pointer file of maximum pointer size"
 (
   set -e
 
-  mkdir repo-issue-1697
-  cd repo-issue-1697
+  mkdir repo-file-max-pointer-size
+  cd repo-file-max-pointer-size
   git init
   git lfs track "*.dat"
 
@@ -205,6 +205,7 @@ begin_test "filter process: non-pointer file of maximum pointer size"
   max_pointer_size="$(lfstest-getlimit --max-pointer-size)"
   head -c "$max_pointer_size" /dev/zero >first.dat
   printf "any contents" > second.dat
+
   git add .
 )
 end_test
@@ -219,22 +220,23 @@ begin_test "filter process: hash-object --stdin --path does not hang"
   git lfs track "*.dat"
   contents="test"
   contents_oid="$(calc_oid "$contents")"
-  expected=$(pointer "$contents_oid" 4 | git hash-object --stdin)
+  expected="$(pointer "$contents_oid" "${#contents}" | git hash-object --stdin)"
 
   # Test with a file size smaller than the size of the read buffer used when
   # decoding pointers.  See https://github.com/git-lfs/git-lfs/issues/3884
   # and https://github.com/git-lfs/git-lfs/pull/3902.
   max_pointer_size="$(lfstest-getlimit --max-pointer-size)"
   head -c $((max_pointer_size * 1000 / 1024)) /dev/zero >first.dat
-  echo a > second.dat
-  # Works for existing file longer than this one.
-  output=$(printf test | git hash-object --path first.dat --stdin)
+  echo "a" >second.dat
+
+  # Works for existing file longer than the input data.
+  output="$(printf "%s" "$contents"| git hash-object --path first.dat --stdin)"
   [ "$expected" = "$output" ]
-  # Works for existing file shorter than this one.
-  output=$(printf test | git hash-object --path second.dat --stdin)
+  # Works for existing file shorter than the input data.
+  output="$(printf "%s" "$contents" | git hash-object --path second.dat --stdin)"
   [ "$expected" = "$output" ]
   # Works for absent file.
-  output=$(printf test | git hash-object --path third.dat --stdin)
+  output="$(printf "%s" "$contents" | git hash-object --path third.dat --stdin)"
   [ "$expected" = "$output" ]
 
   # Test with a file size larger than the maximum length of a Git packet line
@@ -242,10 +244,12 @@ begin_test "filter process: hash-object --stdin --path does not hang"
   max_pktline_len="$(lfstest-getlimit --max-pktline-len)"
   contents_size=$((max_pktline_len + max_pointer_size + 1))
   head -c "$contents_size" /dev/zero >large.dat
-  oid=$(calc_oid_file large.dat)
-  expected=$(pointer "$oid" "$contents_size" | git hash-object --stdin)
-  output=$(git hash-object --path third.dat --stdin <large.dat)
+  contents_oid="$(calc_oid_file large.dat)"
+
+  expected="$(pointer "$contents_oid" "$contents_size" | git hash-object --stdin)"
+  output="$(git hash-object --path large.dat --stdin <large.dat)"
   [ "$expected" = "$output" ]
+
   git add .
 )
 end_test

--- a/t/t-filter-process.sh
+++ b/t/t-filter-process.sh
@@ -190,8 +190,7 @@ begin_test "filter-process: pointer extension"
 )
 end_test
 
-# https://github.com/git-lfs/git-lfs/issues/1697
-begin_test "filter process: add a file with 1024 bytes"
+begin_test "filter process: non-pointer file of maximum pointer size"
 (
   set -e
 
@@ -199,7 +198,12 @@ begin_test "filter process: add a file with 1024 bytes"
   cd repo-issue-1697
   git init
   git lfs track "*.dat"
-  dd if=/dev/zero of=first.dat bs=1024 count=1
+
+  # Test with a file size equal to the size of the read buffer used when
+  # decoding pointers.  See https://github.com/git-lfs/git-lfs/issues/1697
+  # and https://github.com/git-lfs/git-lfs/pull/1699.
+  max_pointer_size="$(lfstest-getlimit --max-pointer-size)"
+  head -c "$max_pointer_size" /dev/zero >first.dat
   printf "any contents" > second.dat
   git add .
 )
@@ -217,7 +221,11 @@ begin_test "filter process: hash-object --stdin --path does not hang"
   contents_oid="$(calc_oid "$contents")"
   expected=$(pointer "$contents_oid" 4 | git hash-object --stdin)
 
-  dd if=/dev/zero of=first.dat bs=1000 count=1
+  # Test with a file size smaller than the size of the read buffer used when
+  # decoding pointers.  See https://github.com/git-lfs/git-lfs/issues/3884
+  # and https://github.com/git-lfs/git-lfs/pull/3902.
+  max_pointer_size="$(lfstest-getlimit --max-pointer-size)"
+  head -c $((max_pointer_size * 1000 / 1024)) /dev/zero >first.dat
   echo a > second.dat
   # Works for existing file longer than this one.
   output=$(printf test | git hash-object --path first.dat --stdin)
@@ -229,9 +237,13 @@ begin_test "filter process: hash-object --stdin --path does not hang"
   output=$(printf test | git hash-object --path third.dat --stdin)
   [ "$expected" = "$output" ]
 
-  dd if=/dev/zero of=large.dat bs=65537 count=1
+  # Test with a file size larger than the maximum length of a Git packet line
+  # (plus some arbitrary additional padding).
+  max_pktline_len="$(lfstest-getlimit --max-pktline-len)"
+  contents_size=$((max_pktline_len + max_pointer_size + 1))
+  head -c "$contents_size" /dev/zero >large.dat
   oid=$(calc_oid_file large.dat)
-  expected=$(pointer "$oid" 65537 | git hash-object --stdin)
+  expected=$(pointer "$oid" "$contents_size" | git hash-object --stdin)
   output=$(git hash-object --path third.dat --stdin <large.dat)
   [ "$expected" = "$output" ]
   git add .

--- a/t/t-fsck.sh
+++ b/t/t-fsck.sh
@@ -142,7 +142,14 @@ create_invalid_pointers() {
   ext="${2:-dat}"
 
   git cat-file blob ":$valid" | awk '{ sub(/$/, "\r"); print }' >"crlf.$ext"
-  lfstest-genrandom --base64 1025 >"large.$ext"
+
+  # Test with a file size larger than the size of the read buffer used when
+  # decoding pointers.  See https://github.com/git-lfs/git-lfs/issues/1729,
+  # https://github.com/git-lfs/git-lfs/pull/1796,
+  # and https://github.com/git-lfs/git-lfs/pull/4525.
+  max_pointer_size="$(lfstest-getlimit --max-pointer-size)"
+  lfstest-genrandom --base64 $((max_pointer_size + 1)) >"large.$ext"
+
   git \
     -c "filter.lfs.process=" \
     -c "filter.lfs.clean=cat" \

--- a/t/t-malformed-pointers.sh
+++ b/t/t-malformed-pointers.sh
@@ -14,10 +14,20 @@ begin_test "malformed pointers"
   git add .gitattributes
   git commit -m "initial commit"
 
-  lfstest-genrandom --base64 1023 >malformed_small.dat
-  lfstest-genrandom --base64 1024 >malformed_exact.dat
-  lfstest-genrandom --base64 1025 >malformed_large.dat
-  lfstest-genrandom --base64 1048576 >malformed_xxl.dat
+  # Test with file sizes smaller than, equal to, and larger than the
+  # size of the read buffer used when decoding pointers.
+  # See https://github.com/git-lfs/git-lfs/issues/1729
+  # and https://github.com/git-lfs/git-lfs/pull/1796.
+  max_pointer_size="$(lfstest-getlimit --max-pointer-size)"
+  lfstest-genrandom --base64 $((max_pointer_size - 1)) >malformed_small.dat
+  lfstest-genrandom --base64 "$max_pointer_size" >malformed_exact.dat
+  lfstest-genrandom --base64 $((max_pointer_size + 1)) >malformed_large.dat
+
+  # Test with a file size significantly larger than the default pipe capacity
+  # of Linux/macOS.  See https://github.com/git-lfs/git-lfs/pull/1922
+  # and https://github.com/git-lfs/git-lfs/pull/1932.
+  max_pipe_capacity="65536"
+  lfstest-genrandom --base64 $((max_pipe_capacity * 16)) >malformed_xxl.dat
 
   git \
     -c "filter.lfs.process=" \

--- a/t/t-pre-push.sh
+++ b/t/t-pre-push.sh
@@ -1248,10 +1248,10 @@ begin_test "pre-push does not traverse Git objects server has"
   clone_repo "$reponame" "$reponame"
 
   endpoint=$(git config remote.origin.url)
-  contents_oid=$(calc_oid 'hi\n')
   git config "lfs.$endpoint.locksverify" false
   git lfs track "*.dat"
   echo "hi" > a.dat
+  contents_oid="$(calc_oid_file "a.dat")"
   git add .gitattributes a.dat
   git commit -m "add a.dat"
 
@@ -1264,8 +1264,8 @@ begin_test "pre-push does not traverse Git objects server has"
 
   assert_server_object "$reponame" $contents_oid "refs/heads/main"
 
-  contents2_oid=$(calc_oid 'hello\n')
   echo "hello" > b.dat
+  contents2_oid="$(calc_oid_file "b.dat")"
   git add .gitattributes b.dat
   git commit -m "add b.dat"
 

--- a/t/t-prune.sh
+++ b/t/t-prune.sh
@@ -1479,8 +1479,12 @@ begin_test "prune doesn't hang on long lines in diff"
     git lfs untrack "*.dat" 2>&1 | tee untrack.log
     grep "Untracking \"\*.dat\"" untrack.log
 
-    # Exceed the default buffer size that would be used by bufio.Scanner
-    dd if=/dev/zero bs=1024 count=128 | tr '\0' 'A' >test.dat
+    # Test with a file size significantly larger than the maximum size
+    # of the token buffer used by the bufio.Scanner interface.
+    # See https://github.com/git-lfs/git-lfs/pull/4557.
+    max_bufio_scan_token_size="$(lfstest-getlimit --max-bufio-scan-token-size)"
+    head -c $((max_bufio_scan_token_size * 2)) /dev/zero | tr '\0' 'A' >test.dat
+
     git add .gitattributes test.dat
 
     git commit -m untracked
@@ -1508,8 +1512,12 @@ begin_test "prune doesn't hang on long lines in stash diff"
     git lfs untrack "*.dat" 2>&1 | tee untrack.log
     grep "Untracking \"\*.dat\"" untrack.log
 
-    # Exceed the default buffer size that would be used by bufio.Scanner
-    dd if=/dev/zero bs=1024 count=128 | tr '\0' 'A' >test.dat
+    # Test with a file size significantly larger than the maximum size
+    # of the token buffer used by the bufio.Scanner interface.
+    # See https://github.com/git-lfs/git-lfs/pull/4557.
+    max_bufio_scan_token_size="$(lfstest-getlimit --max-bufio-scan-token-size)"
+    head -c $((max_bufio_scan_token_size * 2)) /dev/zero | tr '\0' 'A' >test.dat
+
     git stash
 
     git lfs prune

--- a/t/t-pull.sh
+++ b/t/t-pull.sh
@@ -1143,6 +1143,7 @@ begin_test "pull: read-only file"
   filename="a.txt"
 
   setup_remote_repo_with_file "$reponame" "$filename"
+  contents_oid="$(calc_oid_file "$filename")"
 
   pushd "$TRASHDIR" > /dev/null
     GIT_LFS_SKIP_SMUDGE=1 clone_repo "$reponame" "${reponame}-assert"
@@ -1150,7 +1151,7 @@ begin_test "pull: read-only file"
     chmod a-w "$filename"
 
     refute_file_writeable "$filename"
-    assert_pointer "refs/heads/main" "$filename" "$(calc_oid "$filename\n")" 6
+    assert_pointer "refs/heads/main" "$filename" "$contents_oid" 6
 
     git lfs pull
 

--- a/t/t-smudge.sh
+++ b/t/t-smudge.sh
@@ -55,9 +55,14 @@ begin_test "smudge with invalid pointer"
   [ "not a git-lfs file" = "$(echo "not a git-lfs file" | git lfs smudge)" ]
   [ "version " = "$(echo "version " | git lfs smudge)" ]
 
-  # force use of a spool file with non-pointer input longer than max buffer
-  spool="$(lfstest-genrandom --base64 2048)"
-  [ "$spool" = "$(echo "$spool" | git lfs smudge)" ]
+  # Test with input data larger than the internal memory buffer used
+  # to spool data between streams, so a temporary file is used as well.
+  # See https://github.com/git-lfs/git-lfs/pull/1922,
+  # https://github.com/git-lfs/git-lfs/pull/1932,
+  # and https://github.com/git-lfs/git-lfs/pull/5617.
+  max_spool_mem_buffer_size="$(lfstest-getlimit --max-spool-mem-buffer-size)"
+  spool="$(lfstest-genrandom --base64 $((max_spool_mem_buffer_size * 2)))"
+  [ "$spool" = "$(printf "%s" "$spool" | git lfs smudge)" ]
 )
 end_test
 

--- a/t/testhelpers.sh
+++ b/t/testhelpers.sh
@@ -841,7 +841,7 @@ comparison_to_operator() {
 
 # Calculate the object ID from the string passed as the argument
 calc_oid() {
-  printf "$1" | $SHASUM | cut -f 1 -d " "
+  printf "%s" "$1" | $SHASUM | cut -f 1 -d " "
 }
 
 # Calculate the object ID from the file passed as the argument

--- a/tools/iotools.go
+++ b/tools/iotools.go
@@ -13,10 +13,10 @@ import (
 )
 
 const (
-	// memoryBufferLimit is the number of bytes to buffer in memory before
+	// MemoryBufferLimit is the number of bytes to buffer in memory before
 	// spooling the contents of an `io.Reader` in `Spool()` to a temporary
 	// file on disk.
-	memoryBufferLimit = 1024
+	MemoryBufferLimit = 1024
 )
 
 // CopyWithCallback copies reader to writer while performing a progress callback
@@ -102,15 +102,15 @@ func (r *RetriableReader) Read(b []byte) (int, error) {
 // Spool spools the contents from 'from' to 'to' by buffering the entire
 // contents of 'from' into a temporary file created in the directory "dir".
 // That buffer is held in memory until the file grows to larger than
-// 'memoryBufferLimit`, then the remaining contents are spooled to disk.
+// `MemoryBufferLimit`, then the remaining contents are spooled to disk.
 //
 // The temporary file is cleaned up after the copy is complete.
 //
 // The number of bytes written to "to", as well as any error encountered are
 // returned.
 func Spool(to io.Writer, from io.Reader, dir string) (n int64, err error) {
-	// First, buffer up to `memoryBufferLimit` in memory.
-	buf := make([]byte, memoryBufferLimit)
+	// First, buffer up to `MemoryBufferLimit` in memory.
+	buf := make([]byte, MemoryBufferLimit)
 	if bn, err := from.Read(buf); err != nil && err != io.EOF {
 		return int64(bn), err
 	} else {


### PR DESCRIPTION
This PR revises a number of our shell tests so they are able to dynamically adjust the conditions they create to match or exceed certain internal limits in the Git LFS client.

Previously, these tests depended on hard-coded values which could drift out of sync with the actual limits of the client.

In the case of the `clean pseudo pointer with extra data` [test](https://github.com/git-lfs/git-lfs/blob/023ef527434d5bd636b3f8e22222069c85fed15e/t/t-clean.sh#L45-L58) in particular, this has already occurred.  When the test was first developed, in PRs #271, #336, and #447, the size of the internal buffer used to read and parse Git LFS pointers was [only](https://github.com/git-lfs/git-lfs/blob/1f2453349d70360be5dfc57b20b81bd4ed82550c/lfs/pointer.go#L65) 512 bytes, and so the test intentionally creates an invalid Git LFS pointer with sufficient padding to exceed that limit.

However, the size of the internal buffer was later raised to its current [value](https://github.com/git-lfs/git-lfs/blob/023ef527434d5bd636b3f8e22222069c85fed15e/lfs/scanner.go#L12) of 1024 bytes, but the `clean pseudo pointer with extra data`  test was never updated to reflect this change.  (Note that the test happens to [specify](https://github.com/git-lfs/git-lfs/blob/023ef527434d5bd636b3f8e22222069c85fed15e/t/t-clean.sh#L53) the value of `1024` as the `size` field of the invalid pointer it creates, but this is unrelated to the actual size of the string containing the invalid pointer.  To help clarify the arbitrary nature of the value in this `size` field, we now change it to `9999`.)

To allow our shell tests to retrieve the various current internal limits of the Git LFS client, we add a test helper utility program named `lfstest-getlimit` which returns one of several values depending on the option it is passed.  These values include:

- The [size](https://github.com/git-lfs/git-lfs/blob/023ef527434d5bd636b3f8e22222069c85fed15e/lfs/scanner.go#L12) of the internal buffer used when decoding Git LFS pointers.
- The maximum [length](https://github.com/git-lfs/pktline/blob/ca444d533ef1e474d0aab99cdbeed9b048d65241/pkt_line.go#L16) of a Git packet line.
- The [size](https://github.com/git-lfs/git-lfs/blob/023ef527434d5bd636b3f8e22222069c85fed15e/tools/iotools.go#L19) of the internal buffer used before [spooling](https://github.com/git-lfs/git-lfs/blob/023ef527434d5bd636b3f8e22222069c85fed15e/commands/command_smudge.go#L104) non-pointer `smudge` filter data to a temporary file.
- The maximum [size](https://pkg.go.dev/bufio#pkg-constants) of the buffer used when parsing tokens with a `Scanner` structure from the Go standard library's `bufio` package.

We also adjust the behaviour of our `calc_oid()` test helper function so that it no longer [treats](https://github.com/git-lfs/git-lfs/blob/023ef527434d5bd636b3f8e22222069c85fed15e/t/testhelpers.sh#L844) its parameter as a format specification for the `printf` shell built-in command.  This guarantees that even if we accidentally pass special formatting characters like `\` or `%` in the input to the `calc_oid()` function, it will return the same SHA-256 hash value as the Git LFS client would calculate for the same data.

This PR will be most easily reviewed on a commit-by-commit basis.

---

Note that the new test added in PR #6011 requires input data for the `git lfs filter-process` command which exceeds the pointer read buffer size.  We therefore expect to revise that PR's test to make use of the `lfstest-getlimit` helper utility introduced in this PR, thereby avoiding the use of a hard-coded value.