### PR TITLE
Fix typo in git-lfs-prune man page

### DIFF
--- a/docs/man/git-lfs-prune.adoc
+++ b/docs/man/git-lfs-prune.adoc
@@ -149,7 +149,7 @@ You can check for unreachable objects by default by setting
 `lfs.pruneverifyunreachablealways` to true.
 
 By default, `--verify-remote` halts execution if a file cannot be
-verified. Set `--when-unverified=continue` to not halt exceution but
+verified. Set `--when-unverified=continue` to not halt execution but
 continue deleting all objects that can be verified.
 
 == DEFAULT REMOTE


### PR DESCRIPTION
Super simple typo fix on the `git-lfs-prune` man page that was flagged by Debian tooling. `exceution` -> `execution`