### PR TITLE
Return a non-zero exit code when checkout fails

### DIFF
--- a/commands/command_checkout.go
+++ b/commands/command_checkout.go
@@ -91,9 +91,13 @@ func checkoutCommand(cmd *cobra.Command, args []string) {
 		ExitWithError(err)
 	}
 
+	checkoutFailed := false
+
 	meter.Start()
 	for _, p := range pointers {
-		singleCheckout.Run(p)
+		if err := singleCheckout.Run(p); err != nil {
+			checkoutFailed = true
+		}
 
 		// not strictly correct (parallel) but we don't have a callback & it's just local
 		// plus only 1 slot in channel so it'll block & be close
@@ -102,7 +106,13 @@ func checkoutCommand(cmd *cobra.Command, args []string) {
 	}
 
 	meter.Finish()
-	singleCheckout.Close()
+	if err := singleCheckout.Close(); err != nil {
+		checkoutFailed = true
+	}
+
+	if checkoutFailed {
+		ExitWithCode(2)
+	}
 }
 
 func checkoutConflict(file string, stage git.IndexStage) {

--- a/commands/command_pull.go
+++ b/commands/command_pull.go
@@ -50,6 +50,9 @@ func pull(filter *filepathfilter.Filter) {
 	// will chdir to root of working tree, if one exists
 	singleCheckout := newSingleCheckout(cfg.Git, remote)
 	q := newDownloadQueue(singleCheckout.Manifest(), remote, tq.WithProgress(meter))
+
+	checkoutFailed := false
+
 	gitscanner := lfs.NewGitScanner(cfg, func(p *lfs.WrappedPointer, err error) {
 		if err != nil {
 			LoggedError(err, tr.Tr.Get("Scanner error: %s", err))
@@ -63,7 +66,9 @@ func pull(filter *filepathfilter.Filter) {
 		// no need to download objects that exist locally already
 		lfs.LinkOrCopyFromReference(cfg, p.Oid, p.Size)
 		if cfg.LFSObjectExists(p.Oid, p.Size) {
-			singleCheckout.Run(p)
+			if err := singleCheckout.Run(p); err != nil {
+				checkoutFailed = true
+			}
 			return
 		}
 
@@ -82,7 +87,9 @@ func pull(filter *filepathfilter.Filter) {
 	go func() {
 		for t := range dlwatch {
 			for _, p := range pointers.All(t.Oid) {
-				singleCheckout.Run(p)
+				if err := singleCheckout.Run(p); err != nil {
+					checkoutFailed = true
+				}
 			}
 		}
 		wg.Done()
@@ -99,7 +106,9 @@ func pull(filter *filepathfilter.Filter) {
 	wg.Wait()
 	tracerx.PerformanceSince("process queue", processQueue)
 
-	singleCheckout.Close()
+	if err := singleCheckout.Close(); err != nil {
+		checkoutFailed = true
+	}
 
 	success := true
 	for _, err := range q.Errors() {
@@ -111,6 +120,10 @@ func pull(filter *filepathfilter.Filter) {
 		c := getAPIClient()
 		e := c.Endpoints.Endpoint("download", remote)
 		Exit(tr.Tr.Get("Failed to fetch some objects from '%s'", e.Url))
+	}
+
+	if checkoutFailed {
+		ExitWithCode(2)
 	}
 
 	if singleCheckout.Skip() {

--- a/commands/pull.go
+++ b/commands/pull.go
@@ -48,9 +48,9 @@ func newSingleCheckout(gitEnv config.Environment, remote string) abstractCheckou
 type abstractCheckout interface {
 	Manifest() tq.Manifest
 	Skip() bool
-	Run(*lfs.WrappedPointer)
+	Run(*lfs.WrappedPointer) error
 	RunToPath(*lfs.WrappedPointer, string) error
-	Close()
+	Close() error
 }
 
 type singleCheckout struct {
@@ -71,9 +71,9 @@ func (c *singleCheckout) Skip() bool {
 	return false
 }
 
-func (c *singleCheckout) Run(p *lfs.WrappedPointer) {
+func (c *singleCheckout) Run(p *lfs.WrappedPointer) error {
 	if !c.hasWorkTree {
-		return
+		return nil
 	}
 
 	dirWalker := tools.NewDirWalkerForFile("", p.Name, cfg)
@@ -83,7 +83,7 @@ func (c *singleCheckout) Run(p *lfs.WrappedPointer) {
 	if err != nil {
 		if !os.IsNotExist(err) {
 			LoggedError(err, tr.Tr.Get("Checkout error trying to check path for %q: %s", p.Name, err))
-			return
+			return err
 		}
 	} else {
 		// Check the content - either missing or still this pointer (not exist is ok)
@@ -95,34 +95,34 @@ func (c *singleCheckout) Run(p *lfs.WrappedPointer) {
 			output, err := git.DiffIndexWithPaths("HEAD", true, []string{p.Name})
 			if err != nil {
 				LoggedError(err, tr.Tr.Get("Checkout error trying to run diff-index: %s", err))
-				return
+				return err
 			}
 			if strings.HasPrefix(output, ":100644 000000 ") || strings.HasPrefix(output, ":100755 000000 ") {
 				// This file is deleted in the index.  Don't try
 				// to check it out.
-				return
+				return nil
 			}
 		} else {
 			if errors.IsNotAPointerError(err) || errors.IsBadPointerKeyError(err) {
 				// File has non-pointer content, leave it alone
-				return
+				return nil
 			}
 
 			LoggedError(err, tr.Tr.Get("Checkout error for %q: %s", p.Name, err))
-			return
+			return err
 		}
 	}
 
 	if filepointer != nil && filepointer.Oid != p.Oid {
 		// User has probably manually reset a file to another commit
 		// while leaving it a pointer; don't mess with this
-		return
+		return nil
 	}
 
 	if err != nil && os.IsNotExist(err) {
 		if err := dirWalker.WalkAndCreate(); err != nil {
 			LoggedError(err, tr.Tr.Get("Checkout error trying to create path for %q: %s", p.Name, err))
-			return
+			return err
 		}
 	}
 
@@ -130,16 +130,20 @@ func (c *singleCheckout) Run(p *lfs.WrappedPointer) {
 		if errors.IsDownloadDeclinedError(err) {
 			// acceptable error, data not local (fetch not run or include/exclude)
 			Error(tr.Tr.Get("Skipped checkout for %q, content not local. Use fetch to download.", p.Name))
-		} else {
-			FullError(errors.Wrap(err, tr.Tr.Get("could not check out %q", p.Name)))
+			return nil
 		}
-		return
+
+		err = errors.Wrap(err, tr.Tr.Get("could not check out %q", p.Name))
+		FullError(err)
+		return err
 	}
 
 	// errors are only returned when the gitIndexer is starting a new cmd
 	if err := c.gitIndexer.Add(p.Name); err != nil {
 		Panic(err, tr.Tr.Get("Could not update the index"))
 	}
+
+	return nil
 }
 
 // RunToPath checks out the pointer specified by p to the given path.  It does
@@ -149,10 +153,13 @@ func (c *singleCheckout) RunToPath(p *lfs.WrappedPointer, path string) error {
 	return gitfilter.SmudgeToFile(path, p, false, c.manifest, nil)
 }
 
-func (c *singleCheckout) Close() {
+func (c *singleCheckout) Close() error {
 	if err := c.gitIndexer.Close(); err != nil {
 		LoggedError(err, "%s\n%s", tr.Tr.Get("Error updating the Git index:"), c.gitIndexer.Output())
+		return err
 	}
+
+	return nil
 }
 
 type noOpCheckout struct {
@@ -175,8 +182,8 @@ func (c *noOpCheckout) RunToPath(p *lfs.WrappedPointer, path string) error {
 	return nil
 }
 
-func (c *noOpCheckout) Run(p *lfs.WrappedPointer) {}
-func (c *noOpCheckout) Close()                    {}
+func (c *noOpCheckout) Run(p *lfs.WrappedPointer) error { return nil }
+func (c *noOpCheckout) Close() error                    { return nil }
 
 // Don't fire up the update-index command until we have at least one file to
 // give it. Otherwise git interprets the lack of arguments to mean param-less update-index

--- a/docs/man/git-lfs-checkout.adoc
+++ b/docs/man/git-lfs-checkout.adoc
@@ -53,6 +53,10 @@ the `GIT_ATTR_SOURCE` environment variable may be set to `HEAD`, which
 will cause Git to only read attributes from `.gitattributes` files in
 `HEAD` and ignore those in the index or working tree.
 
+If the contents of a Git LFS object cannot be written to a file in the
+working tree, this command reports the error and continues with the
+remaining files, and then exits with a non-zero status.
+
 In a bare repository, this command has no effect.  In a future version,
 this command may exit with an error if it is run in a bare repository.
 

--- a/docs/man/git-lfs-pull.adoc
+++ b/docs/man/git-lfs-pull.adoc
@@ -49,6 +49,10 @@ to `HEAD`, and any `.gitattributes` files in the index or current
 working tree will always be ignored. These constraints do not apply
 with prior versions of Git.
 
+If the contents of a Git LFS object cannot be written to a file in the
+working tree, this command reports the error and continues with the
+remaining files, and then exits with a non-zero status.
+
 == OPTIONS
 
 `-I <paths>`::

--- a/t/t-checkout.sh
+++ b/t/t-checkout.sh
@@ -187,8 +187,8 @@ begin_test "checkout: skip directory file conflicts"
   touch dir1 dir2/dir3
 
   git lfs checkout 2>&1 | tee checkout.log
-  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected checkout to succeed ..."
+  if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected checkout to fail ..."
     exit 1
   fi
   grep '"dir1/a\.dat": not a directory' checkout.log
@@ -200,8 +200,8 @@ begin_test "checkout: skip directory file conflicts"
 
   pushd dir2
     git lfs checkout 2>&1 | tee checkout.log
-    if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-      echo >&2 "fatal: expected checkout to succeed ..."
+    if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+      echo >&2 "fatal: expected checkout to fail ..."
       exit 1
     fi
     grep '"dir1/a\.dat": not a directory' checkout.log
@@ -242,8 +242,8 @@ begin_test "checkout: skip directory symlink conflicts"
   ln -s ../../link2 dir2/dir3
 
   git lfs checkout 2>&1 | tee checkout.log
-  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected checkout to succeed ..."
+  if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected checkout to fail ..."
     exit 1
   fi
   grep '"dir1/a\.dat": not a directory' checkout.log
@@ -262,8 +262,8 @@ begin_test "checkout: skip directory symlink conflicts"
   ln -s ../link2 dir2/dir3
 
   git lfs checkout 2>&1 | tee checkout.log
-  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected checkout to succeed ..."
+  if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected checkout to fail ..."
     exit 1
   fi
   grep '"dir1/a\.dat": not a directory' checkout.log
@@ -278,8 +278,8 @@ begin_test "checkout: skip directory symlink conflicts"
 
   pushd dir2
     git lfs checkout 2>&1 | tee checkout.log
-    if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-      echo >&2 "fatal: expected checkout to succeed ..."
+    if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+      echo >&2 "fatal: expected checkout to fail ..."
       exit 1
     fi
     grep '"dir1/a\.dat": not a directory' checkout.log
@@ -300,8 +300,8 @@ begin_test "checkout: skip directory symlink conflicts"
   ln -s ../../link2 dir2/dir3
 
   git lfs checkout 2>&1 | tee checkout.log
-  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected checkout to succeed ..."
+  if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected checkout to fail ..."
     exit 1
   fi
   grep '"dir1/a\.dat": not a directory' checkout.log
@@ -319,8 +319,8 @@ begin_test "checkout: skip directory symlink conflicts"
   ln -s ../link2 dir2/dir3
 
   git lfs checkout 2>&1 | tee checkout.log
-  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected checkout to succeed ..."
+  if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected checkout to fail ..."
     exit 1
   fi
   grep '"dir1/a\.dat": not a directory' checkout.log
@@ -334,8 +334,8 @@ begin_test "checkout: skip directory symlink conflicts"
 
   pushd dir2
     git lfs checkout 2>&1 | tee checkout.log
-    if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-      echo >&2 "fatal: expected checkout to succeed ..."
+    if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+      echo >&2 "fatal: expected checkout to fail ..."
       exit 1
     fi
     grep '"dir1/a\.dat": not a directory' checkout.log
@@ -380,8 +380,8 @@ begin_test "checkout: skip file symlink conflicts"
   ln -s ../../../../link2 dir1/dir2/dir3/a.dat
 
   git lfs checkout 2>&1 | tee checkout.log
-  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected checkout to succeed ..."
+  if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected checkout to fail ..."
     exit 1
   fi
   grep '"a\.dat": not a regular file' checkout.log
@@ -402,8 +402,8 @@ begin_test "checkout: skip file symlink conflicts"
   ln -s ../../../link2 dir1/dir2/dir3/a.dat
 
   git lfs checkout 2>&1 | tee checkout.log
-  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected checkout to succeed ..."
+  if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected checkout to fail ..."
     exit 1
   fi
   grep '"a\.dat": not a regular file' checkout.log
@@ -419,8 +419,8 @@ begin_test "checkout: skip file symlink conflicts"
 
   pushd dir1/dir2
     git lfs checkout 2>&1 | tee checkout.log
-    if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-      echo >&2 "fatal: expected checkout to succeed ..."
+    if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+      echo >&2 "fatal: expected checkout to fail ..."
       exit 1
     fi
     grep '"a\.dat": not a regular file' checkout.log
@@ -442,8 +442,8 @@ begin_test "checkout: skip file symlink conflicts"
   ln -s ../../../../link2 dir1/dir2/dir3/a.dat
 
   git lfs checkout 2>&1 | tee checkout.log
-  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected checkout to succeed ..."
+  if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected checkout to fail ..."
     exit 1
   fi
   grep '"a\.dat": not a regular file' checkout.log
@@ -461,8 +461,8 @@ begin_test "checkout: skip file symlink conflicts"
   ln -s ../../../link2 dir1/dir2/dir3/a.dat
 
   git lfs checkout 2>&1 | tee checkout.log
-  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected checkout to succeed ..."
+  if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected checkout to fail ..."
     exit 1
   fi
   grep '"a\.dat": not a regular file' checkout.log
@@ -476,8 +476,8 @@ begin_test "checkout: skip file symlink conflicts"
 
   pushd dir1/dir2
     git lfs checkout 2>&1 | tee checkout.log
-    if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-      echo >&2 "fatal: expected checkout to succeed ..."
+    if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+      echo >&2 "fatal: expected checkout to fail ..."
       exit 1
     fi
     grep '"a\.dat": not a regular file' checkout.log
@@ -580,9 +580,19 @@ begin_test "checkout: skip case-based symlink conflicts"
   git checkout -- A.dat dir1/a.dat DIR3 dir1/dir2
 
   git lfs checkout 2>&1 | tee checkout.log
-  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected checkout to succeed ..."
-    exit 1
+  res="${PIPESTATUS[0]}"
+  if [ "$collision" -eq "0" ]; then
+    # case-sensitive filesystem
+    if [ "0" -ne "$res" ]; then
+      echo >&2 "fatal: expected checkout to succeed ..."
+      exit 1
+    fi
+  else
+    # case-insensitive filesystem
+    if [ "0" -eq "$res" ]; then
+      echo >&2 "fatal: expected checkout to fail ..."
+      exit 1
+    fi
   fi
   if [ "$collision" -eq "0" ]; then
     # case-sensitive filesystem
@@ -649,13 +659,21 @@ begin_test "checkout: skip changed files"
   rm a.dat
   mkdir a.dat
 
-  git lfs checkout
+  git lfs checkout 2>&1 | tee checkout.log
+  if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected checkout to fail ..."
+    exit 1
+  fi
 
   [ -d "a.dat" ]
   assert_clean_index
 
   pushd a.dat
-    git lfs checkout
+    git lfs checkout 2>&1 | tee checkout.log
+    if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+      echo >&2 "fatal: expected checkout to fail ..."
+      exit 1
+    fi
   popd
 
   [ -d "a.dat" ]
@@ -803,10 +821,10 @@ begin_test "checkout: read-only directory"
     chmod a-w dir
   fi
   git lfs checkout 2>&1 | tee checkout.log
-  # Note that although the checkout command should log an error, at present
-  # we still expect a zero exit code.
-  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected 'git lfs checkout' to succeed ..."
+  # The file could not be written to the working tree, so the command reports
+  # the error and exits non-zero.
+  if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected 'git lfs checkout' to fail ..."
     exit 1
   fi
 

--- a/t/t-pull.sh
+++ b/t/t-pull.sh
@@ -261,8 +261,8 @@ begin_test "pull: skip directory file conflicts"
   touch dir1 dir2/dir3
 
   git lfs pull 2>&1 | tee pull.log
-  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected pull to succeed ..."
+  if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected pull to fail ..."
     exit 1
   fi
   grep '"dir1/a\.dat": not a directory' pull.log
@@ -278,8 +278,8 @@ begin_test "pull: skip directory file conflicts"
 
   pushd dir2
     git lfs pull 2>&1 | tee pull.log
-    if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-      echo >&2 "fatal: expected pull to succeed ..."
+    if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+      echo >&2 "fatal: expected pull to fail ..."
       exit 1
     fi
     grep '"dir1/a\.dat": not a directory' pull.log
@@ -331,8 +331,8 @@ begin_test "pull: skip directory symlink conflicts"
   ln -s ../../link2 dir2/dir3
 
   git lfs pull 2>&1 | tee pull.log
-  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected pull to succeed ..."
+  if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected pull to fail ..."
     exit 1
   fi
   grep '"dir1/a\.dat": not a directory' pull.log
@@ -355,8 +355,8 @@ begin_test "pull: skip directory symlink conflicts"
   ln -s ../link2 dir2/dir3
 
   git lfs pull 2>&1 | tee pull.log
-  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected pull to succeed ..."
+  if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected pull to fail ..."
     exit 1
   fi
   grep '"dir1/a\.dat": not a directory' pull.log
@@ -375,8 +375,8 @@ begin_test "pull: skip directory symlink conflicts"
 
   pushd dir2
     git lfs pull 2>&1 | tee pull.log
-    if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-      echo >&2 "fatal: expected pull to succeed ..."
+    if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+      echo >&2 "fatal: expected pull to fail ..."
       exit 1
     fi
     grep '"dir1/a\.dat": not a directory' pull.log
@@ -401,8 +401,8 @@ begin_test "pull: skip directory symlink conflicts"
   ln -s ../../link2 dir2/dir3
 
   git lfs pull 2>&1 | tee pull.log
-  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected pull to succeed ..."
+  if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected pull to fail ..."
     exit 1
   fi
   grep '"dir1/a\.dat": not a directory' pull.log
@@ -424,8 +424,8 @@ begin_test "pull: skip directory symlink conflicts"
   ln -s ../link2 dir2/dir3
 
   git lfs pull 2>&1 | tee pull.log
-  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected pull to succeed ..."
+  if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected pull to fail ..."
     exit 1
   fi
   grep '"dir1/a\.dat": not a directory' pull.log
@@ -443,8 +443,8 @@ begin_test "pull: skip directory symlink conflicts"
 
   pushd dir2
     git lfs pull 2>&1 | tee pull.log
-    if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-      echo >&2 "fatal: expected pull to succeed ..."
+    if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+      echo >&2 "fatal: expected pull to fail ..."
       exit 1
     fi
     grep '"dir1/a\.dat": not a directory' pull.log
@@ -500,8 +500,8 @@ begin_test "pull: skip file symlink conflicts"
   ln -s ../../../../link2 dir1/dir2/dir3/a.dat
 
   git lfs pull 2>&1 | tee pull.log
-  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected pull to succeed ..."
+  if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected pull to fail ..."
     exit 1
   fi
   grep '"a\.dat": not a regular file' pull.log
@@ -526,8 +526,8 @@ begin_test "pull: skip file symlink conflicts"
   ln -s ../../../link2 dir1/dir2/dir3/a.dat
 
   git lfs pull 2>&1 | tee pull.log
-  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected pull to succeed ..."
+  if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected pull to fail ..."
     exit 1
   fi
   grep '"a\.dat": not a regular file' pull.log
@@ -547,8 +547,8 @@ begin_test "pull: skip file symlink conflicts"
 
   pushd dir1/dir2
     git lfs pull 2>&1 | tee pull.log
-    if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-      echo >&2 "fatal: expected pull to succeed ..."
+    if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+      echo >&2 "fatal: expected pull to fail ..."
       exit 1
     fi
     grep '"a\.dat": not a regular file' pull.log
@@ -574,8 +574,8 @@ begin_test "pull: skip file symlink conflicts"
   ln -s ../../../../link2 dir1/dir2/dir3/a.dat
 
   git lfs pull 2>&1 | tee pull.log
-  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected pull to succeed ..."
+  if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected pull to fail ..."
     exit 1
   fi
   grep '"a\.dat": not a regular file' pull.log
@@ -597,8 +597,8 @@ begin_test "pull: skip file symlink conflicts"
   ln -s ../../../link2 dir1/dir2/dir3/a.dat
 
   git lfs pull 2>&1 | tee pull.log
-  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected pull to succeed ..."
+  if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected pull to fail ..."
     exit 1
   fi
   grep '"a\.dat": not a regular file' pull.log
@@ -616,8 +616,8 @@ begin_test "pull: skip file symlink conflicts"
 
   pushd dir1/dir2
     git lfs pull 2>&1 | tee pull.log
-    if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-      echo >&2 "fatal: expected pull to succeed ..."
+    if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+      echo >&2 "fatal: expected pull to fail ..."
       exit 1
     fi
     grep '"a\.dat": not a regular file' pull.log
@@ -717,9 +717,19 @@ begin_test "pull: skip case-based symlink conflicts"
   git checkout -- A.dat dir1/a.dat DIR3 dir1/dir2
 
   git lfs pull 2>&1 | tee pull.log
-  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected pull to succeed ..."
-    exit 1
+  res="${PIPESTATUS[0]}"
+  if [ "$collision" -eq "0" ]; then
+    # case-sensitive filesystem
+    if [ "0" -ne "$res" ]; then
+      echo >&2 "fatal: expected pull to succeed ..."
+      exit 1
+    fi
+  else
+    # case-insensitive filesystem
+    if [ "0" -eq "$res" ]; then
+      echo >&2 "fatal: expected pull to fail ..."
+      exit 1
+    fi
   fi
   if [ "$collision" -gt "0" ]; then
     # case-insensitive filesystem
@@ -794,7 +804,11 @@ begin_test "pull: skip changed files"
   mkdir a.dat
 
   rm -rf .git/lfs/objects
-  git lfs pull
+  git lfs pull 2>&1 | tee pull.log
+  if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected pull to fail ..."
+    exit 1
+  fi
   assert_local_object "$contents_oid" 1
 
   [ -d "a.dat" ]
@@ -803,7 +817,11 @@ begin_test "pull: skip changed files"
   rm -rf .git/lfs/objects
 
   pushd a.dat
-    git lfs pull
+    git lfs pull 2>&1 | tee pull.log
+    if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+      echo >&2 "fatal: expected pull to fail ..."
+      exit 1
+    fi
   popd
 
   assert_local_object "$contents_oid" 1
@@ -1118,10 +1136,10 @@ begin_test "pull: read-only directory"
     chmod a-w dir
   fi
   git lfs pull 2>&1 | tee pull.log
-  # Note that although the pull command should log an error, at present
-  # we still expect a zero exit code.
-  if [ "0" -ne "${PIPESTATUS[0]}" ]; then
-    echo >&2 "fatal: expected 'git lfs pull' to succeed ..."
+  # The file could not be written to the working tree, so the command reports
+  # the error and exits non-zero.
+  if [ "0" -eq "${PIPESTATUS[0]}" ]; then
+    echo >&2 "fatal: expected 'git lfs pull' to fail ..."
     exit 1
   fi
 


### PR DESCRIPTION
 Commit 3d8f497ea50ef550d15907bcc91868e608e56c14 of PR #5629 added the "read-only directory" tests, which check that `git lfs checkout` and `git lfs pull` report errors when a Git LFS object's contents cannot be written to a file in the working tree, and noted in its commit message:

> Note that for historical reasons we expect that under these conditions
> the commands will return a zero exit code, indicating success, rather
> than a non-zero exit code, which would indicate failure.  We may adjust
> this behaviour in the future, however, so that the commands also return
> a non-zero exit code in these cases.

This PR makes that adjustment: both commands now count the files they could not check out and exit with a status of 2 when the count is non-zero, matching the download stage of `git lfs pull`. The zero exit status makes checkout failures invisible to callers such as CI jobs. This was raised several times in #4974:

* [oderby, 2022](https://github.com/git-lfs/git-lfs/issues/4974#issuecomment-1122743446): "caused us to miss this in CI for quite some time"
* [jwatte, 2024](https://github.com/git-lfs/git-lfs/issues/4974#issuecomment-2305872017): "The command also exits with status 0, so we don't detect that it failed easily."
* [ravenAtSafe, 2025](https://github.com/git-lfs/git-lfs/issues/4974#issuecomment-3181785718): "We run `git lfs pull` in a Linux CI environment, it returns without indicating any error"

A green GitLab CI pipeline with a missing file was recently traced back to it (https://gitlab.com/gitlab-org/gitlab-runner/-/work_items/39678).

Working tree conflicts, such as a file found where a directory is expected, are also counted as checkout failures. Commit 0cffe93176b870055c9dadbb3cc9a4a440e98396, which added these conflict checks, notes:

> That function returns an error if any of the
> directories in the given path do not already exist and cannot be created,
> and the "git lfs checkout" and "git lfs pull" commands would just report
> that error rather than attempt to resolve it by removing anything.