### PR TITLE
Flush Windows block clone sources before cloning

### DIFF
--- a/tools/util_windows.go
+++ b/tools/util_windows.go
@@ -4,6 +4,7 @@
 package tools
 
 import (
+	"errors"
 	"io"
 	"os"
 	"unsafe"
@@ -20,7 +21,13 @@ var (
 // Instructs the file system to copy a range of file bytes on behalf of an application.
 //
 // https://docs.microsoft.com/windows/win32/api/winioctl/ni-winioctl-fsctl_duplicate_extents_to_file
-const fsctlDuplicateExtentsToFile = 623428
+const (
+	fsctlDuplicateExtentsToFile = 623428
+
+	// fileSupportsBlockRefcounting indicates that a volume supports block
+	// cloning through FSCTL_DUPLICATE_EXTENTS_TO_FILE.
+	fileSupportsBlockRefcounting = 0x08000000
+)
 
 // duplicateExtentsData = DUPLICATE_EXTENTS_DATA structure
 // Contains parameters for the FSCTL_DUPLICATE_EXTENTS control code that performs the Block Cloning operation.
@@ -95,10 +102,19 @@ func CloneFile(writer io.Writer, reader io.Reader) (success bool, err error) {
 	}
 
 	fileSize := srcStat.Size()
-
 	err = dst.Truncate(fileSize) // set file size. There is a requirement "The destination region must not extend past the end of file."
 	if err != nil {
 		return
+	}
+
+	// Some network file systems support block cloning but not volume
+	// information queries, so only skip the sync when the source volume
+	// explicitly reports that block cloning is unsupported.
+	blockCloningSupported, supportErr := volumeSupportsBlockCloning(src)
+	if fileSize > 0 && (supportErr != nil || blockCloningSupported) {
+		if err = syncFileBeforeClone(src); err != nil {
+			return false, err
+		}
 	}
 
 	offset := int64(0)
@@ -126,6 +142,41 @@ func CloneFile(writer io.Writer, reader io.Reader) (success bool, err error) {
 	}
 
 	return err == nil, err
+}
+
+func volumeSupportsBlockCloning(file *os.File) (bool, error) {
+	var flags uint32
+	err := windows.GetVolumeInformationByHandle(
+		windows.Handle(file.Fd()),
+		nil,
+		0,
+		nil,
+		nil,
+		&flags,
+		nil,
+		0,
+	)
+	if err != nil {
+		return false, err
+	}
+
+	return flags&fileSupportsBlockRefcounting != 0, nil
+}
+
+// syncFileBeforeClone commits the source contents to stable storage before a
+// block clone maps its disk extents into the destination. Checkout opens LFS
+// objects read-only, but FlushFileBuffers requires a handle with write access,
+// so open a short-lived writable handle to the same path for the sync.
+func syncFileBeforeClone(src *os.File) (err error) {
+	writable, err := os.OpenFile(src.Name(), os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err = errors.Join(err, writable.Close())
+	}()
+
+	return writable.Sync()
 }
 
 // call FSCTL_DUPLICATE_EXTENTS_TO_FILE IOCTL

--- a/tools/util_windows_test.go
+++ b/tools/util_windows_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/git-lfs/git-lfs/v3/errors"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCloneFile(t *testing.T) {
@@ -48,12 +49,24 @@ func TestCloneFile(t *testing.T) {
 			as := assert.New(t)
 
 			src, err := os.CreateTemp(testDir, tc.name+"_src")
-			as.NoError(err)
+			require.NoError(t, err)
+			srcName := src.Name()
+			t.Cleanup(func() { os.Remove(srcName) })
+
 			dst, err := os.CreateTemp(testDir, tc.name+"_dst")
-			as.NoError(err)
+			require.NoError(t, err)
+			defer dst.Close()
+			dstName := dst.Name()
+			t.Cleanup(func() { os.Remove(dstName) })
 
 			srcHash, err := fillFile(src, tc.size)
-			as.NoError(err)
+			require.NoError(t, err)
+			require.NoError(t, src.Close())
+
+			// Checkout opens LFS objects read-only before attempting a clone.
+			src, err = os.Open(srcName)
+			require.NoError(t, err)
+			defer src.Close()
 
 			ok, err := CloneFile(dst, src)
 			as.NoError(err)
@@ -67,6 +80,21 @@ func TestCloneFile(t *testing.T) {
 			as.Equal(srcHash, dstHash)
 		})
 	}
+}
+
+func TestSyncFileBeforeCloneWithReadOnlyHandle(t *testing.T) {
+	writer, err := os.CreateTemp(t.TempDir(), "src")
+	require.NoError(t, err)
+	defer writer.Close()
+
+	_, err = writer.WriteString("unflushed content")
+	require.NoError(t, err)
+
+	src, err := os.Open(writer.Name())
+	require.NoError(t, err)
+	defer src.Close()
+
+	require.NoError(t, syncFileBeforeClone(src))
 }
 
 func fillFile(target *os.File, size int64) (hash string, err error) {
@@ -84,11 +112,6 @@ func fillFile(target *os.File, size int64) (hash string, err error) {
 	}
 
 	err = target.Truncate(size)
-	if err != nil {
-		return "", err
-	}
-
-	err = target.Sync()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Fixes #6312.

## Summary

- inspect the source volume's `FILE_SUPPORTS_BLOCK_REFCOUNTING` capability before attempting a Windows block clone
- flush non-empty clone sources through a short-lived writable handle before `FSCTL_DUPLICATE_EXTENTS_TO_FILE`
- retain the existing byte-copy fallback when the source cannot be opened and flushed safely
- update the ReFS clone test to use the same read-only, unflushed source shape as checkout, and add coverage for flushing through a read-only caller handle

## Details

Checkout opens objects in the local LFS store read-only. Calling `Sync` on that handle cannot provide the required durability barrier because Windows requires `GENERIC_WRITE` for `FlushFileBuffers`, so the implementation reopens the same path briefly with write access and syncs that handle.

The volume capability check avoids adding a forced disk flush to ordinary copies on local filesystems such as NTFS, where block cloning is unsupported. If the volume query itself is unavailable, as it can be for network filesystems, the code conservatively syncs before preserving the existing clone attempt.

## Validation

- `make test`
- `make test-race`
- cross-compiled the `tools` test package for Windows 386, amd64, and arm64
- cross-compiled and linked all Go packages for Windows amd64
- `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go vet ./tools`

The Windows-specific tests were cross-compiled locally. The existing block-clone test runs against an actual ReFS volume when `REFS_TEST_DIR` is configured; no ReFS volume was available in the local environment.
