### PR TITLE
config: normalize URL-scoped matches

### DIFF
--- a/config/delayed_environment.go
+++ b/config/delayed_environment.go
@@ -56,14 +56,10 @@ func (e *delayedEnvironment) All() map[string][]string {
 	return e.env.All()
 }
 
-// SourceIndex returns a configuration key's last position in source order when
-// available.
-func (e *delayedEnvironment) SourceIndex(key string) (int, bool) {
+// SortedAll returns all configuration entries in source order when available.
+func (e *delayedEnvironment) SortedAll() []EnvironmentEntry {
 	e.Load()
-	if env, ok := e.env.(orderedEnvironment); ok {
-		return env.SourceIndex(key)
-	}
-	return 0, false
+	return e.env.SortedAll()
 }
 
 // Load reads and parses the .gitconfig by calling ReadGitConfig. It

--- a/config/delayed_environment.go
+++ b/config/delayed_environment.go
@@ -56,6 +56,16 @@ func (e *delayedEnvironment) All() map[string][]string {
 	return e.env.All()
 }
 
+// SourceIndex returns a configuration key's last position in source order when
+// available.
+func (e *delayedEnvironment) SourceIndex(key string) (int, bool) {
+	e.Load()
+	if env, ok := e.env.(orderedEnvironment); ok {
+		return env.SourceIndex(key)
+	}
+	return 0, false
+}
+
 // Load reads and parses the .gitconfig by calling ReadGitConfig. It
 // also sets values on the configuration instance `g.config`.
 //

--- a/config/environment.go
+++ b/config/environment.go
@@ -55,11 +55,10 @@ type Environment interface {
 	// All returns a copy of all the key/value pairs for the current
 	// environment.
 	All() map[string][]string
-}
 
-type orderedEnvironment interface {
-	Environment
-	SourceIndex(key string) (int, bool)
+	// SortedAll returns all key/value pairs ordered by each key's final source
+	// occurrence, or nil when the underlying source does not retain ordering.
+	SortedAll() []EnvironmentEntry
 }
 
 type environment struct {
@@ -100,11 +99,11 @@ func (e *environment) All() map[string][]string {
 	return e.Fetcher.All()
 }
 
-func (e *environment) SourceIndex(key string) (int, bool) {
-	if fetcher, ok := e.Fetcher.(orderedFetcher); ok {
-		return fetcher.SourceIndex(key)
+func (e *environment) SortedAll() []EnvironmentEntry {
+	if fetcher, ok := e.Fetcher.(sortedFetcher); ok {
+		return fetcher.SortedAll()
 	}
-	return 0, false
+	return nil
 }
 
 // Int returns the int value associated with the given value, or the value

--- a/config/environment.go
+++ b/config/environment.go
@@ -57,6 +57,11 @@ type Environment interface {
 	All() map[string][]string
 }
 
+type orderedEnvironment interface {
+	Environment
+	SourceIndex(key string) (int, bool)
+}
+
 type environment struct {
 	// Fetcher is the `environment`'s source of data.
 	Fetcher Fetcher
@@ -93,6 +98,13 @@ func (e *environment) Int64(key string, def int64) int64 {
 
 func (e *environment) All() map[string][]string {
 	return e.Fetcher.All()
+}
+
+func (e *environment) SourceIndex(key string) (int, bool) {
+	if fetcher, ok := e.Fetcher.(orderedFetcher); ok {
+		return fetcher.SourceIndex(key)
+	}
+	return 0, false
 }
 
 // Int returns the int value associated with the given value, or the value

--- a/config/fetcher.go
+++ b/config/fetcher.go
@@ -20,3 +20,9 @@ type Fetcher interface {
 	// environment.
 	All() map[string][]string
 }
+
+// orderedFetcher provides access to configuration key positions in source order.
+// Fetchers which do not preserve source order need not implement it.
+type orderedFetcher interface {
+	SourceIndex(key string) (int, bool)
+}

--- a/config/fetcher.go
+++ b/config/fetcher.go
@@ -21,8 +21,15 @@ type Fetcher interface {
 	All() map[string][]string
 }
 
-// orderedFetcher provides access to configuration key positions in source order.
-// Fetchers which do not preserve source order need not implement it.
-type orderedFetcher interface {
-	SourceIndex(key string) (int, bool)
+// EnvironmentEntry contains all values associated with a configuration key.
+type EnvironmentEntry struct {
+	Key    string
+	Values []string
+}
+
+// sortedFetcher provides all configuration entries ordered by each key's final
+// source occurrence. Fetchers which do not preserve source order need not
+// implement it.
+type sortedFetcher interface {
+	SortedAll() []EnvironmentEntry
 }

--- a/config/git_fetcher.go
+++ b/config/git_fetcher.go
@@ -12,12 +12,15 @@ import (
 )
 
 type GitFetcher struct {
-	vmu  sync.RWMutex
-	vals map[string][]string
+	vmu   sync.RWMutex
+	vals  map[string][]string
+	order map[string]int
 }
 
 func readGitConfig(configs ...*git.ConfigurationSource) (gf *GitFetcher, extensions map[string]Extension, uniqRemotes map[string]bool) {
 	vals := make(map[string][]string)
+	order := make(map[string]int)
+	nextIndex := 0
 	ignored := make([]string, 0)
 
 	extensions = make(map[string]Extension)
@@ -97,6 +100,8 @@ func readGitConfig(configs ...*git.ConfigurationSource) (gf *GitFetcher, extensi
 				continue
 			}
 
+			order[key] = nextIndex
+			nextIndex++
 			vals[key] = append(vals[key], val)
 		}
 	}
@@ -108,7 +113,7 @@ func readGitConfig(configs ...*git.ConfigurationSource) (gf *GitFetcher, extensi
 		}
 	}
 
-	gf = &GitFetcher{vals: vals}
+	gf = &GitFetcher{vals: vals, order: order}
 
 	return
 }
@@ -151,6 +156,15 @@ func (g *GitFetcher) All() map[string][]string {
 	}
 
 	return newmap
+}
+
+// SourceIndex returns a configuration key's last position in source order.
+func (g *GitFetcher) SourceIndex(key string) (int, bool) {
+	g.vmu.RLock()
+	defer g.vmu.RUnlock()
+
+	index, ok := g.order[g.caseFoldKey(key)]
+	return index, ok
 }
 
 func (g *GitFetcher) caseFoldKey(key string) string {

--- a/config/git_fetcher.go
+++ b/config/git_fetcher.go
@@ -12,15 +12,15 @@ import (
 )
 
 type GitFetcher struct {
-	vmu   sync.RWMutex
-	vals  map[string][]string
-	order map[string]int
+	vmu      sync.RWMutex
+	vals     map[string][]string
+	order    []string
+	hasOrder bool
 }
 
 func readGitConfig(configs ...*git.ConfigurationSource) (gf *GitFetcher, extensions map[string]Extension, uniqRemotes map[string]bool) {
 	vals := make(map[string][]string)
-	order := make(map[string]int)
-	nextIndex := 0
+	order := make([]string, 0)
 	ignored := make([]string, 0)
 
 	extensions = make(map[string]Extension)
@@ -100,8 +100,7 @@ func readGitConfig(configs ...*git.ConfigurationSource) (gf *GitFetcher, extensi
 				continue
 			}
 
-			order[key] = nextIndex
-			nextIndex++
+			order = append(order, key)
 			vals[key] = append(vals[key], val)
 		}
 	}
@@ -113,7 +112,7 @@ func readGitConfig(configs ...*git.ConfigurationSource) (gf *GitFetcher, extensi
 		}
 	}
 
-	gf = &GitFetcher{vals: vals, order: order}
+	gf = &GitFetcher{vals: vals, order: order, hasOrder: true}
 
 	return
 }
@@ -158,13 +157,36 @@ func (g *GitFetcher) All() map[string][]string {
 	return newmap
 }
 
-// SourceIndex returns a configuration key's last position in source order.
-func (g *GitFetcher) SourceIndex(key string) (int, bool) {
+// SortedAll returns a copy of all key/value pairs, ordered by each key's last
+// occurrence in the Git configuration sources.
+func (g *GitFetcher) SortedAll() []EnvironmentEntry {
 	g.vmu.RLock()
 	defer g.vmu.RUnlock()
 
-	index, ok := g.order[g.caseFoldKey(key)]
-	return index, ok
+	if !g.hasOrder {
+		return nil
+	}
+
+	seen := make(map[string]bool, len(g.vals))
+	entries := make([]EnvironmentEntry, 0, len(g.vals))
+	for i := len(g.order) - 1; i >= 0; i-- {
+		key := g.order[i]
+		if seen[key] {
+			continue
+		}
+
+		seen[key] = true
+		entries = append(entries, EnvironmentEntry{
+			Key:    key,
+			Values: append([]string(nil), g.vals[key]...),
+		})
+	}
+
+	for left, right := 0, len(entries)-1; left < right; left, right = left+1, right-1 {
+		entries[left], entries[right] = entries[right], entries[left]
+	}
+
+	return entries
 }
 
 func (g *GitFetcher) caseFoldKey(key string) string {

--- a/config/url_config.go
+++ b/config/url_config.go
@@ -58,10 +58,11 @@ func (c *URLConfig) Bool(prefix, rawurl, key string, def bool) bool {
 
 func (c *URLConfig) getAll(prefix, rawurl, key string) []string {
 	type urlMatch struct {
-		key       string // The full configuration key
-		hostScore int    // A score indicating the strength of the host match
-		pathScore int    // A score indicating the strength of the path match
-		userMatch int    // Whether we matched on a username. 1 for yes, else 0
+		key         string // The full configuration key
+		hostScore   int    // A score indicating the strength of the host match
+		pathScore   int    // A score indicating the strength of the path match
+		userMatch   int    // Whether we matched on a username. 1 for yes, else 0
+		sourceIndex int    // The key's last position in Git configuration order
 	}
 
 	searchURL, err := url.Parse(rawurl)
@@ -70,6 +71,7 @@ func (c *URLConfig) getAll(prefix, rawurl, key string) []string {
 	}
 
 	config := c.git.All()
+	ordered, _ := c.git.(orderedEnvironment)
 
 	re := regexp.MustCompile(fmt.Sprintf(`\A%s\.(\S+)\.%s\z`, prefix, key))
 
@@ -93,6 +95,9 @@ func (c *URLConfig) getAll(prefix, rawurl, key string) []string {
 
 		match := urlMatch{
 			key: k,
+		}
+		if ordered != nil {
+			match.sourceIndex, _ = ordered.SourceIndex(k)
 		}
 
 		// Rule #1: Scheme must match exactly
@@ -152,7 +157,9 @@ func (c *URLConfig) getAll(prefix, rawurl, key string) []string {
 			continue
 		}
 
-		if match.pathScore == bestMatch.pathScore && match.userMatch > bestMatch.userMatch {
+		if match.pathScore == bestMatch.pathScore &&
+			(match.userMatch > bestMatch.userMatch ||
+				(match.userMatch == bestMatch.userMatch && match.sourceIndex > bestMatch.sourceIndex)) {
 			bestMatch = match
 			continue
 		}

--- a/config/url_config.go
+++ b/config/url_config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -58,73 +59,59 @@ func (c *URLConfig) Bool(prefix, rawurl, key string, def bool) bool {
 
 func (c *URLConfig) getAll(prefix, rawurl, key string) []string {
 	type urlMatch struct {
-		key         string // The full configuration key
-		hostScore   int    // A score indicating the strength of the host match
-		pathScore   int    // A score indicating the strength of the path match
-		userMatch   int    // Whether we matched on a username. 1 for yes, else 0
-		sourceIndex int    // The key's last position in Git configuration order
+		values    []string // The values associated with the configuration key
+		hostScore int      // A score indicating the strength of the host match
+		pathScore int      // A score indicating the strength of the path match
+		userMatch int      // Whether we matched on a username. 1 for yes, else 0
 	}
 
-	searchURL, err := url.Parse(rawurl)
+	searchURL, err := normalizeURL(rawurl, false)
 	if err != nil {
 		return nil
 	}
 
-	config := c.git.All()
-	ordered, _ := c.git.(orderedEnvironment)
+	config, ordered := c.configEntries()
+	re := regexp.MustCompile(fmt.Sprintf(`\A%s\.(\S+)\.%s\z`, regexp.QuoteMeta(prefix), regexp.QuoteMeta(key)))
 
-	re := regexp.MustCompile(fmt.Sprintf(`\A%s\.(\S+)\.%s\z`, prefix, key))
+	bestMatch := urlMatch{}
+	foundMatch := false
 
-	bestMatch := urlMatch{
-		key:       "",
-		hostScore: 0,
-		pathScore: 0,
-		userMatch: 0,
-	}
-
-	for k := range config {
+	for _, entry := range config {
 		// Ensure we're examining the correct type of key and parse out the URL
-		matches := re.FindStringSubmatch(k)
+		matches := re.FindStringSubmatch(entry.Key)
 		if matches == nil {
 			continue
 		}
-		configURL, err := url.Parse(matches[1])
+		configURL, err := normalizeURL(matches[1], true)
 		if err != nil {
 			continue
 		}
 
 		match := urlMatch{
-			key: k,
-		}
-		if ordered != nil {
-			match.sourceIndex, _ = ordered.SourceIndex(k)
+			values: entry.Values,
 		}
 
 		// Rule #1: Scheme must match exactly
-		if searchURL.Scheme != configURL.Scheme {
+		if searchURL.scheme != configURL.scheme {
 			continue
 		}
 
 		// Rule #2: Hosts must match exactly, or through wildcards. More exact
 		// matches should take priority over wildcard matches
-		match.hostScore = compareHosts(searchURL.Hostname(), configURL.Hostname())
+		match.hostScore = compareHosts(searchURL.hostname, configURL.hostname)
 
 		if match.hostScore == 0 {
 			continue
 		}
 
-		if match.hostScore < bestMatch.hostScore {
-			continue
-		}
-
 		// Rule #3: Port Number must match exactly
-		if portForURL(searchURL) != portForURL(configURL) {
+		if searchURL.port != configURL.port {
 			continue
 		}
 
 		// Rule #4: Configured path must match exactly, or as a prefix of
 		// slash-delimited path elements
-		match.pathScore = comparePaths(searchURL.Path, configURL.Path)
+		match.pathScore = comparePaths(searchURL.path, configURL.path)
 
 		if match.pathScore == 0 {
 			continue
@@ -133,60 +120,56 @@ func (c *URLConfig) getAll(prefix, rawurl, key string) []string {
 		// Rule #5: Username must match exactly if present in the config.
 		// If not present, config matches on any username but with lower
 		// priority than an exact username match.
-		if configURL.User != nil {
-			if searchURL.User == nil {
+		if configURL.hasUserinfo && configURL.userinfo != "" {
+			if !searchURL.hasUserinfo || searchURL.userinfo == "" {
 				continue
 			}
 
-			if searchURL.User.Username() != configURL.User.Username() {
+			if searchURL.username != configURL.username {
 				continue
 			}
 
 			match.userMatch = 1
 		}
 
-		// Now combine our various scores to determine if we have found a best
-		// match. Host score > path score > user score
-		if match.hostScore > bestMatch.hostScore {
+		// Combine scores in the same order Git uses. When entries are in source
+		// order, an equally specific later entry replaces the earlier one.
+		better := !foundMatch ||
+			match.hostScore > bestMatch.hostScore ||
+			(match.hostScore == bestMatch.hostScore && match.pathScore > bestMatch.pathScore) ||
+			(match.hostScore == bestMatch.hostScore && match.pathScore == bestMatch.pathScore && match.userMatch > bestMatch.userMatch)
+		equal := foundMatch && match.hostScore == bestMatch.hostScore &&
+			match.pathScore == bestMatch.pathScore && match.userMatch == bestMatch.userMatch
+		if better || (ordered && equal) {
 			bestMatch = match
-			continue
-		}
-
-		if match.pathScore > bestMatch.pathScore {
-			bestMatch = match
-			continue
-		}
-
-		if match.pathScore == bestMatch.pathScore &&
-			(match.userMatch > bestMatch.userMatch ||
-				(match.userMatch == bestMatch.userMatch && match.sourceIndex > bestMatch.sourceIndex)) {
-			bestMatch = match
-			continue
+			foundMatch = true
 		}
 	}
 
-	if bestMatch.key == "" {
+	if !foundMatch {
 		return nil
 	}
 
-	return c.git.GetAll(bestMatch.key)
+	return bestMatch.values
 }
 
-func portForURL(u *url.URL) string {
-	port := u.Port()
-	if port != "" {
-		return port
+func (c *URLConfig) configEntries() ([]EnvironmentEntry, bool) {
+	if entries := c.git.SortedAll(); entries != nil {
+		return entries, true
 	}
-	switch u.Scheme {
-	case "http":
-		return "80"
-	case "https":
-		return "443"
-	case "ssh":
-		return "22"
-	default:
-		return ""
+
+	all := c.git.All()
+	keys := make([]string, 0, len(all))
+	for key := range all {
+		keys = append(keys, key)
 	}
+	sort.Strings(keys)
+
+	entries := make([]EnvironmentEntry, 0, len(keys))
+	for _, key := range keys {
+		entries = append(entries, EnvironmentEntry{Key: key, Values: all[key]})
+	}
+	return entries, false
 }
 
 // compareHosts compares a hostname with a configuration hostname to determine
@@ -200,11 +183,8 @@ func compareHosts(searchHostname, configHostname string) int {
 		return 0
 	}
 
-	score := len(searchHost) + 1
-
 	for i, subdomain := range searchHost {
 		if configHost[i] == "*" {
-			score--
 			continue
 		}
 
@@ -213,48 +193,39 @@ func compareHosts(searchHostname, configHostname string) int {
 		}
 	}
 
-	return score
+	return len(configHostname) + 1
 }
 
 // comparePaths compares a path with a configuration path to determine a match.
 // It returns an integer indicating the strength of the match, or 0 if the two
 // paths did not match.
 func comparePaths(rawSearchPath, rawConfigPath string) int {
-	f := func(c rune) bool {
-		return c == '/'
-	}
-	searchPath := strings.FieldsFunc(rawSearchPath, f)
-	configPath := strings.FieldsFunc(rawConfigPath, f)
-
-	if len(searchPath) < len(configPath) {
-		return 0
+	if score := pathMatchScore(rawSearchPath, rawConfigPath); score > 0 {
+		return score
 	}
 
-	// Start with a base score of 1, so we return something above 0 for a
-	// zero-length path
-	score := 1
-
-	for i, element := range configPath {
-		searchElement := searchPath[i]
-
-		if element == searchElement {
-			score += 2
+	parts := strings.Split(rawSearchPath, slash)
+	for i := 0; i+2 < len(parts); i++ {
+		if !strings.HasSuffix(parts[i], gitExt) || parts[i+1] != infoPart || parts[i+2] != lfsPart {
 			continue
 		}
 
-		if isDefaultLFSUrl(searchElement, searchPath, i+1) {
-			if searchElement[0:len(searchElement)-4] == element {
-				// Since we matched without the `.git` prefix, only add one
-				// point to the score instead of 2
-				score++
-				continue
-			}
-		}
+		parts[i] = strings.TrimSuffix(parts[i], gitExt)
+		return pathMatchScore(strings.Join(parts, slash), rawConfigPath)
+	}
+	return 0
+}
 
-		return 0
+func pathMatchScore(searchPath, configPath string) int {
+	if configPath == slash {
+		return 1
 	}
 
-	return score
+	configPath = strings.TrimSuffix(configPath, slash)
+	if searchPath == configPath || strings.HasPrefix(searchPath, configPath+slash) {
+		return len(configPath) + 1
+	}
+	return 0
 }
 
 func (c *URLConfig) hostsAndPaths(rawurl string) (hosts, paths []string) {

--- a/config/url_config_test.go
+++ b/config/url_config_test.go
@@ -110,3 +110,100 @@ func TestURLConfigEqualMatchesFollowConfigOrder(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeURL(t *testing.T) {
+	tests := map[string]string{
+		"AbCdeF://x.Y":                         "abcdef://x.y/",
+		"http://x:000000080":                   "http://x/",
+		"https://x:000000443":                  "https://x/",
+		"http://x:00000800":                    "http://x:800/",
+		"X://W/%7e%41^%3a":                     "x://w/~A%5E%3A",
+		"x://%41%62(^):%70+d@foo":              "x://Ab(%5E):p+d@foo/",
+		"x://y/./":                             "x://y/",
+		"x://y/a/./b/.././../c":                "x://y/c",
+		"x://y/a/./b/../.././c/":               "x://y/c/",
+		"x://y/%2e/":                           "x://y/",
+		"x://y/a/%2e./":                        "x://y/",
+		"x://y/a/./?/././..":                   "x://y/a/?/././..",
+		"x://q/\xc2\x80":                       "x://q/%C2%80",
+		"https://USER@EXAMPLE.COM:0443/a/%7eb": "https://USER@example.com/a/~b",
+	}
+
+	for rawurl, expected := range tests {
+		t.Run(rawurl, func(t *testing.T) {
+			normalized, err := normalizeURL(rawurl, false)
+			if assert.NoError(t, err) {
+				assert.Equal(t, expected, normalized.String())
+			}
+		})
+	}
+}
+
+func TestNormalizeURLRejectsInvalidURLs(t *testing.T) {
+	tests := []string{
+		"",
+		"scheme",
+		"0test://acme.co",
+		"scheme://",
+		"scheme://host:0",
+		"scheme://host:65536",
+		"scheme://host:invalid",
+		"scheme://hos%41/",
+		"scheme://host/%fg",
+		"scheme://host/a/../..",
+		"scheme://*.example.com",
+	}
+
+	for _, rawurl := range tests {
+		t.Run(rawurl, func(t *testing.T) {
+			_, err := normalizeURL(rawurl, false)
+			assert.Error(t, err)
+		})
+	}
+
+	normalized, err := normalizeURL("scheme://*.example.com", true)
+	if assert.NoError(t, err) {
+		assert.Equal(t, "scheme://*.example.com/", normalized.String())
+	}
+}
+
+func TestURLConfigMatchesNormalizedURLs(t *testing.T) {
+	u := NewURLConfig(EnvironmentOf(MapFetcher(map[string][]string{
+		"http.https://example.com.key":                 {"root"},
+		"http.HTTPS://EXAMPLE.COM:0443/a/./b.key":      {"canonical path"},
+		"http.https://example.com/users/%7euser.key":   {"escaped unreserved"},
+		"http.https://example.com/a%2fb.key":           {"escaped slash"},
+		"http.https://*.example.com/wildcard/%2e.key":  {"wildcard"},
+		"http.https://user%31@example.com/private.key": {"username"},
+	})))
+
+	tests := map[string]string{
+		"https://example.com/a/b/c":               "canonical path",
+		"https://example.com/users/~user/profile": "escaped unreserved",
+		"https://example.com/a/c":                 "root",
+		"https://sub.example.com/wildcard/child":  "wildcard",
+		"https://user1@example.com/private/repo":  "username",
+	}
+
+	for rawurl, expected := range tests {
+		t.Run(rawurl, func(t *testing.T) {
+			value, ok := u.Get("http", rawurl, "key")
+			assert.True(t, ok)
+			assert.Equal(t, expected, value)
+		})
+	}
+}
+
+func TestGitFetcherSortedAll(t *testing.T) {
+	fetcher, _, _ := readGitConfig(git.ParseConfigLines(
+		"http.https://host.com.key=first\n"+
+			"http.https://host.com/.key=middle\n"+
+			"http.https://host.com.key=last",
+		false,
+	))
+
+	assert.Equal(t, []EnvironmentEntry{
+		{Key: "http.https://host.com/.key", Values: []string{"middle"}},
+		{Key: "http.https://host.com.key", Values: []string{"first", "last"}},
+	}, fetcher.SortedAll())
+}

--- a/config/url_config_test.go
+++ b/config/url_config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"testing"
 
+	"github.com/git-lfs/git-lfs/v3/git"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -70,5 +71,42 @@ func TestURLConfig(t *testing.T) {
 	for rawurl, expected := range getAll {
 		values := u.GetAll("http", rawurl, "key")
 		assert.Equal(t, expected, values, "get all: "+rawurl)
+	}
+}
+
+func TestURLConfigEqualMatchesFollowConfigOrder(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		config string
+		want   string
+	}{
+		{
+			name: "trailing slash last",
+			config: "http.https://host.com.key=without slash\n" +
+				"http.https://host.com/.key=with slash",
+			want: "with slash",
+		},
+		{
+			name: "trailing slash first",
+			config: "http.https://host.com/.key=with slash\n" +
+				"http.https://host.com.key=without slash",
+			want: "without slash",
+		},
+		{
+			name: "same key repeated last",
+			config: "http.https://host.com.key=first\n" +
+				"http.https://host.com/.key=with slash\n" +
+				"http.https://host.com.key=last",
+			want: "last",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fetcher, _, _ := readGitConfig(git.ParseConfigLines(test.config, false))
+			u := NewURLConfig(EnvironmentOf(fetcher))
+
+			value, ok := u.Get("http", "https://host.com/repo", "key")
+			assert.True(t, ok)
+			assert.Equal(t, test.want, value)
+		})
 	}
 }

--- a/config/url_normalize.go
+++ b/config/url_normalize.go
@@ -1,0 +1,328 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	urlUnsafeChars   = " <>\"%{}|\\^`"
+	urlReservedChars = ":/?#[]@!$&'()*+,;="
+)
+
+type normalizedURL struct {
+	scheme      string
+	userinfo    string
+	hasUserinfo bool
+	username    string
+	host        string
+	hostname    string
+	port        string
+	path        string
+	suffix      string
+}
+
+func (u *normalizedURL) String() string {
+	var b strings.Builder
+	b.WriteString(u.scheme)
+	b.WriteString("://")
+	if u.hasUserinfo {
+		b.WriteString(u.userinfo)
+		b.WriteByte('@')
+	}
+	b.WriteString(u.host)
+	if u.port != "" {
+		b.WriteByte(':')
+		b.WriteString(u.port)
+	}
+	b.WriteString(u.path)
+	b.WriteString(u.suffix)
+	return b.String()
+}
+
+// normalizeURL normalizes a complete URL using the matching rules Git applies
+// to URL-scoped configuration. It intentionally keeps reserved characters
+// escaped when they were escaped in the input, since decoding them could alter
+// URL component boundaries.
+func normalizeURL(rawurl string, allowGlobs bool) (*normalizedURL, error) {
+	schemeEnd := strings.Index(rawurl, "://")
+	if schemeEnd <= 0 || !validURLScheme(rawurl[:schemeEnd]) {
+		return nil, fmt.Errorf("invalid URL scheme or missing ://")
+	}
+
+	scheme := strings.ToLower(rawurl[:schemeEnd])
+	remainder := rawurl[schemeEnd+3:]
+	authorityEnd := strings.IndexAny(remainder, "/?#")
+	if authorityEnd < 0 {
+		authorityEnd = len(remainder)
+	}
+	authority := remainder[:authorityEnd]
+	tail := remainder[authorityEnd:]
+
+	hasUserinfo := false
+	userinfo := ""
+	username := ""
+	if at := strings.IndexByte(authority, '@'); at >= 0 {
+		hasUserinfo = true
+		var err error
+		userinfo, err = normalizeURLEscapes(authority[:at])
+		if err != nil {
+			return nil, err
+		}
+		username = userinfo
+		if colon := strings.IndexByte(username, ':'); colon >= 0 {
+			username = username[:colon]
+		}
+		authority = authority[at+1:]
+	}
+
+	host, hostname, rawPort, hasPort, err := splitURLHostPort(authority)
+	if err != nil {
+		return nil, err
+	}
+	if hostname == "" && scheme != "file" {
+		return nil, fmt.Errorf("missing host")
+	}
+	if !validURLHost(hostname, allowGlobs) {
+		return nil, fmt.Errorf("invalid characters in host name")
+	}
+
+	host = strings.ToLower(host)
+	hostname = strings.ToLower(hostname)
+	port := ""
+	if hasPort && rawPort != "" {
+		if scheme == "file" {
+			return nil, fmt.Errorf("file URL may not have a port")
+		}
+		if !allASCIIDigits(rawPort) {
+			return nil, fmt.Errorf("invalid port number")
+		}
+		rawPort = strings.TrimLeft(rawPort, "0")
+		if rawPort == "" {
+			return nil, fmt.Errorf("invalid port number")
+		}
+		portNumber, err := strconv.Atoi(rawPort)
+		if err != nil || portNumber < 1 || portNumber > 65535 {
+			return nil, fmt.Errorf("invalid port number")
+		}
+		if !((scheme == "http" && portNumber == 80) ||
+			(scheme == "https" && portNumber == 443) ||
+			(scheme == "ssh" && portNumber == 22)) {
+			port = strconv.Itoa(portNumber)
+		}
+	}
+
+	pathEnd := strings.IndexAny(tail, "?#")
+	if pathEnd < 0 {
+		pathEnd = len(tail)
+	}
+	path, err := normalizeURLPath(tail[:pathEnd])
+	if err != nil {
+		return nil, err
+	}
+	suffix, err := normalizeURLEscapes(tail[pathEnd:])
+	if err != nil {
+		return nil, err
+	}
+
+	return &normalizedURL{
+		scheme:      scheme,
+		userinfo:    userinfo,
+		hasUserinfo: hasUserinfo,
+		username:    username,
+		host:        host,
+		hostname:    hostname,
+		port:        port,
+		path:        path,
+		suffix:      suffix,
+	}, nil
+}
+
+func validURLScheme(scheme string) bool {
+	for i := 0; i < len(scheme); i++ {
+		c := scheme[i]
+		if i == 0 && !isASCIIAlpha(c) {
+			return false
+		}
+		if !isASCIIAlpha(c) && !isASCIIDigit(c) && c != '+' && c != '-' && c != '.' {
+			return false
+		}
+	}
+	return scheme != ""
+}
+
+func splitURLHostPort(authority string) (host, hostname, port string, hasPort bool, err error) {
+	if strings.HasPrefix(authority, "[") {
+		closeBracket := strings.IndexByte(authority, ']')
+		if closeBracket < 0 {
+			return "", "", "", false, fmt.Errorf("invalid IPv6 host")
+		}
+		host = authority[:closeBracket+1]
+		hostname = authority[1:closeBracket]
+		remainder := authority[closeBracket+1:]
+		if remainder == "" {
+			return host, hostname, "", false, nil
+		}
+		if remainder[0] != ':' {
+			return "", "", "", false, fmt.Errorf("invalid host or port")
+		}
+		return host, hostname, remainder[1:], true, nil
+	}
+
+	colon := strings.LastIndexByte(authority, ':')
+	if colon >= 0 {
+		if strings.Contains(authority[:colon], ":") {
+			return "", "", "", false, fmt.Errorf("IPv6 host must be bracketed")
+		}
+		return authority[:colon], authority[:colon], authority[colon+1:], true, nil
+	}
+	return authority, authority, "", false, nil
+}
+
+func validURLHost(host string, allowGlobs bool) bool {
+	for i := 0; i < len(host); i++ {
+		c := host[i]
+		if isASCIIAlpha(c) || isASCIIDigit(c) || strings.ContainsRune(".-_:", rune(c)) {
+			continue
+		}
+		if allowGlobs && c == '*' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func normalizeURLPath(rawPath string) (string, error) {
+	if strings.HasPrefix(rawPath, "/") {
+		rawPath = rawPath[1:]
+	}
+
+	path := []byte{'/'}
+	for {
+		nextSlash := strings.IndexByte(rawPath, '/')
+		rawSegment := rawPath
+		if nextSlash >= 0 {
+			rawSegment = rawPath[:nextSlash]
+		}
+
+		segment, err := normalizeURLEscapes(rawSegment)
+		if err != nil {
+			return "", err
+		}
+		segmentStart := len(path)
+		path = append(path, segment...)
+		skipSlash := false
+
+		switch segment {
+		case ".":
+			if segmentStart == 1 {
+				path = path[:len(path)-1]
+				skipSlash = true
+			} else {
+				path = path[:len(path)-2]
+			}
+		case "..":
+			previousSlash := len(path) - 3
+			if previousSlash == 0 {
+				return "", fmt.Errorf("invalid .. path segment")
+			}
+			for {
+				previousSlash--
+				if previousSlash < 0 {
+					return "", fmt.Errorf("invalid .. path segment")
+				}
+				if path[previousSlash] == '/' {
+					break
+				}
+			}
+			if previousSlash == 0 {
+				path = path[:1]
+				skipSlash = true
+			} else {
+				path = path[:previousSlash]
+			}
+		}
+
+		if nextSlash < 0 {
+			break
+		}
+		rawPath = rawPath[nextSlash+1:]
+		if !skipSlash {
+			path = append(path, '/')
+		}
+	}
+
+	return string(path), nil
+}
+
+func normalizeURLEscapes(raw string) (string, error) {
+	var b strings.Builder
+	b.Grow(len(raw))
+
+	for i := 0; i < len(raw); i++ {
+		c := raw[i]
+		wasEscaped := false
+		if c == '%' {
+			if i+2 >= len(raw) {
+				return "", fmt.Errorf("invalid URL escape")
+			}
+			high, okHigh := fromHex(raw[i+1])
+			low, okLow := fromHex(raw[i+2])
+			if !okHigh || !okLow {
+				return "", fmt.Errorf("invalid URL escape")
+			}
+			c = high<<4 | low
+			i += 2
+			wasEscaped = true
+		}
+
+		mustEscape := c <= 0x1f || c >= 0x7f ||
+			strings.ContainsRune(urlUnsafeChars, rune(c)) ||
+			(wasEscaped && strings.ContainsRune(urlReservedChars, rune(c)))
+		if mustEscape {
+			const hex = "0123456789ABCDEF"
+			b.WriteByte('%')
+			b.WriteByte(hex[c>>4])
+			b.WriteByte(hex[c&0x0f])
+		} else {
+			b.WriteByte(c)
+		}
+	}
+
+	return b.String(), nil
+}
+
+func fromHex(c byte) (byte, bool) {
+	switch {
+	case c >= '0' && c <= '9':
+		return c - '0', true
+	case c >= 'a' && c <= 'f':
+		return c - 'a' + 10, true
+	case c >= 'A' && c <= 'F':
+		return c - 'A' + 10, true
+	default:
+		return 0, false
+	}
+}
+
+func allASCIIDigits(value string) bool {
+	if value == "" {
+		return false
+	}
+	for i := 0; i < len(value); i++ {
+		if !isASCIIDigit(value[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func isASCIIAlpha(c byte) bool {
+	return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z'
+}
+
+func isASCIIDigit(c byte) bool {
+	return c >= '0' && c <= '9'
+}

--- a/lfshttp/client.go
+++ b/lfshttp/client.go
@@ -676,3 +676,7 @@ func (e testEnv) All() map[string][]string {
 	}
 	return m
 }
+
+func (e testEnv) SortedAll() []config.EnvironmentEntry {
+	return nil
+}

--- a/t/t-config-url-match.sh
+++ b/t/t-config-url-match.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+. "$(dirname "$0")/testlib.sh"
+
+begin_test "SSL certificate matches root path"
+(
+  set -e
+
+  if [ "$IS_WINDOWS" -eq 1 ]; then
+    git config --global "http.sslBackend" "openssl"
+  fi
+
+  git config --global "http.$LFS_CLIENT_CERT_URL.sslCert" "$LFS_CLIENT_CERT_FILE"
+  git config --global "http.$LFS_CLIENT_CERT_URL.sslKey" "$LFS_CLIENT_KEY_FILE"
+
+  reponame="config-ssl-cert-match-root-path"
+  setup_remote_repo "$reponame"
+  clone_repo_clientcert "$reponame" "$reponame"
+
+  git lfs track "*.bin"
+
+  contents="test"
+  printf "%s" "$contents" >a.bin
+
+  git add .gitattributes a.bin
+  git commit -m "initial commit"
+
+  git push origin main
+
+  # Test with the global "http.<url>.sslCert" option reset to an invalid
+  # certificate file and a local "http.<url>/.sslCert" option set to the
+  # valid file.  The global option should be ignored in favour of the local
+  # one, even though the local option's URL has a trailing slash character.
+  # See https://github.com/git-lfs/git-lfs/issues/6112.
+  git config --global "http.$LFS_CLIENT_CERT_URL.sslCert" "$TRASHDIR/nonexistent/cert.pem"
+  git config "http.$LFS_CLIENT_CERT_URL/.sslCert" "$LFS_CLIENT_CERT_FILE"
+
+  # The reported issue occurred only half the time, on average, due
+  # to Go's arbitrary map key ordering.  To increase the likelihood of
+  # reproducing the problem, repeat the check up to eight times.
+  for ((i=0; i<8; i++)); do
+    rm -rf .git/lfs/objects
+
+    git lfs pull
+
+    assert_local_object "$(calc_oid "$contents")" "${#contents}"
+  done
+)
+end_test
+
+begin_test "SSL certificate matches canonical path"
+(
+  set -e
+
+  if [ "$IS_WINDOWS" -eq 1 ]; then
+    git config --global "http.sslBackend" "openssl"
+  fi
+
+  git config --global "http.$LFS_CLIENT_CERT_URL.sslCert" "$LFS_CLIENT_CERT_FILE"
+  git config --global "http.$LFS_CLIENT_CERT_URL.sslKey" "$LFS_CLIENT_KEY_FILE"
+
+  reponame="config-ssl-cert-match-canonical-path"
+  setup_remote_repo "$reponame"
+  clone_repo_clientcert "$reponame" "$reponame"
+
+  git lfs track "*.bin"
+
+  contents="test"
+  printf "%s" "$contents" >a.bin
+
+  git add .gitattributes a.bin
+  git commit -m "initial commit"
+
+  git push origin main
+
+  # Test with the global "http.<url>.sslCert" option reset to an invalid
+  # certificate file and a local "http.<url>/./.sslCert" option set to the
+  # valid file.  The global option should be ignored in favour of the local
+  # one, even though the local option's URL has a spurious path segment.
+  git config --global "http.$LFS_CLIENT_CERT_URL.sslCert" "$TRASHDIR/nonexistent/cert.pem"
+  git config "http.$LFS_CLIENT_CERT_URL/./.sslCert" "$LFS_CLIENT_CERT_FILE"
+
+  # First push a new commit that does not include any Git LFS objects to
+  # confirm Git matches the local option's URL to the remote, regardless
+  # of the spurious path segment.
+  echo "test" >a.txt
+  git add a.txt
+  git commit -m "second commit"
+
+  git push origin main
+
+  # Next confirm Git LFS also matches the local option's URL to the remote,
+  # regardless of the spurious path segment.
+  rm -rf .git/lfs/objects
+
+  git lfs pull
+
+  assert_local_object "$(calc_oid "$contents")" "${#contents}"
+)
+end_test


### PR DESCRIPTION
## Summary

- normalize URL-scoped configuration before matching, including scheme and host casing, percent escapes, default and zero-padded ports, and dot path segments
- expose a source-ordered `Environment.SortedAll()` snapshot so equally specific canonical matches follow Git configuration order without secondary index lookups
- preserve Git LFS's `.git/info/lfs` path compatibility and cover both the reported trailing-slash case and canonical-path matching

Fixes #6112

## Testing

- `make test`
- `make PKGS=config test-race`
- `go vet ./config`
- `make -C t PROVE_EXTRA_ARGS=-v t-config-url-match.sh t-extra-header.sh t-clone.sh t-lock.sh t-fetch.sh`
