### PR TITLE
gitattr: handle invalid wildmatch patterns

### DIFF
--- a/git/gitattr/attr.go
+++ b/git/gitattr/attr.go
@@ -165,10 +165,10 @@ func ParseLines(r io.Reader) ([]Line, string, error) {
 
 		var line Line
 		if pattern != "" {
-			matchPattern := wildmatch.NewWildmatch(pattern,
-				wildmatch.Basename, wildmatch.SystemCase,
-				wildmatch.GitAttributes,
-			)
+			matchPattern, err := newPattern(pattern)
+			if err != nil {
+				return nil, "", err
+			}
 			line = &patternLine{matchPattern, lineAttrs}
 		} else {
 			line = &macroLine{macro, lineAttrs}
@@ -181,6 +181,19 @@ func ParseLines(r io.Reader) ([]Line, string, error) {
 		return nil, "", err
 	}
 	return lines, splitter.LineEnding(), nil
+}
+
+func newPattern(pattern string) (matchPattern *wildmatch.Wildmatch, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = errors.New(tr.Tr.Get("invalid attribute pattern %q: %v", pattern, recovered))
+		}
+	}()
+
+	return wildmatch.NewWildmatch(pattern,
+		wildmatch.Basename, wildmatch.SystemCase,
+		wildmatch.GitAttributes,
+	), nil
 }
 
 // copies bufio.ScanLines(), counting LF vs CRLF in a file

--- a/git/gitattr/attr_test.go
+++ b/git/gitattr/attr_test.go
@@ -146,6 +146,15 @@ func TestParseLinesUnbalancedQuotes(t *testing.T) {
 		"unbalanced quote: %s", text))
 }
 
+func TestParseLinesInvalidPattern(t *testing.T) {
+	const text = "Chromium[[:space]]Embedded binary"
+	lines, _, err := ParseLines(strings.NewReader(text))
+
+	assert.Empty(t, lines)
+	assert.EqualError(t, err,
+		"invalid attribute pattern \"Chromium[[:space]]Embedded\": unclosed character class")
+}
+
 func TestParseLinesWithNoAttributes(t *testing.T) {
 	lines, _, err := ParseLines(strings.NewReader("*.dat"))
 

--- a/git/gitattr/files.go
+++ b/git/gitattr/files.go
@@ -173,6 +173,7 @@ func AttrPathsFromReader(mp *MacroProcessor, fpath, workingDir string, rdr io.Re
 
 	lines, eol, err := ParseLines(rdr)
 	if err != nil {
+		tracerx.Printf("Error parsing attributes from %s: %v", fpath, err)
 		return nil
 	}
 

--- a/t/t-post-checkout.sh
+++ b/t/t-post-checkout.sh
@@ -121,6 +121,26 @@ begin_test "post-checkout"
 )
 end_test
 
+begin_test "post-checkout with an invalid attribute pattern"
+(
+  set -e
+
+  reponame="post-checkout-invalid-attribute-pattern"
+  mkdir "$reponame"
+  cd "$reponame"
+  git init
+
+  echo 'Chromium[[:space]]Embedded[[:space]]Framework lockable' >.gitattributes
+
+  GIT_TRACE=1 git lfs post-checkout \
+    0000000000000000000000000000000000000000 \
+    0000000000000000000000000000000000000000 1 2>&1 | tee post-checkout.log
+
+  grep 'invalid attribute pattern "Chromium\[\[:space\]\]Embedded\[\[:space\]\]Framework": unclosed character class' post-checkout.log
+  [ "0" -eq "$(grep -c "panic:" post-checkout.log)" ]
+)
+end_test
+
 begin_test "post-checkout with subdirectories"
 (
   set -e

--- a/t/t-post-checkout.sh
+++ b/t/t-post-checkout.sh
@@ -230,7 +230,7 @@ begin_test "post-checkout with an invalid attribute pattern"
     0000000000000000000000000000000000000000 1 2>&1 | tee post-checkout.log
   [ 0 -eq "${PIPESTATUS[0]}" ]
 
-  grep "Error parsing attributes from .*/\.gitattributes: invalid attribute pattern" post-checkout.log
+  grep "Error parsing attributes from .*$(escape_path "$PATH_SEPARATOR")\.gitattributes: invalid attribute pattern" post-checkout.log
   grep -F "invalid attribute pattern \"$invalid_pattern\": unclosed character class" post-checkout.log
   [ 0 -eq "$(grep -c "panic:" post-checkout.log)" ]
 
@@ -244,7 +244,7 @@ begin_test "post-checkout with an invalid attribute pattern"
     0000000000000000000000000000000000000000 1 2>&1 | tee post-checkout.log
   [ 0 -eq "${PIPESTATUS[0]}" ]
 
-  grep "Error parsing attributes from .*/\.gitattributes: invalid attribute pattern" post-checkout.log
+  grep "Error parsing attributes from .*$(escape_path "$PATH_SEPARATOR")\.gitattributes: invalid attribute pattern" post-checkout.log
   grep -F "invalid attribute pattern \"$invalid_pattern\": wildmatch: unknown class" post-checkout.log
   [ 0 -eq "$(grep -c "panic:" post-checkout.log)" ]
 )

--- a/t/t-post-checkout.sh
+++ b/t/t-post-checkout.sh
@@ -121,26 +121,6 @@ begin_test "post-checkout"
 )
 end_test
 
