### PR TITLE
Update Linux distributions and include Debian ARM64 links in releases

### DIFF
--- a/script/lib/distro.rb
+++ b/script/lib/distro.rb
@@ -106,7 +106,6 @@ class DistroMap
           "debian/trixie",             # EOL June 2030
           "debian/forky",              # Current testing (Debian 14)
           "linuxmint/gigi",            # LMDE LTS release based on Debian 13
-          "ubuntu/questing",           # EOL July 2026
           "ubuntu/resolute",           # EOL July 2031
         ]
       },

--- a/script/lib/distro.rb
+++ b/script/lib/distro.rb
@@ -134,8 +134,13 @@ class DistroMapProgram
 
   def distro_markdown
     platform_architectures = {
-      "rpm" => ".x86_64",
-      "deb" => "_amd64",
+      "rpm" => [
+        { arch: ".x86_64" },
+      ],
+      "deb" => [
+        { arch: "_amd64", name: "AMD64" },
+        { arch: "_arm64", name: "ARM64" },
+      ],
     }
     separator = {
       "rpm" => "-",
@@ -143,8 +148,10 @@ class DistroMapProgram
     }
     result = @dmap.entries.values.map do |entry|
       type = entry[:package_type]
-      arch = platform_architectures[type]
-      "[#{entry[:name]}](https://packagecloud.io/github/git-lfs/packages/#{entry[:component]}/git-lfs#{separator[type]}VERSION#{entry[:package_tag]}#{arch}.#{type}/download)\n"
+      platform_architectures[type].map do |arch|
+        arch_name = arch.key?(:name) ? " (#{arch[:name]})" : ""
+        "[#{entry[:name]}#{arch_name}](https://packagecloud.io/github/git-lfs/packages/#{entry[:component]}/git-lfs#{separator[type]}VERSION#{entry[:package_tag]}#{arch[:arch]}.#{type}/download)\n"
+      end.join
     end.join
     @stdout.puts result
   end

--- a/script/lib/distro.rb
+++ b/script/lib/distro.rb
@@ -133,7 +133,7 @@ class DistroMapProgram
   end
 
   def distro_markdown
-    arch = {
+    platform_architectures = {
       "rpm" => ".x86_64",
       "deb" => "_amd64",
     }
@@ -141,9 +141,10 @@ class DistroMapProgram
       "rpm" => "-",
       "deb" => "_",
     }
-    result = @dmap.entries.map do |_k, v|
-      type = v[:package_type]
-      "[#{v[:name]}](https://packagecloud.io/github/git-lfs/packages/#{v[:component]}/git-lfs#{separator[type]}VERSION#{v[:package_tag]}#{arch[type]}.#{type}/download)\n"
+    result = @dmap.entries.values.map do |entry|
+      type = entry[:package_type]
+      arch = platform_architectures[type]
+      "[#{entry[:name]}](https://packagecloud.io/github/git-lfs/packages/#{entry[:component]}/git-lfs#{separator[type]}VERSION#{entry[:package_tag]}#{arch}.#{type}/download)\n"
     end.join
     @stdout.puts result
   end


### PR DESCRIPTION
This PR updates our release scripts so that the GitHub release pages they generate will now include links to the Debian packages that we build for the ARM64 architecture.

At present, our release [pages](https://github.com/git-lfs/git-lfs/releases) only provide links to the AMD64 versions the Debian packages that we publish on Packagecloud, but since PR #5977 we have built all of our Debian packages for both of the AMD64 and ARM64 architectures.

As well, this PR removes one entry from the list of the Linux distributions and versions for which our scripts will publish RPM and Debian packages, as the Ubuntu 25.10 ("Questing Quokka") interim release has reached the end of its support lifecycle.

This PR will be most easily reviewed on a commit-by-commit basis.

#### Release Page Link Details

The existing links generated by our release scripts have the following form, using Debian 12 ("bookworm") as an example:

```markdown
[Debian 12](https://packagecloud.io/github/git-lfs/packages/debian/bookworm/git-lfs_<version>_amd64.deb/download)
```

With the changes from this PR, they will now have the form:

```markdown
[Debian 12 (AMD64)](https://packagecloud.io/github/git-lfs/packages/debian/bookworm/git-lfs_<version>_amd64.deb/download)
[Debian 12 (ARM64)](https://packagecloud.io/github/git-lfs/packages/debian/bookworm/git-lfs_<version>_arm64.deb/download)
```