### PR TITLE
t/t-pre-push.sh: use calc_oid_file in URL optimization test

### DIFF
--- a/t/t-pre-push.sh
+++ b/t/t-pre-push.sh
@@ -1226,10 +1226,10 @@ begin_test "pre-push uses optimization if remote URL matches"
   clone_repo "$reponame" "$reponame"
 
   endpoint=$(git config remote.origin.url)
-  contents_oid=$(calc_oid 'hi\n')
   git config "lfs.$endpoint.locksverify" false
   git lfs track "*.dat"
   echo "hi" > a.dat
+  contents_oid="$(calc_oid_file "a.dat")"
   git add .gitattributes a.dat
   git commit -m "add a.dat"
 


### PR DESCRIPTION
In https://github.com/git-lfs/git-lfs/pull/6285 we changed the `calc_oid()` test helper to pass an explicit `"%s"` format string to the printf shell built-in command, so that it no longer interprets backslash escape sequences such as "\n" in its input.

We converted the `calc_oid()` calls in the "pre-push does not traverse Git objects server has" test to use the `calc_oid_file()` helper instead, so that the object IDs are computed from the actual file contents. However, we overlooked the identical pattern in the "pre-push uses optimization if remote URL matches" test, which still calls `calc_oid 'hi\n'`.

With the revised `calc_oid()` helper this now computes the SHA-256 hash of the literal four-byte string `"hi\n"` rather than the three-byte content of the `"a.dat"` file, which is created with "echo hi".  The resulting object ID is therefore wrong.  Because the test only passes this ID to `refute_server_object()`, which merely asserts the object is absent from the server, the test continues to pass.

We therefore update this test to mirror its sibling and derive `contents_oid` from the `"a.dat"` file using `calc_oid_file()`, after the file has been written.