### PR TITLE
lfshttp: coordinate Retry-After by hostname

### DIFF
--- a/lfshttp/client.go
+++ b/lfshttp/client.go
@@ -70,6 +70,8 @@ type Client struct {
 
 	hostClients map[hostData]*http.Client
 	clientMu    sync.Mutex
+	retryAfter  map[string]time.Time
+	retryMu     sync.Mutex
 
 	httpLogger *syncLogger
 
@@ -327,6 +329,11 @@ func (c *Client) DoWithRedirect(cli *http.Client, req *http.Request, remote stri
 
 	requests := max(0, retries) + 1
 	for i := 0; i < requests; i++ {
+		if err := c.waitForRetryAfter(req.Context(), req.URL.Hostname()); err != nil {
+			c.traceResponse(req, tracedReq, nil)
+			return nil, nil, err
+		}
+
 		res, err = cli.Do(req)
 		if err == nil {
 			break

--- a/lfshttp/errors.go
+++ b/lfshttp/errors.go
@@ -67,6 +67,9 @@ func (c *Client) handleResponse(res *http.Response) error {
 		h := res.Header.Get("Retry-After")
 		retLaterErr := errors.NewRetriableLaterError(err, h)
 		if retLaterErr != nil {
+			if retryAt, ok := errors.IsRetriableLaterError(retLaterErr); ok && res.Request != nil {
+				c.setRetryAfter(res.Request.URL.Hostname(), retryAt)
+			}
 			return retLaterErr
 		}
 		return errors.NewRetriableError(err)

--- a/lfshttp/retry_after.go
+++ b/lfshttp/retry_after.go
@@ -1,0 +1,78 @@
+package lfshttp
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/rubyist/tracerx"
+)
+
+const defaultMaxRetryTime = 300
+
+func (c *Client) setRetryAfter(hostname string, retryAt time.Time) {
+	hostname = strings.ToLower(hostname)
+	delay := time.Until(retryAt)
+	// TransferQueue rejects server-requested delays beyond maxRetryTime. Do
+	// not stall otherwise viable requests to this host for a delay the queue
+	// will not honor.
+	if hostname == "" || delay <= 0 || delay > c.maxRetryTime() {
+		return
+	}
+
+	c.retryMu.Lock()
+	defer c.retryMu.Unlock()
+
+	if current := c.retryAfter[hostname]; !retryAt.After(current) {
+		return
+	}
+	if c.retryAfter == nil {
+		c.retryAfter = make(map[string]time.Time)
+	}
+	c.retryAfter[hostname] = retryAt
+}
+
+func (c *Client) maxRetryTime() time.Duration {
+	seconds := defaultMaxRetryTime
+	if c.gitEnv != nil {
+		if configured := c.gitEnv.Int("lfs.transfer.maxretrytime", 0); configured > 0 {
+			seconds = configured
+		}
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+func (c *Client) waitForRetryAfter(ctx context.Context, hostname string) error {
+	hostname = strings.ToLower(hostname)
+	if hostname == "" {
+		return nil
+	}
+
+	for {
+		c.retryMu.Lock()
+		retryAt, ok := c.retryAfter[hostname]
+		wait := time.Until(retryAt)
+		if !ok || wait <= 0 {
+			if ok {
+				delete(c.retryAfter, hostname)
+			}
+			c.retryMu.Unlock()
+			return nil
+		}
+		c.retryMu.Unlock()
+
+		tracerx.Printf("http: waiting %.2fs before sending another request to %s", wait.Seconds(), hostname)
+		timer := time.NewTimer(wait)
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return ctx.Err()
+		}
+	}
+}

--- a/lfshttp/retry_after_test.go
+++ b/lfshttp/retry_after_test.go
@@ -1,0 +1,89 @@
+package lfshttp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientWaitsForRetryAfterOnSameHost(t *testing.T) {
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		if r.URL.Path == "/rate-limited" {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := NewClient(nil)
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/rate-limited", nil)
+	require.NoError(t, err)
+	res, err := c.Do(req)
+	require.Error(t, err)
+	require.Equal(t, http.StatusTooManyRequests, res.StatusCode)
+	require.NoError(t, res.Body.Close())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	req, err = http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/next", nil)
+	require.NoError(t, err)
+	_, err = c.Do(req)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.EqualValues(t, 1, requests.Load(), "request should be cancelled before reaching the rate-limited host")
+
+	started := time.Now()
+	req, err = http.NewRequest(http.MethodGet, srv.URL+"/next", nil)
+	require.NoError(t, err)
+	res, err = c.Do(req)
+	require.NoError(t, err)
+	require.NoError(t, res.Body.Close())
+	assert.GreaterOrEqual(t, time.Since(started), 850*time.Millisecond)
+	assert.EqualValues(t, 2, requests.Load())
+}
+
+func TestClientRetryAfterIsScopedByHostname(t *testing.T) {
+	c := NewClient(nil)
+	c.setRetryAfter("limited.example.com", time.Now().Add(time.Second))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	require.NoError(t, c.waitForRetryAfter(ctx, "other.example.com"))
+
+	err := c.waitForRetryAfter(ctx, "LIMITED.EXAMPLE.COM")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestClientRetryAfterKeepsLatestDeadline(t *testing.T) {
+	c := NewClient(nil)
+	hostname := "limited.example.com"
+	later := time.Now().Add(2 * time.Second)
+	c.setRetryAfter(hostname, later)
+	c.setRetryAfter(hostname, later.Add(-time.Second))
+
+	c.retryMu.Lock()
+	actual := c.retryAfter[hostname]
+	c.retryMu.Unlock()
+	assert.Equal(t, later, actual)
+}
+
+func TestClientDoesNotWaitPastMaxRetryTime(t *testing.T) {
+	c := NewClient(NewContext(nil, nil, map[string]string{
+		"lfs.transfer.maxretrytime": "1",
+	}))
+	c.setRetryAfter("limited.example.com", time.Now().Add(2*time.Second))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	require.NoError(t, c.waitForRetryAfter(ctx, "limited.example.com"))
+}


### PR DESCRIPTION
## Summary

- remember valid `Retry-After` deadlines by hostname in the shared HTTP client
- delay new requests to the affected hostname without blocking other hosts
- make waits request-context-aware and retain the latest concurrent deadline
- avoid host-wide waits that exceed `lfs.transfer.maxRetryTime`

## Rationale

The transfer queue currently delays only the object whose request received a 429 response. Other workers can therefore continue sending requests to the same hostname during the server's requested delay, producing another burst of 429 responses.

This moves the coordination into `lfshttp.Client`, where API and object-transfer requests share a hostname-keyed deadline. Requests already in flight are left alone; requests started after the deadline is recorded wait until it expires or their context is cancelled.

## Testing

- `make test`
- `make test-race`
- `make -C t t-batch-storage-retries-ratelimit.sh`
- `GOOS=windows GOARCH=amd64 go test -c ./lfshttp`

Fixes #6106
