### PR TITLE
Remove stale Linux distributions before v3.8.0 release

### DIFF
--- a/script/lib/distro.rb
+++ b/script/lib/distro.rb
@@ -45,7 +45,6 @@ class DistroMap
         package_tag: "-1.el9",
         equivalent: [
           "el/9",                      # EOL May 2032
-          "opensuse/15.6",             # EOL April 2026
           "sles/15.7",                 # EOL July 2031
         ],
       },
@@ -57,7 +56,6 @@ class DistroMap
         package_tag: "-1.el10",
         equivalent: [
           "el/10",                     # EOL May 2035
-          "fedora/42",                 # EOL May 2026
           "fedora/43",                 # EOL December 2026
           "fedora/44",                 # EOL May 2027
           "opensuse/16.0",             # EOL October 2027


### PR DESCRIPTION
As we anticipate releasing Git LFS version 3.8.0 in the near future, we first update our list of the Linux distributions and versions for which our scripts will publish RPM and Debian packages.

In particular, we remove the OpenSUSE Leap 15.6 and Fedora 42 distribution versions, as they have reached the end of their
support lifecycles.