### PR TITLE
fetch,pull: support literal path arguments

### DIFF
--- a/commands/command_fetch.go
+++ b/commands/command_fetch.go
@@ -90,6 +90,7 @@ func getIncludeExcludeArgs(cmd *cobra.Command) (include, exclude *string) {
 }
 
 func fetchCommand(cmd *cobra.Command, args []string) {
+	args, paths := splitArgsAtDash(cmd, args)
 	setupRepository()
 
 	var refs []*git.Ref
@@ -149,6 +150,9 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 		if fetchRecentArg {
 			Exit(tr.Tr.Get("Cannot combine --all with --recent"))
 		}
+		if len(paths) > 0 {
+			Exit(tr.Tr.Get("Cannot combine --all with paths"))
+		}
 		if include != nil || exclude != nil {
 			Exit(tr.Tr.Get("Cannot combine --all with --include or --exclude"))
 		}
@@ -168,6 +172,13 @@ func fetchCommand(cmd *cobra.Command, args []string) {
 
 	} else { // !all
 		filter := buildFilepathFilter(cfg, include, exclude, true)
+		if len(paths) > 0 {
+			var err error
+			filter, err = buildFilepathFilterForPaths(filter, paths)
+			if err != nil {
+				Exit(tr.Tr.Get("Invalid path argument: %s", err))
+			}
+		}
 
 		// Fetch refs sequentially per arg order; duplicates in later refs will be ignored
 		for _, ref := range refs {

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -17,6 +17,7 @@ import (
 )
 
 func pullCommand(cmd *cobra.Command, args []string) {
+	args, paths := splitArgsAtDash(cmd, args)
 	requireGitVersion()
 	setupRepository()
 
@@ -29,6 +30,13 @@ func pullCommand(cmd *cobra.Command, args []string) {
 
 	includeArg, excludeArg := getIncludeExcludeArgs(cmd)
 	filter := buildFilepathFilter(cfg, includeArg, excludeArg, true)
+	if len(paths) > 0 {
+		var err error
+		filter, err = buildFilepathFilterForPaths(filter, paths)
+		if err != nil {
+			Exit(tr.Tr.Get("Invalid path argument: %s", err))
+		}
+	}
 	pull(filter)
 }
 

--- a/commands/path_args.go
+++ b/commands/path_args.go
@@ -1,0 +1,108 @@
+package commands
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/git-lfs/git-lfs/v3/errors"
+	"github.com/git-lfs/git-lfs/v3/filepathfilter"
+	"github.com/git-lfs/git-lfs/v3/lfs"
+	"github.com/git-lfs/git-lfs/v3/tools"
+	"github.com/git-lfs/git-lfs/v3/tr"
+	"github.com/spf13/cobra"
+)
+
+func splitArgsAtDash(cmd *cobra.Command, args []string) (commandArgs, paths []string) {
+	if n := cmd.ArgsLenAtDash(); n >= 0 {
+		return args[:n], args[n:]
+	}
+	return args, nil
+}
+
+type pathFilterPattern struct {
+	filter *filepathfilter.Filter
+	paths  []filepathfilter.Pattern
+}
+
+func (p *pathFilterPattern) Match(filename string) bool {
+	if !p.filter.Allows(filename) {
+		return false
+	}
+	for _, path := range p.paths {
+		if path.Match(filename) {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *pathFilterPattern) String() string {
+	paths := make([]string, 0, len(p.paths))
+	for _, path := range p.paths {
+		paths = append(paths, path.String())
+	}
+	return strings.Join(paths, ",")
+}
+
+func buildFilepathFilterForPaths(filter *filepathfilter.Filter, paths []string) (*filepathfilter.Filter, error) {
+	rooted, err := repositoryRelativePaths(paths)
+	if err != nil {
+		return nil, err
+	}
+
+	patterns := make([]filepathfilter.Pattern, 0, len(rooted))
+	for _, path := range rooted {
+		patterns = append(patterns, filepathfilter.NewLiteralPathPattern(path, cfg.Git))
+	}
+
+	return filepathfilter.NewFromPatterns(
+		[]filepathfilter.Pattern{&pathFilterPattern{filter: filter, paths: patterns}},
+		nil,
+		filepathfilter.DefaultValue(false),
+		determineFilepathFilterCache(cfg),
+	), nil
+}
+
+func repositoryRelativePaths(paths []string) ([]string, error) {
+	rooted := make([]string, 0, len(paths))
+	workingDir := cfg.LocalWorkingDir()
+
+	var converter lfs.PathConverter
+	if workingDir != "" {
+		var err error
+		converter, err = lfs.NewCurrentToRepoPathConverter(cfg)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for _, original := range paths {
+		if original == "" {
+			return nil, errors.New(tr.Tr.Get("empty path is not valid"))
+		}
+
+		converted := original
+		if converter != nil {
+			converted = converter.Convert(original)
+			// The converter passes paths through when invoked at the repository
+			// root, so make absolute paths relative explicitly in that case.
+			if filepath.IsAbs(converted) {
+				var err error
+				converted, err = filepath.Rel(workingDir, tools.ResolveSymlinks(converted))
+				if err != nil {
+					return nil, err
+				}
+			}
+		} else if filepath.IsAbs(converted) {
+			return nil, errors.New(tr.Tr.Get("path %q is outside the repository", original))
+		}
+
+		converted = filepath.ToSlash(filepath.Clean(converted))
+		if converted == ".." || strings.HasPrefix(converted, "../") {
+			return nil, errors.New(tr.Tr.Get("path %q is outside the repository", original))
+		}
+		rooted = append(rooted, converted)
+	}
+
+	return rooted, nil
+}

--- a/docs/man/git-lfs-fetch.adoc
+++ b/docs/man/git-lfs-fetch.adoc
@@ -8,8 +8,8 @@ git-lfs-fetch - Download all Git LFS files for a given ref
 
 [source,role=synopsis,subs="verbatim,quotes"]
 ----
-*git lfs fetch* [_options_] [_<remote>_ [_<ref>_...]]
-*git lfs fetch* [_options_] _<remote>_ *--stdin*
+*git lfs fetch* [_options_] [_<remote>_ [_<ref>_...]] [*--* [_<path>_...]]
+*git lfs fetch* [_options_] _<remote>_ *--stdin* [*--* [_<path>_...]]
 ----
 
 == DESCRIPTION
@@ -19,6 +19,12 @@ See <<_default_remote>> and <<_default_refs>> for what happens if you don't
 specify.
 
 This does not update the working copy.
+
+One or more literal file or directory paths may be provided after `--` to
+restrict the objects which are downloaded. Paths are interpreted relative to
+the current working directory, and a directory path includes all files below
+that directory. The paths also respect any include and exclude paths in the Git
+configuration or supplied with `--include` and `--exclude`.
 
 == OPTIONS
 
@@ -39,8 +45,9 @@ This does not update the working copy.
   Download all objects that are referenced by any commit reachable from the refs
   provided as arguments. If no refs are provided, then all refs are fetched.
   This is primarily for backup and migration purposes. Cannot be combined with
-  --recent or --include/--exclude. Ignores any globally configured include and
-  exclude paths to ensure that all objects are downloaded.
+  --recent, --include/--exclude, or paths after `--`. Ignores any globally
+  configured include and exclude paths to ensure that all objects are
+  downloaded.
 `--stdin`::
   Read a list of newline-delimited refs from standard input instead of the
   command line.
@@ -158,6 +165,12 @@ by any commit in the `main` and `develop` branches
 * Fetch the LFS objects for a branch from origin
 +
 `git lfs fetch origin mybranch`
+* Fetch the LFS object for a file in the current ref
++
+`git lfs fetch -- path/to/file.dat`
+* Fetch the LFS objects below a directory for a branch from origin
++
+`git lfs fetch origin mybranch -- path/to/directory`
 * Fetch the LFS objects for 2 branches and a commit from origin
 +
 `git lfs fetch origin main mybranch e445b45c1c9c6282614f201b62778e4c0688b5c8`

--- a/docs/man/git-lfs-pull.adoc
+++ b/docs/man/git-lfs-pull.adoc
@@ -8,13 +8,20 @@ git-lfs-pull - Download all Git LFS files for current ref & checkout
 
 [source,role=synopsis,subs="verbatim,quotes"]
 ----
-*git lfs pull* [_options_] [_<remote>_]
+*git lfs pull* [_options_] [_<remote>_] [*--* [_<path>_...]]
 ----
 
 == DESCRIPTION
 
 Download Git LFS objects for the currently checked out ref, and update
 the working copy with the downloaded content if required.
+
+One or more literal file or directory paths may be provided after `--` to
+restrict the objects which are downloaded and the files which are updated in
+the working copy. Paths are interpreted relative to the current working
+directory, and a directory path includes all files below that directory. The
+paths also respect any include and exclude paths in the Git configuration or
+supplied with `--include` and `--exclude`.
 
 This is generally equivalent to running the following two commands:
 
@@ -81,6 +88,15 @@ string clears the value.
 Without arguments, pull downloads from the default remote. The default
 remote is the same as for `git pull`, i.e. based on the remote branch
 you're tracking first, or origin otherwise.
+
+== EXAMPLES
+
+* Pull the LFS object for a file from the default remote
++
+`git lfs pull -- path/to/file.dat`
+* Pull the LFS objects below a directory from origin
++
+`git lfs pull origin -- path/to/directory`
 
 == SEE ALSO
 

--- a/filepathfilter/filepathfilter.go
+++ b/filepathfilter/filepathfilter.go
@@ -180,6 +180,33 @@ func (w *wm) String() string {
 	return w.p
 }
 
+type literalPath struct {
+	p        string
+	caseFold bool
+}
+
+// NewLiteralPathPattern returns a pattern which matches a repository-relative
+// path literally. A directory path also matches all of its descendants.
+func NewLiteralPathPattern(p string, gitEnv Environment) Pattern {
+	p = strings.TrimSuffix(p, "/")
+	caseFold := gitEnv != nil && gitEnv.Bool("core.ignorecase", false)
+	if caseFold {
+		p = strings.ToLower(p)
+	}
+	return &literalPath{p: p, caseFold: caseFold}
+}
+
+func (p *literalPath) Match(filename string) bool {
+	if p.caseFold {
+		filename = strings.ToLower(filename)
+	}
+	return p.p == "." || filename == p.p || strings.HasPrefix(filename, p.p+"/")
+}
+
+func (p *literalPath) String() string {
+	return p.p
+}
+
 const (
 	sep byte = '/'
 )

--- a/filepathfilter/filepathfilter_test.go
+++ b/filepathfilter/filepathfilter_test.go
@@ -6,6 +6,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type testEnvironment map[string]string
+
+func (e testEnvironment) Get(key string) (string, bool) {
+	value, ok := e[key]
+	return value, ok
+}
+
+func (e testEnvironment) Bool(key string, def bool) bool {
+	value, ok := e[key]
+	if !ok {
+		return def
+	}
+	return value == "true"
+}
+
 func TestPatternMatch(t *testing.T) {
 	assertPatternMatch(t, "*",
 		"a",
@@ -104,6 +119,38 @@ func TestPatternMatch(t *testing.T) {
 	// Absolute
 	assertPatternMatch(t, "*.dat", "/path/to/sub/.git/test.dat")
 	assertPatternMatch(t, "**/.git", "/path/to/sub/.git")
+}
+
+func TestLiteralPathPattern(t *testing.T) {
+	pattern := NewLiteralPathPattern("dir/literal[1]*?.dat", nil)
+
+	assert.True(t, pattern.Match("dir/literal[1]*?.dat"))
+	assert.False(t, pattern.Match("dir/literal1x.dat"))
+	assert.False(t, pattern.Match("other/dir/literal[1]*?.dat"))
+}
+
+func TestLiteralPathPatternMatchesDirectoryContents(t *testing.T) {
+	pattern := NewLiteralPathPattern("dir/", nil)
+
+	assert.True(t, pattern.Match("dir"))
+	assert.True(t, pattern.Match("dir/file.dat"))
+	assert.True(t, pattern.Match("dir/nested/file.dat"))
+	assert.False(t, pattern.Match("directory/file.dat"))
+	assert.False(t, pattern.Match("other/dir/file.dat"))
+}
+
+func TestLiteralPathPatternRespectsCoreIgnoreCase(t *testing.T) {
+	pattern := NewLiteralPathPattern("Dir/File.dat", testEnvironment{"core.ignorecase": "true"})
+
+	assert.True(t, pattern.Match("dir/file.DAT"))
+	assert.False(t, pattern.Match("other/dir/file.dat"))
+}
+
+func TestLiteralPathPatternMatchesRepositoryRoot(t *testing.T) {
+	pattern := NewLiteralPathPattern(".", nil)
+
+	assert.True(t, pattern.Match("file.dat"))
+	assert.True(t, pattern.Match("dir/file.dat"))
 }
 
 func assertPatternMatch(t *testing.T, pattern string, filenames ...string) {

--- a/t/t-fetch-pull-paths.sh
+++ b/t/t-fetch-pull-paths.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+
+. "$(dirname "$0")/testlib.sh"
+
+reponame="$(basename "$0" ".sh")"
+top_contents="top"
+top_oid=$(calc_oid "$top_contents")
+space_contents="space"
+space_oid=$(calc_oid "$space_contents")
+other_contents="other"
+other_oid=$(calc_oid "$other_contents")
+literal_contents="literal"
+literal_oid=$(calc_oid "$literal_contents")
+wildcard_contents="wildcard"
+wildcard_oid=$(calc_oid "$wildcard_contents")
+
+begin_test "setup fetch and pull path tests"
+(
+  set -e
+
+  setup_remote_repo "$reponame"
+  clone_repo "$reponame" repo
+
+  git lfs track "*.dat"
+  mkdir dir
+  printf "%s" "$top_contents" >top.dat
+  printf "%s" "$space_contents" >"dir/file with spaces.dat"
+  printf "%s" "$other_contents" >dir/other.dat
+  printf "%s" "$literal_contents" >"literal[1].dat"
+  printf "%s" "$wildcard_contents" >literal1.dat
+
+  git add .
+  git commit -m "add LFS files"
+  git push origin main
+
+  GIT_LFS_SKIP_SMUDGE=1 clone_repo "$reponame" clone
+)
+end_test
+
+begin_test "fetch literal paths after a double dash"
+(
+  set -e
+  cd clone
+  rm -rf .git/lfs/objects
+
+  git lfs fetch --dry-run origin main -- "literal[1].dat" 2>&1 | tee fetch.log
+  grep "fetch $literal_oid => literal\[1\]\.dat" fetch.log
+  grep "$wildcard_oid" fetch.log && exit 1 || true
+
+  git lfs fetch origin main -- "literal[1].dat"
+  assert_local_object "$literal_oid" 7
+  refute_local_object "$wildcard_oid"
+  refute_local_object "$top_oid"
+)
+end_test
+
+begin_test "fetch paths relative to a subdirectory"
+(
+  set -e
+  cd clone
+  rm -rf .git/lfs/objects
+
+  pushd dir
+    git lfs fetch -- "../top.dat"
+  popd
+
+  assert_local_object "$top_oid" 3
+  refute_local_object "$space_oid"
+  refute_local_object "$other_oid"
+)
+end_test
+
+begin_test "fetch an absolute literal path"
+(
+  set -e
+  cd clone
+  rm -rf .git/lfs/objects
+
+  git lfs fetch -- "$(pwd)/dir/file with spaces.dat"
+
+  assert_local_object "$space_oid" 5
+  refute_local_object "$top_oid"
+  refute_local_object "$other_oid"
+)
+end_test
+
+begin_test "fetch all files below a literal directory path"
+(
+  set -e
+  cd clone
+  rm -rf .git/lfs/objects
+
+  git lfs fetch -- dir
+
+  assert_local_object "$space_oid" 5
+  assert_local_object "$other_oid" 5
+  refute_local_object "$top_oid"
+  refute_local_object "$literal_oid"
+  refute_local_object "$wildcard_oid"
+)
+end_test
+
+begin_test "fetch paths also respect include filters"
+(
+  set -e
+  cd clone
+  rm -rf .git/lfs/objects
+
+  git lfs fetch --include="top.dat" -- "dir/other.dat"
+
+  refute_local_object "$top_oid"
+  refute_local_object "$other_oid"
+)
+end_test
+
+begin_test "fetch paths with refs read from standard input"
+(
+  set -e
+  cd clone
+  rm -rf .git/lfs/objects
+
+  printf "main\n" | git lfs fetch origin --stdin -- top.dat
+
+  assert_local_object "$top_oid" 3
+  refute_local_object "$space_oid"
+  refute_local_object "$other_oid"
+)
+end_test
+
+begin_test "fetch --all rejects literal paths"
+(
+  set -e
+  cd clone
+
+  if git lfs fetch --all -- top.dat 2>fetch.log; then
+    echo >&2 "fatal: expected fetch --all with a path to fail"
+    exit 1
+  fi
+  grep "Cannot combine --all with paths" fetch.log
+)
+end_test
+
+begin_test "pull a literal path and leave other pointers unchanged"
+(
+  set -e
+  cd clone
+  rm -rf .git/lfs/objects
+  rm -rf dir top.dat "literal[1].dat" literal1.dat
+  GIT_LFS_SKIP_SMUDGE=1 git checkout -f HEAD -- .
+
+  git lfs pull origin -- "dir/file with spaces.dat"
+
+  [ "$space_contents" = "$(cat "dir/file with spaces.dat")" ]
+  grep "version https://git-lfs.github.com/spec/v1" top.dat
+  grep "version https://git-lfs.github.com/spec/v1" dir/other.dat
+  grep "version https://git-lfs.github.com/spec/v1" "literal[1].dat"
+  assert_local_object "$space_oid" 5
+  refute_local_object "$top_oid"
+  refute_local_object "$other_oid"
+)
+end_test
+
+begin_test "pull a path relative to a subdirectory"
+(
+  set -e
+  cd clone
+  rm -rf .git/lfs/objects
+  rm -rf dir top.dat "literal[1].dat" literal1.dat
+  GIT_LFS_SKIP_SMUDGE=1 git checkout -f HEAD -- .
+
+  pushd dir
+    git lfs pull -- "../literal[1].dat"
+  popd
+
+  [ "$literal_contents" = "$(cat "literal[1].dat")" ]
+  grep "version https://git-lfs.github.com/spec/v1" literal1.dat
+  assert_local_object "$literal_oid" 7
+  refute_local_object "$wildcard_oid"
+)
+end_test
+
+begin_test "pull all files below a literal directory path"
+(
+  set -e
+  cd clone
+  rm -rf .git/lfs/objects
+  rm -rf dir top.dat "literal[1].dat" literal1.dat
+  GIT_LFS_SKIP_SMUDGE=1 git checkout -f HEAD -- .
+
+  git lfs pull -- dir
+
+  [ "$space_contents" = "$(cat "dir/file with spaces.dat")" ]
+  [ "$other_contents" = "$(cat dir/other.dat)" ]
+  grep "version https://git-lfs.github.com/spec/v1" top.dat
+  grep "version https://git-lfs.github.com/spec/v1" "literal[1].dat"
+  assert_local_object "$space_oid" 5
+  assert_local_object "$other_oid" 5
+  refute_local_object "$top_oid"
+  refute_local_object "$literal_oid"
+)
+end_test


### PR DESCRIPTION
## Summary

- allow `git lfs fetch` and `git lfs pull` to accept literal file or directory paths after `--`
- resolve relative and absolute paths against the repository while preserving filenames containing wildcard characters
- combine explicit paths with existing fetch include/exclude filters, and reject path filtering with `fetch --all`
- document the new syntax and add focused unit and integration coverage

Paths are matched literally rather than as gitignore patterns, so a filename such as `literal[1].dat` cannot accidentally select `literal1.dat`. Directory arguments include their descendants, and matching follows `core.ignorecase` where configured.

## Tests

- `make test`
- `make -C t test` (105 test files, 835 tests)
- `go vet ./commands ./filepathfilter`

Closes #5946
