### PR TITLE
Fix Linux release package build and upload issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,6 +196,7 @@ jobs:
         PACKAGECLOUD_TOKEN: ${{secrets.PACKAGECLOUD_TOKEN}}
   build-docker-arm:
     name: Build Linux ARM packages
+    environment: production
     runs-on: ubuntu-24.04-arm
     steps:
     - uses: actions/checkout@v7

--- a/script/lib/distro.rb
+++ b/script/lib/distro.rb
@@ -88,11 +88,8 @@ class DistroMap
         package_tag: "",
         equivalent: [
           "debian/bookworm",           # EOL June 2028
-          "linuxmint/faye",            # LMDE LTS release based on Debian 12
           "linuxmint/wilma",           # EOL April 2029
           "linuxmint/xia",             # EOL April 2029
-          "linuxmint/zara",            # EOL April 2029
-          "linuxmint/zena",            # EOL April 2029
           "ubuntu/noble",              # EOL June 2029
         ]
       },
@@ -105,7 +102,6 @@ class DistroMap
         equivalent: [
           "debian/trixie",             # EOL June 2030
           "debian/forky",              # Current testing (Debian 14)
-          "linuxmint/gigi",            # LMDE LTS release based on Debian 13
           "ubuntu/resolute",           # EOL July 2031
         ]
       },

--- a/script/packagecloud.rb
+++ b/script/packagecloud.rb
@@ -57,7 +57,7 @@ package_files.each do |full_path|
       # script and our attempt to upload over the existing package failed
       # because PackageCloud doesn't allow that. Ignore the failure since we
       # already have the package uploaded.
-      if result.response != '{"filename":["has already been taken"]}'
+      if result.response !~ /{"filename":\["'.*' has already been taken"\]}/
         raise "packagecloud put_package failed, error: #{result.response}"
       end
     end


### PR DESCRIPTION
This PR addresses three issues encountered during the release process for Git LFS version 3.8.0.

First, at present Packagecloud does not support either of the newest versions of the Linux Mint distribution, Linux Mint 22.2 ("Zara") and 22.3 ("Zena"), nor do they support any Linux Mint Debian Edition (LMDE) versions, so our release workflow will fail if it tries to upload packages for those versions.  To avoid this problem, for the time being we remove all of these versions from the [list](https://github.com/git-lfs/git-lfs/blob/aece9221f8c09221a14395d964806b956289bc07/script/lib/distro.rb#L24-L112) of Linux distribution versions for which we will build and release packages.

Second, the script we use to upload packages to Packagecloud [tries](https://github.com/git-lfs/git-lfs/blob/aece9221f8c09221a14395d964806b956289bc07/script/packagecloud.rb#L60) to detect and ignore errors caused when a file upload is rejected because a file already exists on the platform with the same name and set of parameters.  However, our script checks for an error message different than the one now returned by the Packagecloud API when a file upload conflicts with an existing file, so we update our script to check for the current version of this error message.

Third, we restore a missing `environment` property from the release workflow [job](https://github.com/git-lfs/git-lfs/blob/aece9221f8c09221a14395d964806b956289bc07/.github/workflows/release.yml#L197-L213) we use to build Linux packages for the ARM64 architecture.  While this property is not required for the job to succeed, the other primary jobs in our workflow specify the same property, and so will only execute once we approve a release in GitHub's certificate management utility.  Using a consistent property for all our primary jobs will guarantee they only execute once we approve a release.

Note that all of this PR's changes were tested successfully in a private repository.