-begin_test "post-checkout with an invalid attribute pattern"
-(
-  set -e
-
-  reponame="post-checkout-invalid-attribute-pattern"
-  mkdir "$reponame"
-  cd "$reponame"
-  git init
-
-  echo 'Chromium[[:space]]Embedded[[:space]]Framework lockable' >.gitattributes
-
-  GIT_TRACE=1 git lfs post-checkout \
-    0000000000000000000000000000000000000000 \
-    0000000000000000000000000000000000000000 1 2>&1 | tee post-checkout.log
-
-  grep 'invalid attribute pattern "Chromium\[\[:space\]\]Embedded\[\[:space\]\]Framework": unclosed character class' post-checkout.log
-  [ "0" -eq "$(grep -c "panic:" post-checkout.log)" ]
-)
-end_test
-
 begin_test "post-checkout with subdirectories"
 (
   set -e
@@ -227,5 +207,45 @@ begin_test "post-checkout with subdirectories"
   # Confirm that contents of existing files were updated even though were read-only
   [ "$(cat bin/file2.dat)" == "file 2 updated in branch2" ]
   [ "$(cat file3.big)" == "file 3 updated in branch2" ]
+)
+end_test
+
+begin_test "post-checkout with an invalid attribute pattern"
+(
+  set -e
+
+  reponame="post-checkout-invalid-attribute-pattern"
+  mkdir "$reponame"
+  cd "$reponame"
+  git init
+
+  # Test with a ".gitattributes" file which contains a pattern with
+  # an incomplete POSIX named character class ("[[:space]]").
+  # See https://github.com/git-lfs/git-lfs/issues/6120.
+  invalid_pattern="file[[:space:]]with[[:space]]incomplete_class"
+  echo "$invalid_pattern lockable" >.gitattributes
+
+  GIT_TRACE=1 git lfs post-checkout \
+    0000000000000000000000000000000000000000 \
+    0000000000000000000000000000000000000000 1 2>&1 | tee post-checkout.log
+  [ 0 -eq "${PIPESTATUS[0]}" ]
+
+  grep "Error parsing attributes from .*/\.gitattributes: invalid attribute pattern" post-checkout.log
+  grep -F "invalid attribute pattern \"$invalid_pattern\": unclosed character class" post-checkout.log
+  [ 0 -eq "$(grep -c "panic:" post-checkout.log)" ]
+
+  # Test with a ".gitattributes" file which contains a pattern with
+  # an invalid POSIX named character class.
+  invalid_pattern="file[[:space:]]with[[:invalid:]]class"
+  echo "$invalid_pattern lockable" >.gitattributes
+
+  GIT_TRACE=1 git lfs post-checkout \
+    0000000000000000000000000000000000000000 \
+    0000000000000000000000000000000000000000 1 2>&1 | tee post-checkout.log
+  [ 0 -eq "${PIPESTATUS[0]}" ]
+
+  grep "Error parsing attributes from .*/\.gitattributes: invalid attribute pattern" post-checkout.log
+  grep -F "invalid attribute pattern \"$invalid_pattern\": wildmatch: unknown class" post-checkout.log
+  [ 0 -eq "$(grep -c "panic:" post-checkout.log)" ]
 )
 end_test


### PR DESCRIPTION
## Summary

- convert invalid Git attribute wildmatch patterns from panics into parse errors
- trace working-tree attribute parse failures so hooks return cleanly
- cover both the parser and `post-checkout` hook paths

## Testing

- `make test`
- `make -C t t-post-checkout.sh`

Fixes #6120
